### PR TITLE
Add bash completion guidance for macOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ gist is as simple as using one of the following:
 # Bash
 $ rustup completions bash > /etc/bash_completion.d/rustup.bash-completion
 
+# Bash (macOS/Homebrew)
+$ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion
+
 # Fish
 $ rustup completions fish > ~/.config/fish/completions/rustup.fish
 

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -162,6 +162,13 @@ r"DISCUSSION:
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take affect.
 
+    BASH (macOS/Homebrew):
+
+    Homebrew stores bash completion files within the Homebrew directory.
+    With the `bash-completion` brew formula installed, run the command:
+
+    `rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion`
+
     FISH:
 
     Fish completion files are commonly stored in


### PR DESCRIPTION
For macOS users, one of the easiest and most popular ways to "get bash completion working" is via  [Homebrew](https://brew.sh/)'s `bash-completion` formula (which other formulas rely upon for completion support). 

E.g. many users will have installed completions for Git using [this guide](https://github.com/bobthecow/git-flow-completion/wiki/Install-Bash-git-completion#os-x--macos).

This PR adds documentation (to `rustup help completions`) for installing rustup completions for macOS users.