### PR TITLE
windows: detect architecture on website, update to matching arch (#1353)

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -1448,7 +1448,19 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     }
 
     // Get build triple
-    let triple = dist::TargetTriple::from_build();
+    let build_triple = dist::TargetTriple::from_build();
+    let triple = if cfg!(windows) {
+        // For windows x86 builds seem slow when used with windows defender.
+        // The website defaulted to i686-windows-gnu builds for a long time.
+        // This ensures that we update to a version thats appropriate for users
+        // and also works around if the website messed up the detection.
+        // If someone really wants to use another version, he still can enforce
+        // that using the environment variable RUSTUP_OVERRIDE_HOST_TRIPLE.
+
+        dist::TargetTriple::from_host().unwrap_or(build_triple)
+    } else {
+        build_triple
+    };
 
     let update_root = env::var("RUSTUP_UPDATE_ROOT")
         .unwrap_or(String::from(UPDATE_ROOT));

--- a/www/index.html
+++ b/www/index.html
@@ -28,10 +28,18 @@
   <pre>curl https://sh.rustup.rs -sSf | sh</pre>
 </div>
 
-<div id="platform-instructions-win" class="instructions" style="display: none;">
+<div id="platform-instructions-win32" class="instructions" style="display: none;">
   <p>
     Download and run
-    <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+    <a href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+    then follow the onscreen instructions.
+  </p>
+</div>
+
+<div id="platform-instructions-win64" class="instructions" style="display: none;">
+  <p>
+    Download and run
+    <a href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
 </div>

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -1,10 +1,11 @@
+var platforms = ["default", "unknown", "win32", "win64", "unix"];
 var platform_override = null;
 
 function detect_platform() {
     "use strict";
 
-    if (platform_override) {
-        return platform_override;
+    if (platform_override !== null) {
+        return platforms[platform_override];
     }
 
     var os = "unknown";
@@ -20,7 +21,10 @@ function detect_platform() {
     if (navigator.platform == "Linux mips") {os = "unix";}
     if (navigator.platform == "Linux mips64") {os = "unix";}
     if (navigator.platform == "Mac") {os = "unix";}
-    if (navigator.platform == "Win32") {os = "win";}
+    if (navigator.platform == "Win32") {os = "win32";}
+    if (navigator.platform == "Win64" ||
+        navigator.userAgent.indexOf("WOW64") != -1 || 
+        navigator.userAgent.indexOf("Win64") != -1) { os = "win64"; }
     if (navigator.platform == "FreeBSD x86_64") {os = "unix";}
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}
     if (navigator.platform == "NetBSD x86_64") {os = "unix";}
@@ -28,7 +32,7 @@ function detect_platform() {
 
     // I wish I knew by now, but I don't. Try harder.
     if (os == "unknown") {
-        if (navigator.appVersion.indexOf("Win")!=-1) {os = "win";}
+        if (navigator.appVersion.indexOf("Win")!=-1) {os = "win32";}
         if (navigator.appVersion.indexOf("Mac")!=-1) {os = "unix";}
         // rust-www/#692 - FreeBSD epiphany!
         if (navigator.appVersion.indexOf("FreeBSD")!=-1) {os = "unix";}
@@ -42,39 +46,17 @@ function adjust_for_platform() {
 
     var platform = detect_platform();
 
-    var unix_div = document.getElementById("platform-instructions-unix");
-    var win_div = document.getElementById("platform-instructions-win");
-    var unknown_div = document.getElementById("platform-instructions-unknown");
-    var default_div = document.getElementById("platform-instructions-default");
-
-    unix_div.style.display = "none";
-    win_div.style.display = "none";
-    unknown_div.style.display = "none";
-    default_div.style.display = "none";
-
-    if (platform == "unix") {
-        unix_div.style.display = "block";
-    } else if (platform == "win") {
-        win_div.style.display = "block";
-    } else if (platform == "unknown") {
-        unknown_div.style.display = "block";
-    } else {
-        default_div.style.display = "block";
-    }
+    platforms.forEach(function (platform_elem) {
+        var platform_div = document.getElementById("platform-instructions-" + platform_elem);
+        platform_div.style.display = "none";
+        if (platform == platform_elem) {
+            platform_div.style.display = "block";
+        }
+    });
 }
 
 function cycle_platform() {
-    if (platform_override == null) {
-        platform_override = "default";
-    } else if (platform_override == "default") {
-        platform_override = "unknown";
-    } else if (platform_override == "unknown") {
-        platform_override = "win";
-    } else if (platform_override == "win") {
-        platform_override = "unix";
-    } else if (platform_override == "unix") {
-        platform_override = "default";
-    }
+    platform_override = (platform_override + 1) % platforms.length;
     adjust_for_platform();
 }
 


### PR DESCRIPTION
Updates on windows will now switch over to host appropriate versions,
ensuring the best user experience (e.g. x86_64 builds on x64).

The website can distinguish between Win64/Win32 builds now and
a new platform can be introduced more easily.

r? @alexcrichton 