### PR TITLE
Don't set low speed limits for curl

### DIFF
--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -146,10 +146,6 @@ pub mod curl {
             // Take at most 30s to connect
             try!(handle.connect_timeout(Duration::new(30, 0)).chain_err(|| "failed to set connect timeout"));
 
-            // Fail if less than 10 bytes are transferred every 30 seconds
-            try!(handle.low_speed_limit(10).chain_err(|| "failed to set low speed limit"));
-            try!(handle.low_speed_time(Duration::new(30, 0)).chain_err(|| "failed to set low speed time"));
-
             {
                 let cberr = RefCell::new(None);
                 let mut transfer = handle.transfer();


### PR DESCRIPTION
On some country, the network might be very slow occasionally. Setting
"low speed limit" and "low speed time" will make rustup fail nearly all
the time. Removing the settings will make rustup work on the unstable
networks.

This fixed #902 .