### PR TITLE
 Fallbacks to wget if curl not installed

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -331,9 +331,14 @@ err() {
 }
 
 need_cmd() {
-    if ! command -v "$1" > /dev/null 2>&1
+    if ! check_cmd "$1"
     then err "need '$1' (command not found)"
     fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+    return $?
 }
 
 need_ok() {
@@ -362,9 +367,9 @@ ignore() {
 # This wraps curl or wget. Try curl first, if not installed,
 # use wget instead.
 downloader() {
-    if command -v curl > /dev/null 2>&1
+    if check_cmd curl
     then _dld=curl
-    elif command -v wget > /dev/null 2>&1
+    elif check_cmd wget
     then _dld=wget
     else _dld='curl or wget' # to be used in error message of need_cmd
     fi


### PR DESCRIPTION
Tested in ubuntu docker with 
 1. Both curl and wget installed
 2. only wget installed
 3. only curl installed

Console output for wget looks like this :
```shell
root@845dcc4ba103:/# wget -qO- https://raw.githubusercontent.com/thibaultdelor/rustup.rs/faa08bd786b7282500cc4162a2f428484c891130/rustup-init.sh | sh
info: downloading installer
--2018-03-08 06:54:27--  https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init
Resolving static.rust-lang.org (static.rust-lang.org)... 54.230.135.47, 54.230.135.132, 54.230.135.130, ...
Connecting to static.rust-lang.org (static.rust-lang.org)|54.230.135.47|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 12984456 (12M) [application/x-sharedlib]
Saving to: '/tmp/tmp.DQhaNqhC4q/rustup-init'

/tmp/tmp.DQhaNqhC4q/rustu 100%[==================================>]  12.38M  11.0MB/s    in 1.1s    

2018-03-08 06:54:29 (11.0 MB/s) - '/tmp/tmp.DQhaNqhC4q/rustup-init' saved [12984456/12984456]


Welcome to Rust!

This will download and install the official compiler for the Rust programming 
language, and its package manager, Cargo.

It will add the cargo, rustc, rustup and other commands to Cargo's bin 
directory, located at:

  /root/.cargo/bin

This path will then be added to your PATH environment variable by modifying the
profile file located at:

  /root/.profile

You can uninstall at any time with rustup self uninstall and these changes will
be reverted.

Current installation options:

   default host triple: x86_64-unknown-linux-gnu
     default toolchain: stable
  modify PATH variable: yes

1) Proceed with installation (default)
2) Customize installation
3) Cancel installation

```