### PR TITLE
Teach rustup to override the toolchain from a version file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ And it runs on all platforms Rust supports, including Windows.
 * [How rustup works](#how-rustup-works)
 * [Keeping Rust up to date](#keeping-rust-up-to-date)
 * [Working with nightly Rust](#working-with-nightly-rust)
-* [Directory overrides](#directory-overrides)
 * [Toolchain specification](#toolchain-specification)
+* [Directory overrides](#directory-overrides)
+* [The version file](#the-version-file)
+* [Toolchain override shorthand](#toolchain-override-shorthand)
 * [Cross-compilation](#cross-compilation)
 * [Working with Rust on Windows](#working-with-rust-on-windows)
 * [Working with custom toolchains](#working-with-custom-toolchains-and-local-builds)
@@ -231,29 +233,6 @@ info: downloading self-updates
 
 ```
 
-## Directory overrides
-
-Directories can be assigned their own Rust toolchain with
-`rustup override`. When a directory has an override then
-any time `rustc` or `cargo` is run inside that directory,
-or one of its child directories, the override toolchain
-will be invoked.
-
-To pin to a specific nightly:
-
-```
-rustup override set nightly-2014-12-18
-```
-
-Or a specific stable release:
-
-```
-rustup override set 1.0.0
-```
-
-To see the active toolchain use `rustup show`. To remove the override
-and use the default toolchain again, `rustup override unset`.
-
 ## Toolchain specification
 
 Many `rustup` commands deal with *toolchains*, a single installation
@@ -298,6 +277,65 @@ Toolchain names that don't name a channel instead can be used to name
 
 [MSVC-based toolchain]: https://www.rust-lang.org/downloads.html#win-foot
 [custom toolchains]: #working-with-custom-toolchains-and-local-builds
+
+## Toolchain override shorthand
+
+The `rustup` toolchain proxies can be instructed directly to use a
+specific toolchain, a convience for developers who often test
+different toolchains. If the first argument to `cargo`, `rustc` or
+other tools in the toolchain begins with `+`, it will be interpreted
+as a rustup toolchain name, and that toolchain will be preferred,
+as in
+
+```
+cargo +beta test
+```
+
+## Directory overrides
+
+Directories can be assigned their own Rust toolchain with
+`rustup override`. When a directory has an override then
+any time `rustc` or `cargo` is run inside that directory,
+or one of its child directories, the override toolchain
+will be invoked.
+
+To pin to a specific nightly:
+
+```
+rustup override set nightly-2014-12-18
+```
+
+Or a specific stable release:
+
+```
+rustup override set 1.0.0
+```
+
+To see the active toolchain use `rustup show`. To remove the override
+and use the default toolchain again, `rustup override unset`.
+
+## The version file
+
+`rustup` directory overrides are a local configuration, stored in
+`$RUSTUP_HOME`. Some projects though find themselves 'pinned' to a
+specific release of Rust and want this information reflected in their
+source repository. This is most often the case for nightly-only
+software that pins to a revision from the release archives.
+
+In these cases the toolchain can be named in the project's directory
+in a file called `.rust-version`, the content of which is the name of
+a single `rustup` toolchain, and which is suitable to check in to
+source control.
+
+The toolchains named in this file have a more restricted form than
+rustup toolchains generally, and may only contain the names of the
+three release channels, 'stable', 'beta', 'nightly', Rust version
+numbers, like '1.0.0', and optionally an archive date, like
+'nightly-2017-01-01'. They may not name custom toolchains, nor
+host-specific toolchains.
+
+The version file has lower precedence than all other methods of
+specifying the toolchain.
 
 ## Cross-compilation
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ And it runs on all platforms Rust supports, including Windows.
 * [Keeping Rust up to date](#keeping-rust-up-to-date)
 * [Working with nightly Rust](#working-with-nightly-rust)
 * [Toolchain specification](#toolchain-specification)
-* [Directory overrides](#directory-overrides)
-* [The version file](#the-version-file)
 * [Toolchain override shorthand](#toolchain-override-shorthand)
+* [Directory overrides](#directory-overrides)
+* [The toolchain file](#the-toolchain-file)
+* [Override precedence](#override-precedence)
 * [Cross-compilation](#cross-compilation)
 * [Working with Rust on Windows](#working-with-rust-on-windows)
 * [Working with custom toolchains](#working-with-custom-toolchains-and-local-builds)
@@ -293,13 +294,12 @@ cargo +beta test
 
 ## Directory overrides
 
-Directories can be assigned their own Rust toolchain with
-`rustup override`. When a directory has an override then
-any time `rustc` or `cargo` is run inside that directory,
-or one of its child directories, the override toolchain
-will be invoked.
+Directories can be assigned their own Rust toolchain with `rustup
+override`. When a directory has an override then any time `rustc` or
+`cargo` is run inside that directory, or one of its child directories,
+the override toolchain will be invoked.
 
-To pin to a specific nightly:
+To use to a specific nightly for a directory:
 
 ```
 rustup override set nightly-2014-12-18
@@ -314,7 +314,7 @@ rustup override set 1.0.0
 To see the active toolchain use `rustup show`. To remove the override
 and use the default toolchain again, `rustup override unset`.
 
-## The version file
+## The toolchain file
 
 `rustup` directory overrides are a local configuration, stored in
 `$RUSTUP_HOME`. Some projects though find themselves 'pinned' to a
@@ -323,7 +323,7 @@ source repository. This is most often the case for nightly-only
 software that pins to a revision from the release archives.
 
 In these cases the toolchain can be named in the project's directory
-in a file called `.rust-version`, the content of which is the name of
+in a file called `rust-toolchain`, the content of which is the name of
 a single `rustup` toolchain, and which is suitable to check in to
 source control.
 
@@ -334,8 +334,27 @@ numbers, like '1.0.0', and optionally an archive date, like
 'nightly-2017-01-01'. They may not name custom toolchains, nor
 host-specific toolchains.
 
-The version file has lower precedence than all other methods of
-specifying the toolchain.
+## Override precedence
+
+There are several ways to specify which toolchain `rustup` should
+execute:
+
+* An explicit toolchain, e.g. `cargo +beta`,
+* The `RUSTUP_TOOLCHAIN` environment variable,
+* A directory override, ala `rustup override set beta`,
+* The `rust-toolchain` file,
+* The default toolchain,
+
+and they are prefered by rustup in that order, with the explicit
+toolchain having highest precedence, and the default toolchain having
+the lowest. There is one exception though: directory overrides and the
+`rust-toolchain` file are also preferred by their proximity to the
+current directory. That is, these two override methods are discovered
+by walking up the directory tree toward the filesystem root, and a
+`rust-toolchain` file that is closer to the current directory will be
+prefered over a directory override that is further away.
+
+To verify which toolchain is active use `rustup show`.
 
 ## Cross-compilation
 

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -302,6 +302,10 @@ impl PartialToolchainDesc {
             target: TargetTriple(trip),
         }
     }
+
+    pub fn has_triple(&self) -> bool {
+        self.target.arch.is_some() || self.target.os.is_some() || self.target.env.is_some()
+    }
 }
 
 impl ToolchainDesc {
@@ -373,6 +377,16 @@ impl ToolchainDesc {
     pub fn is_tracking(&self) -> bool {
         let channels = ["nightly", "beta", "stable"];
         channels.iter().any(|x| *x == self.channel) && self.date.is_none()
+    }
+}
+
+// A little convenience for just parsing a channel name or archived channel name
+pub fn validate_channel_name(name: &str) -> Result<()> {
+    let toolchain = PartialToolchainDesc::from_str(&name)?;
+    if toolchain.has_triple() {
+        Err(format!("target triple in channel name '{}'", name).into())
+    } else {
+        Ok(())
     }
 }
 

--- a/src/rustup/settings.rs
+++ b/src/rustup/settings.rs
@@ -162,18 +162,9 @@ impl Settings {
         self.overrides.insert(key, toolchain);
     }
 
-    pub fn find_override(&self, dir_unresolved: &Path, notify_handler: &Fn(Notification))
-            -> Option<(String, PathBuf)> {
-        let dir = utils::canonicalize_path(dir_unresolved, &|n| notify_handler(n.into()));
-        let mut maybe_path = Some(&*dir);
-        while let Some(path) = maybe_path {
-            let key = Self::path_to_key(path, notify_handler);
-            if let Some(toolchain) = self.overrides.get(&key) {
-                return Some((toolchain.to_owned(), path.to_owned()));
-            }
-            maybe_path = path.parent();
-        }
-        None
+    pub fn dir_override(&self, dir: &Path, notify_handler: &Fn(Notification)) -> Option<String> {
+        let key = Self::path_to_key(dir, notify_handler);
+        self.overrides.get(&key).map(|s| s.clone())
     }
 
     pub fn parse(data: &str) -> Result<Self> {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -847,8 +847,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
         let rustup_sh_dir = config.homedir.join(".rustup.sh");
 
         let multirust_dir_str = &format!("{}", multirust_dir.display());
-        let old_rustup_sh_toolchain_file = rustup_dir.join("rustup-version");
-        let new_rustup_sh_toolchain_file = rustup_sh_dir.join("rustup-version");
+        let old_rustup_sh_version_file = rustup_dir.join("rustup-version");
+        let new_rustup_sh_version_file = rustup_sh_dir.join("rustup-version");
 
         // First write data into ~/.multirust
         run_no_home(config, &["rustup", "default", "stable"],
@@ -862,8 +862,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
 
         // Now add rustup.sh data to ~/.rustup
         fs::create_dir_all(&rustup_dir).unwrap();
-        raw::write_file(&old_rustup_sh_toolchain_file, "1").unwrap();
-        assert!(old_rustup_sh_toolchain_file.exists());
+        raw::write_file(&old_rustup_sh_version_file, "1").unwrap();
+        assert!(old_rustup_sh_version_file.exists());
 
         // Now do the upgrade, and ~/.rustup will be moved to ~/.rustup.sh
         let out = run_no_home(config, &["rustup", "toolchain", "list"], &[]);
@@ -872,8 +872,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
         assert!(multirust_dir.exists());
         assert!(fs::symlink_metadata(&multirust_dir).unwrap().file_type().is_symlink());
         assert!(rustup_dir.exists());
-        assert!(!old_rustup_sh_toolchain_file.exists());
-        assert!(new_rustup_sh_toolchain_file.exists());
+        assert!(!old_rustup_sh_version_file.exists());
+        assert!(new_rustup_sh_version_file.exists());
     });
 }
 
@@ -887,8 +887,8 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
         let rustup_sh_dir = config.homedir.join(".rustup.sh");
 
         let multirust_dir_str = &format!("{}", multirust_dir.display());
-        let old_rustup_sh_toolchain_file = rustup_dir.join("rustup-version");
-        let new_rustup_sh_toolchain_file = rustup_sh_dir.join("rustup-version");
+        let old_rustup_sh_version_file = rustup_dir.join("rustup-version");
+        let new_rustup_sh_version_file = rustup_sh_dir.join("rustup-version");
 
         // First write data into ~/.multirust
         run_no_home(config, &["rustup", "default", "stable"],
@@ -905,14 +905,14 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
 
         // Now add rustup.sh data to ~/.rustup
         fs::create_dir_all(&rustup_dir).unwrap();
-        raw::write_file(&old_rustup_sh_toolchain_file, "1").unwrap();
+        raw::write_file(&old_rustup_sh_version_file, "1").unwrap();
 
         // Also to ~/.rustup.sh
         fs::create_dir_all(&rustup_sh_dir).unwrap();
-        raw::write_file(&new_rustup_sh_toolchain_file, "1").unwrap();
+        raw::write_file(&new_rustup_sh_version_file, "1").unwrap();
 
-        assert!(old_rustup_sh_toolchain_file.exists());
-        assert!(new_rustup_sh_toolchain_file.exists());
+        assert!(old_rustup_sh_version_file.exists());
+        assert!(new_rustup_sh_version_file.exists());
 
         // Now do the upgrade, and ~/.rustup will be moved to ~/.rustup.sh
         let out = run_no_home(config, &["rustup", "toolchain", "list"], &[]);
@@ -923,8 +923,8 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
         assert!(fs::symlink_metadata(&multirust_dir).unwrap().file_type().is_symlink());
 
         assert!(rustup_dir.exists());
-        assert!(!old_rustup_sh_toolchain_file.exists());
-        assert!(new_rustup_sh_toolchain_file.exists());
+        assert!(!old_rustup_sh_version_file.exists());
+        assert!(new_rustup_sh_version_file.exists());
     });
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -14,7 +14,7 @@ use rustup_mock::clitools::{self, Config, Scenario,
                                expect_stderr_ok, expect_stdout_ok,
                                expect_err,
                                set_current_dist_date,
-                               this_host_triple};
+                               this_host_triple, change_dir};
 
 macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
 
@@ -522,6 +522,98 @@ r"");
 }
 
 #[test]
+fn show_toolchain_version_file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        expect_ok_ex(config, &["rustup", "show"],
+&format!(r"Default host: {0}
+
+installed toolchains
+--------------------
+
+stable-{0} (default)
+nightly-{0}
+
+active toolchain
+----------------
+
+nightly-{0} (overridden by '{1}')
+1.3.0 (hash-n-2)
+
+", this_host_triple(), version_file.display()),
+r"");
+    });
+}
+
+#[test]
+fn show_toolchain_version_nested_file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        let subdir = cwd.join("foo");
+
+        fs::create_dir_all(&subdir).unwrap();
+        change_dir(&subdir, &|| {
+            expect_ok_ex(config, &["rustup", "show"],
+                         &format!(r"Default host: {0}
+
+installed toolchains
+--------------------
+
+stable-{0} (default)
+nightly-{0}
+
+active toolchain
+----------------
+
+nightly-{0} (overridden by '{1}')
+1.3.0 (hash-n-2)
+
+", this_host_triple(), version_file.display()),
+                         r"");
+        });
+    });
+}
+
+#[test]
+fn show_toolchain_version_file_override_not_installed() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        // I'm not sure this should really be erroring when the toolchain
+        // is not installed; just capturing the behavior.
+        let mut cmd = clitools::cmd(config, "rustup", &["show"]);
+        clitools::env(config, &mut cmd);
+        let out = cmd.output().unwrap();
+        assert!(!out.status.success());
+        let stderr = String::from_utf8(out.stderr).unwrap();
+        assert!(stderr.starts_with(
+                "error: override toolchain 'nightly' is not installed"));
+        assert!(stderr.contains(
+            &format!("the version file at '{}' specifies an uninstalled toolchain",
+                     version_file.display())));
+    });
+}
+
+#[test]
 fn show_toolchain_override_not_installed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
@@ -568,7 +660,7 @@ fn show_toolchain_env_not_installed() {
         // is not installed; just capturing the behavior.
         assert!(!out.status.success());
         let stderr = String::from_utf8(out.stderr).unwrap();
-        assert!(stderr.starts_with("error: toolchain 'nightly' is not installed\n"));
+        assert!(stderr.starts_with("error: override toolchain 'nightly' is not installed\n"));
     });
 }
 
@@ -850,5 +942,153 @@ fn multirust_upgrade_works_with_proxy() {
         assert!(multirust_dir.exists());
         assert!(fs::symlink_metadata(&multirust_dir).unwrap().file_type().is_symlink());
         assert!(rustup_dir.exists());
+    });
+}
+
+#[test]
+fn file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+    });
+}
+
+#[test]
+fn file_override_subdir() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        let subdir = cwd.join("subdir");
+        fs::create_dir_all(&subdir).unwrap();
+        change_dir(&subdir, &|| {
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        });
+    });
+}
+
+
+#[test]
+fn file_override_with_archive() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly-2015-01-01"]);
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly-2015-01-01").unwrap();
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+    });
+}
+
+#[test]
+fn directory_override_beats_file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        expect_ok(config, &["rustup", "override", "set", "beta"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+    });
+}
+
+#[test]
+fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        // not installing nightly
+
+        expect_ok(config, &["rustup", "override", "set", "beta"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+    });
+}
+
+#[test]
+fn env_override_beats_file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        let mut cmd = clitools::cmd(config, "rustc", &["--version"]);
+        clitools::env(config, &mut cmd);
+        cmd.env("RUSTUP_TOOLCHAIN", "beta");
+
+        let out = cmd.output().unwrap();
+        assert!(String::from_utf8(out.stdout).unwrap().contains("hash-b-2"));
+    });
+}
+
+#[test]
+fn plus_override_beats_file_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly").unwrap();
+
+        expect_stdout_ok(config, &["rustc", "+beta", "--version"], "hash-b-2");
+    });
+}
+
+#[test]
+fn bad_file_override() {
+    setup(&|config| {
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "gumbo").unwrap();
+
+        expect_err(config, &["rustc", "--version"],
+                   "invalid channel name 'gumbo' in");
+    });
+}
+
+#[test]
+fn file_override_with_target_info() {
+    setup(&|config| {
+        let cwd = ::std::env::current_dir().unwrap();
+        let version_file = cwd.join(".rust-version");
+        raw::write_file(&version_file, "nightly-x86_64-unknown-linux-gnu").unwrap();
+
+        expect_err(config, &["rustc", "--version"],
+                   "target triple in channel name 'nightly-x86_64-unknown-linux-gnu'");
     });
 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -522,15 +522,15 @@ r"");
 }
 
 #[test]
-fn show_toolchain_version_file_override() {
+fn show_toolchain_toolchain_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
+        let toolchain_file = cwd.join("rust-toolchain");
 
-        raw::write_file(&version_file, "nightly").unwrap();
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         expect_ok_ex(config, &["rustup", "show"],
 &format!(r"Default host: {0}
@@ -547,7 +547,7 @@ active toolchain
 nightly-{0} (overridden by '{1}')
 1.3.0 (hash-n-2)
 
-", this_host_triple(), version_file.display()),
+", this_host_triple(), toolchain_file.display()),
 r"");
     });
 }
@@ -559,9 +559,9 @@ fn show_toolchain_version_nested_file_override() {
         expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
+        let toolchain_file = cwd.join("rust-toolchain");
 
-        raw::write_file(&version_file, "nightly").unwrap();
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         let subdir = cwd.join("foo");
 
@@ -582,21 +582,21 @@ active toolchain
 nightly-{0} (overridden by '{1}')
 1.3.0 (hash-n-2)
 
-", this_host_triple(), version_file.display()),
+", this_host_triple(), toolchain_file.display()),
                          r"");
         });
     });
 }
 
 #[test]
-fn show_toolchain_version_file_override_not_installed() {
+fn show_toolchain_toolchain_file_override_not_installed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
+        let toolchain_file = cwd.join("rust-toolchain");
 
-        raw::write_file(&version_file, "nightly").unwrap();
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         // I'm not sure this should really be erroring when the toolchain
         // is not installed; just capturing the behavior.
@@ -608,8 +608,8 @@ fn show_toolchain_version_file_override_not_installed() {
         assert!(stderr.starts_with(
                 "error: override toolchain 'nightly' is not installed"));
         assert!(stderr.contains(
-            &format!("the version file at '{}' specifies an uninstalled toolchain",
-                     version_file.display())));
+            &format!("the toolchain file at '{}' specifies an uninstalled toolchain",
+                     toolchain_file.display())));
     });
 }
 
@@ -846,8 +846,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
         let rustup_sh_dir = config.homedir.join(".rustup.sh");
 
         let multirust_dir_str = &format!("{}", multirust_dir.display());
-        let old_rustup_sh_version_file = rustup_dir.join("rustup-version");
-        let new_rustup_sh_version_file = rustup_sh_dir.join("rustup-version");
+        let old_rustup_sh_toolchain_file = rustup_dir.join("rustup-version");
+        let new_rustup_sh_toolchain_file = rustup_sh_dir.join("rustup-version");
 
         // First write data into ~/.multirust
         run_no_home(config, &["rustup", "default", "stable"],
@@ -861,8 +861,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
 
         // Now add rustup.sh data to ~/.rustup
         fs::create_dir_all(&rustup_dir).unwrap();
-        raw::write_file(&old_rustup_sh_version_file, "1").unwrap();
-        assert!(old_rustup_sh_version_file.exists());
+        raw::write_file(&old_rustup_sh_toolchain_file, "1").unwrap();
+        assert!(old_rustup_sh_toolchain_file.exists());
 
         // Now do the upgrade, and ~/.rustup will be moved to ~/.rustup.sh
         let out = run_no_home(config, &["rustup", "toolchain", "list"], &[]);
@@ -871,8 +871,8 @@ fn multirust_dir_upgrade_old_rustup_exists() {
         assert!(multirust_dir.exists());
         assert!(fs::symlink_metadata(&multirust_dir).unwrap().file_type().is_symlink());
         assert!(rustup_dir.exists());
-        assert!(!old_rustup_sh_version_file.exists());
-        assert!(new_rustup_sh_version_file.exists());
+        assert!(!old_rustup_sh_toolchain_file.exists());
+        assert!(new_rustup_sh_toolchain_file.exists());
     });
 }
 
@@ -886,8 +886,8 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
         let rustup_sh_dir = config.homedir.join(".rustup.sh");
 
         let multirust_dir_str = &format!("{}", multirust_dir.display());
-        let old_rustup_sh_version_file = rustup_dir.join("rustup-version");
-        let new_rustup_sh_version_file = rustup_sh_dir.join("rustup-version");
+        let old_rustup_sh_toolchain_file = rustup_dir.join("rustup-version");
+        let new_rustup_sh_toolchain_file = rustup_sh_dir.join("rustup-version");
 
         // First write data into ~/.multirust
         run_no_home(config, &["rustup", "default", "stable"],
@@ -904,14 +904,14 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
 
         // Now add rustup.sh data to ~/.rustup
         fs::create_dir_all(&rustup_dir).unwrap();
-        raw::write_file(&old_rustup_sh_version_file, "1").unwrap();
+        raw::write_file(&old_rustup_sh_toolchain_file, "1").unwrap();
 
         // Also to ~/.rustup.sh
         fs::create_dir_all(&rustup_sh_dir).unwrap();
-        raw::write_file(&new_rustup_sh_version_file, "1").unwrap();
+        raw::write_file(&new_rustup_sh_toolchain_file, "1").unwrap();
 
-        assert!(old_rustup_sh_version_file.exists());
-        assert!(new_rustup_sh_version_file.exists());
+        assert!(old_rustup_sh_toolchain_file.exists());
+        assert!(new_rustup_sh_toolchain_file.exists());
 
         // Now do the upgrade, and ~/.rustup will be moved to ~/.rustup.sh
         let out = run_no_home(config, &["rustup", "toolchain", "list"], &[]);
@@ -922,8 +922,8 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
         assert!(fs::symlink_metadata(&multirust_dir).unwrap().file_type().is_symlink());
 
         assert!(rustup_dir.exists());
-        assert!(!old_rustup_sh_version_file.exists());
-        assert!(new_rustup_sh_version_file.exists());
+        assert!(!old_rustup_sh_toolchain_file.exists());
+        assert!(new_rustup_sh_toolchain_file.exists());
     });
 }
 
@@ -954,8 +954,8 @@ fn file_override() {
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
@@ -970,8 +970,8 @@ fn file_override_subdir() {
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         let subdir = cwd.join("subdir");
         fs::create_dir_all(&subdir).unwrap();
@@ -991,8 +991,8 @@ fn file_override_with_archive() {
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly-2015-01-01").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly-2015-01-01").unwrap();
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
     });
@@ -1009,12 +1009,37 @@ fn directory_override_beats_file_override() {
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
     });
 }
+
+#[test]
+fn close_file_override_beats_far_directory_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+
+        expect_ok(config, &["rustup", "override", "set", "beta"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+
+        let cwd = ::std::env::current_dir().unwrap();
+
+        let subdir = cwd.join("subdir");
+        fs::create_dir_all(&subdir).unwrap();
+
+        let toolchain_file = subdir.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
+
+        change_dir(&subdir, &|| {
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        });
+    });
+}
+
 
 #[test]
 fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
@@ -1027,8 +1052,8 @@ fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
     });
@@ -1042,8 +1067,8 @@ fn env_override_beats_file_override() {
         expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         let mut cmd = clitools::cmd(config, "rustc", &["--version"]);
         clitools::env(config, &mut cmd);
@@ -1062,8 +1087,8 @@ fn plus_override_beats_file_override() {
         expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly").unwrap();
 
         expect_stdout_ok(config, &["rustc", "+beta", "--version"], "hash-b-2");
     });
@@ -1073,8 +1098,8 @@ fn plus_override_beats_file_override() {
 fn bad_file_override() {
     setup(&|config| {
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "gumbo").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "gumbo").unwrap();
 
         expect_err(config, &["rustc", "--version"],
                    "invalid channel name 'gumbo' in");
@@ -1085,8 +1110,8 @@ fn bad_file_override() {
 fn file_override_with_target_info() {
     setup(&|config| {
         let cwd = ::std::env::current_dir().unwrap();
-        let version_file = cwd.join(".rust-version");
-        raw::write_file(&version_file, "nightly-x86_64-unknown-linux-gnu").unwrap();
+        let toolchain_file = cwd.join("rust-toolchain");
+        raw::write_file(&toolchain_file, "nightly-x86_64-unknown-linux-gnu").unwrap();
 
         expect_err(config, &["rustc", "--version"],
                    "target triple in channel name 'nightly-x86_64-unknown-linux-gnu'");

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -504,10 +504,8 @@ r"");
 }
 
 #[test]
+#[ignore(windows)] // FIXME Windows shows UNC paths
 fn show_toolchain_override() {
-    // FIXME rustup displays UNC paths
-    if cfg!(windows) { return }
-
     setup(&|config| {
         let cwd = ::std::env::current_dir().unwrap();
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
@@ -522,6 +520,7 @@ r"");
 }
 
 #[test]
+#[ignore(windows)] // FIXME Windows shows UNC paths
 fn show_toolchain_toolchain_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
@@ -553,6 +552,7 @@ r"");
 }
 
 #[test]
+#[ignore(windows)] // FIXME Windows shows UNC paths
 fn show_toolchain_version_nested_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
@@ -589,6 +589,7 @@ nightly-{0} (overridden by '{1}')
 }
 
 #[test]
+#[ignore(windows)] // FIXME Windows shows UNC paths
 fn show_toolchain_toolchain_file_override_not_installed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);


### PR DESCRIPTION
This adds a .rust-version file similar to rbenv's .ruby-version.

The form of toolchain supported here is limited to channel names,
explicit versions, and optional archive dates.

From the readme:

## The version file

`rustup` directory overrides are a local configuration, stored in
`$RUSTUP_HOME`. Some projects though find themselves 'pinned' to a
specific release of Rust and want this information reflected in their
source repository. This is most often the case for nightly-only
software that pins to a revision from the release archives.

In these cases the toolchain can be named in the project's directory
in a file called `.rust-version`, the content of which the name of a
single `rustup` toolchain, and which is suitable to check in to source
control.

The toolchains named in this file have a more restricted form than
rustup toolchains generally, and may only contain the names of the
three release channels, 'stable', 'beta', 'nightly', Rust version
numbers, like '1.0.0', and optionally an archive date, like
'nightly-2017-01-01'. They may not name custom toolchains, nor
host-specific toolchains.

The version file has lower precedence than all other methods of
specifying the toolchain.

----------------

Some observations and questions about the design:

The file is called `.rust-version` with precedent from rbenv. The contents
of this file though would better be described as a "rust release channel",
or "rustup toolchain". A better name might be `.rustup-toolchain` though
the acceptable values in the file are a subset of valid toolchain names.

One might reuse the `.cargo` directory for this, putting the file in
e.g. `.cargo/rust-version`. This seems reasonable, and would establish
a strong precent for tools reusing `.cargo`; it would go against the
rbenv precedent. It would also go against the existing rustup
precedent where rustup stores it's global state in its own `~/.rustup`
folder - but note that I have some small desire to move `~/.rustup`
into `~/.cargo/rustup` as a simplification.

Opinions about the above?

This doesn't allow specifying the host triple, nor does it allow
custom toolchains.

The search semantics are based off of the current working directory, though
one might feasibly expect them to be based off of the Cargo.toml directory.
That is `cargo --manifest=foo/Cargo.toml` will not search in `foo`. Existing
overrides have this limitation as well.

Fixes https://github.com/rust-lang-nursery/rustup.rs/issues/460

cc @SimonSapin @Diggsey @alexcrichton @yazaddaruvala 

