### PR TITLE
Allow rustup to handle unavailable packages

### DIFF
--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -112,7 +112,7 @@ impl Manifestation {
             use manifest::*;
             let pkg: Option<&Package> = new_manifest.get_package(&c.pkg).ok();
             let target_pkg: Option<&TargetedPackage> = pkg.and_then(|p| p.get_target(c.target.as_ref()).ok());
-            target_pkg.map(|tp| tp.available) != Some(true)
+            target_pkg.map(|tp| tp.available()) != Some(true)
         }).cloned().collect();
 
         if !unavailable_components.is_empty() {
@@ -124,12 +124,14 @@ impl Manifestation {
         for component in components_to_install {
             let package = try!(new_manifest.get_package(&component.pkg));
             let target_package = try!(package.get_target(component.target.as_ref()));
+
+            let bins = target_package.bins.as_ref().expect("components available");
             let c_u_h =
-                if let (Some(url), Some(hash)) = (target_package.xz_url.clone(),
-                                                 target_package.xz_hash.clone()) {
+                if let (Some(url), Some(hash)) = (bins.xz_url.clone(),
+                                                  bins.xz_hash.clone()) {
                     (component, Format::Xz, url, hash)
                 } else {
-                    (component, Format::Gz, target_package.url.clone(), target_package.hash.clone())
+                    (component, Format::Gz, bins.url.clone(), bins.hash.clone())
                 };
             components_urls_and_hashes.push(c_u_h);
         }

--- a/src/rustup-dist/tests/manifest.rs
+++ b/src/rustup-dist/tests/manifest.rs
@@ -26,9 +26,9 @@ fn parse_smoke_test() {
     assert!(rust_pkg.version.contains("1.3.0"));
 
     let rust_target_pkg = rust_pkg.get_target(Some(&x86_64_unknown_linux_gnu)).unwrap();
-    assert_eq!(rust_target_pkg.available, true);
-    assert_eq!(rust_target_pkg.url, "example.com");
-    assert_eq!(rust_target_pkg.hash, "...");
+    assert_eq!(rust_target_pkg.available(), true);
+    assert_eq!(rust_target_pkg.bins.clone().unwrap().url, "example.com");
+    assert_eq!(rust_target_pkg.bins.clone().unwrap().hash, "...");
 
     let ref component = rust_target_pkg.components[0];
     assert_eq!(component.pkg, "rustc");
@@ -40,7 +40,7 @@ fn parse_smoke_test() {
 
     let docs_pkg = pkg.get_package("rust-docs").unwrap();
     let docs_target_pkg = docs_pkg.get_target(Some(&x86_64_unknown_linux_gnu)).unwrap();
-    assert_eq!(docs_target_pkg.url, "example.com");
+    assert_eq!(docs_target_pkg.bins.clone().unwrap().url, "example.com");
 }
 
 #[test]

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -491,7 +491,7 @@ impl<'a> Toolchain<'a> {
                     component: component.clone(),
                     required: true,
                     installed: installed,
-                    available: component_target_pkg.available,
+                    available: component_target_pkg.available(),
                 });
             }
 
@@ -510,7 +510,7 @@ impl<'a> Toolchain<'a> {
                     component: extension.clone(),
                     required: false,
                     installed: installed,
-                    available: extension_target_pkg.available,
+                    available: extension_target_pkg.available(),
                 });
             }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -668,7 +668,7 @@ fn make_component_unavailable(config: &Config, name: &str, target: &TargetTriple
     {
         let mut std_pkg = manifest.packages.get_mut(name).unwrap();
         let mut target_pkg = std_pkg.targets.get_mut(target).unwrap();
-        target_pkg.available = false;
+        target_pkg.bins = None;
     }
     let ref manifest_str = manifest.stringify();
     rustup_utils::raw::write_file(manifest_path, manifest_str).unwrap();


### PR DESCRIPTION
Before this, if a package was unavailable (like nightly is at the moment),
it would error out with a message like "error: missing key: 'url'" because
at the moment a few of the rust-analysis packages didn't build. This resulted
in the `channel-rust-nightly.toml` to be created with blocks like this:

```toml
[pkg.rust-analysis.target.aarch64-apple-ios]
available = false

[pkg.rust-analysis.target.aarch64-linux-android]
available = false

[pkg.rust-analysis.target.aarch64-unknown-fuchsia]
available = false

[pkg.rust-analysis.target.aarch64-unknown-linux-gnu]
available = true
hash = "be50ffa6f94770929b53bae553977cb6d78b03506f033d14a7251c7b0cdb9035"
url = "https://static.rust-lang.org/dist/2017-04-13/rust-analysis-nightly-aarch64-unknown-linux-gnu.tar.gz"
```

rustup assumed that there'd always be a `hash` and `url`, which is not
the case when packages are unavaible. This patch then just updates
rustup to handle their absence.

Closes #1063