### PR TITLE
Ensure that intermediate directories exist when unpacking an entry

### DIFF
--- a/src/rustup-dist/src/component/package.rs
+++ b/src/rustup-dist/src/component/package.rs
@@ -199,6 +199,14 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
         // Throw away the first path component
         components.next();
         let full_path = path.join(&components.as_path());
+
+        // Create the full path to the entry if it does not exist already
+        match full_path.parent() {
+            Some(parent) if !parent.exists() =>
+                try!(::std::fs::create_dir_all(&parent).chain_err(|| ErrorKind::ExtractingPackage)),
+            _ => (),
+        };
+
         try!(entry.unpack(&full_path).chain_err(|| ErrorKind::ExtractingPackage));
     }
 


### PR DESCRIPTION
The `unpack` function assumes that the directory in which the file is
being extracted exists, while most `tar` tools will automatically
create the intermediate directories if they are missing.

This would have avoided #1092.