### PR TITLE
Store downloaded files in a persistent directory until installation

### DIFF
--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -47,21 +47,6 @@ pub fn download(url: &Url,
     Err("no working backends".into())
 }
 
-pub fn download_to_path(url: &Url,
-                        path: &Path,
-                        callback: Option<&Fn(Event) -> Result<()>>)
-                        -> Result<()> {
-    for &backend in BACKENDS {
-        match download_to_path_with_backend(backend, url, path, callback) {
-            Err(Error(ErrorKind::BackendUnavailable(_), _)) => (),
-            Err(e) => return Err(e),
-            Ok(()) => return Ok(()),
-        }
-    }
-
-    Err("no working backends".into())
-}
-
 pub fn download_with_backend(backend: Backend,
                              url: &Url,
                              callback: &Fn(Event) -> Result<()>)

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -8,9 +8,12 @@ use manifest::Component;
 use manifest::Manifest as ManifestV2;
 use manifestation::{Manifestation, UpdateStatus, Changes};
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::ops;
+use url::Url;
 use std::fmt;
 use std::env;
+use std::fs;
 
 use regex::Regex;
 use sha2::{Sha256, Digest};
@@ -482,7 +485,89 @@ pub fn download_and_check<'a>(url_str: &str,
 pub struct DownloadCfg<'a> {
     pub dist_root: &'a str,
     pub temp_cfg: &'a temp::Cfg,
+    pub download_dir: &'a PathBuf,
     pub notify_handler: &'a Fn(Notification),
+}
+
+
+pub struct File {
+    path: PathBuf,
+}
+
+impl ops::Deref for File {
+    type Target = Path;
+
+    fn deref(&self) -> &Path {
+        ops::Deref::deref(&self.path)
+    }
+}
+
+impl<'a> DownloadCfg<'a> {
+
+    fn notify_handler(&self, event: Notification) {
+        (self.notify_handler)(event);
+    }
+
+    pub fn download(&self, url: &Url, hash: &str) -> Result<File> {
+
+        try!(utils::ensure_dir_exists("Download Directory", &self.download_dir, &|n| self.notify_handler(n.into())));
+        let target_file = self.download_dir.join(Path::new(hash));
+
+        if target_file.exists() {
+            let mut hasher = Sha256::new();
+            use std::io::Read;
+            let mut downloaded = try!(fs::File::open(&target_file).chain_err(|| "opening already downloaded file"));
+            let mut buf = [0; 1024];
+            loop {
+                if let Ok(n) = downloaded.read(&mut buf) {
+                    if n == 0 { break; }
+                    hasher.input(&buf[..n]);
+                } else {
+                    break;
+                }
+            }
+            let cached_result = hasher.result_str();
+            if hash == cached_result {
+                self.notify_handler(Notification::FileAlreadyDownloaded);
+                self.notify_handler(Notification::ChecksumValid(&url.to_string()));
+                return Ok(File { path: target_file, });
+            } else {
+                self.notify_handler(Notification::CachedFileChecksumFailed);
+                try!(fs::remove_file(&target_file).chain_err(|| "cleaning up previous download"));
+            }
+        }
+
+        let mut hasher = Sha256::new();
+
+        try!(utils::download_file(&url,
+                                  &target_file,
+                                  Some(&mut hasher),
+                                  &|n| self.notify_handler(n.into())));
+
+        let actual_hash = hasher.result_str();
+
+        if hash != actual_hash {
+            // Incorrect hash
+            return Err(ErrorKind::ChecksumFailed {
+                url: url.to_string(),
+                expected: hash.to_string(),
+                calculated: actual_hash,
+            }.into());
+        } else {
+            self.notify_handler(Notification::ChecksumValid(&url.to_string()));
+            return Ok(File { path: target_file, })
+        }
+    }
+
+    pub fn clean(&self, hashes: &Vec<String>) -> Result<()> {
+        for hash in hashes.iter() {
+            let used_file = self.download_dir.join(hash);
+            if self.download_dir.join(&used_file).exists() {
+                try!(fs::remove_file(used_file).chain_err(|| "cleaning up cached downloads"));
+            }
+        }
+        Ok(())
+    }
 }
 
 pub fn download_hash(url: &str, cfg: DownloadCfg) -> Result<String> {
@@ -551,7 +636,7 @@ pub fn update_from_dist_<'a>(download: DownloadCfg<'a>,
         Ok(Some((m, hash))) => {
             return match try!(manifestation.update(&m,
                                                    changes,
-                                                   &download.temp_cfg,
+                                                   &download,
                                                    download.notify_handler.clone())) {
                 UpdateStatus::Unchanged => Ok(None),
                 UpdateStatus::Changed => Ok(Some(hash)),

--- a/src/rustup-dist/src/lib.rs
+++ b/src/rustup-dist/src/lib.rs
@@ -7,6 +7,7 @@ extern crate walkdir;
 extern crate toml;
 extern crate flate2;
 extern crate tar;
+extern crate url;
 #[macro_use]
 extern crate rustup_utils;
 #[macro_use]

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -140,7 +140,7 @@ impl Manifestation {
 
             let url_url = try!(utils::parse_url(&url));
 
-            let dowloaded_file = try!(download_cfg.download(&url_url, &hash).chain_err(|| {
+            let dowloaded_file = try!(download_cfg.download(&url_url, &hash, &notify_handler).chain_err(|| {
                 ErrorKind::ComponentDownloadFailed(component.clone())
             }));
             things_downloaded.push(hash);

--- a/src/rustup-dist/src/notifications.rs
+++ b/src/rustup-dist/src/notifications.rs
@@ -18,6 +18,8 @@ pub enum Notification<'a> {
     NoUpdateHash(&'a Path),
     ChecksumValid(&'a str),
     SignatureValid(&'a str),
+    FileAlreadyDownloaded,
+    CachedFileChecksumFailed,
     RollingBack,
     ExtensionNotInstalled(&'a Component),
     NonFatalError(&'a Error),
@@ -48,6 +50,7 @@ impl<'a> Notification<'a> {
             Temp(ref n) => n.level(),
             Utils(ref n) => n.level(),
             ChecksumValid(_) | NoUpdateHash(_) |
+            FileAlreadyDownloaded |
             DownloadingLegacyManifest  => NotificationLevel::Verbose,
             Extracting(_, _) | SignatureValid(_)  |
             DownloadingComponent(_, _, _) |
@@ -56,7 +59,7 @@ impl<'a> Notification<'a> {
             ManifestChecksumFailedHack |
             RollingBack | DownloadingManifest(_) => NotificationLevel::Info,
             CantReadUpdateHash(_) | ExtensionNotInstalled(_) |
-            MissingInstalledComponent(_) => NotificationLevel::Warn,
+            MissingInstalledComponent(_) | CachedFileChecksumFailed => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
         }
     }
@@ -80,6 +83,8 @@ impl<'a> Display for Notification<'a> {
             NoUpdateHash(path) => write!(f, "no update hash at: '{}'", path.display()),
             ChecksumValid(_) => write!(f, "checksum passed"),
             SignatureValid(_) => write!(f, "signature valid"),
+            FileAlreadyDownloaded => write!(f, "reusing previously downloaded file"),
+            CachedFileChecksumFailed => write!(f, "bad checksum for cached download"),
             RollingBack => write!(f, "rolling back changes"),
             ExtensionNotInstalled(c) => {
                 write!(f, "extension '{}' was not installed", c.name())
@@ -106,4 +111,3 @@ impl<'a> Display for Notification<'a> {
         }
     }
 }
-

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -38,6 +38,7 @@ pub struct Cfg {
     pub settings_file: SettingsFile,
     pub toolchains_dir: PathBuf,
     pub update_hash_dir: PathBuf,
+    pub download_dir: PathBuf,
     pub temp_cfg: temp::Cfg,
     pub gpg_key: Cow<'static, str>,
     pub env_override: Option<String>,
@@ -60,6 +61,7 @@ impl Cfg {
 
         let toolchains_dir = multirust_dir.join("toolchains");
         let update_hash_dir = multirust_dir.join("update-hashes");
+        let download_dir = multirust_dir.join("downloads");
 
         // GPG key
         let gpg_key = if let Some(path) = env::var_os("RUSTUP_GPG_KEY")
@@ -103,6 +105,7 @@ impl Cfg {
             settings_file: settings_file,
             toolchains_dir: toolchains_dir,
             update_hash_dir: update_hash_dir,
+            download_dir: download_dir,
             temp_cfg: temp_cfg,
             gpg_key: gpg_key,
             notify_handler: notify_handler,

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -158,6 +158,7 @@ impl<'a> Toolchain<'a> {
         dist::DownloadCfg {
             dist_root: &self.cfg.dist_root_url,
             temp_cfg: &self.cfg.temp_cfg,
+            download_dir: &self.cfg.download_dir,
             notify_handler: &*self.dist_handler,
         }
     }
@@ -582,7 +583,7 @@ impl<'a> Toolchain<'a> {
 
             try!(manifestation.update(&manifest,
                                       changes,
-                                      self.download_cfg().temp_cfg,
+                                      &self.download_cfg(),
                                       self.download_cfg().notify_handler.clone()));
 
             Ok(())
@@ -631,7 +632,7 @@ impl<'a> Toolchain<'a> {
 
             try!(manifestation.update(&manifest,
                                       changes,
-                                      self.download_cfg().temp_cfg,
+                                      &self.download_cfg(),
                                       self.download_cfg().notify_handler.clone()));
 
             Ok(())


### PR DESCRIPTION
This PR should go some way to addressing #889 by caching downloaded
components in a persistent directory until they have been installed.

This way, if the download/install process is interrupted, the file
that made it can be re-used. This should help ease the pain of
intermittent connections. 