### PR TITLE
Fix 'show' so it displays helpful information if the active toolchain is not installed.

### DIFF
--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -326,6 +326,14 @@ impl Cfg {
         })
     }
 
+    pub fn get_default(&self) -> Result<String> {
+        self.settings_file.with(|s| { 
+            Ok(s.default_toolchain.clone().unwrap())
+        })
+    }
+
+
+
     pub fn list_toolchains(&self) -> Result<Vec<String>> {
         if utils::is_directory(&self.toolchains_dir) {
             let mut toolchains: Vec<_> = try!(utils::read_dir("toolchains", &self.toolchains_dir))


### PR DESCRIPTION
Fixed 'show' so that it displays helpful information if the active toolchain is not installed.

```
$ export RUSTUP_TOOLCHAIN=beta
$ rustup show
Default host: x86_64-unknown-linux-gnu
installed toolchains
--------------------

stable-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu

active toolchain
----------------

(error: override toolchain 'beta' is not installed, the RUSTUP_TOOLCHAIN environment variable specifies an uninstalled toolchain)
```

Fixes #1178