### PR TITLE
(tmp) fix for help.rs suggestion

### DIFF
--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -66,7 +66,7 @@ r"DISCUSSION:
 
     'channel' is either a named release channel or an explicit version
     number, such as '1.8.0'. Channel names can be optionally appended
-    with an archive date, as in 'nightly-2014-12-18', in which case
+    with an archive date, as in 'nightly-2017-05-09', in which case
     the toolchain is downloaded from the archive for that date.
 
     Finally, the host may be specified as a target triple. This is


### PR DESCRIPTION
2017-05-09? It's today, and it seems to work. This "fix" is almost useless but it's better than the current displayed date that does not work (see https://github.com/rust-lang-nursery/rustup.rs/issues/787) and is a bit old. If merged, I think a better PR may be done with a less random date. Feel free to close if stupid/useless/both! (I'm just trying to help on "easy" issues to dive into rust, even if it's only text edit!)