### PR TITLE
Ignore IntelliJ project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /target
 /Cargo.lock
 /.settings
+/.idea/
 *~
 /**/target


### PR DESCRIPTION
Ignore project directory added automatically when IntelliJ opens the rustup directory.