### PR TITLE
Update proxy setting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,22 +421,22 @@ is invoked for a custom toolchain and it is not available, `rustup`
 will attempt to use `cargo` from one of the release channels*,
 preferring 'nightly', then 'beta' or 'stable'.
 
-## Working with HTTP proxies
+## Working with network proxies
 
 Enterprise networks often don't have direct outside HTTP access, but enforce
-the use of HTTP proxies. If you're on such a network, you can request that
+the use of proxies. If you're on such a network, you can request that
 rustup uses a proxy by setting its URL in the environment. In most cases,
-setting `http_proxy` should be sufficient. On a Unix-like system with a
+setting `https_proxy` should be sufficient. On a Unix-like system with a
 shell like __bash__ or __zsh__, you could use:
 
 ```
-export http_proxy=http://proxy.example.com:8080
+export https_proxy=socks5://proxy.example.com:1080 # or http://proxy.example.com:8080
 ```
 
 On Windows, the command would be:
 
 ```
-set http_proxy=http://proxy.example.com:8080
+set https_proxy=socks5://proxy.example.com:1080
 ```
 
 If you need a more complex setup, rustup supports the convention used by


### PR DESCRIPTION
There are two changes:
1. Use `https_proxy` rather than `http_proxy` because the latter doesn't work at all. All traffic from rustup seems to go via https.
2. Use SOCKS proxy as example, since it is nowadays more widely-used (thanks to GFW in China) and more powerful. Also, avoiding using two `http`s makes it more obvious that other proxy types are also supported without needing to check the manual of curl.