### PR TITLE
Include shell completion for Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ gist is as simple as using one of the following:
 
 ```
 # Bash
-$ rustup completions bash > /etc/bash_completion.d/rustup.bash-completion
+$ rustup completions bash >> ~/.bash_completion
 
 # Bash (macOS/Homebrew)
 $ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion
@@ -500,9 +500,9 @@ If you need a more complex setup, rustup supports the convention used by
 the __curl__ program, documented in the ENVIRONMENT section of
 [its manual page][curlman].
 
-Note that some versions of `libcurl` apparently require you to drop the 
-`http://` or `https://` prefix in environment variables. For example, 
-`export http_proxy=proxy.example.com:1080` (and likewise for HTTPS). 
+Note that some versions of `libcurl` apparently require you to drop the
+`http://` or `https://` prefix in environment variables. For example,
+`export http_proxy=proxy.example.com:1080` (and likewise for HTTPS).
 If you are getting an SSL `unknown protocol` error from `rustup` via `libcurl`
 but the command-line `curl` command works fine, this may be the problem.
 

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -1,5 +1,6 @@
 //! Just a dumping ground for cli stuff
 
+use clap::ArgMatches;
 use rustup::{self, Cfg, Notification, Toolchain, UpdateStatus};
 use rustup::telemetry_analysis::TelemetryAnalysis;
 use errors::*;
@@ -326,24 +327,32 @@ pub fn list_components(toolchain: &Toolchain) -> Result<()> {
     Ok(())
 }
 
-pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
+pub fn list_toolchains(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchains = cfg.list_toolchains()?;
 
     if toolchains.is_empty() {
-        println!("no installed toolchains");
+        if !m.is_present("default") {
+            println!("no installed toolchains");
+        }
     } else {
-        if let Ok(Some(def_toolchain)) = cfg.find_default() {
-            for toolchain in toolchains {
-                let if_default = if def_toolchain.name() == &*toolchain {
-                    " (default)"
-                } else {
-                    ""
-                };
-                println!("{}{}", &toolchain, if_default);
+        if !m.is_present("default") {
+            if let Ok(Some(def_toolchain)) = cfg.find_default() {
+                for toolchain in toolchains {
+                    let if_default = if def_toolchain.name() == &*toolchain {
+                        " (default)"
+                    } else {
+                        ""
+                    };
+                    println!("{}{}", &toolchain, if_default);
+                }
+            } else {
+                for toolchain in toolchains {
+                    println!("{}", &toolchain);
+                }
             }
         } else {
-            for toolchain in toolchains {
-                println!("{}", &toolchain);
+            if let Ok(Some(def_toolchain)) = cfg.find_default() {
+                println!("{}", def_toolchain.name());
             }
         }
     }

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -155,10 +155,10 @@ r"DISCUSSION:
 
     BASH:
 
-    Completion files are commonly stored in `/etc/bash_completion.d/`.
-    Run the command:
+    Completion files are commonly stored in `/etc/bash_completion.d/`,
+    but can be appended in `~/.bash_completion` too. Run the command:
 
-        $ rustup completions bash > /etc/bash_completion.d/rustup.bash-completion
+        $ rustup completions bash >> ~/.bash_completion
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take affect.

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -36,7 +36,7 @@ pub fn main() -> Result<()> {
         ("default", Some(m)) => default_(cfg, m)?,
         ("toolchain", Some(c)) => match c.subcommand() {
             ("install", Some(m)) => update(cfg, m)?,
-            ("list", Some(_)) => common::list_toolchains(cfg)?,
+            ("list", Some(m)) => common::list_toolchains(cfg, m)?,
             ("link", Some(m)) => toolchain_link(cfg, m)?,
             ("uninstall", Some(m)) => toolchain_remove(cfg, m)?,
             (_, _) => unreachable!(),
@@ -172,7 +172,14 @@ pub fn cli() -> App<'static, 'static> {
                 .setting(AppSettings::VersionlessSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(SubCommand::with_name("list").about("List installed toolchains"))
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List installed toolchains")
+                        .arg(
+                            Arg::with_name("default")
+                                .help("Show only the default toolchain"),
+                        ),
+                )
                 .subcommand(
                     SubCommand::with_name("install")
                         .about("Install or update a given toolchain")

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -80,11 +80,34 @@ pub fn main() -> Result<()> {
         },
         ("completions", Some(c)) => {
             if let Some(shell) = c.value_of("shell") {
+                let shell = shell.parse::<Shell>().unwrap();
+                let prefix = "~/.rustup/toolchains/$(rustup toolchain list --default)";
+
                 cli().gen_completions_to(
                     "rustup",
-                    shell.parse::<Shell>().unwrap(),
+                    shell,
                     &mut io::stdout(),
                 );
+
+                match shell {
+                    Shell::Bash => {
+                        writeln!(
+                            &mut io::stdout(),
+                            "\n. {}{}",
+                            prefix,
+                            "/etc/bash_completion.d/cargo"
+                        );
+                    }
+                    Shell::Zsh => {
+                        writeln!(
+                            &mut io::stdout(),
+                            "\n. {}{}",
+                            prefix,
+                            "/share/zsh/site-functions/_cargo"
+                        );
+                    }
+                    _ => (),
+                };
             }
         }
         (_, _) => unreachable!(),

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -200,6 +200,7 @@ pub fn cli() -> App<'static, 'static> {
                         .about("List installed toolchains")
                         .arg(
                             Arg::with_name("default")
+                                .long("default")
                                 .help("Show only the default toolchain"),
                         ),
                 )


### PR DESCRIPTION
*   Include shell completion for Cargo on `rustup completions` (#387,  rust-lang/cargo#5596)
*   Add argument to show only the default toolchain: `rustup toolchain list --default` (#450, #1406)
*   Update the `rustup completions bash` instructions to use home directory (#1199)