### PR TITLE
Default to MSVC on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "clap 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "download 0.3.0",
  "error-chain 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -579,7 +580,6 @@ version = "0.6.5"
 dependencies = [
  "error-chain 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "gcc 0.3.32 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.4.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ winapi = "0.2.8"
 winreg = "0.3.2"
 user32-sys = "0.1.2"
 kernel32-sys = "0.2.1"
+gcc = "0.3.28"
 
 [dev-dependencies]
 rustup-mock = { path = "src/rustup-mock", version = "0.6.5" }

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -22,6 +22,8 @@ extern crate markdown;
 extern crate toml;
 
 #[cfg(windows)]
+extern crate gcc;
+#[cfg(windows)]
 extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -32,7 +32,6 @@ winapi = "0.2.8"
 winreg = "0.3.2"
 user32-sys = "0.1.2"
 kernel32-sys = "0.2.1"
-gcc = "0.3.28"
 
 [target."cfg(not(windows))".dependencies]
 libc = "0.2.0"

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -116,7 +116,6 @@ impl TargetTriple {
     pub fn from_host() -> Option<Self> {
         #[cfg(windows)]
         fn inner() -> Option<TargetTriple> {
-            use gcc::windows_registry;
             use kernel32::GetNativeSystemInfo;
             use std::mem;
 
@@ -136,16 +135,9 @@ impl TargetTriple {
                 _ => return None,
             };
 
-            // Now try to find an installation of msvc, using the gcc crate to do the hard work
+            // Default to msvc
             let msvc_triple = format!("{}-pc-windows-msvc", arch);
-            let gnu_triple = format!("{}-pc-windows-gnu", arch);
-            if let Some(_) = windows_registry::find_tool(&msvc_triple, "cl.exe") {
-                // Found msvc, so default to the msvc triple
-                Some(TargetTriple(msvc_triple))
-            } else {
-                // No msvc found, so use gnu triple as a fallback
-                Some(TargetTriple(gnu_triple))
-            }
+            Some(TargetTriple(msvc_triple))
         }
 
         #[cfg(not(windows))]

--- a/src/rustup-dist/src/lib.rs
+++ b/src/rustup-dist/src/lib.rs
@@ -21,8 +21,6 @@ extern crate winreg;
 extern crate user32;
 #[cfg(windows)]
 extern crate kernel32;
-#[cfg(windows)]
-extern crate gcc;
 #[cfg(not(windows))]
 extern crate libc;
 

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -265,6 +265,9 @@ pub fn env(config: &Config, cmd: &mut Command) {
 
     // Setting HOME will confuse the sudo check for rustup-init. Override it
     cmd.env("RUSTUP_INIT_SKIP_SUDO_CHECK", "yes");
+
+    // Skip the MSVC warning check since it's environment dependent
+    cmd.env("RUSTUP_INIT_SKIP_MSVC_CHECK", "yes");
 }
 
 pub fn run(config: &Config, name: &str, args: &[&str], env: &[(&str, &str)]) -> SanitizedOutput {


### PR DESCRIPTION
Instead of picking MSVC/GNU based on detection, just default to MSVC.
During install, if MSVC is not detected provide guidance.

This is more predictable and easier to explain.

r? @alexcrichton 