### PR TITLE
Correct changelog entry for 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.9.0
+# 1.10.0
 
 * [Warn when tools are missing and allow an override][pr1337]
 


### PR DESCRIPTION
The header of the newest section was 1.9.0 but I'm pretty sure it should have been 1.10.0 as it was bumped in the 1.10 commit.