### PR TITLE
Add sensible-browser to the browser list

### DIFF
--- a/src/rustup-utils/src/raw.rs
+++ b/src/rustup-utils/src/raw.rs
@@ -367,7 +367,7 @@ pub fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
 pub fn open_browser(path: &Path) -> io::Result<bool> {
     #[cfg(not(windows))]
     fn inner(path: &Path) -> io::Result<bool> {
-        let commands = ["xdg-open", "open", "firefox", "chromium"];
+        let commands = ["xdg-open", "open", "firefox", "chromium", "sensible-browser"];
         if let Some(cmd) = find_cmd(&commands) {
             Command::new(cmd)
                 .arg(path)


### PR DESCRIPTION
Users on Debian-based systems who are running without a GUI might still have a text based web browser such as w3m or lynx. Debian gives us the sensible-browser command to launch one of these (either by environment variable or with the alternatives system). xdg-open still comes first, since GUI users will be less inclined to configure the sensible utils. This will also allow running the GUI web browser in a non-xdg system that doesn't specifically have firefox or chromium.