### PR TITLE
Added a link to all installers to the homepage

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -26,14 +26,16 @@
 <div id="platform-instructions-unix" class="instructions" style="display: none;">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
   <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <p class="other-platforms-help">You appear to be running Unix. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
 </div>
 
 <div id="platform-instructions-win" class="instructions" style="display: none;">
   <p>
     Download and run
-    <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+    <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
+  <p class="other-platforms-help">You appear to be running Windows. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
 </div>
 
 <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -64,7 +66,7 @@
   <div>
     <p>
       If you are running Windows,<br/>download and run
-      <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>
@@ -82,7 +84,7 @@
   <div>
     <p>
       If you are running Windows,<br/>download and run
-      <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -80,6 +80,10 @@ body#idx p {
     margin-bottom: 2em;
 }
 
+body#idx p.other-platforms-help {
+    font-size: 16px;
+}
+
 .instructions {
     background-color: rgb(250, 250, 250);
     margin-left: auto;
@@ -103,7 +107,8 @@ hr {
 }
 
 #platform-instructions-unix > pre,
-#platform-instructions-default > div > pre {
+#platform-instructions-default > div > pre,
+#platform-instructions-unknown > div > pre {
     background-color: #515151;
     color: white;
     margin-left: auto;
@@ -115,8 +120,9 @@ hr {
     box-shadow: inset 0px 0px 20px 0px #333333;
 }
 
-#platform-instructions-win a,
-#platform-instructions-default a {
+#platform-instructions-win a.windows-download,
+#platform-instructions-default a.windows-download,
+#platform-instructions-unknown a.windows-download {
     display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -106,6 +106,18 @@ function set_up_cycle_button() {
     };
 }
 
+function go_to_default_platform() {
+    platform_override = "default";
+    adjust_for_platform();
+}
+
+function set_up_default_platform_buttons() {
+    var defaults_buttons = document.getElementsByClassName('default-platform-button');
+    for (var i = 0; i < defaults_buttons.length; i++) {
+        defaults_buttons[i].onclick = go_to_default_platform;
+    }
+}
+
 function fill_in_bug_report_values() {
     var nav_plat = document.getElementById("nav-plat");
     var nav_app = document.getElementById("nav-app");
@@ -116,5 +128,6 @@ function fill_in_bug_report_values() {
 (function () {
     adjust_for_platform();
     set_up_cycle_button();
+    set_up_default_platform_buttons();
     fill_in_bug_report_values();
 }());


### PR DESCRIPTION
Good afternoon folks. I came across #1253 by chance, and thought it looked like something I could help with. I've added links under the Unix-specific and Windows-specific installation instructions in a smaller font that points to the 'default' set of installation instructions that lists all platforms.

While I was looking at this, I also noticed that the instructions for the 'unknown' OS didn't quite look the same as for the 'default' platform, so I updated some CSS selectors.

I'm open to any suggestions if you want me to do this slightly differently, or change the wording a bit :)