### PR TITLE
update shebang to reflect bashisms

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2016 The Rust Project Developers. See the COPYRIGHT
 # file at the top-level directory of this distribution and at
 # http://rust-lang.org/COPYRIGHT.


### PR DESCRIPTION
Update shebang, given that `local` is not a POSIX semantic. Discovered this when trying to run the rustup installer on Oracle Solaris, where `/bin/sh` is a symlink to ksh93.

Note that the rustup.rs website should also pipe to `bash`, not `sh`.

Alternatively, we can rewrite this script in pure POSIX sh, though I leave that to cooler heads.