### PR TITLE
Add MIPS/s390x builders (with PPC64 compilation fixed)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,39 +19,59 @@ matrix:
     # bundle all the gcc cross compilers to enable us to build OpenSSL
     - os: linux
       env: TARGET=arm-unknown-linux-gnueabi
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=arm-unknown-linux-gnueabihf
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=armv7-unknown-linux-gnueabihf
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=aarch64-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=x86_64-unknown-freebsd
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=x86_64-unknown-netbsd
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=powerpc-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=powerpc64-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
     - os: linux
       env: TARGET=powerpc64le-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-04-05
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mipsel-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips64-unknown-linux-gnuabi64
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=mips64el-unknown-linux-gnuabi64
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           SKIP_TESTS=1
+    - os: linux
+      env: TARGET=s390x-unknown-linux-gnu
+           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
            SKIP_TESTS=1
 
     # On OSX we want to target 10.7 so we ensure that the appropriate

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -80,6 +80,31 @@ case $TARGET in
     OPENSSL_CC=powerpc64le-linux-gnu-gcc
     OPENSSL_AR=powerpc64le-linux-gnu-ar
     ;;
+  mips-*-linux-*)
+    OPENSSL_OS=linux-mips32
+    OPENSSL_CC=mips-linux-gnu-gcc
+    OPENSSL_AR=mips-linux-gnu-ar
+    ;;
+  mipsel-*-linux-*)
+    OPENSSL_OS=linux-mips32
+    OPENSSL_CC=mipsel-linux-gnu-gcc
+    OPENSSL_AR=mipsel-linux-gnu-ar
+    ;;
+  mips64-*-linux-*)
+    OPENSSL_OS=linux64-mips64
+    OPENSSL_CC=mips64-linux-gnuabi64-gcc
+    OPENSSL_AR=mips64-linux-gnuabi64-ar
+    ;;
+  mips64el-*-linux-*)
+    OPENSSL_OS=linux64-mips64
+    OPENSSL_CC=mips64el-linux-gnuabi64-gcc
+    OPENSSL_AR=mips64el-linux-gnuabi64-ar
+    ;;
+  s390x-*-linux-*)
+    OPENSSL_OS=linux64-s390x
+    OPENSSL_CC=s390x-linux-gnu-gcc
+    OPENSSL_AR=s390x-linux-gnu-ar
+    ;;
   *)
     echo "can't cross compile OpenSSL for $TARGET"
     exit 1

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -71,8 +71,8 @@ case $TARGET in
     ;;
   powerpc64-*-linux-*)
     OPENSSL_OS=linux-ppc64
-    OPENSSL_CC=powerpc-linux-gnu-gcc
-    OPENSSL_AR=powerpc-linux-gnu-ar
+    OPENSSL_CC=powerpc64-linux-gnu-gcc-5
+    OPENSSL_AR=powerpc64-linux-gnu-ar
     OPENSSL_CFLAGS=-m64
     ;;
   powerpc64le-*-linux-*)


### PR DESCRIPTION
This is a continuation of #797; rebased on master and applied PPC64 workaround. Let's see what the CI's are thinking.