### PR TITLE
Give correct error message if user tries to install an unavailable toolchain

### DIFF
--- a/src/rustup-cli/errors.rs
+++ b/src/rustup-cli/errors.rs
@@ -27,6 +27,10 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        InvalidToolchainName(t: String) {
+            description("invalid toolchain name")
+            display("invalid toolchain name: '{}'", t)
+        }
         InfiniteRecursion {
             description("infinite recursion detected")
         }

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -468,7 +468,7 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
             let status = if !toolchain.is_custom() {
                 Some(try!(toolchain.install_from_dist(m.is_present("force"))))
             } else if !toolchain.exists() {
-                return Err(ErrorKind::ToolchainNotInstalled(toolchain.name().to_string()).into());
+                return Err(ErrorKind::InvalidToolchainName(toolchain.name().to_string()).into());
             } else {
                 None
             };


### PR DESCRIPTION
 Currently if a user runs `rustup install unavailable-toolchain`, the error message is: `error: toolchain 'unavailable-toolchain' is not installed`. This is error message is weird, since the user runs rustup to install the toolchain. This commit copies the "InvalidToolchainName error from rustup-dist, and configures rustup install to use this error.
