### PR TITLE
add environment variable RUST_DIST_URL_REPLACE for pkg mirror

### DIFF
--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -131,6 +131,7 @@ impl Manifestation {
             notify_handler(Notification::DownloadingComponent(&component.pkg,
                                                               &self.target_triple,
                                                               component.target.as_ref()));
+															  
             let url = if altered {
                 let mut turl=url.replace(DEFAULT_DIST_SERVER, temp_cfg.dist_server.as_str());
                 for i in temp_cfg.replace_url.as_str().split(";") {
@@ -143,7 +144,6 @@ impl Manifestation {
             } else {
                 url
             };
-			println!("downloadurl {}\n",url);
 
             // Download each package to temp file
             let temp_file = try!(temp_cfg.new_file());

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -132,10 +132,18 @@ impl Manifestation {
                                                               &self.target_triple,
                                                               component.target.as_ref()));
             let url = if altered {
-                url.replace(DEFAULT_DIST_SERVER, temp_cfg.dist_server.as_str())
+                let mut turl=url.replace(DEFAULT_DIST_SERVER, temp_cfg.dist_server.as_str());
+                for i in temp_cfg.replace_url.as_str().split(";") {
+                    let rp:Vec<&str>=i.split("=").collect();
+                    if 2==rp.len() {
+                        turl=turl.replace(rp[0],rp[1]);
+                    }
+                }
+                turl
             } else {
                 url
             };
+			println!("downloadurl {}\n",url);
 
             // Download each package to temp file
             let temp_file = try!(temp_cfg.new_file());

--- a/src/rustup-dist/src/temp.rs
+++ b/src/rustup-dist/src/temp.rs
@@ -37,6 +37,7 @@ pub enum Notification<'a> {
 
 pub struct Cfg {
     root_directory: PathBuf,
+	pub replace_url: String,
     pub dist_server: String,
     notify_handler: Box<Fn(Notification)>,
 }
@@ -132,10 +133,11 @@ impl Display for Error {
 }
 
 impl Cfg {
-    pub fn new(root_directory: PathBuf, dist_server: &str, notify_handler: Box<Fn(Notification)>) -> Self {
+    pub fn new(root_directory: PathBuf, dist_server: &str,replace_url:&str, notify_handler: Box<Fn(Notification)>) -> Self {
         Cfg {
             root_directory: root_directory,
             dist_server: dist_server.to_owned(),
+            replace_url:replace_url.to_owned(),
             notify_handler: notify_handler,
         }
     }

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -320,7 +320,7 @@ fn setup(edit: Option<&Fn(&str, &mut MockPackage)>,
     let work_tempdir = TempDir::new("multirust").unwrap();
     let ref temp_cfg = temp::Cfg::new(work_tempdir.path().to_owned(),
                                       DEFAULT_DIST_SERVER,
-									  "https://dev-static=https://static;=",
+                                      ""
                                       Box::new(|_| ()));
 
     let ref url = Url::parse(&format!("file://{}", dist_tempdir.path().to_string_lossy())).unwrap();

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -320,6 +320,7 @@ fn setup(edit: Option<&Fn(&str, &mut MockPackage)>,
     let work_tempdir = TempDir::new("multirust").unwrap();
     let ref temp_cfg = temp::Cfg::new(work_tempdir.path().to_owned(),
                                       DEFAULT_DIST_SERVER,
+									  "https://dev-static=https://static;=",
                                       Box::new(|_| ()));
 
     let ref url = Url::parse(&format!("file://{}", dist_tempdir.path().to_string_lossy())).unwrap();

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -320,7 +320,7 @@ fn setup(edit: Option<&Fn(&str, &mut MockPackage)>,
     let work_tempdir = TempDir::new("multirust").unwrap();
     let ref temp_cfg = temp::Cfg::new(work_tempdir.path().to_owned(),
                                       DEFAULT_DIST_SERVER,
-                                      ""
+                                      "",
                                       Box::new(|_| ()));
 
     let ref url = Url::parse(&format!("file://{}", dist_tempdir.path().to_string_lossy())).unwrap();

--- a/src/rustup-dist/tests/install.rs
+++ b/src/rustup-dist/tests/install.rs
@@ -17,6 +17,7 @@ use std::io::Write;
 use tempdir::TempDir;
 use rustup_mock::{MockInstallerBuilder, MockCommand};
 
+
 // Just testing that the mocks work
 #[test]
 fn mock_smoke_test() {
@@ -110,7 +111,7 @@ fn basic_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -148,7 +149,7 @@ fn multiple_component_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -191,7 +192,7 @@ fn uninstall() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -243,7 +244,7 @@ fn component_bad_version() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -289,7 +290,7 @@ fn unix_permissions() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -333,7 +334,7 @@ fn install_to_prefix_that_does_not_exist() {
     let prefix = InstallPrefix::from(does_not_exist.clone());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 

--- a/src/rustup-dist/tests/install.rs
+++ b/src/rustup-dist/tests/install.rs
@@ -111,7 +111,7 @@ fn basic_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -149,7 +149,7 @@ fn multiple_component_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -192,7 +192,7 @@ fn uninstall() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -244,7 +244,7 @@ fn component_bad_version() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -290,7 +290,7 @@ fn unix_permissions() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 
@@ -334,7 +334,7 @@ fn install_to_prefix_that_does_not_exist() {
     let prefix = InstallPrefix::from(does_not_exist.clone());
 
     let tmpdir = TempDir::new("multirust").unwrap();
-    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(tmpdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
     let notify = |_: Notification| ();
     let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
 

--- a/src/rustup-dist/tests/transactions.rs
+++ b/src/rustup-dist/tests/transactions.rs
@@ -22,7 +22,7 @@ fn add_file() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -44,7 +44,7 @@ fn add_file_then_rollback() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -60,7 +60,7 @@ fn add_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -87,7 +87,7 @@ fn copy_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -109,7 +109,7 @@ fn copy_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -131,7 +131,7 @@ fn copy_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -161,7 +161,7 @@ fn copy_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -191,7 +191,7 @@ fn copy_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -221,7 +221,7 @@ fn copy_dir_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -246,7 +246,7 @@ fn remove_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -267,7 +267,7 @@ fn remove_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -288,7 +288,7 @@ fn remove_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -311,7 +311,7 @@ fn remove_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -333,7 +333,7 @@ fn remove_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -355,7 +355,7 @@ fn remove_dir_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -378,7 +378,7 @@ fn write_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -400,7 +400,7 @@ fn write_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -419,7 +419,7 @@ fn write_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -446,7 +446,7 @@ fn modify_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -466,7 +466,7 @@ fn modify_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -486,7 +486,7 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -504,7 +504,7 @@ fn modify_file_that_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -527,7 +527,7 @@ fn modify_twice_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -550,7 +550,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -646,7 +646,7 @@ fn rollback_failure_keeps_going() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 

--- a/src/rustup-dist/tests/transactions.rs
+++ b/src/rustup-dist/tests/transactions.rs
@@ -22,7 +22,7 @@ fn add_file() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -44,7 +44,7 @@ fn add_file_then_rollback() {
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let notify = |_: Notification| ();
     let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
@@ -60,7 +60,7 @@ fn add_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -87,7 +87,7 @@ fn copy_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -109,7 +109,7 @@ fn copy_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -131,7 +131,7 @@ fn copy_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -161,7 +161,7 @@ fn copy_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -191,7 +191,7 @@ fn copy_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -221,7 +221,7 @@ fn copy_dir_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -246,7 +246,7 @@ fn remove_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -267,7 +267,7 @@ fn remove_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -288,7 +288,7 @@ fn remove_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -311,7 +311,7 @@ fn remove_dir() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -333,7 +333,7 @@ fn remove_dir_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -355,7 +355,7 @@ fn remove_dir_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -378,7 +378,7 @@ fn write_file() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -400,7 +400,7 @@ fn write_file_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -419,7 +419,7 @@ fn write_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -446,7 +446,7 @@ fn modify_file_that_not_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -466,7 +466,7 @@ fn modify_file_that_exists() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -486,7 +486,7 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -504,7 +504,7 @@ fn modify_file_that_exists_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -527,7 +527,7 @@ fn modify_twice_then_rollback() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -550,7 +550,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 
@@ -646,7 +646,7 @@ fn rollback_failure_keeps_going() {
     let prefixdir = TempDir::new("multirust").unwrap();
     let txdir = TempDir::new("multirust").unwrap();
 
-    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "https://dev-static=https://static;=", Box::new(|_| ()));
+    let tmpcfg = temp::Cfg::new(txdir.path().to_owned(), DEFAULT_DIST_SERVER, "", Box::new(|_| ()));
 
     let prefix = InstallPrefix::from(prefixdir.path().to_owned());
 

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -90,7 +90,7 @@ impl Cfg {
             }
         };
         let notify_clone = notify_handler.clone();
-        let urlreplace = match env::var("RUST_DIST_URL_RELPACE") {
+        let urlreplace = match env::var("RUST_DIST_URL_REPLACE") {
             Ok(ref s) if !s.is_empty() => {
                 s.clone()
             }

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -89,10 +89,17 @@ impl Cfg {
                     .to_owned()
             }
         };
-
         let notify_clone = notify_handler.clone();
+        let urlreplace = match env::var("RUST_DIST_URL_RELPACE") {
+            Ok(ref s) if !s.is_empty() => {
+                s.clone()
+            }
+            _ => String::from("")
+        };
+        
         let temp_cfg = temp::Cfg::new(multirust_dir.join("tmp"),
                                       dist_root_server.as_str(),
+                                      urlreplace.as_str(),
                                       Box::new(move |n| {
                                           (notify_clone)(n.into())
                                       }));


### PR DESCRIPTION
windows:
set RUST_DIST_URL_REPLACE=https://pkgserver.com/path/=http://pkgmirror.com/path/
linux:
export RUST_DIST_URL_REPLACE=https://pkgserver.com/path/=http://pkgmirror.com/path/

Signed-off-by: hjiayz <hjiayz@hotmail.com>