### PR TITLE
Vendor docker configuration for powerpc-unknown-linux-gnu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
            SKIP_TESTS=1
     - os: linux
       env: TARGET=powerpc-unknown-linux-gnu
-           DOCKER=alexcrichton/rust-slave-linux-cross:2016-11-11
+           DOCKER=powerpc-unknown-linux-gnu
            SKIP_TESTS=1
     - os: linux
       env: TARGET=powerpc64-unknown-linux-gnu

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y \
+  gcc-powerpc-linux-gnu \
+  curl \
+  ca-certificates \
+  perl \
+  make \
+  gcc
+
+ENV CC_powerpc_unknown_linux_gnu=powerpc-linux-gnu-gcc


### PR DESCRIPTION
The container we were previously using was using using a preinstalled toolchain
anyway, and this was left out by accident from 3e99a693a