### PR TITLE
[WIP] Add subcommand to check for available updates without updating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,7 @@ cache:
 
 branches:
   only:
+    - check-update
     - master
     - stable
     - auto
@@ -162,3 +163,7 @@ after_deploy:
   - sudo pip install awscli
   - aws configure set preview.cloudfront true
   - aws cloudfront create-invalidation --paths "rustup/$TARGET/* rustup/dev/$TARGET/* rustup/www/* rustup/dev/www/* rustup/* rustup/dev/*"
+
+notifications:
+  slack:
+    secure: Yi7yIoASW8wxFyHVkMfjNq2sQvrkW07blHC7qFo5LadZ6wBUCR4HP/Sty2rwSpI9TD3WnYLC4DC8KNFabVmetdPi+vYHX3MdwUPqZAHYOkfDk8xeHTqzRSjelwUcqISm7b89J4DbtgVXs/4VrWZXyDVBygw6voOegArEPARFmZknVgYA6VxTEDx3M2NBq2YUDONLHnf5xjYzvtRimpidr1UXO7GqgAKGileRzrUNRGxhnFUoVeHlD4dpzgawRbhQtxVFGQKALv03p1fNk2MRfWkPKO0WPVcePNK8Se90OhoIWTa0IaBBx3myE8QgHr8mcUyx0IjZ1JMFufnLav1gyUOBlwtFX/xqJEY7FCdApfMLCSIAJFTaBVoBFmnvpkZTUsisvzydkuqihrJx+Kbd4sPR2ETz4NUcqmuR4dv7+s9iecN50ef7FaUdxJnPPiJ85EnkDF7mHEoola7fq8HqteRnD02Iu0rf+78Y0fpgF2B9DXs2j8spim2Gg6OVOQVa+tT3NyRHKu88iy9uPjyMV6AUHJpZgYejfKTiNFHxFBwyhIzUUPrhuMyaibe9ic6zZ2Qt6uiiDgqxU0hbsUPKMYbLbf0z8vyMtstlJRG5luHWDDItTmCvByBf5TqBj/vYcwndyTkz+AtHD0skTN/uG8eqaZ6HO5Zv0hHmW6pOrok=

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,6 @@ cache:
 
 branches:
   only:
-    - check-update
     - master
     - stable
     - auto
@@ -163,7 +162,3 @@ after_deploy:
   - sudo pip install awscli
   - aws configure set preview.cloudfront true
   - aws cloudfront create-invalidation --paths "rustup/$TARGET/* rustup/dev/$TARGET/* rustup/www/* rustup/dev/www/* rustup/* rustup/dev/*"
-
-notifications:
-  slack:
-    secure: Yi7yIoASW8wxFyHVkMfjNq2sQvrkW07blHC7qFo5LadZ6wBUCR4HP/Sty2rwSpI9TD3WnYLC4DC8KNFabVmetdPi+vYHX3MdwUPqZAHYOkfDk8xeHTqzRSjelwUcqISm7b89J4DbtgVXs/4VrWZXyDVBygw6voOegArEPARFmZknVgYA6VxTEDx3M2NBq2YUDONLHnf5xjYzvtRimpidr1UXO7GqgAKGileRzrUNRGxhnFUoVeHlD4dpzgawRbhQtxVFGQKALv03p1fNk2MRfWkPKO0WPVcePNK8Se90OhoIWTa0IaBBx3myE8QgHr8mcUyx0IjZ1JMFufnLav1gyUOBlwtFX/xqJEY7FCdApfMLCSIAJFTaBVoBFmnvpkZTUsisvzydkuqihrJx+Kbd4sPR2ETz4NUcqmuR4dv7+s9iecN50ef7FaUdxJnPPiJ85EnkDF7mHEoola7fq8HqteRnD02Iu0rf+78Y0fpgF2B9DXs2j8spim2Gg6OVOQVa+tT3NyRHKu88iy9uPjyMV6AUHJpZgYejfKTiNFHxFBwyhIzUUPrhuMyaibe9ic6zZ2Qt6uiiDgqxU0hbsUPKMYbLbf0z8vyMtstlJRG5luHWDDItTmCvByBf5TqBj/vYcwndyTkz+AtHD0skTN/uG8eqaZ6HO5Zv0hHmW6pOrok=

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ And it runs on all platforms Rust supports, including Windows.
 * [Installation](#installation)
 * [How rustup works](#how-rustup-works)
 * [Keeping Rust up to date](#keeping-rust-up-to-date)
+* [Checking for available updates](#checking-for-available-updates)
 * [Working with nightly Rust](#working-with-nightly-rust)
 * [Toolchain specification](#toolchain-specification)
 * [Toolchain override shorthand](#toolchain-override-shorthand)
@@ -170,6 +171,23 @@ $ rustup self update
 info: checking for self-updates
 info: downloading self-updates
 ```
+
+## Checking for available updates
+
+To check for availbale updates without actually updating, you can run `rustup check`:
+
+```
+$ rustup check
+info: syncing channel updates for 'stable'
+info: checking for self-updates
+info: rustup is up to date
+
+   stable up-to-date: rustc 1.7.0 (a5d1e7a59 2016-02-29)
+
+```
+
+Running `rustup check` checks for updates to `rustup` itself, as well as all installed toolchains.
+Similarly to `rustup update`, you can use `rustup self check` to check for updates to `rustup` alone.
 
 ## Working with nightly Rust
 

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -155,6 +155,14 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, rustup::Result<Updat
                 banner = "unchanged";
                 color = None;
             }
+            Ok(UpdateStatus::UpToDate) => {
+                banner = "up-to-date";
+                color = None;
+            }
+            Ok(UpdateStatus::UpdateAvailable) => {
+                banner = "update-available";
+                color = Some(term2::color::BRIGHT_GREEN);
+            }
             Err(_) => {
                 banner = "update failed";
                 color = Some(term2::color::BRIGHT_RED);
@@ -189,16 +197,21 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, rustup::Result<Updat
     Ok(())
 }
 
-pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
+pub fn update_all_channels(cfg: &Cfg, self_update: bool, check_only: bool) -> Result<()> {
 
-    let toolchains = try!(cfg.update_all_channels());
+    let toolchains = try!(cfg.update_all_channels(check_only));
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
     }
 
     let setup_path = if self_update {
-        try!(self_update::prepare_update())
+        if check_only {
+            self_update::check_update()?;
+            None
+        } else {
+            self_update::prepare_update()?
+        }
     } else {
         None
     };

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -28,6 +28,15 @@ r"DISCUSSION:
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.";
 
+pub static CHECK_HELP: &'static str =
+r"DISCUSSION:
+    With no toolchain specified, the `check` command checks each of
+    the installed toolchains from the official release channels, then
+    checks rustup itself.
+
+    If given a toolchain argument then `check` checks that
+    toolchain.";
+
 pub static INSTALL_HELP: &'static str =
 r"DISCUSSION:
     Installs a specific rust toolchain.

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -74,6 +74,7 @@ pub fn main() -> Result<()> {
         ("self", Some(c)) => {
             match c.subcommand() {
                 ("update", Some(_)) => try!(self_update::update()),
+                ("check", Some(_)) => try!(self_update::check_update()),
                 ("uninstall", Some(m)) => try!(self_uninstall(m)),
                 (_ ,_) => unreachable!(),
             }
@@ -298,7 +299,7 @@ pub fn cli() -> App<'static, 'static> {
                  .help("Standard library API documentation"))
             .group(ArgGroup::with_name("page")
                  .args(&["book", "std"])));
-    
+
     if cfg!(not(target_os = "windows")) {
         app = app
             .subcommand(SubCommand::with_name("man")
@@ -310,7 +311,7 @@ pub fn cli() -> App<'static, 'static> {
                          .long("toolchain")
                          .takes_value(true)));
     }
-    
+
     app.subcommand(SubCommand::with_name("self")
         .about("Modify the rustup installation")
         .setting(AppSettings::VersionlessSubcommands)
@@ -318,6 +319,8 @@ pub fn cli() -> App<'static, 'static> {
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .subcommand(SubCommand::with_name("update")
             .about("Download and install updates to rustup"))
+        .subcommand(SubCommand::with_name("check")
+            .about("Check available updates to rustup"))
         .subcommand(SubCommand::with_name("uninstall")
             .about("Uninstall rustup.")
             .arg(Arg::with_name("no-prompt")

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -667,7 +667,7 @@ fn maybe_install_rust(toolchain_str: &str, default_host_triple: &str, verbose: b
         // Set host triple first as it will affect resolution of toolchain_str
         try!(cfg.set_default_host_triple(default_host_triple));
         let toolchain = try!(cfg.get_toolchain(toolchain_str, false));
-        let status = try!(toolchain.install_from_dist());
+        let status = try!(toolchain.install_from_dist(false));
         try!(cfg.set_default(toolchain_str));
         println!("");
         try!(common::show_channel_update(cfg, toolchain_str, Ok(status)));

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -1309,6 +1309,7 @@ pub fn update() -> Result<()> {
         err!("you should probably use your system package manager to update rustup");
         process::exit(1);
     }
+
     let setup_path = try!(prepare_update());
     if let Some(ref p) = setup_path {
         let version = match get_new_rustup_version(p) {
@@ -1333,14 +1334,12 @@ pub fn check_update() -> Result<()> {
         process::exit(1);
     }
 
-    // Get current version
-    let current_version = env!("CARGO_PKG_VERSION");
-    // Download available version
     let available_version = download_available_version()?;
+    let current_version = env!("CARGO_PKG_VERSION");
     if available_version == current_version {
         info!("rustup is up to date");
     } else {
-        info!("rustup update to {} is available", available_version);
+        info!("self-update to {} is available", available_version);
     }
 
     Ok(())
@@ -1379,9 +1378,7 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
         try!(utils::remove_file("setup", setup_path));
     }
 
-    // Get current version
     let current_version = env!("CARGO_PKG_VERSION");
-    // Download available version
     let available_version = download_available_version()?;
     // If up-to-date
     if available_version == current_version {

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -465,8 +465,6 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                             remove: &[Component])
                             -> Result<Option<String>> {
 
-    let fresh_install = !prefix.path().exists();
-
     let res = update_from_dist_(download,
                                 update_hash,
                                 toolchain,
@@ -475,6 +473,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                                 remove);
 
     // Don't leave behind an empty / broken installation directory
+    let fresh_install = !prefix.path().exists();
     if res.is_err() && fresh_install {
         // FIXME Ignoring cascading errors
         let _ = utils::remove_dir("toolchain", prefix.path(),
@@ -484,7 +483,7 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
     res
 }
 
-pub fn update_from_dist_<'a>(download: DownloadCfg<'a>,
+fn update_from_dist_<'a>(download: DownloadCfg<'a>,
                             update_hash: Option<&Path>,
                             toolchain: &ToolchainDesc,
                             prefix: &InstallPrefix,
@@ -553,6 +552,45 @@ pub fn update_from_dist_<'a>(download: DownloadCfg<'a>,
             })
         }
         Err(e) => Err(e),
+    }
+}
+
+pub fn check_update_dist<'a>(download: DownloadCfg<'a>,
+                              update_hash: Option<&Path>,
+                              toolchain: &ToolchainDesc)
+                              -> Result<Option<bool>> {
+    let toolchain_str = toolchain.to_string();
+
+    // TODO: Add a notification about which manifest version is going to be used
+    // TODO: Proceed to try v1 as a fallback
+    (download.notify_handler)(Notification::DownloadingManifest(&toolchain_str));
+    match v2_manifest_hash_match(download, update_hash, toolchain) {
+        Ok(hash_match) => return Ok(Some(!hash_match)),
+        Err(Error(ErrorKind::ChecksumFailed { .. }, _)) => {
+            return Ok(None)
+        }
+        Err(e) => return Err(e),
+    }
+}
+
+fn v2_manifest_hash_match<'a>(download: DownloadCfg<'a>,
+                         update_hash: Option<&Path>,
+                         toolchain: &ToolchainDesc)
+                         -> Result<bool> {
+    let manifest_url = toolchain.manifest_v2_url(download.dist_root);
+    let hash_match_res = download.download_check_hash_match(&manifest_url, update_hash);
+
+    if let Ok(hash_match) = hash_match_res {
+        Ok(hash_match)
+    } else {
+        match *hash_match_res.as_ref().unwrap_err().kind() {
+            // Checksum failed - issue warning to try again later
+            ErrorKind::ChecksumFailed { .. } => {
+                (download.notify_handler)(Notification::ManifestChecksumFailedHack)
+            }
+            _ => {}
+        }
+        Err(hash_match_res.unwrap_err())
     }
 }
 

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -327,7 +327,7 @@ impl Cfg {
     }
 
     pub fn get_default(&self) -> Result<String> {
-        self.settings_file.with(|s| { 
+        self.settings_file.with(|s| {
             Ok(s.default_toolchain.clone().unwrap())
         })
     }
@@ -350,7 +350,7 @@ impl Cfg {
         }
     }
 
-    pub fn update_all_channels(&self) -> Result<Vec<(String, Result<UpdateStatus>)>> {
+    pub fn update_all_channels(&self, check_only: bool) -> Result<Vec<(String, Result<UpdateStatus>)>> {
         let toolchains = try!(self.list_toolchains());
 
         // Convert the toolchain strings to Toolchain values
@@ -365,7 +365,7 @@ impl Cfg {
         // Update toolchains and collect the results
         let toolchains = toolchains.map(|(n, t)| {
             let t = t.and_then(|t| {
-                let t = t.install_from_dist();
+                let t = t.install_from_dist(check_only);
                 if let Err(ref e) = t {
                     (self.notify_handler)(Notification::NonFatalError(e));
                 }

--- a/src/rustup/install.rs
+++ b/src/rustup/install.rs
@@ -68,6 +68,19 @@ impl<'a> InstallMethod<'a> {
         }
     }
 
+    pub fn check_update(self) -> Result<bool> {
+        if let InstallMethod::Dist(toolchain, update_hash, dl_cfg) = self {
+            let update_available = try!(dist::check_update_dist(dl_cfg, update_hash, toolchain));
+            if let Some(update_available) = update_available {
+                Ok(update_available)
+            } else {
+                Ok(false)
+            }
+        } else {
+            unreachable!();
+        }
+    }
+
     fn tar_gz(src: &Path, path: &Path, temp_cfg: &temp::Cfg,
               notify_handler: &Fn(Notification)) -> Result<()> {
         notify_handler(Notification::Extracting(src, path));


### PR DESCRIPTION
This PR adds subcommand to check for available updates for installed toolchains and rustup itself without actually updating.

This PR is WIP because no consensus is built about what name is proper for the subcommand or option.
Currently I have chosen `check` subcommand.
I guess there are many candidates:

* New subcommand
  * `check`
  * `check-update`
* Adding an option to `update` subcommand
  * `--no-download`
  * `--dry`
  * `--dry-run`
* and any other suggestions

Fixes #1249.