### PR TITLE
Fix pkgconfig for openssl build

### DIFF
--- a/ci/build-run-docker.sh
+++ b/ci/build-run-docker.sh
@@ -22,3 +22,10 @@ docker run \
   -e SKIP_TESTS=$SKIP_TESTS \
   -it $DOCKER \
   ci/run-docker.sh
+
+# check that rustup-init was built with ssl support
+# see https://github.com/rust-lang-nursery/rustup.rs/issues/1051
+if ! (nm target/$TARGET/release/rustup-init | grep Curl_ssl_version &> /dev/null); then
+  echo "Missing ssl support!!!!"
+  exit 1
+fi

--- a/ci/run-docker.sh
+++ b/ci/run-docker.sh
@@ -177,6 +177,9 @@ else
    install=$final_install_path
 fi
 
+# the install dir was renamed, so we need to update pkgconfig
+sed -i -e 's/-partial//g' $install/lib/pkgconfig/*
+
 # Variables to the openssl-sys crate to link statically against the OpenSSL we
 # just compiled above
 export OPENSSL_STATIC=1


### PR DESCRIPTION
To avoid cache problems https://github.com/rust-lang-nursery/rustup.rs/pull/1028 uses a temporary install directory for openssl. When the openssl install is completed the install dir is renamed. In doing so the pkgconfig files become invalid and libcurl-sys fails to find openssl and is built without https support. This fix the pkgconfig files. Fixes https://github.com/rust-lang-nursery/rustup.rs/issues/1051.