### PR TITLE
Warn when tools are missing and allow to override

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -189,9 +189,9 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, rustup::Result<Updat
     Ok(())
 }
 
-pub fn update_all_channels(cfg: &Cfg, self_update: bool) -> Result<()> {
+pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> Result<()> {
 
-    let toolchains = try!(cfg.update_all_channels());
+    let toolchains = try!(cfg.update_all_channels(force_update));
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -747,7 +747,7 @@ fn maybe_install_rust(toolchain_str: &str, default_host_triple: &str, verbose: b
         // Set host triple first as it will affect resolution of toolchain_str
         try!(cfg.set_default_host_triple(default_host_triple));
         let toolchain = try!(cfg.get_toolchain(toolchain_str, false));
-        let status = try!(toolchain.install_from_dist());
+        let status = try!(toolchain.install_from_dist(false));
         try!(cfg.set_default(toolchain_str));
         println!("");
         try!(common::show_channel_update(cfg, toolchain_str, Ok(status)));

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -462,7 +462,8 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                             toolchain: &ToolchainDesc,
                             prefix: &InstallPrefix,
                             add: &[Component],
-                            remove: &[Component])
+                            remove: &[Component],
+                            force_update: bool)
                             -> Result<Option<String>> {
 
     let fresh_install = !prefix.path().exists();
@@ -472,7 +473,8 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
                                 toolchain,
                                 prefix,
                                 add,
-                                remove);
+                                remove,
+                                force_update);
 
     // Don't leave behind an empty / broken installation directory
     if res.is_err() && fresh_install {
@@ -485,12 +487,13 @@ pub fn update_from_dist<'a>(download: DownloadCfg<'a>,
 }
 
 pub fn update_from_dist_<'a>(download: DownloadCfg<'a>,
-                            update_hash: Option<&Path>,
-                            toolchain: &ToolchainDesc,
-                            prefix: &InstallPrefix,
-                            add: &[Component],
-                            remove: &[Component])
-                            -> Result<Option<String>> {
+                             update_hash: Option<&Path>,
+                             toolchain: &ToolchainDesc,
+                             prefix: &InstallPrefix,
+                             add: &[Component],
+                             remove: &[Component],
+                             force_update: bool)
+                             -> Result<Option<String>> {
 
     let toolchain_str = toolchain.to_string();
     let manifestation = try!(Manifestation::open(prefix.clone(), toolchain.target.clone()));
@@ -507,6 +510,7 @@ pub fn update_from_dist_<'a>(download: DownloadCfg<'a>,
             (download.notify_handler)(Notification::DownloadedManifest(&m.date, m.get_rust_version().ok()));
             return match try!(manifestation.update(&m,
                                                    changes,
+                                                   force_update,
                                                    &download,
                                                    download.notify_handler.clone())) {
                 UpdateStatus::Unchanged => Ok(None),

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -91,11 +91,14 @@ impl Manifestation {
     /// distribution manifest to "rustlib/rustup-dist.toml" and a
     /// configuration containing the component name-target pairs to
     /// "rustlib/rustup-config.toml".
-    pub fn update(&self,
-                  new_manifest: &Manifest,
-                  changes: Changes,
-                  download_cfg: &DownloadCfg,
-                  notify_handler: &Fn(Notification)) -> Result<UpdateStatus> {
+    pub fn update(
+        &self,
+        new_manifest: &Manifest,
+        changes: Changes,
+        force_update: bool,
+        download_cfg: &DownloadCfg,
+        notify_handler: &Fn(Notification),
+    ) -> Result<UpdateStatus> {
 
         // Some vars we're going to need a few times
         let temp_cfg = download_cfg.temp_cfg;
@@ -119,7 +122,11 @@ impl Manifestation {
         update.missing_essential_components(&self.target_triple)?;
 
         // Validate that the requested components are available
-        update.unavailable_components(new_manifest)?;
+        match update.unavailable_components(new_manifest) {
+            Ok(_) => {},
+            _ if force_update => {},
+            Err(e) => return Err(e),
+        }
 
         let altered = temp_cfg.dist_server != DEFAULT_DIST_SERVER;
 

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -40,6 +40,22 @@ impl Changes {
             remove_extensions: Vec::new(),
         }
     }
+
+    fn check_invariants(&self, rust_target_package: &TargetedPackage, config: &Option<Config>) {
+        for component_to_add in &self.add_extensions {
+            assert!(rust_target_package.extensions.contains(component_to_add),
+                    "package must contain extension to add");
+            assert!(!self.remove_extensions.contains(component_to_add),
+                    "can't both add and remove extensions");
+        }
+        for component_to_remove in &self.remove_extensions {
+            assert!(rust_target_package.extensions.contains(component_to_remove),
+                    "package must contain extension to remove");
+            let config = config.as_ref().expect("removing extension on fresh install?");
+            assert!(config.components.contains(component_to_remove),
+                    "removing package that isn't installed");
+        }
+    }
 }
 
 #[derive(PartialEq, Debug)]
@@ -86,78 +102,31 @@ impl Manifestation {
         let prefix = self.installation.prefix();
         let ref rel_installed_manifest_path = prefix.rel_manifest_file(DIST_MANIFEST);
         let ref installed_manifest_path = prefix.path().join(rel_installed_manifest_path);
-        let rust_package = try!(new_manifest.get_package("rust"));
-        let rust_target_package = try!(rust_package.get_target(Some(&self.target_triple)));
-
-        // Load the previous dist manifest
-        let ref old_manifest = try!(self.load_manifest());
-
-        // Load the configuration and list of installed components.
-        let ref config = try!(self.read_config());
 
         // Create the lists of components needed for installation
-        let component_lists = try!(build_update_component_lists(new_manifest, old_manifest, config,
-                                                                changes, &rust_target_package,
-                                                                notify_handler));
-        let (components_to_uninstall,
-             components_to_install,
-             final_component_list) = component_lists;
+        let update = try!(Update::build_update(
+            self,
+            new_manifest,
+            changes,
+            notify_handler,
+        ));
 
-        if components_to_uninstall.is_empty() && components_to_install.is_empty() {
+        if update.nothing_changes() {
             return Ok(UpdateStatus::Unchanged);
         }
 
         // Make sure we don't accidentally uninstall the essential components! (see #1297)
-        let missing_essential_components = ["rustc", "cargo"]
-            .iter()
-            .filter_map(|pkg| if final_component_list.iter().any(|c| &c.pkg == pkg) {
-                None
-            } else {
-                Some(Component {
-                    pkg: pkg.to_string(),
-                    target: Some(self.target_triple.clone()),
-                })
-            })
-            .collect::<Vec<_>>();
-        if !missing_essential_components.is_empty() {
-            return Err(ErrorKind::RequestedComponentsUnavailable(missing_essential_components).into());
-        }
+        update.missing_essential_components(&self.target_triple)?;
 
         // Validate that the requested components are available
-        let unavailable_components: Vec<Component> = components_to_install.iter().filter(|c| {
-            use manifest::*;
-            let pkg: Option<&Package> = new_manifest.get_package(&c.pkg).ok();
-            let target_pkg: Option<&TargetedPackage> = pkg.and_then(|p| p.get_target(c.target.as_ref()).ok());
-            target_pkg.map(|tp| tp.available()) != Some(true)
-        }).cloned().collect();
-
-        if !unavailable_components.is_empty() {
-            return Err(ErrorKind::RequestedComponentsUnavailable(unavailable_components).into());
-        }
-
-        // Map components to urls and hashes
-        let mut components_urls_and_hashes: Vec<(Component, Format, String, String)> = Vec::new();
-        for component in components_to_install {
-            let package = try!(new_manifest.get_package(&component.pkg));
-            let target_package = try!(package.get_target(component.target.as_ref()));
-
-            let bins = target_package.bins.as_ref().expect("components available");
-            let c_u_h =
-                if let (Some(url), Some(hash)) = (bins.xz_url.clone(),
-                                                  bins.xz_hash.clone()) {
-                    (component, Format::Xz, url, hash)
-                } else {
-                    (component, Format::Gz, bins.url.clone(), bins.hash.clone())
-                };
-            components_urls_and_hashes.push(c_u_h);
-        }
+        update.unavailable_components(new_manifest)?;
 
         let altered = temp_cfg.dist_server != DEFAULT_DIST_SERVER;
 
         // Download component packages and validate hashes
         let mut things_to_install: Vec<(Component, Format, File)> = Vec::new();
         let mut things_downloaded: Vec<String> = Vec::new();
-        for (component, format, url, hash) in components_urls_and_hashes {
+        for (component, format, url, hash) in update.components_urls_and_hashes(new_manifest)? {
 
             notify_handler(Notification::DownloadingComponent(&component.pkg,
                                                               &self.target_triple,
@@ -183,10 +152,11 @@ impl Manifestation {
 
         // If the previous installation was from a v1 manifest we need
         // to uninstall it first.
+        let ref config = try!(self.read_config());
         tx = try!(self.maybe_handle_v2_upgrade(config, tx));
 
         // Uninstall components
-        for component in components_to_uninstall {
+        for component in update.components_to_uninstall {
 
             notify_handler(Notification::RemovingComponent(&component.pkg,
                                                            &self.target_triple,
@@ -245,7 +215,7 @@ impl Manifestation {
         // `Components` *also* tracks what is installed, but it only tracks names, not
         // name/target. Needs to be fixed in rust-installer.
         let mut config = Config::new();
-        config.components = final_component_list;
+        config.components = update.final_component_list;
         let ref config_str = config.stringify();
         let ref rel_config_path = prefix.rel_manifest_file(CONFIG_FILE);
         let ref config_path = prefix.path().join(rel_config_path);
@@ -410,108 +380,194 @@ impl Manifestation {
     }
 }
 
-/// Returns components to uninstall, install, and the list of all
-/// components that will be up to date after the update.
-fn build_update_component_lists(
-    new_manifest: &Manifest,
-    old_manifest: &Option<Manifest>,
-    config: &Option<Config>,
-    changes: Changes,
-    rust_target_package: &TargetedPackage,
-    notify_handler: &Fn(Notification),
-    ) -> Result<(Vec<Component>, Vec<Component>, Vec<Component>)> {
+struct Update {
+    components_to_uninstall: Vec<Component>,
+    components_to_install: Vec<Component>,
+    final_component_list: Vec<Component>,
+    missing_components: Vec<Component>,
+}
 
-    // Check some invariantns
-    for component_to_add in &changes.add_extensions {
-        assert!(rust_target_package.extensions.contains(component_to_add),
-                "package must contain extension to add");
-        assert!(!changes.remove_extensions.contains(component_to_add),
-                "can't both add and remove extensions");
-    }
-    for component_to_remove in &changes.remove_extensions {
-        assert!(rust_target_package.extensions.contains(component_to_remove),
-                "package must contain extension to remove");
-        let config = config.as_ref().expect("removing extension on fresh install?");
-        assert!(config.components.contains(component_to_remove),
-                "removing package that isn't installed");
-    }
+impl Update {
+    /// Returns components to uninstall, install, and the list of all
+    /// components that will be up to date after the update.
+    fn build_update(
+        manifestation: &Manifestation,
+        new_manifest: &Manifest,
+        changes: Changes,
+        notify_handler: &Fn(Notification),
+    ) -> Result<Update> {
+        // Load the configuration and list of installed components.
+        let config = try!(manifestation.read_config());
 
-    // The list of components already installed, empty if a new install
-    let starting_list = config.as_ref().map(|c| c.components.clone()).unwrap_or(Vec::new());
+        // The package to install.
+        let rust_package = try!(new_manifest.get_package("rust"));
+        let rust_target_package = try!(rust_package.get_target(Some(&manifestation.target_triple)));
 
-    // The list of components we'll have installed at the end
-    let mut final_component_list = Vec::new();
+        changes.check_invariants(rust_target_package, &config);
 
-    // Find the final list of components we want to be left with when
-    // we're done: required components, added extensions, and existing
-    // installed extensions.
+        // The list of components already installed, empty if a new install
+        let starting_list = config.as_ref().map(|c| c.components.clone()).unwrap_or(Vec::new());
 
-    // Add components required by the package, according to the
-    // manifest
-    for required_component in &rust_target_package.components {
-        final_component_list.push(required_component.clone());
-    }
+        let mut result = Update {
+            components_to_uninstall: vec![],
+            components_to_install: vec![],
+            final_component_list: vec![],
+            missing_components: vec![],
+        };
 
-    // Add requested extension components
-    for extension in &changes.add_extensions {
-        final_component_list.push(extension.clone());
-    }
+        // Find the final list of components we want to be left with when
+        // we're done: required components, added extensions, and existing
+        // installed extensions.
+        result.build_final_component_list(
+            &starting_list,
+            rust_target_package,
+            new_manifest,
+            &changes,
+        );
 
-    // Add extensions that are already installed
-    for existing_component in &starting_list {
-        let is_removed = changes.remove_extensions.contains(existing_component);
+        // If this is a full upgrade then the list of components to
+        // uninstall is all that are currently installed, and those
+        // to install the final list. It's a complete reinstall.
+        //
+        // If it's a modification then the components to uninstall are
+        // those that are currently installed but not in the final list.
+        // To install are those on the final list but not already
+        // installed.
+        let old_manifest = try!(manifestation.load_manifest());
+        let just_modifying_existing_install = old_manifest.as_ref() == Some(new_manifest);
 
-        if !is_removed {
-            // If there is a rename in the (new) manifest, then we uninstall the component with the
-            // old name and install a component with the new name
-            if new_manifest.renames.contains_key(&existing_component.pkg) {
-                let mut renamed_component = existing_component.clone();
-                renamed_component.pkg = new_manifest.renames[&existing_component.pkg].to_owned();
-                let is_already_included = final_component_list.contains(&renamed_component);
-                if !is_already_included {
-                    final_component_list.push(renamed_component);
+        if just_modifying_existing_install {
+            for existing_component in &starting_list {
+                if !result.final_component_list.contains(existing_component) {
+                    result.components_to_uninstall.push(existing_component.clone())
                 }
+            }
+            for component in &result.final_component_list {
+                if !starting_list.contains(component) {
+                    result.components_to_install.push(component.clone());
+                } else {
+                    if changes.add_extensions.contains(&component) {
+                        notify_handler(Notification::ComponentAlreadyInstalled(&component));
+                    }
+                }
+            }
+        } else {
+            result.components_to_uninstall = starting_list.clone();
+            result.components_to_install = result.final_component_list.clone();
+        }
+
+        Ok(result)
+    }
+
+    /// Build the list of components we'll have installed at the end
+    fn build_final_component_list(
+        &mut self,
+        starting_list: &[Component],
+        rust_target_package: &TargetedPackage,
+        new_manifest: &Manifest,
+        changes: &Changes
+    ) {
+        // Add components required by the package, according to the
+        // manifest
+        for required_component in &rust_target_package.components {
+            self.final_component_list.push(required_component.clone());
+        }
+
+        // Add requested extension components
+        for extension in &changes.add_extensions {
+            self.final_component_list.push(extension.clone());
+        }
+
+        // Add extensions that are already installed
+        for existing_component in starting_list {
+            let is_removed = changes.remove_extensions.contains(existing_component);
+
+            if !is_removed {
+                // If there is a rename in the (new) manifest, then we uninstall the component with the
+                // old name and install a component with the new name
+                if new_manifest.renames.contains_key(&existing_component.pkg) {
+                    let mut renamed_component = existing_component.clone();
+                    renamed_component.pkg = new_manifest.renames[&existing_component.pkg].to_owned();
+                    let is_already_included = self.final_component_list.contains(&renamed_component);
+                    if !is_already_included {
+                        self.final_component_list.push(renamed_component);
+                    }
+                } else {
+                    let is_already_included = self.final_component_list.contains(existing_component);
+                    if !is_already_included {
+                        let component_is_present = rust_target_package.extensions.contains(existing_component)
+                            || rust_target_package.components.contains(existing_component);
+
+                        if component_is_present {
+                            self.final_component_list.push(existing_component.clone());
+                        } else {
+                            self.missing_components.push(existing_component.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn nothing_changes(&self) -> bool {
+        self.components_to_uninstall.is_empty() && self.components_to_install.is_empty()
+    }
+
+    fn missing_essential_components(&self, target_triple: &TargetTriple) -> Result<()> {
+        let missing_essential_components = ["rustc", "cargo"]
+            .iter()
+            .filter_map(|pkg| if self.final_component_list.iter().any(|c| &c.pkg == pkg) {
+                None
             } else {
-                let is_extension = rust_target_package.extensions.contains(existing_component);
-                let is_already_included = final_component_list.contains(existing_component);
-                if is_extension && !is_already_included {
-                    final_component_list.push(existing_component.clone());
-                }
-            }
+                Some(Component {
+                    pkg: pkg.to_string(),
+                    target: Some(target_triple.clone()),
+                })
+            })
+            .collect::<Vec<_>>();
+
+        if !missing_essential_components.is_empty() {
+            return Err(ErrorKind::RequestedComponentsUnavailable(missing_essential_components).into());
         }
+
+        Ok(())
     }
 
-    let mut components_to_uninstall = Vec::new();
-    let mut components_to_install = Vec::new();
+    fn unavailable_components(&self, new_manifest: &Manifest) -> Result<()> {
+        let mut unavailable_components: Vec<Component> = self.components_to_install.iter().filter(|c| {
+            use manifest::*;
+            let pkg: Option<&Package> = new_manifest.get_package(&c.pkg).ok();
+            let target_pkg: Option<&TargetedPackage> = pkg.and_then(|p| p.get_target(c.target.as_ref()).ok());
+            target_pkg.map(|tp| tp.available()) != Some(true)
+        }).cloned().collect();
 
-    // If this is a full upgrade then the list of components to
-    // uninstall is all that are currently installed, and those
-    // to install the final list. It's a complete reinstall.
-    //
-    // If it's a modification then the components to uninstall are
-    // those that are currently installed but not in the final list.
-    // To install are those on the final list but not already
-    // installed.
-    let just_modifying_existing_install = old_manifest.as_ref() == Some(new_manifest);
-    if !just_modifying_existing_install {
-        components_to_uninstall = starting_list.clone();
-        components_to_install = final_component_list.clone();
-    } else {
-        for existing_component in &starting_list {
-            if !final_component_list.contains(existing_component) {
-                components_to_uninstall.push(existing_component.clone())
-            }
+        unavailable_components.extend_from_slice(&self.missing_components);
+
+        if !unavailable_components.is_empty() {
+            return Err(ErrorKind::RequestedComponentsUnavailable(unavailable_components).into());
         }
-        for component in &final_component_list {
-            if !starting_list.contains(component) {
-                components_to_install.push(component.clone());
-            } else {
-                if changes.add_extensions.contains(&component) {
-                    notify_handler(Notification::ComponentAlreadyInstalled(&component));
-                }
-            }
-        }
+
+        Ok(())
     }
 
-    Ok((components_to_uninstall, components_to_install, final_component_list))
+    /// Map components to urls and hashes
+    fn components_urls_and_hashes(&self, new_manifest: &Manifest) -> Result<Vec<(Component, Format, String, String)>> {
+        let mut components_urls_and_hashes = Vec::new();
+        for component in &self.components_to_install {
+            let package = try!(new_manifest.get_package(&component.pkg));
+            let target_package = try!(package.get_target(component.target.as_ref()));
+
+            let bins = target_package.bins.as_ref().expect("components available");
+            let c_u_h =
+                if let (Some(url), Some(hash)) = (bins.xz_url.clone(),
+                                                  bins.xz_hash.clone()) {
+                    (component.clone(), Format::Xz, url, hash)
+                } else {
+                    (component.clone(), Format::Gz, bins.url.clone(), bins.hash.clone())
+                };
+            components_urls_and_hashes.push(c_u_h);
+        }
+
+        Ok(components_urls_and_hashes)
+    }
 }

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -409,7 +409,13 @@ fn update_from_dist(dist_server: &Url,
         remove_extensions: remove.to_owned(),
     };
 
-    manifestation.update(&manifest, changes, download_cfg, download_cfg.notify_handler.clone())
+    manifestation.update(
+        &manifest,
+        changes,
+        false,
+        download_cfg,
+        download_cfg.notify_handler.clone(),
+    )
 }
 
 fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> Result<Url> {

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -393,6 +393,27 @@ fn update_from_dist(dist_server: &Url,
                     download_cfg: &DownloadCfg,
                     temp_cfg: &temp::Cfg) -> Result<UpdateStatus> {
 
+    update_from_dist_(
+        dist_server,
+        toolchain,
+        prefix,
+        add,
+        remove,
+        download_cfg,
+        temp_cfg,
+        false,
+    )
+}
+
+fn update_from_dist_(dist_server: &Url,
+                     toolchain: &ToolchainDesc,
+                     prefix: &InstallPrefix,
+                     add: &[Component],
+                     remove: &[Component],
+                     download_cfg: &DownloadCfg,
+                     temp_cfg: &temp::Cfg,
+                     force_update: bool) -> Result<UpdateStatus> {
+
     // Download the dist manifest and place it into the installation prefix
     let ref manifest_url = try!(make_manifest_url(dist_server, toolchain));
     let manifest_file = try!(temp_cfg.new_file());
@@ -412,7 +433,7 @@ fn update_from_dist(dist_server: &Url,
     manifestation.update(
         &manifest,
         changes,
-        false,
+        force_update,
         download_cfg,
         download_cfg.notify_handler.clone(),
     )
@@ -520,8 +541,8 @@ fn upgrade() {
 }
 
 #[test]
-fn update_removes_components_that_dont_exist() {
-    // On day 1 install the 'bonus' component, on day 2 its no londer a component
+fn force_update() {
+    // On day 1 install the 'bonus' component, on day 2 its no longer a component
     let edit = &|date: &str, pkg: &mut MockPackage| {
         if date == "2016-02-01" {
             let mut tpkg = pkg.targets.iter_mut().find(|p| p.target == "x86_64-apple-darwin").unwrap();
@@ -531,12 +552,22 @@ fn update_removes_components_that_dont_exist() {
             });
         }
     };
+
     setup(Some(edit), false, &|url, toolchain, prefix, download_cfg, temp_cfg| {
         change_channel_date(url, "nightly", "2016-02-01");
+        // Update with bonus.
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
         assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
         change_channel_date(url, "nightly", "2016-02-02");
-        update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
+
+        // Update without bonus, should fail.
+        let err = update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap_err();
+        match *err.kind() {
+            ErrorKind::RequestedComponentsUnavailable(..) => {},
+            _ => panic!()
+        }
+        // Force update without bonus, should succeed, but bonus binary will be missing.
+        update_from_dist_(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg, true).unwrap();
         assert!(!utils::path_exists(&prefix.path().join("bin/bonus")));
     });
 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -752,7 +752,7 @@ fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
 fn proxy_toolchain_shorthand() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "update" , "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+stable", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+nightly", "--version"], "hash-n-2");


### PR DESCRIPTION
Closes #1277 

Idea here is to not update if the RLS is missing (for example). There was actually functionality to do this already, but it was not catching the RLS and Rustfmt since they were missing in an unexpected way.

The second commit adds `rustup update --force` to update even if some components are missing

r? @alexcrichton 