### PR TITLE
Prevent `rustup update` to a toolchain without `rustc` or `cargo`.

### DIFF
--- a/src/rustup-dist/tests/install.rs
+++ b/src/rustup-dist/tests/install.rs
@@ -337,21 +337,21 @@ fn unix_permissions() {
     let tx = pkg.install(&components, "mycomponent", None, tx).unwrap();
     tx.commit();
 
-    let m = fs::metadata(instdir.path().join("bin/foo")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("bin/foo")).unwrap().permissions().mode();
     assert_eq!(m, 0o755);
-    let m = fs::metadata(instdir.path().join("lib/bar")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("lib/bar")).unwrap().permissions().mode();
     assert_eq!(m, 0o644);
-    let m = fs::metadata(instdir.path().join("lib/foobar")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("lib/foobar")).unwrap().permissions().mode();
     assert_eq!(m, 0o755);
-    let m = fs::metadata(instdir.path().join("doc/stuff/")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("doc/stuff/")).unwrap().permissions().mode();
     assert_eq!(m, 0o755);
-    let m = fs::metadata(instdir.path().join("doc/stuff/doc1")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("doc/stuff/doc1")).unwrap().permissions().mode();
     assert_eq!(m, 0o644);
-    let m = fs::metadata(instdir.path().join("doc/stuff/morestuff")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("doc/stuff/morestuff")).unwrap().permissions().mode();
     assert_eq!(m, 0o755);
-    let m = fs::metadata(instdir.path().join("doc/stuff/morestuff/doc2")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("doc/stuff/morestuff/doc2")).unwrap().permissions().mode();
     assert_eq!(m, 0o644);
-    let m = fs::metadata(instdir.path().join("doc/stuff/morestuff/tool")).unwrap().permissions().mode();
+    let m = 0o777 & fs::metadata(instdir.path().join("doc/stuff/morestuff/tool")).unwrap().permissions().mode();
     assert_eq!(m, 0o755);
 }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -567,3 +567,20 @@ r"info: no toolchain installed for 'test'
 ");
     });
 }
+
+// issue #1297
+#[test]
+fn update_unavailable_rustc() {
+    clitools::setup(Scenario::Unavailable, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+
+        set_current_dist_date(config, "2015-01-02");
+        expect_err(config, &["rustup", "update", "nightly"],
+            "some components unavailable for download: 'rustc', 'cargo'");
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+    });
+}

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -683,8 +683,8 @@ fn make_component_unavailable(config: &Config, name: &str, target: &TargetTriple
     let ref manifest_str = rustup_utils::raw::read_file(manifest_path).unwrap();
     let mut manifest = Manifest::parse(manifest_str).unwrap();
     {
-        let mut std_pkg = manifest.packages.get_mut(name).unwrap();
-        let mut target_pkg = std_pkg.targets.get_mut(target).unwrap();
+        let std_pkg = manifest.packages.get_mut(name).unwrap();
+        let target_pkg = std_pkg.targets.get_mut(target).unwrap();
         target_pkg.bins = None;
     }
     let ref manifest_str = manifest.stringify();


### PR DESCRIPTION
When the Rust CI is misconfigured, it is possible to produce a nightly where `rustc` or `cargo` is not available. This makes the entire toolchain unusable (for one day at least).

This PR tries to prevent the update operation from starting at all if these essential components are missing, so the user would still have a working though outdated toolchain.

Resolves #1297.