### PR TITLE
Add PATH in post-install message when not modifying PATH

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -112,7 +112,7 @@ macro_rules! post_install_msg_unix {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home}/bin) in your `PATH`
 environment variable. Next time you log in this will be done
 automatically.
 
@@ -125,7 +125,7 @@ macro_rules! post_install_msg_win {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home}\bin) in your `PATH`
 environment variable. Future applications will automatically have the
 correct environment, but you may need to restart your current shell.
 "
@@ -298,7 +298,8 @@ pub fn install(no_prompt: bool, verbose: bool,
                 format!(post_install_msg_unix!(),
                          cargo_home = cargo_home)
             } else {
-                format!(post_install_msg_win!())
+                format!(post_install_msg_win!(),
+                        cargo_home = cargo_home)
             }
         } else {
             if cfg!(unix) {

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -148,7 +148,7 @@ macro_rules! post_install_msg_win_no_modify_path {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory ({cargo_home_bin}) in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home}\bin) in your `PATH`
 environment variable. This has not been done automatically.
 "
     };
@@ -204,7 +204,11 @@ fn canonical_cargo_home() -> Result<String> {
 
     let default_cargo_home = utils::home_dir().unwrap_or(PathBuf::from(".")).join(".cargo");
     if default_cargo_home == path {
-        path_str = String::from("$HOME/.cargo");
+        if cfg!(unix) {
+            path_str = String::from("$HOME/.cargo");
+        } else {
+            path_str = String::from(r"%HOMEPATH%\.cargo");
+        } 
     }
 
     Ok(path_str)
@@ -288,9 +292,9 @@ pub fn install(no_prompt: bool, verbose: bool,
 
     // More helpful advice, skip if -y
     if !no_prompt {
+        let cargo_home = try!(canonical_cargo_home());
         let msg = if !opts.no_modify_path {
             if cfg!(unix) {
-                let cargo_home = try!(canonical_cargo_home());
                 format!(post_install_msg_unix!(),
                          cargo_home = cargo_home)
             } else {
@@ -298,14 +302,11 @@ pub fn install(no_prompt: bool, verbose: bool,
             }
         } else {
             if cfg!(unix) {
-                let cargo_home = try!(canonical_cargo_home());
                 format!(post_install_msg_unix_no_modify_path!(),
                          cargo_home = cargo_home)
             } else {
-                let cargo_home = try!(utils::cargo_home());
-                let cargo_home_bin = cargo_home.join("bin");
                 format!(post_install_msg_win_no_modify_path!(),
-                        cargo_home_bin = cargo_home_bin.display())
+                        cargo_home = cargo_home)
             }
         };
         term2::stdout().md(msg);

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -207,7 +207,7 @@ fn canonical_cargo_home() -> Result<String> {
         if cfg!(unix) {
             path_str = String::from("$HOME/.cargo");
         } else {
-            path_str = String::from(r"%HOMEPATH%\.cargo");
+            path_str = String::from(r"%USERPROFILE%\.cargo");
         } 
     }
 

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -148,7 +148,7 @@ macro_rules! post_install_msg_win_no_modify_path {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory ({cargo_home}/bin) in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home_bin}) in your `PATH`
 environment variable. This has not been done automatically.
 "
     };
@@ -303,8 +303,9 @@ pub fn install(no_prompt: bool, verbose: bool,
                          cargo_home = cargo_home)
             } else {
                 let cargo_home = try!(utils::cargo_home());
+                let cargo_home_bin = cargo_home.join("bin");
                 format!(post_install_msg_win_no_modify_path!(),
-                        cargo_home = cargo_home.display())
+                        cargo_home_bin = cargo_home_bin.display())
             }
         };
         term2::stdout().md(msg);

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -136,7 +136,7 @@ macro_rules! post_install_msg_unix_no_modify_path {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home}/bin) in your `PATH`
 environment variable.
 
 To configure your current shell run `source {cargo_home}/env`
@@ -148,7 +148,7 @@ macro_rules! post_install_msg_win_no_modify_path {
     () => {
 r"# Rust is installed now. Great!
 
-To get started you need Cargo's bin directory in your `PATH`
+To get started you need Cargo's bin directory ({cargo_home}/bin) in your `PATH`
 environment variable. This has not been done automatically.
 "
     };
@@ -302,7 +302,9 @@ pub fn install(no_prompt: bool, verbose: bool,
                 format!(post_install_msg_unix_no_modify_path!(),
                          cargo_home = cargo_home)
             } else {
-                format!(post_install_msg_win_no_modify_path!())
+                let cargo_home = try!(utils::cargo_home());
+                format!(post_install_msg_win_no_modify_path!(),
+                        cargo_home = cargo_home.display())
             }
         };
         term2::stdout().md(msg);


### PR DESCRIPTION
Fixes #374 

Unix:
```
To get started you need Cargo's bin directory ($HOME/.cargo/bin) in your PATH
environment variable.
```

Windows:
```
To get started you need Cargo's bin directory (C:\Users\f-bro\.cargo\bin) in
your PATH environment variable. This has not been done automatically.
```