### PR TITLE
provide better help than cryptic 'no default toolchain configured'

### DIFF
--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -307,7 +307,7 @@ impl Cfg {
 
     pub fn toolchain_for_dir(&self, path: &Path) -> Result<(Toolchain, Option<OverrideReason>)> {
         self.find_override_toolchain_or_default(path)
-            .and_then(|r| r.ok_or("no default toolchain configured".into()))
+            .and_then(|r| r.ok_or("no default toolchain configured, set RUSTUP_HOME? see https://github.com/rust-lang-nursery/rustup.rs/wiki".into()))
     }
 
     pub fn create_command_for_dir(&self, path: &Path, binary: &str) -> Result<Command> {


### PR DESCRIPTION
context: see https://github.com/Linuxbrew/homebrew-core/pull/1762 (`brew install ripgrep` failed with this cryptic error and no explanation)

5 issues mentioning `no default toolchain configured` here, and many more popping up on google search. This will help the next user falling into this:

https://github.com/rust-lang-nursery/rustup.rs/issues?utf8=%E2%9C%93&q=%22error%3A%20no%20default%20toolchain%20configured%22