### PR TITLE
Display helpful advices even with -y.

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -297,28 +297,27 @@ pub fn install(no_prompt: bool, verbose: bool,
         process::exit(1);
     }
 
-    // More helpful advice, skip if -y
-    if !no_prompt {
-        let cargo_home = try!(canonical_cargo_home());
-        let msg = if !opts.no_modify_path {
-            if cfg!(unix) {
-                format!(post_install_msg_unix!(),
-                         cargo_home = cargo_home)
-            } else {
-                format!(post_install_msg_win!(),
-                        cargo_home = cargo_home)
-            }
+    let cargo_home = try!(canonical_cargo_home());
+    let msg = if !opts.no_modify_path {
+        if cfg!(unix) {
+            format!(post_install_msg_unix!(),
+                     cargo_home = cargo_home)
         } else {
-            if cfg!(unix) {
-                format!(post_install_msg_unix_no_modify_path!(),
-                         cargo_home = cargo_home)
-            } else {
-                format!(post_install_msg_win_no_modify_path!(),
-                        cargo_home = cargo_home)
-            }
-        };
-        term2::stdout().md(msg);
+            format!(post_install_msg_win!(),
+                    cargo_home = cargo_home)
+        }
+    } else {
+        if cfg!(unix) {
+            format!(post_install_msg_unix_no_modify_path!(),
+                     cargo_home = cargo_home)
+        } else {
+            format!(post_install_msg_win_no_modify_path!(),
+                    cargo_home = cargo_home)
+        }
+    };
+    term2::stdout().md(msg);
 
+    if !no_prompt {
         // On windows, where installation happens in a console
         // that may have opened just for this purpose, require
         // the user to press a key to continue.

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -234,6 +234,18 @@ pub fn expect_err_ex(config: &Config, args: &[&str],
     }
 }
 
+pub fn expect_ok_contains(config: &Config, args: &[&str],
+                    stdout: &str, stderr: &str) {
+    let out = run(config, args[0], &args[1..], &[]);
+    if !out.ok || !out.stdout.contains(stdout) || !out.stderr.contains(stderr) {
+        print_command(args, &out);
+        println!("expected.ok: {}", true);
+        print_indented("expected.stdout.contains", stdout);
+        print_indented("expected.stderr.contains", stderr);
+        panic!();
+    }
+}
+
 pub fn expect_timeout_ok(config: &Config, timeout: Duration, args: &[&str]) {
     let mut child = cmd(config, args[0], &args[1..])
         .stdout(Stdio::null())

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -27,6 +27,8 @@ use std::process::Command;
 use remove_dir_all::remove_dir_all;
 use rustup_mock::clitools::{self, Config, Scenario,
                                expect_ok, expect_ok_ex,
+                               expect_ok_contains,
+                               expect_stderr_ok,
                                expect_stdout_ok,
                                expect_err, expect_err_ex,
                                this_host_triple};
@@ -34,8 +36,6 @@ use rustup_mock::dist::{calc_hash};
 use rustup_mock::{get_path, restore_path};
 use rustup_utils::{utils, raw};
 
-#[cfg(windows)]
-use rustup_mock::clitools::expect_stderr_ok;
 
 macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
 
@@ -777,7 +777,7 @@ fn as_rustup_setup() {
 #[test]
 fn first_install_exact() {
     setup(&|config| {
-        expect_ok_ex(config, &["rustup-init", "-y"],
+        expect_ok_contains(config, &["rustup-init", "-y"],
 r"
   stable installed - 1.1.0 (hash-s-2)
 
@@ -802,9 +802,7 @@ info: default toolchain set to 'stable'
 fn reinstall_exact() {
     setup(&|config| {
         expect_ok(config, &["rustup-init", "-y"]);
-        expect_ok_ex(config, &["rustup-init", "-y"],
-r"
-",
+        expect_stderr_ok(config, &["rustup-init", "-y"],
 r"info: updating existing rustup installation
 "
                   );


### PR DESCRIPTION
Currently -y disables any helpful advices, but example usages of curl-based rustup installation frequently include -y (unfortunately).
Since -y is not a silent flag but a yes-to-all flag, we can always display advices instead and (on Windows) only pause unless -y is given.