### PR TITLE
Fix OpenSSL linkage by using the final install-directory in the build

### DIFF
--- a/ci/build-run-docker.sh
+++ b/ci/build-run-docker.sh
@@ -25,9 +25,7 @@ docker run \
 
 # check that rustup-init was built with ssl support
 # see https://github.com/rust-lang-nursery/rustup.rs/issues/1051
-out=$(nm target/$TARGET/release/rustup-init | grep Curl_ssl_init)
-
-if [ -z "$out" ]; then
-  echo "error: Missing ssl support!!!!" >&2
+if ! (nm target/$TARGET/release/rustup-init | grep Curl_ssl_version &> /dev/null); then
+  echo "Missing ssl support!!!!" >&2
   exit 1
 fi

--- a/ci/build-run-docker.sh
+++ b/ci/build-run-docker.sh
@@ -22,3 +22,12 @@ docker run \
   -e SKIP_TESTS=$SKIP_TESTS \
   -it $DOCKER \
   ci/run-docker.sh
+
+# check that rustup-init was built with ssl support
+# see https://github.com/rust-lang-nursery/rustup.rs/issues/1051
+out=$(nm target/$TARGET/release/rustup-init | grep Curl_ssl_init)
+
+if [ -z "$out" ]; then
+  echo "error: Missing ssl support!!!!" >&2
+  exit 1
+fi


### PR DESCRIPTION
This PR addresses #1051 by avoiding moving OpenSSL's install-target directory after it's been configured. It also encorporates the regression test suggested by @malbarbo on https://github.com/rust-lang-nursery/rustup.rs/pull/1054.

It still makes sense to move directories about to avoid getting a partially-built copy of openssl, and I think it makes sense to cache the finished product rather than the src/build directory. 

I haven't been able to test the output on one of the affected platforms (although the check on symbols passes) as I don't know a good way to get artefacts out of the travis build. 