### PR TITLE
Detect servo's Mac platform string.

### DIFF
--- a/www/rustup.js
+++ b/www/rustup.js
@@ -15,6 +15,7 @@ function detect_platform() {
     if (navigator.platform == "Linux aarch64") {os = "unix";}
     if (navigator.platform == "Linux armv6l") {os = "unix";}
     if (navigator.platform == "Linux armv7l") {os = "unix";}
+    if (navigator.platform == "Mac") {os = "unix";}
     if (navigator.platform == "Win32") {os = "win";}
     if (navigator.platform == "FreeBSD x86_64") {os = "unix";}
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}


### PR DESCRIPTION
Makes the platform detection work for the servo nightly on MacOS.

Fixes #854.