### PR TITLE
Alias 'rustup toolchain uninstall' to 'rustup uninstall'

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -31,6 +31,7 @@ pub fn main() -> Result<()> {
         ("show", Some(_)) => try!(show(cfg)),
         ("install", Some(m)) => try!(update(cfg, m)),
         ("update", Some(m)) => try!(update(cfg, m)),
+        ("uninstall", Some(m)) => try!(toolchain_remove(cfg, m)),
         ("default", Some(m)) => try!(default_(cfg, m)),
         ("toolchain", Some(c)) => {
             match c.subcommand() {
@@ -130,6 +131,12 @@ pub fn cli() -> App<'static, 'static> {
             .about("Update Rust toolchains")
             .after_help(TOOLCHAIN_INSTALL_HELP)
             .setting(AppSettings::Hidden) // synonym for 'toolchain install'
+            .arg(Arg::with_name("toolchain")
+                .required(true)
+                .multiple(true)))
+        .subcommand(SubCommand::with_name("uninstall")
+            .about("Uninstall Rust toolchains")
+            .setting(AppSettings::Hidden) // synonym for 'toolchain uninstall'
             .arg(Arg::with_name("toolchain")
                 .required(true)
                 .multiple(true)))

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -567,6 +567,22 @@ fn toolchain_update_is_like_update() {
     });
 }
 
+
+#[test]
+fn toolchain_uninstall_is_like_uninstall() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "uninstall", "nightly"]);
+        let mut cmd = clitools::cmd(config, "rustup", &["show"]);
+        clitools::env(config, &mut cmd);
+        let out = cmd.output().unwrap();
+        assert!(out.status.success());
+        let stdout = String::from_utf8(out.stdout).unwrap();
+        assert!(!stdout.contains(
+            for_host!("'nightly-2015-01-01-{}'")));
+
+    });
+}
+
 #[test]
 fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {


### PR DESCRIPTION
See issue: #730. 

This PR aliases `rustup toolchain uninstall` to `rustup uninstall`, making uninstallation more symmetrical with installation, which already views `rustup install` and `rustup toolchain install` as equivalent.

The `rustup uninstall` alias is directly patterned off of the implementation of
`rustup install`. I’ve also added a test in cli-rustup.rs to verify.

The issue linked also alludes to some confusing irregularities in the documentation (random flipping between use of 'update' and 'install'), and a softer question about whether `rustup toolchain remove` should be aliased to `rustup remove` as well.

This is my first crack at a PR here, so I was a bit sheepish to wade into those more contentious elements of the issue, but I would be glad to dig deeper into the semantic consistency of these various aliases if there's any interest, and someone thinks I'm headed in the right direction. Thanks! 

 