### PR TITLE
Recursive tool invocations should invoke the proxy, not the tool dire…

### DIFF
--- a/src/rustup-cli/proxy_mode.rs
+++ b/src/rustup-cli/proxy_mode.rs
@@ -34,9 +34,9 @@ pub fn main() -> Result<()> {
 
     // Build command args now while we know whether or not to skip arg 1.
     let cmd_args: Vec<_> = if toolchain.is_none() {
-        env::args_os().collect()
+        env::args_os().skip(1).collect()
     } else {
-        env::args_os().take(1).chain(env::args_os().skip(2)).collect()
+        env::args_os().skip(2).collect()
     };
 
     let cfg = try!(set_globals(false));
@@ -51,6 +51,6 @@ fn direct_proxy(cfg: &Cfg, arg0: &str, toolchain: Option<&str>, args: &[OsString
         None => try!(cfg.create_command_for_dir(&try!(utils::current_dir()), arg0)),
         Some(tc) => try!(cfg.create_command_for_toolchain(tc, arg0)),
     };
-    Ok(try!(run_command_for_dir(cmd, &args, &cfg)))
+    Ok(try!(run_command_for_dir(cmd, arg0, args, &cfg)))
 }
 

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -487,7 +487,7 @@ fn run(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let args: Vec<_> = args.collect();
     let cmd = try!(cfg.create_command_for_toolchain(toolchain, args[0]));
 
-    Ok(try!(command::run_command_for_dir(cmd, &args, &cfg)))
+    Ok(try!(command::run_command_for_dir(cmd, args[0], &args[1..], &cfg)))
 }
 
 fn which(cfg: &Cfg, m: &ArgMatches) -> Result<()> {

--- a/src/rustup-mock/src/mock_bin_src.rs
+++ b/src/rustup-mock/src/mock_bin_src.rs
@@ -1,4 +1,6 @@
+use std::process::Command;
 use std::io::{self, BufWriter, Write};
+use std::env::consts::EXE_SUFFIX;
 
 fn main() {
     let args: Vec<_> = ::std::env::args().collect();
@@ -13,6 +15,12 @@ fn main() {
         for _ in 0 .. 10000 {
             buf.write_all(b"error: a value named `fail` has already been defined in this module [E0428]\n").unwrap();
         }
+    } else if args.get(1) == Some(&"--call-rustc".to_string()) {
+        // Used by the fallback_cargo_calls_correct_rustc test. Tests that
+        // the environment has been set up right such that invoking rustc
+        // will actually invoke the wrapper
+        let rustc = &format!("rustc{}", EXE_SUFFIX);
+        Command::new(rustc).arg("--version").status().unwrap();
     } else {
         panic!("bad mock proxy commandline");
     }


### PR DESCRIPTION
…ctly

The way the proxy was setting up the PATH variable contained two bugs:
first, that it allowed the toolchain path to precede the value of CARGO_HOME/bin;
but second that it didn't add CARGO_HOME/bin to the path at all. The result
was that when e.g. cargo execs rustc, it was directly execing the toolchain
rustc.

Now it execs the proxy, assuming that CARGO_HOME/bin is set up correctly,
and guaranteeing not to run the toolchain tool directly.

Fixes #809

r? @Diggsey cc @japaric @michaelwoerister