### PR TITLE
Add a quick troubleshooting tip to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,12 @@ If you need a more complex setup, rustup supports the convention used by
 the __curl__ program, documented in the ENVIRONMENT section of
 [its manual page][curlman].
 
+Note that some versions of `libcurl` apparently require you to drop the 
+`http://` or `https://` prefix in environment variables. For example, 
+`export http_proxy=proxy.example.com:1080` (and likewise for HTTPS). 
+If you are getting an SSL `unknown protocol` error from `rustup` via `libcurl`
+but the command-line `curl` command works fine, this may be the problem.
+
 [curlman]: https://curl.haxx.se/docs/manpage.html
 
 


### PR DESCRIPTION
It took me and IT about a month to figure this out. I thought it was a problem with the version of SSL installed on the squid proxy, whereas they thought it was a problem with my setup. It turned out to be very strange behavior from `curl` and `libcurl`. I thought it might be useful to pass the tip on.