### PR TITLE
Allow adding the host as a target.

### DIFF
--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -407,8 +407,9 @@ fn build_update_component_lists(
 
     // Check some invariantns
     for component_to_add in &changes.add_extensions {
-        assert!(rust_target_package.extensions.contains(component_to_add),
-                "package must contain extension to add");
+        assert!(rust_target_package.components.contains(component_to_add) ||
+                rust_target_package.extensions.contains(component_to_add),
+                "package must contain the component or extension to add");
         assert!(!changes.remove_extensions.contains(component_to_add),
                 "can't both add and remove extensions");
     }
@@ -442,7 +443,9 @@ fn build_update_component_lists(
 
     // Add requested extension components
     for extension in &changes.add_extensions {
-        final_component_list.push(extension.clone());
+        if !final_component_list.contains(extension) {
+            final_component_list.push(extension.clone());
+        }
     }
 
     // Add extensions that are already installed

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -48,11 +48,6 @@ error_chain! {
             description("toolchain does not contain component")
             display("toolchain '{}' does not contain component {}", t, c.description())
         }
-        AddingRequiredComponent(t: String, c: Component) {
-            description("required component cannot be added")
-            display("component {} is required for toolchain '{}' and cannot be re-added",
-                    c.description(), t)
-        }
         ParsingSettings(e: Vec<toml::ParserError>) {
             description("error parsing settings")
         }

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -580,15 +580,11 @@ impl<'a> Toolchain<'a> {
             let targ_pkg = rust_pkg.targets.get(&toolchain.target)
                 .expect("installed manifest should have a known target");
 
-            if targ_pkg.components.contains(&component) {
-                return Err(ErrorKind::AddingRequiredComponent(self.name.to_string(), component).into());
-            }
-
             if !targ_pkg.extensions.contains(&component) {
                 let wildcard_component = Component { target: None, ..component.clone() };
                 if targ_pkg.extensions.contains(&wildcard_component) {
                     component = wildcard_component;
-                } else {
+                } else if !targ_pkg.components.contains(&component) {
                     return Err(ErrorKind::UnknownComponent(self.name.to_string(), component).into());
                 }
             }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -564,8 +564,7 @@ fn add_target_host() {
     setup(&|config| {
         let trip = TargetTriple::from_build();
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(config, &["rustup", "target", "add", &trip.to_string()],
-                   for_host!("component 'rust-std' for target '{0}' is required for toolchain 'nightly-{0}' and cannot be re-added"));
+        expect_ok(config, &["rustup", "target", "add", &trip.to_string()]);
     });
 }
 


### PR DESCRIPTION
The `rustup target add` subcommand treated the current host
as an argument differently from any other, issuing an
`AddingRequiredComponent` error result.

This made it difficult for scripts to ensure a consistent target
set since one could not just say `rustup target add $target1 $target2`
without first checking whether `$target1` or `$target2` happen
to match the host triplet and filtering that target out.

Instead, allow adding a required component and treat it like
any other already-installed extension. This involves some
extra effort to de-duplicate the list of components to avoid
printing the 'up to date' message more than once.