### PR TITLE
Add rustfmt to the tools list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,12 +1,3 @@
-[root]
-name = "rustup-win-installer"
-version = "1.7.0"
-dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustup 1.7.0",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "adler32"
 version = "1.0.2"
@@ -897,6 +888,15 @@ dependencies = [
  "userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rustup-win-installer"
+version = "1.7.0"
+dependencies = [
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustup 1.7.0",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -383,6 +383,16 @@ pub fn set_permissions(path: &Path, perms: fs::Permissions) -> Result<()> {
     })
 }
 
+pub fn file_size(path: &Path) -> Result<u64> {
+    let metadata = fs::metadata(path).chain_err(|| {
+        ErrorKind::ReadingFile {
+            name: "metadata for",
+            path: PathBuf::from(path),
+        }
+    })?;
+    Ok(metadata.len())
+}
+
 pub fn make_executable(path: &Path) -> Result<()> {
     #[cfg(windows)]
     fn inner(_: &Path) -> Result<()> {

--- a/src/rustup-win-installer/src/lib.rs
+++ b/src/rustup-win-installer/src/lib.rs
@@ -16,7 +16,7 @@ pub const LOGMSG_STANDARD: i32 = 2;
 
 // TODO: share this with self_update.rs
 static TOOLS: &'static [&'static str]
-    = &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls"];
+    = &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls", "rustfmt", "cargo-fmt"];
 
 #[no_mangle]
 /// This is be run as a `deferred` action after `InstallFiles` on install and upgrade


### PR DESCRIPTION
r? @alexcrichton 

We should probably add something for cargo-fmt too once https://github.com/rust-lang/rust/pull/46031 lands, but I'm not sure if we can just add it to the list or not, seeing as it is not its own component.