### PR TITLE
Don't cache target/release folder on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,6 @@ cache:
   # don't use travis's native `cargo` caching, which just grabs the whole folder.
   directories:
     - target/$TARGET/openssl/openssl-install
-    - target/$TARGET/release
     - target/release/deps
 
 branches:


### PR DESCRIPTION
I suspect this is causing the following error I'm seeing during deploy:

```
sh: 1: cannot create target/i686-unknown-linux-gnu/release/cli_inst_interactive-f17347ea614c070e.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256.sha256: File name too long
```

I don't know why this folder needs to be cached anyway.

r? @alexcrichton 