### PR TITLE
Fix syntax of Powershell environment variable accesses in CLI help

### DIFF
--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -234,13 +234,13 @@ r"DISCUSSION:
 
     Now open the file provided by `$profile` (if you used the
     `New-Item` command it will be
-    `%USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+    `${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
 
     Next, we either save the completions file into our profile, or
     into a separate file and source it inside our profile. To save the
     completions into our profile simply use
 
-        PS C:\> rustup completions powershell >> %USERPROFILE%\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1";
+        PS C:\> rustup completions powershell >> ${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1";
 
 pub static TOOLCHAIN_ARG_HELP: &'static str = "Toolchain name, such as 'stable', 'nightly', \
                                                or '1.8.0'. For more information see `rustup \


### PR DESCRIPTION
The Rustup help for completions (accessed through `rustup completions --help`) uses the syntax `%USERPROFILE%` to access the user's USERPROFILE environment variable. While this is fine in CMD, it doesn't seem to be valid in Powershell 5.1 (which is what I'm using on Windows 10) or since version 3 of Powershell, at least (judging by the [Microsoft documentation](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-3.0)).

Instead, the syntax `$env:USERPROFILE` should be used, viz:

````Powershell
PS C:\> rustup completions powershell >>${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
````