### PR TITLE
Enforce timeouts for reading rustc version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,7 @@ dependencies = [
  "toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "user32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ rustc-serialize = "0.3"
 sha2 = "0.1.2"
 markdown = "0.2"
 toml = "0.1.27"
+wait-timeout = "0.1.5"
 
 [target."cfg(windows)".dependencies]
 winapi = "0.2.8"

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -20,6 +20,7 @@ extern crate tempdir;
 extern crate sha2;
 extern crate markdown;
 extern crate toml;
+extern crate wait_timeout;
 
 #[cfg(windows)]
 extern crate gcc;


### PR DESCRIPTION
Some rustc versions (1.3.0 through 1.10.0 if my analysis is correct) are no longer working in recent macOS Sierra, in that they do not produce a correct output nor do not properly terminate in a timely
manner (e.g. loops indefinitely).

Having them in the current toolchain makes `rustup update` or (sometimes) `rustup show` unresponsive, so a timeout of one second has been added to correctly show that they are no longer working.

Fixes #766.