### PR TITLE
Update flaky test case

### DIFF
--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -167,8 +167,7 @@ fn remove_override_nonexistent() {
                 });
                 path
             };
-            // FIXME TempDir seems to succumb to difficulties removing dirs on windows
-            let _ = rustup_utils::raw::remove_dir(&path);
+            rustup_utils::raw::remove_dir(&path).expect("unable to remove tempdir");
             assert!(!path.exists());
             expect_ok_ex(config, &["rustup", "override", keyword, "--nonexistent"],
                          r"",


### PR DESCRIPTION
This is the only test case I continue to see failing on appveyor. Weird because it is obviously a remove_dir_all bug, so I'd expect it to be fixed.

This is just remove the fixme and making the error handling better. I don't know what the real fix is.

cc @Diggsey 