### PR TITLE
[Webpage] Add a "show all OS Button"

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -88,6 +88,12 @@
   </div>
 </div>
 
+<div id="other-os" style="display: none;">
+  <a id="other-os-button" href="#">
+    Install rustup on another OS?
+  </a>
+</div>
+
 <p>
   Need help? <a href="https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners">Ask on #rust-beginners</a>.
 </p>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -149,3 +149,9 @@ hr {
     margin-right: auto;
     padding: 1em;
 }
+
+#other-os {
+    font-size: 16px;
+    line-height: 2em;
+    transform: translateY(11px);
+}

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -106,6 +106,24 @@ function set_up_cycle_button() {
     };
 }
 
+function show_other_os() {
+    platform_override = "default";
+    adjust_for_platform();
+
+    var other_os_div = document.getElementById("other-os");
+    other_os_div.style.display = "none";
+
+    return false;
+}
+
+function set_up_other_os_button() {
+    var other_os_button = document.getElementById("other-os-button");
+    var other_os_div = document.getElementById("other-os");
+
+    other_os_button.onclick = show_other_os;
+    other_os_div.style.display = "block";
+}
+
 function fill_in_bug_report_values() {
     var nav_plat = document.getElementById("nav-plat");
     var nav_app = document.getElementById("nav-app");
@@ -116,5 +134,6 @@ function fill_in_bug_report_values() {
 (function () {
     adjust_for_platform();
     set_up_cycle_button();
+    set_up_other_os_button();
     fill_in_bug_report_values();
 }());


### PR DESCRIPTION
Try to fix issue #1253. The logic works for users with enabled & disabled Javascript.

Open questions from my side:
* Should I change the color of the „other os link“? At the moment it has the same color as all other links on the page.
* Is the link text „Install rustup on another OS?“ appropriate?