### PR TITLE
Better error message when not running in a tty

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -114,8 +114,8 @@ main() {
         # reading stdin.  This script was piped into `sh` though and
         # doesn't have stdin to pass to its children. Instead we're going
         # to explicitly connect /dev/tty to the installer's stdin.
-        if [ ! -e "/dev/tty" ]; then
-            err "/dev/tty does not exist"
+        if [ ! -t 1 ]; then
+            err "Unable to run interactively. Run with -y to accept defaults, --help for additional options"
         fi
 
         run "$_file" "$@" < /dev/tty


### PR DESCRIPTION
-t returns true if the provided file descriptor is open and refers
to a terminal.

    jelford@ ~/s/rustup.rs> echo (./rustup-init.sh )
    info: downloading installer
    rustup: Unable to run interactively. Run with -y to accept defaults, --help for additional options

    jelford@ ~/s/rustup.rs> echo (./rustup-init.sh -y)
    info: downloading installer
    info: updating existing rustup installation

Should close https://github.com/rust-lang-nursery/rustup.rs/issues/648