### PR TITLE
cargo: update to markdown 0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,8 +344,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "markdown"
-version = "0.1.2"
-source = "git+https://github.com/Diggsey/markdown.rs.git#d56d7cad4fe4937913cb83fe7e3990bf2364b917"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pipeline 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -524,7 +524,7 @@ dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)",
+ "markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.73 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -984,7 +984,7 @@ dependencies = [
 "checksum libc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "a51822fc847e7a8101514d1d44e354ba2ffa7d4c194dcab48870740e327cac70"
 "checksum libz-sys 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c18b5826abbfafb0160b37e1991e2d327c1fe38c955e496ea306f72c06d7570c"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
-"checksum markdown 0.1.2 (git+https://github.com/Diggsey/markdown.rs.git)" = "<none>"
+"checksum markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb7e864aa1dccbebb05751e899bc84c639df47490c0c24caf4b1a77770b6566"
 "checksum matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "15305656809ce5a4805b1ff2946892810992197ce1270ff79baded852187942e"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf93a79c700c9df8227ec6a4f0f27a8948373c079312bac24549d944cef85f64"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ rand = "0.3.11"
 scopeguard = "0.1.2"
 rustc-serialize = "0.3"
 sha2 = "0.1.2"
-markdown = { git="https://github.com/Diggsey/markdown.rs.git" }
+markdown = "0.2"
 toml = "0.1.27"
 
 [target."cfg(windows)".dependencies]

--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -5,7 +5,7 @@
 use std::io;
 use term;
 use rustup_utils::tty;
-use markdown::parser::{Block, Span, ListItem};
+use markdown::{Block, Span, ListItem};
 use markdown::tokenize;
 
 pub use term::color;


### PR DESCRIPTION
This switches markdown dependency to the upstream crate, which now
exposes all required bits.

One step further towards #835.