### PR TITLE
Added a link to all installers to the homepage

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -26,7 +26,7 @@
 <div id="platform-instructions-unix" class="instructions" style="display: none;">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
   <pre>curl https://sh.rustup.rs -sSf | sh</pre>
-  <p class="other-platforms-help">You appear to be running Unix. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
+  <p class="other-platforms-help">You appear to be running Unix. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
 <div id="platform-instructions-win32" class="instructions" style="display: none;">
@@ -35,7 +35,7 @@
     <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p class="other-platforms-help">You appear to be running Windows 32 bit. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
+  <p class="other-platforms-help">You appear to be running Windows 32 bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
 <div id="platform-instructions-win64" class="instructions" style="display: none;">
@@ -44,7 +44,7 @@
     <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p class="other-platforms-help">You appear to be running Windows 64 bit. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
+  <p class="other-platforms-help">You appear to be running Windows 64 bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
 <div id="platform-instructions-unknown" class="instructions" style="display: none;">

--- a/www/index.html
+++ b/www/index.html
@@ -26,22 +26,25 @@
 <div id="platform-instructions-unix" class="instructions" style="display: none;">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
   <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <p class="other-platforms-help">You appear to be running Unix. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
 </div>
 
 <div id="platform-instructions-win32" class="instructions" style="display: none;">
   <p>
     Download and run
-    <a href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
+    <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
+  <p class="other-platforms-help">You appear to be running Windows 32 bit. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
 </div>
 
 <div id="platform-instructions-win64" class="instructions" style="display: none;">
   <p>
     Download and run
-    <a href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+    <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
+  <p class="other-platforms-help">You appear to be running Windows 64 bit. Click <a class="default-platform-button" href="#">here</a> to see the installer for all supported platforms.</p>
 </div>
 
 <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -72,7 +75,7 @@
   <div>
     <p>
       If you are running Windows,<br/>download and run
-      <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>
@@ -90,7 +93,7 @@
   <div>
     <p>
       If you are running Windows,<br/>download and run
-      <a href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -80,6 +80,10 @@ body#idx p {
     margin-bottom: 2em;
 }
 
+body#idx p.other-platforms-help {
+    font-size: 16px;
+}
+
 .instructions {
     background-color: rgb(250, 250, 250);
     margin-left: auto;
@@ -103,7 +107,8 @@ hr {
 }
 
 #platform-instructions-unix > pre,
-#platform-instructions-default > div > pre {
+#platform-instructions-default > div > pre,
+#platform-instructions-unknown > div > pre {
     background-color: #515151;
     color: white;
     margin-left: auto;
@@ -115,8 +120,9 @@ hr {
     box-shadow: inset 0px 0px 20px 0px #333333;
 }
 
-#platform-instructions-win a,
-#platform-instructions-default a {
+#platform-instructions-win a.windows-download,
+#platform-instructions-default a.windows-download,
+#platform-instructions-unknown a.windows-download {
     display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -81,7 +81,7 @@ body#idx p {
 }
 
 body#idx p.other-platforms-help {
-    font-size: 16px;
+    font-size: 0.6em;
 }
 
 .instructions {

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -88,6 +88,18 @@ function set_up_cycle_button() {
     };
 }
 
+function go_to_default_platform() {
+    platform_override = 0;
+    adjust_for_platform();
+}
+
+function set_up_default_platform_buttons() {
+    var defaults_buttons = document.getElementsByClassName('default-platform-button');
+    for (var i = 0; i < defaults_buttons.length; i++) {
+        defaults_buttons[i].onclick = go_to_default_platform;
+    }
+}
+
 function fill_in_bug_report_values() {
     var nav_plat = document.getElementById("nav-plat");
     var nav_app = document.getElementById("nav-app");
@@ -98,5 +110,6 @@ function fill_in_bug_report_values() {
 (function () {
     adjust_for_platform();
     set_up_cycle_button();
+    set_up_default_platform_buttons();
     fill_in_bug_report_values();
 }());


### PR DESCRIPTION
re #1253

I have just resolved conflict of https://github.com/rust-lang-nursery/rustup.rs/pull/1270 and adapted to the new index page.

Here is how it looks:
![otheros2](https://user-images.githubusercontent.com/693797/37123510-9fee51a6-22b8-11e8-9fe0-81b2ab5b323c.gif)
