### PR TITLE
www: MIPS support and cleanups

### DIFF
--- a/www/rustup.js
+++ b/www/rustup.js
@@ -14,10 +14,10 @@ function detect_platform() {
     var os = "unknown";
 
     if (navigator.platform == "Linux x86_64") {os = "unix";}
-    if (navigator.platform == "Linux i686") {os = "unix";}
+    if (navigator.platform == "Linux i686") {os = android_or_unix();}
     if (navigator.platform == "Linux i686 on x86_64") {os = "unix";}
-    if (navigator.platform == "Linux aarch64") {os = "unix";}
-    if (navigator.platform == "Linux armv6l") {os = "unix";}
+    if (navigator.platform == "Linux aarch64") {os = android_or_unix();}
+    if (navigator.platform == "Linux armv6l") {os = android_or_unix();}
     if (navigator.platform == "Linux armv7l") {os = android_or_unix();}
     if (navigator.platform == "Linux ppc64") {os = "unix";}
     if (navigator.platform == "Linux mips") {os = "unix";}

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -1,5 +1,9 @@
 var platform_override = null;
 
+function android_or_unix() {
+  return (navigator.appVersion.indexOf("Android") != -1) ? "android" : "unix";
+}
+
 function detect_platform() {
     "use strict";
 
@@ -14,7 +18,7 @@ function detect_platform() {
     if (navigator.platform == "Linux i686 on x86_64") {os = "unix";}
     if (navigator.platform == "Linux aarch64") {os = "unix";}
     if (navigator.platform == "Linux armv6l") {os = "unix";}
-    if (navigator.platform == "Linux armv7l") {os = "unix";}
+    if (navigator.platform == "Linux armv7l") {os = android_or_unix();}
     if (navigator.platform == "Linux ppc64") {os = "unix";}
     if (navigator.platform == "Linux mips") {os = "unix";}
     if (navigator.platform == "Linux mips64") {os = "unix";}
@@ -24,11 +28,6 @@ function detect_platform() {
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}
     if (navigator.platform == "NetBSD x86_64") {os = "unix";}
     if (navigator.platform == "NetBSD amd64") {os = "unix";}
-
-    if (navigator.platform == "Linux armv7l"
-        && navigator.appVersion.indexOf("Android") != -1 ) {
-        os = "android";
-    }
 
     // I wish I knew by now, but I don't. Try harder.
     if (os == "unknown") {

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -16,6 +16,8 @@ function detect_platform() {
     if (navigator.platform == "Linux armv6l") {os = "unix";}
     if (navigator.platform == "Linux armv7l") {os = "unix";}
     if (navigator.platform == "Linux ppc64") {os = "unix";}
+    if (navigator.platform == "Linux mips") {os = "unix";}
+    if (navigator.platform == "Linux mips64") {os = "unix";}
     if (navigator.platform == "Mac") {os = "unix";}
     if (navigator.platform == "Win32") {os = "win";}
     if (navigator.platform == "FreeBSD x86_64") {os = "unix";}


### PR DESCRIPTION
Adds detection logic for MIPS hosts. Also cleaned up the Android probing in the meantime to probe all ~~AOSP-supported architectures~~ Android targets that is accompanied with `rust-std` builds.

Note: for better user experience, please don't merge until #797 lands and confirming the MIPS binaries are correctly published.