### PR TITLE
Document installing to a custom location using CARGO_HOME and RUSTUP_HOME environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ For `zsh`, you must then add the following line in your `~/.zshrc` before
 fpath+=~/.zfunc
 ```
 
+#### Choosing where to install
+
+`rustup` allows you to customise your installation by setting the environment
+variables `CARGO_HOME` and `RUSTUP_HOME` while running the `rustup-init`
+executable. As mentioned in the [Environment Variables] section, `RUSTUP_HOME`
+sets the root rustup folder, which is used for storing installed
+toolchains and configuration options. `CARGO_HOME` contains cache files used
+by [cargo].
+
+Note that you will need to ensure these environment variables are always
+set and that `CARGO_HOME/bin` is in the `$PATH` environment variable when
+using the toolchain.
+
+[Environment Variables]: #environment-variables
+[cargo]: https://github.com/rust-lang/cargo
+
 ## How rustup works
 
 `rustup` is a *toolchain multiplexer*. It installs and manages many

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ fpath+=~/.zfunc
 #### Choosing where to install
 
 `rustup` allows you to customise your installation by setting the environment
-variables `CARGO_HOME` and `RUSTUP_HOME` while running the `rustup-init`
+variables `CARGO_HOME` and `RUSTUP_HOME` before running the `rustup-init`
 executable. As mentioned in the [Environment Variables] section, `RUSTUP_HOME`
 sets the root rustup folder, which is used for storing installed
 toolchains and configuration options. `CARGO_HOME` contains cache files used


### PR DESCRIPTION
This should Fix #994 

Add a section `Choosing where to install` to the `install` section of the README discussing the
use of `CARGO_HOME` and `RUSTUP_HOME`