### PR TITLE
migrate to winapi 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,15 +688,6 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "psapi-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,11 +805,9 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "psapi-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -837,9 +826,8 @@ dependencies = [
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -850,7 +838,6 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -862,9 +849,8 @@ dependencies = [
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xz2 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -882,7 +868,7 @@ dependencies = [
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xz2 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -891,22 +877,17 @@ dependencies = [
 name = "rustup-utils"
 version = "1.9.0"
 dependencies = [
- "advapi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "download 0.4.0",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -916,7 +897,7 @@ version = "1.9.0"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustup 1.9.0",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1063,15 +1044,6 @@ dependencies = [
  "digest 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "shell32-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1345,24 +1317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "user32-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "userenv-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "utf8-ranges"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1560,7 +1514,6 @@ dependencies = [
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pipeline 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
-"checksum psapi-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f71c7e142c25f297077a8ebc21f10847096b5d21ad7619d7bf0c1fcecb40bb0"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)" = "9e7944d95d25ace8f377da3ac7068ce517e4c646754c43a1b1849177bbf72e59"
 "checksum redox_syscall 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "df1a5c588807af3b0cbbfa2f1358f2d5ec6ad546858c1ccd30dfbb127021706b"
@@ -1591,7 +1544,6 @@ dependencies = [
 "checksum serde_json 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9db7266c7d63a4c4b7fe8719656ccdd51acf1bed6124b174f933b009fb10bcb"
 "checksum serde_urlencoded 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce0fd303af908732989354c6f02e05e2e6d597152870f2c6990efb0577137480"
 "checksum sha2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d963c78ce367df26d7ea8b8cc655c651b42e8a1e584e869c1e17dae3ccb116a"
-"checksum shell32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee04b46101f57121c9da2b151988283b6beb79b34f5bb29a58ee48cb695122c"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
@@ -1624,8 +1576,6 @@ dependencies = [
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
-"checksum user32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ef4711d107b21b410a3a974b1204d9accc8b10dad75d8324b5d755de1617d47"
-"checksum userenv-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "71d28ea36bbd9192d75bd9fa9b39f96ddb986eaee824adae5d53b6e51919b2f3"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vcpkg 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e0a7d8bed3178a8fb112199d466eeca9ed09a14ba8ad67718179b4fd5487d0b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,12 +57,9 @@ url = "1.1.0"
 wait-timeout = "0.1.5"
 
 [target."cfg(windows)".dependencies]
-winapi = "0.2.8"
+winapi = { version = "0.3", features = ["jobapi", "jobapi2", "processthreadsapi", "psapi", "synchapi", "winuser"] }
 winreg = "0.4.0"
-user32-sys = "0.2.0"
-kernel32-sys = "0.2.1"
 gcc = "0.3.50"
-psapi-sys = "0.1"
 
 [dev-dependencies]
 rustup-mock = { path = "src/rustup-mock", version = "1.1.0" }

--- a/src/rustup-cli/job.rs
+++ b/src/rustup-cli/job.rs
@@ -34,21 +34,21 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    extern crate kernel32;
     extern crate winapi;
-    extern crate psapi;
 
     use std::ffi::OsString;
     use std::io;
     use std::mem;
     use std::os::windows::prelude::*;
+    use winapi::shared::*;
+    use winapi::um::*;
 
     pub struct Setup {
         job: Handle,
     }
 
     pub struct Handle {
-        inner: winapi::HANDLE,
+        inner: ntdef::HANDLE,
     }
 
     fn last_err() -> io::Error {
@@ -65,7 +65,7 @@ mod imp {
         // use job objects, so we instead just ignore errors and assume that
         // we're otherwise part of someone else's job object in this case.
 
-        let job = kernel32::CreateJobObjectW(0 as *mut _, 0 as *const _);
+        let job = jobapi2::CreateJobObjectW(0 as *mut _, 0 as *const _);
         if job.is_null() {
             return None
         }
@@ -75,22 +75,22 @@ mod imp {
         // process in the object should be killed. Note that this includes our
         // entire process tree by default because we've added ourselves and and
         // our children will reside in the job once we spawn a process.
-        let mut info: winapi::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+        let mut info: winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
         info = mem::zeroed();
         info.BasicLimitInformation.LimitFlags =
-            winapi::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-        let r = kernel32::SetInformationJobObject(job.inner,
-                        winapi::JobObjectExtendedLimitInformation,
-                        &mut info as *mut _ as winapi::LPVOID,
-                        mem::size_of_val(&info) as winapi::DWORD);
+            winnt::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let r = jobapi2::SetInformationJobObject(job.inner,
+                        winnt::JobObjectExtendedLimitInformation,
+                        &mut info as *mut _ as minwindef::LPVOID,
+                        mem::size_of_val(&info) as minwindef::DWORD);
         if r == 0 {
             return None
         }
 
         // Assign our process to this job object, meaning that our children will
         // now live or die based on our existence.
-        let me = kernel32::GetCurrentProcess();
-        let r = kernel32::AssignProcessToJobObject(job.inner, me);
+        let me = processthreadsapi::GetCurrentProcess();
+        let r = jobapi2::AssignProcessToJobObject(job.inner, me);
         if r == 0 {
             return None
         }
@@ -118,13 +118,13 @@ mod imp {
                     info!("killed some, going for more");
                 }
 
-                let mut info: winapi::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
+                let mut info: winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
                 info = mem::zeroed();
-                let r = kernel32::SetInformationJobObject(
+                let r = jobapi2::SetInformationJobObject(
                             self.job.inner,
-                            winapi::JobObjectExtendedLimitInformation,
-                            &mut info as *mut _ as winapi::LPVOID,
-                            mem::size_of_val(&info) as winapi::DWORD);
+                            winnt::JobObjectExtendedLimitInformation,
+                            &mut info as *mut _ as minwindef::LPVOID,
+                            mem::size_of_val(&info) as minwindef::DWORD);
                 if r == 0 {
                     info!("failed to configure job object to defaults: {}",
                           last_err());
@@ -137,16 +137,16 @@ mod imp {
         unsafe fn kill_remaining(&mut self) -> bool {
             #[repr(C)]
             struct Jobs {
-                header: winapi::JOBOBJECT_BASIC_PROCESS_ID_LIST,
-                list: [winapi::ULONG_PTR; 1024],
+                header: winnt::JOBOBJECT_BASIC_PROCESS_ID_LIST,
+                list: [basetsd::ULONG_PTR; 1024],
             }
 
             let mut jobs: Jobs = mem::zeroed();
-            let r = kernel32::QueryInformationJobObject(
+            let r = jobapi2::QueryInformationJobObject(
                             self.job.inner,
-                            winapi::JobObjectBasicProcessIdList,
-                            &mut jobs as *mut _ as winapi::LPVOID,
-                            mem::size_of_val(&jobs) as winapi::DWORD,
+                            winnt::JobObjectBasicProcessIdList,
+                            &mut jobs as *mut _ as minwindef::LPVOID,
+                            mem::size_of_val(&jobs) as minwindef::DWORD,
                             0 as *mut _);
             if r == 0 {
                 info!("failed to query job object: {}", last_err());
@@ -159,17 +159,17 @@ mod imp {
 
             let list = list.iter().filter(|&&id| {
                 // let's not kill ourselves
-                id as winapi::DWORD != kernel32::GetCurrentProcessId()
+                id as minwindef::DWORD != processthreadsapi::GetCurrentProcessId()
             }).filter_map(|&id| {
                 // Open the process with the necessary rights, and if this
                 // fails then we probably raced with the process exiting so we
                 // ignore the problem.
-                let flags = winapi::PROCESS_QUERY_INFORMATION |
-                            winapi::PROCESS_TERMINATE |
-                            winapi::SYNCHRONIZE;
-                let p = kernel32::OpenProcess(flags,
-                                              winapi::FALSE,
-                                              id as winapi::DWORD);
+                let flags = winnt::PROCESS_QUERY_INFORMATION |
+                            winnt::PROCESS_TERMINATE |
+                            winnt::SYNCHRONIZE;
+                let p = processthreadsapi::OpenProcess(flags,
+                                                       minwindef::FALSE,
+                                                       id as minwindef::DWORD);
                 if p.is_null() {
                     None
                 } else {
@@ -180,12 +180,12 @@ mod imp {
                 // If it's not then we likely raced with something else
                 // recycling this PID, so we just skip this step.
                 let mut res = 0;
-                let r = kernel32::IsProcessInJob(p.inner, self.job.inner, &mut res);
+                let r = jobapi::IsProcessInJob(p.inner, self.job.inner, &mut res);
                 if r == 0 {
                     info!("failed to test is process in job: {}", last_err());
                     return false
                 }
-                res == winapi::TRUE
+                res == minwindef::TRUE
             });
 
 
@@ -195,7 +195,7 @@ mod imp {
                 let mut buf = [0; 1024];
                 let r = psapi::GetProcessImageFileNameW(p.inner,
                                                         buf.as_mut_ptr(),
-                                                        buf.len() as winapi::DWORD);
+                                                        buf.len() as minwindef::DWORD);
                 if r == 0 {
                     info!("failed to get image name: {}", last_err());
                     continue
@@ -224,14 +224,14 @@ mod imp {
                 // Ok, this isn't mspdbsrv, let's kill the process. After we
                 // kill it we wait on it to ensure that the next time around in
                 // this function we're not going to see it again.
-                let r = kernel32::TerminateProcess(p.inner, 1);
+                let r = processthreadsapi::TerminateProcess(p.inner, 1);
                 if r == 0 {
                     info!("\tfailed to kill subprocess: {}", last_err());
                     info!("\tassuming subprocess is dead...");
                 } else {
                     info!("\tterminated subprocess");
                 }
-                let r = kernel32::WaitForSingleObject(p.inner, winapi::INFINITE);
+                let r = synchapi::WaitForSingleObject(p.inner, winbase::INFINITE);
                 if r != 0 {
                     info!("failed to wait for process to die: {}", last_err());
                     return false
@@ -245,7 +245,7 @@ mod imp {
 
     impl Drop for Handle {
         fn drop(&mut self) {
-            unsafe { kernel32::CloseHandle(self.inner); }
+            unsafe { handleapi::CloseHandle(self.inner); }
         }
     }
 }

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -40,10 +40,6 @@ extern crate gcc;
 extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;
-#[cfg(windows)]
-extern crate user32;
-#[cfg(windows)]
-extern crate kernel32;
 extern crate libc;
 
 #[macro_use]
@@ -172,8 +168,7 @@ fn make_environment_compatible() {
 #[cfg(windows)]
 fn fix_windows_reg_key() {
     use winreg::RegKey;
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let env = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE);

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -32,10 +32,8 @@ rustup-mock = { path = "../rustup-mock" }
 tempdir = "0.3.4"
 
 [target."cfg(windows)".dependencies]
-winapi = "0.2.8"
+winapi = { version = "0.3", features = ["handleapi", "sysinfoapi", "tlhelp32", "winnt"] }
 winreg = "0.4"
-user32-sys = "0.2.0"
-kernel32-sys = "0.2.1"
 
 [target."cfg(not(windows))".dependencies]
 libc = "0.2.0"

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -116,7 +116,7 @@ impl TargetTriple {
     pub fn from_host() -> Option<Self> {
         #[cfg(windows)]
         fn inner() -> Option<TargetTriple> {
-            use kernel32::GetNativeSystemInfo;
+            use winapi::um::sysinfoapi::GetNativeSystemInfo;
             use std::mem;
 
             // First detect architecture
@@ -129,7 +129,7 @@ impl TargetTriple {
                 GetNativeSystemInfo(&mut sys_info);
             }
 
-            let arch = match sys_info.wProcessorArchitecture {
+            let arch = match unsafe { sys_info.u.s() }.wProcessorArchitecture {
                 PROCESSOR_ARCHITECTURE_AMD64 => "x86_64",
                 PROCESSOR_ARCHITECTURE_INTEL => "i686",
                 _ => return None,

--- a/src/rustup-dist/src/lib.rs
+++ b/src/rustup-dist/src/lib.rs
@@ -16,10 +16,6 @@ extern crate sha2;
 extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;
-#[cfg(windows)]
-extern crate user32;
-#[cfg(windows)]
-extern crate kernel32;
 #[cfg(not(windows))]
 extern crate libc;
 

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -22,6 +22,6 @@ sha2 = "0.6.0"
 wait-timeout = "0.1.3"
 
 [target."cfg(windows)".dependencies]
-winapi = "0.2.8"
+winapi = "0.3"
 winreg = "0.4.0"
 

--- a/src/rustup-mock/src/lib.rs
+++ b/src/rustup-mock/src/lib.rs
@@ -165,7 +165,7 @@ impl MockContents {
 #[cfg(windows)]
 pub fn get_path() -> Option<String> {
     use winreg::RegKey;
-    use winapi::*;
+    use winreg::enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();
@@ -176,8 +176,7 @@ pub fn get_path() -> Option<String> {
 #[cfg(windows)]
 pub fn restore_path(p: &Option<String>) {
     use winreg::{RegKey, RegValue};
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE).unwrap();

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -24,10 +24,6 @@ toml = "0.4"
 url = "1.1"
 
 [target."cfg(windows)".dependencies]
-advapi32-sys = "0.2.0"
-kernel32-sys = "0.2.1"
-ole32-sys = "0.2.0"
-shell32-sys = "0.1.1"
-userenv-sys = "0.2.0"
-winapi = "0.2.8"
+winapi = { version = "0.3", features = ["combaseapi", "errhandlingapi", "fileapi", "handleapi", 
+    "ioapiset", "minwindef", "processthreadsapi", "shlobj", "shtypes", "userenv", "winbase", "winerror", "winnt", "winioctl"] }
 winreg = "0.4.0"

--- a/src/rustup-utils/src/lib.rs
+++ b/src/rustup-utils/src/lib.rs
@@ -14,16 +14,6 @@ extern crate semver;
 extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;
-#[cfg(windows)]
-extern crate shell32;
-#[cfg(windows)]
-extern crate ole32;
-#[cfg(windows)]
-extern crate kernel32;
-#[cfg(windows)]
-extern crate advapi32;
-#[cfg(windows)]
-extern crate userenv;
 
 #[cfg(unix)]
 extern crate libc;

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -10,7 +10,7 @@ use sha2::Sha256;
 use notifications::{Notification};
 use raw;
 #[cfg(windows)]
-use winapi::DWORD;
+use winapi::shared::minwindef::DWORD;
 #[cfg(windows)]
 use winreg;
 use std::cmp::Ord;
@@ -438,11 +438,12 @@ pub fn to_absolute<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 #[cfg(windows)]
 pub fn home_dir() -> Option<PathBuf> {
     use std::ptr;
-    use kernel32::{GetCurrentProcess, GetLastError, CloseHandle};
-    use advapi32::OpenProcessToken;
-    use userenv::GetUserProfileDirectoryW;
-    use winapi::ERROR_INSUFFICIENT_BUFFER;
-    use winapi::winnt::TOKEN_READ;
+    use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
+    use winapi::um::errhandlingapi::GetLastError;
+    use winapi::um::handleapi::CloseHandle;
+    use winapi::um::processthreadsapi::{GetCurrentProcess, OpenProcessToken};
+    use winapi::um::userenv::GetUserProfileDirectoryW;
+    use winapi::um::winnt::TOKEN_READ;
     use scopeguard;
 
     ::std::env::var_os("USERPROFILE").map(PathBuf::from).or_else(|| unsafe {
@@ -473,8 +474,8 @@ fn fill_utf16_buf<F1, F2, T>(mut f1: F1, f2: F2) -> io::Result<T>
     where F1: FnMut(*mut u16, DWORD) -> DWORD,
           F2: FnOnce(&[u16]) -> T
 {
-    use kernel32::{GetLastError, SetLastError};
-    use winapi::{ERROR_INSUFFICIENT_BUFFER};
+    use winapi::um::errhandlingapi::{GetLastError, SetLastError};
+    use winapi::shared::winerror::ERROR_INSUFFICIENT_BUFFER;
 
     // Start off with a stack buf but then spill over to the heap if we end up
     // needing more space.

--- a/src/rustup-win-installer/Cargo.toml
+++ b/src/rustup-win-installer/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib"]
 default = ["rustup/msi-installed"]
 
 [dependencies]
-winapi = "0.2"
+winapi = { version = "0.3", features = ["ntdef", "minwindef"] }
 rustup = { path = "../../", version = "1.1.0" }
 
 [build-dependencies]

--- a/src/rustup-win-installer/src/lib.rs
+++ b/src/rustup-win-installer/src/lib.rs
@@ -6,7 +6,9 @@ extern crate rustup;
 use std::ffi::CString;
 use std::path::PathBuf;
 use std::collections::HashMap;
-use ::winapi::{HRESULT, PCSTR, UINT, LPCWSTR, LPWSTR, LPVOID};
+
+use winapi::shared::ntdef::{HRESULT, PCSTR, LPCWSTR, LPWSTR};
+use winapi::shared::minwindef::{UINT, LPVOID};
 
 pub type MSIHANDLE = u32;
 

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -523,7 +523,7 @@ fn install_doesnt_modify_path_if_passed_no_modify_path() {
 #[cfg(windows)]
 fn install_doesnt_modify_path_if_passed_no_modify_path() {
     use winreg::RegKey;
-    use winapi::*;
+    use winreg::enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         let root = RegKey::predef(HKEY_CURRENT_USER);
@@ -947,8 +947,7 @@ fn rustup_init_works_with_weird_names() {
 #[cfg(windows)]
 fn doesnt_write_wrong_path_type_to_reg() {
     use winreg::RegKey;
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         expect_ok(config, &["rustup-init", "-y"]);
@@ -974,8 +973,7 @@ fn doesnt_write_wrong_path_type_to_reg() {
 #[cfg(windows)]
 fn windows_handle_empty_path_registry_key() {
     use winreg::RegKey;
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         let root = RegKey::predef(HKEY_CURRENT_USER);
@@ -1003,8 +1001,7 @@ fn windows_handle_empty_path_registry_key() {
 #[cfg(windows)]
 fn windows_uninstall_removes_semicolon_from_path() {
     use winreg::RegKey;
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         let root = RegKey::predef(HKEY_CURRENT_USER);
@@ -1034,8 +1031,7 @@ fn windows_uninstall_removes_semicolon_from_path() {
 #[cfg(windows)]
 fn install_doesnt_mess_with_a_non_unicode_path() {
     use winreg::{RegKey, RegValue};
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         let root = RegKey::predef(HKEY_CURRENT_USER);
@@ -1064,8 +1060,7 @@ fn install_doesnt_mess_with_a_non_unicode_path() {
 #[cfg(windows)]
 fn uninstall_doesnt_mess_with_a_non_unicode_path() {
     use winreg::{RegKey, RegValue};
-    use winreg::enums::RegType;
-    use winapi::*;
+    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
 
     setup(&|config| {
         expect_ok(config, &["rustup-init", "-y"]);


### PR DESCRIPTION
- [x] Some of those changes should also be applied to cargo, to keep those common files consistent.
filed https://github.com/rust-lang/cargo/pull/4877