### PR TITLE
Use command in BROWSER env if present for `doc` command

### DIFF
--- a/src/rustup-utils/src/raw.rs
+++ b/src/rustup-utils/src/raw.rs
@@ -355,9 +355,15 @@ pub fn open_browser(path: &Path) -> io::Result<bool> {
     #[cfg(not(windows))]
     fn inner(path: &Path) -> io::Result<bool> {
         use std::process::Stdio;
+        use std::env;
+
+        let env_browser = env::var_os("BROWSER").map(|b| env::split_paths(&b).collect::<Vec<_>>());
+        let env_commands = env_browser.as_ref()
+            .map(|cmds| cmds.iter().by_ref().filter_map(|b| b.to_str()).collect())
+            .unwrap_or(vec![]);
 
         let commands = ["xdg-open", "open", "firefox", "chromium", "sensible-browser"];
-        if let Some(cmd) = find_cmd(&commands) {
+        if let Some(cmd) = find_cmd(&env_commands).or(find_cmd(&commands)) {
             Command::new(cmd)
                 .arg(path)
                 .stdin(Stdio::null())


### PR DESCRIPTION
If the BROWSER enviroment variable is found, it is used as a list of
commands to be tested before the hardcoded ones to launch a browser.

Issue #1287