### PR TITLE
readme: add tmp dir hint to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,6 +585,18 @@ at your option.
 4. Push to the branch: `git push origin my-new-feature`
 5. Submit a pull request :D
 
+For developing on `rustup` itself, you may want to install into a temporary
+directory, with a series of commands similar to this:
+
+```bash
+$ cargo build
+$ mkdir home
+$ RUSTUP_HOME=home CARGO_HOME=home target/debug/rustup-init --no-modify-path -y
+```
+
+You can then try out rustup with your changes by running `home/bin/rustup`, without
+affecting any existing installation.
+
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any

--- a/README.md
+++ b/README.md
@@ -591,7 +591,8 @@ directory, with a series of commands similar to this:
 ```bash
 $ cargo build
 $ mkdir home
-$ RUSTUP_HOME=home CARGO_HOME=home target/debug/rustup-init --no-modify-path -y
+$ export RUSTUP_HOME=home CARGO_HOME=home
+$ target/debug/rustup-init --no-modify-path -y
 ```
 
 You can then try out rustup with your changes by running `home/bin/rustup`, without

--- a/README.md
+++ b/README.md
@@ -591,12 +591,13 @@ directory, with a series of commands similar to this:
 ```bash
 $ cargo build
 $ mkdir home
-$ export RUSTUP_HOME=home CARGO_HOME=home
-$ target/debug/rustup-init --no-modify-path -y
+$ RUSTUP_HOME=home CARGO_HOME=home target/debug/rustup-init --no-modify-path -y
 ```
 
-You can then try out rustup with your changes by running `home/bin/rustup`, without
-affecting any existing installation.
+You can then try out `rustup` with your changes by running `home/bin/rustup`, without
+affecting any existing installation. Remember to keep those two environment variables
+set when running your compiled `rustup-init` or the toolchains it installs, but _unset_
+when rebuilding `rustup` itself.
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the


### PR DESCRIPTION
Adds a useful build incantation to the Contributing section of the README. Thanks @retep998 for guiding me to it on IRC.