### PR TITLE
RLS support

### DIFF
--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -126,6 +126,7 @@ fn do_compatibility_hacks() {
     make_environment_compatible();
     fix_windows_reg_key();
     delete_multirust_bin();
+    add_rls_proxy();
 }
 
 // Convert any MULTIRUST_ env vars to RUSTUP_ and warn about them
@@ -184,6 +185,20 @@ fn delete_multirust_bin() {
         let legacy_bin = home.join(format!("bin/multirust{}", EXE_SUFFIX));
         if legacy_bin.exists() {
             let _ = fs::remove_file(legacy_bin);
+        }
+    }
+}
+
+// RLS was introduced in an upgrade. Make sure the proxy exists.
+fn add_rls_proxy() {
+    use rustup_utils::utils;
+    use std::env::consts::EXE_SUFFIX;
+
+    if let Ok(home) = utils::cargo_home() {
+        let ref rustup_bin = home.join(format!("bin/rustup{}", EXE_SUFFIX));
+        let ref rls_bin = home.join(format!("bin/rls{}", EXE_SUFFIX));
+        if rustup_bin.exists() && !rls_bin.exists() {
+            let _ = utils::hard_or_symlink_file(rustup_bin, rls_bin);
         }
     }
 }

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -126,7 +126,6 @@ fn do_compatibility_hacks() {
     make_environment_compatible();
     fix_windows_reg_key();
     delete_multirust_bin();
-    add_rls_proxy();
 }
 
 // Convert any MULTIRUST_ env vars to RUSTUP_ and warn about them
@@ -185,20 +184,6 @@ fn delete_multirust_bin() {
         let legacy_bin = home.join(format!("bin/multirust{}", EXE_SUFFIX));
         if legacy_bin.exists() {
             let _ = fs::remove_file(legacy_bin);
-        }
-    }
-}
-
-// RLS was introduced in an upgrade. Make sure the proxy exists.
-fn add_rls_proxy() {
-    use rustup_utils::utils;
-    use std::env::consts::EXE_SUFFIX;
-
-    if let Ok(home) = utils::cargo_home() {
-        let ref rustup_bin = home.join(format!("bin/rustup{}", EXE_SUFFIX));
-        let ref rls_bin = home.join(format!("bin/rls{}", EXE_SUFFIX));
-        if rustup_bin.exists() && !rls_bin.exists() {
-            let _ = utils::hard_or_symlink_file(rustup_bin, rls_bin);
         }
     }
 }

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -594,9 +594,7 @@ fn install_bins() -> Result<()> {
     // like Android, does not support hardlinks, so we fallback to symlinks.
     for tool in TOOLS {
         let ref tool_path = bin_path.join(&format!("{}{}", tool, EXE_SUFFIX));
-        if utils::hardlink_file(rustup_path, tool_path).is_err() {
-            try!(utils::symlink_file(rustup_path, tool_path))
-        }
+        try!(utils::hard_or_symlink_file(rustup_path, tool_path));
     }
 
     Ok(())

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -191,7 +191,7 @@ tools, but otherwise, install the C++ build tools before proceeding.
 "#;
 
 static TOOLS: &'static [&'static str]
-    = &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb"];
+    = &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls"];
 
 static UPDATE_ROOT: &'static str
     = "https://static.rust-lang.org/rustup";

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -255,7 +255,8 @@ pub struct SanitizedOutput {
 }
 
 pub fn cmd(config: &Config, name: &str, args: &[&str]) -> Command {
-    let mut cmd = Command::new(name);
+    let exe_path = config.exedir.join(format!("{}{}", name, EXE_SUFFIX));
+    let mut cmd = Command::new(exe_path);
     cmd.args(args);
     env(config, &mut cmd);
     cmd

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -402,7 +402,7 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
                                      (cross_std2, CROSS_ARCH2.to_string())]),
                         ("rustc", vec![(rustc, triple.clone())]),
                         ("cargo", vec![(cargo, triple.clone())]),
-                        ("rls", vec![(rls, host_triple.clone())]),
+                        ("rls", vec![(rls, triple.clone())]),
                         ("rust-docs", vec![(rust_docs, triple.clone())]),
                         ("rust-src", vec![(rust_src, "*".to_string())]),
                         ("rust", vec![(rust, triple.clone())])];

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -99,6 +99,7 @@ pub fn setup(s: Scenario, f: &Fn(&Config)) {
     let setup_path = config.exedir.join(format!("rustup-init{}", EXE_SUFFIX));
     let rustc_path = config.exedir.join(format!("rustc{}", EXE_SUFFIX));
     let cargo_path = config.exedir.join(format!("cargo{}", EXE_SUFFIX));
+    let rls_path = config.exedir.join(format!("rls{}", EXE_SUFFIX));
 
     // Don't copy an executable via `fs::copy` on Unix because that'll require
     // opening up the destination for writing. If one thread in our process then
@@ -119,6 +120,7 @@ pub fn setup(s: Scenario, f: &Fn(&Config)) {
     fs::hard_link(rustup_path, setup_path).unwrap();
     fs::hard_link(rustup_path, rustc_path).unwrap();
     fs::hard_link(rustup_path, cargo_path).unwrap();
+    fs::hard_link(rustup_path, rls_path).unwrap();
 
     // Make sure the host triple matches the build triple. Otherwise testing a 32-bit build of
     // rustup on a 64-bit machine will fail, because the tests do not have the host detection
@@ -365,6 +367,7 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
     let std = build_mock_std_installer(host_triple);
     let rustc = build_mock_rustc_installer(host_triple, version, version_hash);
     let cargo = build_mock_cargo_installer(version, version_hash);
+    let rls = build_mock_rls_installer(version, version_hash);
     let rust_docs = build_mock_rust_doc_installer();
     let rust = build_combined_installer(&[&std, &rustc, &cargo, &rust_docs]);
     let cross_std1 = build_mock_cross_std_installer(CROSS_ARCH1, date);
@@ -378,6 +381,7 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
                                      (cross_std2, CROSS_ARCH2.to_string())]),
                    ("rustc", vec![(rustc, host_triple.clone())]),
                    ("cargo", vec![(cargo, host_triple.clone())]),
+                   ("rls", vec![(rls, host_triple.clone())]),
                    ("rust-docs", vec![(rust_docs, host_triple.clone())]),
                    ("rust-src", vec![(rust_src, "*".to_string())]),
                    ("rust", vec![(rust, host_triple.clone())])];
@@ -386,6 +390,7 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
         let std = build_mock_std_installer(MULTI_ARCH1);
         let rustc = build_mock_rustc_installer(MULTI_ARCH1, version, version_hash);
         let cargo = build_mock_cargo_installer(version, version_hash);
+        let rls = build_mock_rls_installer(version, version_hash);
         let rust_docs = build_mock_rust_doc_installer();
         let rust = build_combined_installer(&[&std, &rustc, &cargo, &rust_docs]);
         let cross_std1 = build_mock_cross_std_installer(CROSS_ARCH1, date);
@@ -398,6 +403,7 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
                                      (cross_std2, CROSS_ARCH2.to_string())]),
                         ("rustc", vec![(rustc, triple.clone())]),
                         ("cargo", vec![(cargo, triple.clone())]),
+                        ("rls", vec![(rls, host_triple.clone())]),
                         ("rust-docs", vec![(rust_docs, triple.clone())]),
                         ("rust-src", vec![(rust_src, "*".to_string())]),
                         ("rust", vec![(rust, triple.clone())])];
@@ -443,6 +449,10 @@ fn build_mock_channel(s: Scenario, channel: &str, date: &str,
             });
             target_pkg.components.push(MockComponent {
                 name: "rust-docs".to_string(),
+                target: target.to_string()
+            });
+            target_pkg.extensions.push(MockComponent {
+                name: "rls".to_string(),
                 target: target.to_string()
             });
             target_pkg.extensions.push(MockComponent {
@@ -540,6 +550,17 @@ fn build_mock_cargo_installer(version: &str, version_hash: &str) -> MockInstalle
             ("cargo".to_string(),
              vec![MockCommand::File(cargo.clone())],
              vec![(cargo, mock_bin("cargo", version, version_hash))])
+                ]
+    }
+}
+
+fn build_mock_rls_installer(version: &str, version_hash: &str) -> MockInstallerBuilder {
+    let cargo = format!("bin/rls{}", EXE_SUFFIX);
+    MockInstallerBuilder {
+        components: vec![
+            ("rls".to_string(),
+             vec![MockCommand::File(cargo.clone())],
+             vec![(cargo, mock_bin("rls", version, version_hash))])
                 ]
     }
 }

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -255,8 +255,7 @@ pub struct SanitizedOutput {
 }
 
 pub fn cmd(config: &Config, name: &str, args: &[&str]) -> Command {
-    let exe_path = config.exedir.join(format!("{}{}", name, EXE_SUFFIX));
-    let mut cmd = Command::new(exe_path);
+    let mut cmd = Command::new(name);
     cmd.args(args);
     env(config, &mut cmd);
     cmd
@@ -292,7 +291,7 @@ pub fn run(config: &Config, name: &str, args: &[&str], env: &[(&str, &str)]) -> 
     for env in env {
         cmd.env(env.0, env.1);
     }
-    let out = cmd.output().unwrap();
+    let out = cmd.output().expect("failed to run test command");
 
     SanitizedOutput {
         ok: out.status.success(),

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -263,6 +263,13 @@ pub fn symlink_dir(src: &Path, dest: &Path, notify_handler: &Fn(Notification)) -
     })
 }
 
+pub fn hard_or_symlink_file(src: &Path, dest: &Path) -> Result<()> {
+    if hardlink_file(src, dest).is_err() {
+        symlink_file(src, dest)?;
+    }
+    Ok(())
+}
+
 pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
     raw::hardlink(src, dest).chain_err(|| {
         ErrorKind::LinkingFile {

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -15,6 +15,7 @@ use time::Duration;
 use std::ops::Sub;
 use std::ops::Add;
 use std::time::Duration as StdDuration;
+use std::env::consts::EXE_SUFFIX;
 
 macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
 
@@ -403,5 +404,27 @@ fn telemetry_cleanup_removes_old_files() {
         let count = contents.count();
 
         assert!(count == 100);
+    });
+}
+
+#[test]
+fn rls_exists_in_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        expect_ok(config, &["rls", "--version"]);
+    });
+}
+
+#[test]
+fn rls_does_not_exist_in_toolchain() {
+    setup(&|config| {
+        // FIXME: If rls exists in the toolchain, this should suggest a command
+        // to run to install it
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_err(config, &["rls", "--version"],
+                   &format!("toolchain 'stable-{}' does not have the binary `rls{}`",
+                            this_host_triple(), EXE_SUFFIX));
     });
 }

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -47,6 +47,31 @@ pub fn setup(f: &Fn(&Config)) {
         }
         let _g = LOCK.lock();
 
+        // For these tests we are running the bins out of ~/.cargo/bin,
+        // as during a real install, not the test 'exedir' that most
+        // of the test suite uses. We still need rustup-init though
+        // to begin the installation, so delete every bin except that.
+        for entry in fs::read_dir(&config.exedir).unwrap() {
+            let entry = entry.unwrap();
+            // ffs Path/OsStr...
+            let is_rustup_init = entry.path()
+                .file_name().unwrap_or_default()
+                .to_string_lossy().contains("rustup-init");
+            if is_rustup_init {
+                continue;
+            }
+            fs::remove_file(entry.path()).unwrap();
+        }
+
+        // Likewise set up PATH to include ~/.cargo/bin
+        let prev_path = env::var_os("PATH");
+        let mut new_path = config.cargodir.join("bin").into_os_string();
+        if let Some(ref p) = prev_path {
+            new_path.push(if cfg!(windows) { ";" } else { ":" });
+            new_path.push(p);
+        }
+        env::set_var("PATH", new_path);
+
         // An windows these tests mess with the user's PATH. Save
         // and restore them here to keep from trashing things.
         let saved_path = get_path();
@@ -1171,24 +1196,57 @@ fn rls_proxy_set_up_after_install() {
     });
 }
 
+// This is testing that, when the rls proxy doesn't exist, rustup proxies will
+// create it lazily. This has to happen because rustup's self-updates aren't
+// able to execute arbitrary code at update time.
 #[test]
-fn rls_proxy_set_up_after_upgrade() {
+fn rls_proxy_set_up_lazily_after_upgrade_via_proxy() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
+
         // Delete the rls proxy to simulate an upgrade from an older rustup that
         // didn't include it
-        let rls_bin = config.cargodir.join(format!("bin/rls{}", EXE_SUFFIX));
+        let ref rls_bin = config.cargodir.join(format!("bin/rls{}", EXE_SUFFIX));
         fs::remove_file(rls_bin).expect("rls_bin");
-        // Hm, delete this one in exedir too...
-        // FIXME Shouldn't be necessary
-        let rls_proxy = config.exedir.join(format!("rls{}", EXE_SUFFIX));
-        fs::remove_file(rls_proxy).expect("rls_proxy");
+
         // RLS doesn't work now
+        assert!(!rls_bin.exists());
         let mut cmd = clitools::cmd(config, "rls", &["--version"]);
         assert!(cmd.output().is_err());
-        expect_ok(config, &["rustup", "self", "update"]);
-        // And now it does
+
+        // Run a proxy to trigger a lazy upgrade
+        expect_ok(config, &["rustc", "--version"]);
+
+        // Now RLS works
+        assert!(rls_bin.exists());
+        expect_ok(config, &["rls", "--version"]);
+    });
+}
+
+// Same as above but instead of the proxies triggering the update, it's rustup
+// directly
+#[test]
+fn rls_proxy_set_up_lazily_after_upgrade_via_rustup() {
+    update_setup(&|config, _| {
+        expect_ok(config, &["rustup-init", "-y"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+
+        // Delete the rls proxy to simulate an upgrade from an older rustup that
+        // didn't include it
+        let ref rls_bin = config.cargodir.join(format!("bin/rls{}", EXE_SUFFIX));
+        fs::remove_file(rls_bin).expect("rls_bin");
+
+        // RLS doesn't work now
+        assert!(!rls_bin.exists());
+        let mut cmd = clitools::cmd(config, "rls", &["--version"]);
+        assert!(cmd.output().is_err());
+
+        // Run rustup to trigger the update
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+
+        // Now RLS works
+        assert!(rls_bin.exists());
         expect_ok(config, &["rls", "--version"]);
     });
 }


### PR DESCRIPTION
I think this is sufficient for basic support.

With this PR, rustup will create 'rls' proxies in CARGO_HOME/bin, and will do so lazily when that binary doesn't exist.

After this PR one can write

```
rustup component add rls
rustup component add rust-src
rustup component add rust-analysis
```

to get a working RLS, assuming the 'rls' package is deployed.

Next steps are to make `rustup component` accept multiple components, so RLS can be installed with just `rustup compnent add rls rust-src rust-analysis` (cc @durka).

I'd suggest that RLS have nice error handling for cases where rust-src and rust-analysis aren't available. It might suggest running the proper rustup commands.

rustup probably needs to emit a better error message when somebody tries to run `rls` without installing it. Since the proxy always exists, it will say something like "the binary 'rls' doesn't exist in toolchain X". It would be better for rustup to know which package contains 'rls' and say so.

cc @nrc @jonathandturner 
