### PR TITLE
Support `rustup-init --default-toolchain none`

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,7 @@ the shell script. Some examples:
 $ curl https://sh.rustup.rs -sSf | sh -s -- --help
 $ curl https://sh.rustup.rs -sSf | sh -s -- --no-modify-path
 $ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly
+$ curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain none
 ```
 
 If you prefer you can directly download `rustup-init` for the

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -36,6 +36,7 @@ FLAGS:
 OPTIONS:
         --default-host <default-host>              Choose a default host triple
         --default-toolchain <default-toolchain>    Choose a default toolchain to install
+        --default-toolchain none                   Do not install any toolchains
 EOF
 }
 

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -587,7 +587,7 @@ fn customize_install(mut opts: InstallOpts) -> Result<InstallOpts> {
         &opts.default_host_triple));
 
     opts.default_toolchain = try!(common::question_str(
-        "Default toolchain? (stable/beta/nightly)",
+        "Default toolchain? (stable/beta/nightly/none)",
         &opts.default_toolchain));
 
     opts.no_modify_path = !try!(common::question_bool(
@@ -660,7 +660,10 @@ fn maybe_install_rust(toolchain_str: &str, default_host_triple: &str, verbose: b
     // a toolchain the user actually wants. Don't do anything.  FIXME:
     // This logic should be part of InstallOpts so that it isn't
     // possible to select a toolchain then have it not be installed.
-    if try!(cfg.find_default()).is_none() {
+    if toolchain_str == "none" {
+        info!("skipping toolchain installation");
+        println!("");
+    } else if try!(cfg.find_default()).is_none() {
         // Set host triple first as it will affect resolution of toolchain_str
         try!(cfg.set_default_host_triple(default_host_triple));
         let toolchain = try!(cfg.get_toolchain(toolchain_str, false));

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -130,6 +130,16 @@ fn with_no_modify_path() {
 }
 
 #[test]
+fn with_no_toolchain() {
+    setup(&|config| {
+        let out = run_input(config, &["rustup-init", "--default-toolchain=none"], "\n\n");
+        assert!(out.ok);
+
+        expect_stdout_ok(config, &["rustup", "show"], "no active toolchain");
+    });
+}
+
+#[test]
 fn with_non_default_toolchain() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init", "--default-toolchain=nightly"], "\n\n");


### PR DESCRIPTION
To address this use case https://github.com/rust-lang-nursery/rustup.rs/issues/309#issuecomment-213839631.

This is especially useful when user directories have quotas into which large components (e.g. docs) do not fit.