### PR TITLE
[MSI] Allow self-update via msiexec

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -198,6 +198,8 @@ pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
     }
 
     let setup_path = if self_update {
+        // FIXME: The MSI installed version will do the actual self-upgrade (if available)
+        //        right here. This is probably bad.
         try!(self_update::prepare_update())
     } else {
         None

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -1397,6 +1397,19 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
+    // For MSI installed version, spawn `msiexec` to download and install the new version
+    if cfg!(feature = "msi-installed") {
+        let url = format!("{}/archive/{}/{}/rustup.msi", update_root,
+                          available_version, triple);
+        try!(Command::new("msiexec")
+                .arg("/i")
+                .arg(url)
+                .spawn()
+                .chain_err(|| "failed to spawn msiexec"));
+        // Exit immediately
+        process::exit(0);
+    }
+
     // Get download URL
     let url = format!("{}/archive/{}/{}/rustup-init{}", update_root,
                       available_version, triple, EXE_SUFFIX);


### PR DESCRIPTION
I put this up here mainly for discussion:

There are two possible ways to implement `self update` for the MSI version:
1) _[this is implemented here]_ Pass a URL to `msiexec` and thus delegate downloading the file from the internet.
2) Download the MSI file using the existing update download logic and then run `msiexec` on the downloaded MSI.

There are some tradeoffs:
- The main problem with version (1) is that it won't respect the proxy settings for rustup. There is no way to change the proxy settings for `msiexec`, it will always use the Windows defaults (inherited from Internet Explorer). This is probably a deal breaker. I still implemented this here to show that it works and because it wasn't much work.
- The problem with version (2) is that after spawning `msiexec`, we need to exit the current `rustup` process (because the MSI can't install an new `rustup.exe` when the old one is still running). However, we want to delete the downloaded `.msi` file after the update has been run. In version (1), `msiexec` does that automatically. We would probably need to check for stale MSI files when `rustup.exe` is run (after the update)?
- Version (1) also shows a nice GUI dialog with a progress bar while downloading the MSI.
- Version (1) does not work with `file://` URLs, which are used in unit tests for locally testing `self update`.
- For version (1), the code would need to be refactored, because currently the update is downloaded in `prepare_update()` and only executed later in `run_update(...)`, but the MSI version as implemented in this PR does everything in `prepare_update()`.