### PR TITLE
Make executable name case insensitive

### DIFF
--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -74,26 +74,27 @@ fn run_multirust() -> Result<()> {
     let arg0 = env::args().next().map(|a| PathBuf::from(a));
     let name = arg0.as_ref()
         .and_then(|a| a.file_stem())
-        .and_then(|a| a.to_str());
+        .and_then(|a| a.to_str())
+        .map(|a| a.to_lowercase());
     match name {
-        Some("rustup") => {
+        Some(ref n) if n == "rustup" => {
             rustup_mode::main()
         }
-        Some(n) if n.starts_with("multirust-setup")||
-                   n.starts_with("rustup-setup") ||
-                   n.starts_with("rustup-init") => {
+        Some(ref n) if n.starts_with("multirust-setup")||
+                       n.starts_with("rustup-setup") ||
+                       n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to
             // e.g. multirust-setup(2), and this allows all variations
             // to work.
             setup_mode::main()
         }
-        Some(n) if n.starts_with("rustup-gc-") => {
+        Some(ref n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where
             // multirust deletes its own exe
             self_update::complete_windows_uninstall()
         }
-        Some(n) if n.starts_with("multirust-") => {
+        Some(ref n) if n.starts_with("multirust-") => {
             // This is for compatibility with previous revisions of
             // multirust-rs self-update, which expect multirust-rs to
             // be available on the server, downloads it to

--- a/src/rustup-cli/proxy_mode.rs
+++ b/src/rustup-cli/proxy_mode.rs
@@ -18,7 +18,8 @@ pub fn main() -> Result<()> {
     let arg0 = args.next().map(|a| PathBuf::from(a));
     let arg0 = arg0.as_ref()
         .and_then(|a| a.file_name())
-        .and_then(|a| a.to_str());
+        .and_then(|a| a.to_str())
+        .map(|a| a.to_lowercase());
     let ref arg0 = try!(arg0.ok_or(ErrorKind::NoExeName));
 
     // Check for a toolchain specifier.


### PR DESCRIPTION
This is mainly for solving the issue that on Windows, filename is case-insensitive, but when rustup is called with non-lowercased name, it sometimes fails to handle correctly.

e.g. when you call `rustc.EXE` rather than `rustc.exe`, it would report
> error: command failed: 'rustc.EXE'
> info: caused by: The system cannot find the file specified. (os error 2)

and if you call it `RustUp`, it would report
> error: infinite recursion detected

Although this is mostly a Windows-only issue, I guess it doesn't harm much if we extend this behavior to all platforms, which makes the code simpler.

I tried to write a test, but it seems I cannot test the `rustc.EXE` case in test, because `rustup_mock::clitools::cmd` attaches the executable suffix unconditionally.