### PR TITLE
Automatically install override toolchain when missing.

### DIFF
--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -259,16 +259,20 @@ impl Cfg {
                 }
             };
 
-            match self.verify_toolchain(&name) {
-                Ok(t) => {
-                    Ok(Some((t, reason)))
+            match self.get_toolchain(&name, false) {
+                Ok(toolchain) => {
+                    if toolchain.exists() {
+                        Ok(Some((toolchain, reason)))
+                    } else if toolchain.is_custom() {
+                        // Strip the confusing NotADirectory error and only mention that the override
+                        // toolchain is not installed.
+                        Err(Error::from(reason_err))
+                            .chain_err(|| ErrorKind::OverrideToolchainNotInstalled(name.to_string()))
+                    } else {
+                        try!(toolchain.install_from_dist());
+                        Ok(Some((toolchain, reason)))
+                    }
                 }
-                Err(Error(ErrorKind::Utils(::rustup_utils::ErrorKind::NotADirectory { .. }), _)) => {
-                    // Strip the confusing NotADirectory error and only mention that the override
-                    // toolchain is not installed.
-                    Err(Error::from(reason_err))
-                        .chain_err(|| ErrorKind::OverrideToolchainNotInstalled(name.to_string()))
-                },
                 Err(e) => {
                     Err(e)
                         .chain_err(|| Error::from(reason_err))

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -139,8 +139,7 @@ fn remove_override_toolchain_err_handling() {
             expect_ok(config, &["rustup", "default", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
             expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-            expect_err(config, &["rustc"],
-                               for_host!("toolchain 'beta-{0}' is not installed"));
+            expect_stderr_ok(config, &["rustc", "--version"], "info: installing component");
         });
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -182,8 +182,7 @@ fn remove_override_toolchain_err_handling() {
             expect_ok(config, &["rustup", "default", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
             expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-            expect_err(config, &["rustc"],
-                               for_host!("toolchain 'beta-{0}' is not installed"));
+            expect_stderr_ok(config, &["rustc", "--version"], "info: installing component");
         });
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -188,6 +188,24 @@ fn remove_override_toolchain_err_handling() {
 }
 
 #[test]
+fn file_override_toolchain_err_handling() {
+    setup(&|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain");
+        rustup_utils::raw::write_file(&toolchain_file, "beta").unwrap();
+        expect_stderr_ok(config, &["rustc", "--version"], "info: installing component");
+    });
+}
+
+#[test]
+fn plus_override_toolchain_err_handling() {
+    setup(&|config| {
+        expect_err(config, &["rustc", "+beta"],
+                           for_host!("toolchain 'beta-{0}' is not installed"));
+    });
+}
+
+#[test]
 fn bad_sha_on_manifest() {
     setup(&|config| {
         // Corrupt the sha


### PR DESCRIPTION
A typical scenario is:

* I work on a repository that uses `rust-toolchain` to pin to a specific Nightly version
* I run `git pull`, `rust-toolchain` has been changed to update to a new Rust version
* I run `cargo build`

Result before this PR (typically): rustup fails with an error like:

```
error: override toolchain 'nightly-2017-08-31' is not installed
info: caused by: the toolchain file at '/home/simon/projects/servo/rust-toolchain' specifies an uninstalled toolchain
```

A better result would be to automatically install toolchains as needed.

Closes #1218