### PR TITLE
An additional indication for input after the first question

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -44,6 +44,7 @@ pub fn confirm_advanced() -> Result<Confirm> {
     println!("1) Proceed with installation (default)");
     println!("2) Customize installation");
     println!("3) Cancel installation");
+    print!(">");
 
     let _ = std::io::stdout().flush();
     let input = read_line()?;

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -85,7 +85,7 @@ fn blank_lines_around_stderr_log_output_install() {
         assert!(out.stdout.contains(
             r"
 3) Cancel installation
-
+>
 
   stable installed - 1.1.0 (hash-s-2)
 
@@ -107,7 +107,7 @@ fn blank_lines_around_stderr_log_output_update() {
         assert!(out.stdout.contains(
             r"
 3) Cancel installation
-
+>
 
 
 Rust is installed now. Great!


### PR DESCRIPTION
```
1) Proceed with installation (default)
2) Customize installation
3) Cancel installation
> 
```

To help indicate to the user that they are expected to enter a number and press enter. It's probably my fault for trying to install rust first thing in the morning, but I sat at this screen for 2 or 3 sips of coffee waiting for it to proceed before realizing I needed to press return. Maybe this caret will help someone else avoid my delay! :smile: 