### PR TITLE
Search PATH for binaries run by `rustup run`

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -369,6 +369,7 @@ fn do_pre_install_sanity_checks() -> Result<()> {
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because
 // sudo is configured not to change $HOME. Don't let that bogosity happen.
+#[allow(dead_code)]
 fn do_anti_sudo_check(no_prompt: bool) -> Result<()> {
     #[cfg(unix)]
     #[inline(never)] // FIXME #679. Mysterious crashes on OS X 10.10+

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -284,6 +284,19 @@ fn custom_toolchain_cargo_fallback_run() {
 }
 
 #[test]
+fn rustup_run_searches_path() {
+    setup(&|config| {
+        #[cfg(windows)]
+        let hello_cmd = &["rustup", "run", "nightly", "cmd", "/C", "echo hello"];
+        #[cfg(not(windows))]
+        let hello_cmd = &["rustup", "run", "nightly", "sh", "-c", "echo hello"];
+
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_stdout_ok(config, hello_cmd, "hello");
+    });
+}
+
+#[test]
 fn multirust_env_compat() {
     setup(&|config| {
         let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly"]);


### PR DESCRIPTION
Fixes #641, #210 