### PR TITLE
Increase Rust detection timeout to 3 seconds

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -235,7 +235,7 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
             // we guard against such cases by enforcing a reasonable timeout to read.
             let mut line1 = None;
             if let Ok(mut child) = cmd.spawn() {
-                let timeout = Duration::new(1, 0);
+                let timeout = Duration::new(3, 0);
                 match child.wait_timeout(timeout) {
                     Ok(Some(status)) if status.success() => {
                         let out = child.stdout.expect("Child::stdout requested but not present");

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -248,6 +248,7 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
                     }
                     Ok(None) => {
                         let _ = child.kill();
+                        return String::from("(timeout reading rustc version)")
                     }
                     Ok(Some(_)) | Err(_) => {}
                 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang-nursery/rustup.rs/issues/1118

With 3 seconds timeout cold start isn't issue anymore.

To simulate cold start use:
```
sync ; echo 3 | sudo tee /proc/sys/vm/drop_caches
rustup update
```