### PR TITLE
Clarify Windows build preferences in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,13 +548,13 @@ The primary installation method, as described at
 [www.rustup.rs](https://www.rustup.rs), differs by platform:
 
 * On Windows, download and run the [rustup-init.exe built for
-  `i686-pc-windows-gnu` target][setup]. Despite being built against the GNU
-  toolchain, _the Windows build of rustup will install Rust for the MSVC
-  toolchain if it detects that MSVC is installed_. If you prefer to install GNU
-  toolchains or x86_64 toolchains by default this can be modified at install
-  time, either interactively or with the `--default-host` flag, or after
-  installation via `rustup set default-host`. In general, this is the build
-  of rustup one should install on Windows.
+  `i686-pc-windows-gnu` target][setup]. In general, this is the build of rustup
+  one should install on Windows. Despite being built against the GNU toolchain,
+  _the Windows build of rustup will install Rust for the MSVC toolchain if it
+  detects that MSVC is installed_. If you prefer to install GNU toolchains or
+  x86_64 toolchains by default this can be modified at install time, either
+  interactively or with the `--default-host` flag, or after installation via
+  `rustup set default-host`.
 * On Unix, run `curl https://sh.rustup.rs -sSf | sh` in your
   shell. This downloads and runs [`rustup-init.sh`], which in turn
   downloads and runs the correct version of the `rustup-init`


### PR DESCRIPTION
Given the earlier dicussion of MSVC toolchain vs GNU toolchain on Windows, for someone not perfectly familiar with the terminology here, the current placement of the sentence "In general, this is the build of rustup one should install on Windows." confusingly may seem to imply that the *GNU toolchain* is preferred over the *MSVC toolchain*. I would request that the sentences be rearranged as in this pull request to clarify that *build* has nothing to do with which toolchain.

(Or possibly remove the sentence in question entirely? Given that the reader is being directed to install this particular build, does it make sense to also say that this build is the one that should be installed?)