### PR TITLE
Make sure rustup uses utils::rename* consistently. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /target
 /Cargo.lock
 /.settings
+/.idea/
 *~
 /**/target

--- a/src/rustup-dist/src/download.rs
+++ b/src/rustup-dist/src/download.rs
@@ -85,7 +85,8 @@ impl<'a> DownloadCfg<'a> {
             }.into());
         } else {
             (self.notify_handler)(Notification::ChecksumValid(&url.to_string()));
-            try!(fs::rename(&partial_file_path, &target_file));
+
+            utils::rename_file("downloaded", &partial_file_path, &target_file)?;
             return Ok(File { path: target_file });
         }
     }

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -79,23 +79,11 @@ pub fn write_str(name: &'static str, file: &mut File, path: &Path, s: &str) -> R
 }
 
 pub fn rename_file(name: &'static str, src: &Path, dest: &Path) -> Result<()> {
-    fs::rename(src, dest).chain_err(|| {
-        ErrorKind::RenamingFile {
-            name: name,
-            src: PathBuf::from(src),
-            dest: PathBuf::from(dest),
-        }
-    })
+    rename(name, src, dest)
 }
 
 pub fn rename_dir(name: &'static str, src: &Path, dest: &Path) -> Result<()> {
-    fs::rename(src, dest).chain_err(|| {
-        ErrorKind::RenamingDirectory {
-            name: name,
-            src: PathBuf::from(src),
-            dest: PathBuf::from(dest),
-        }
-    })
+    rename(name, src, dest)
 }
 
 pub fn filter_file<F: FnMut(&str) -> bool>(name: &'static str,
@@ -604,8 +592,7 @@ pub fn do_rustup_home_upgrade() -> bool {
     fn rename_rustup_dir_to_rustup_sh() -> Result<()> {
         let dirs = (rustup_dir(), rustup_sh_dir());
         if let (Some(rustup), Some(rustup_sh)) = dirs {
-            fs::rename(&rustup, &rustup_sh)
-                .chain_err(|| "unable to rename rustup dir")?;
+            rename_dir("installation", &rustup, &rustup_sh).chain_err(|| "unable to rename rustup dir")?;
         }
 
         Ok(())
@@ -614,8 +601,7 @@ pub fn do_rustup_home_upgrade() -> bool {
     fn rename_multirust_dir_to_rustup() -> Result<()> {
         let dirs = (multirust_dir(), rustup_dir());
         if let (Some(rustup), Some(rustup_sh)) = dirs {
-            fs::rename(&rustup, &rustup_sh)
-                .chain_err(|| "unable to rename multirust dir")?;
+            rename_dir("multirust installation", &rustup, &rustup_sh).chain_err(|| "unable to rename multirust dir")?;
         }
 
         Ok(())
@@ -831,6 +817,15 @@ pub fn toolchain_sort<T: AsRef<str>>(v: &mut Vec<T>) {
     });
 }
 
+fn rename(name: &'static str, src: &Path, dest: &Path) -> Result<()> {
+    fs::rename(src, dest).chain_err(|| {
+        ErrorKind::RenamingFile {
+            name: name,
+            src: PathBuf::from(src),
+            dest: PathBuf::from(dest),
+        }
+    })
+}
 
 #[cfg(test)]
 mod tests {

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -935,7 +935,7 @@ fn rustup_init_works_with_weird_names() {
             &format!("rustup-init{}", EXE_SUFFIX));
         let ref new = config.exedir.join(
             &format!("rustup-init(2){}", EXE_SUFFIX));
-        fs::rename(old, new).unwrap();
+        utils::rename_file("test", old, new).unwrap();
         expect_ok(config, &["rustup-init(2)", "-y"]);
         let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
         assert!(rustup.exists());
@@ -1181,7 +1181,7 @@ fn install_over_unupgraded_multirust_dir() {
         // Move .rustup to .multirust so the next rustup-init will be
         // an upgrade from ~/.multirust to ~/.rustup
         raw::remove_dir(&multirust_dir).unwrap();
-        fs::rename(&rustup_dir, &multirust_dir).unwrap();
+        utils::rename_file("test", &rustup_dir, &multirust_dir).unwrap();
         assert!(!rustup_dir.exists());
         assert!(multirust_dir.exists());
 


### PR DESCRIPTION
This is a small refactoring tho prepare the codebase for further changes
to the renaming functionality, e.g. ability to recover from atomic
rename errors - makes sure that `fs::rename` is only used via wrappers in `utils`

See #1239.
Best to merge after #1388 

cc @nrc 