### PR TITLE
add faq entry for downloading rust source

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,12 @@ rustup is the successor to [multirust]. rustup began as multirust-rs,
 a rewrite of multirust from shell script to Rust, by [Diggory Blake],
 and is now maintained by The Rust Project.
 
+### Can rustup download the Rust source code?
+
+The Rust source can be obtained by running `rustup component add rust-src`. 
+It will be downloaded to the `<toolchain root>/lib/rustlib/src/rust` 
+directory of the current toolchain.
+
 ### rustup fails with Windows error 32
 
 If rustup fails with Windows error 32, it may be due to antivirus


### PR DESCRIPTION
This change request is made because I have experienced it to be really hard finding out how to get the rust source code using rustup. It might be obvious for an experienced user, who knows what the components command does, but it wasn't exactly easy to google it and this might help some people who need the source for racer or similar programs.