### PR TITLE
fix ToolchainDesc is_tracking

### DIFF
--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -374,7 +374,8 @@ impl ToolchainDesc {
     }
 
     pub fn is_tracking(&self) -> bool {
-        self.date.is_none()
+        let channels = ["nightly", "beta", "stable"];
+        channels.iter().any(|x| *x == self.channel) && self.date.is_none()
     }
 }
 


### PR DESCRIPTION
issue #756.

I wonder, why is not ToolchainDesc.channel a enum?