### PR TITLE
Remove trailing . from instructions

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -118,7 +118,7 @@ To get started you need Cargo's bin directory in your `PATH`
 environment variable. Next time you log in this will be done
 automatically.
 
-To configure your current shell run `source {cargo_home}/env`.
+To configure your current shell run `source {cargo_home}/env`
 "
     };
 }
@@ -141,7 +141,7 @@ r"# Rust is installed now. Great!
 To get started you need Cargo's bin directory in your `PATH`
 environment variable.
 
-To configure your current shell run `source {cargo_home}/env`.
+To configure your current shell run `source {cargo_home}/env`
 "
     };
 }


### PR DESCRIPTION
Even though the . makes sense grammatically, it can confuse users.


Here's a screenshot (macos, default terminal) with the current trailing dot:
http://i.imgur.com/5HqQBEN.png

As you can see, that can easily confuse new users into copying and pasting the command with the trailing . and not sure what went wrong.