### PR TITLE
Remove unnecessary pub mod

### DIFF
--- a/src/rustup-dist/src/component/mod.rs
+++ b/src/rustup-dist/src/component/mod.rs
@@ -9,10 +9,7 @@ pub use self::package::*;
 // Transactional file system tools
 mod transaction;
 // The representation of a package, its components, and installation
-//
-// FIXME: Because of rust-lang/rust#18241 this must be pub to pub reexport
-// the inner Package trait.
-pub mod package;
+mod package;
 // The representation of *installed* components, and uninstallation
 mod components;
 


### PR DESCRIPTION
rust-lang/rust#18241 is fixed now, so this mod doesn't need to be pub.

Possible downside: the minimum compiler version to build is now 1.9.0 or thereabouts.