### PR TITLE
Remove error reporting from rustup-init.sh

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -118,9 +118,9 @@ main() {
             err "Unable to run interactively. Run with -y to accept defaults, --help for additional options"
         fi
 
-        run "$_file" "$@" < /dev/tty
+        ignore "$_file" "$@" < /dev/tty
     else
-        run "$_file" "$@"
+        ignore "$_file" "$@"
     fi
 
     local _retval=$?
@@ -359,15 +359,7 @@ ensure() {
 # intentionally ignored. Usually, because it's being executed
 # as part of error handling.
 ignore() {
-    run "$@"
-}
-
-# Runs a command.
-run() {
     "$@"
-    local _retval=$?
-
-    return $_retval
 }
 
 main "$@" || exit 1

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -362,12 +362,12 @@ ignore() {
     run "$@"
 }
 
-# Runs a command and prints it to stderr if it fails.
+# Runs a command and terminates unsuccessfully if it fails.
 run() {
     "$@"
     local _retval=$?
     if [ $_retval != 0 ]; then
-        say_err "command failed: $*"
+        exit 1
     fi
     return $_retval
 }

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -362,13 +362,11 @@ ignore() {
     run "$@"
 }
 
-# Runs a command and terminates unsuccessfully if it fails.
+# Runs a command.
 run() {
     "$@"
     local _retval=$?
-    if [ $_retval != 0 ]; then
-        exit 1
-    fi
+
     return $_retval
 }
 


### PR DESCRIPTION
In response to #987 I made rustup-init.sh terminate unsuccessfully instead of printing a message in case there is an error running rustup-init.exe.