### PR TITLE
Bring rustup.js and markup into alingment with rust-www

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -31,20 +31,24 @@
 
 <div id="platform-instructions-win32" class="instructions" style="display: none;">
   <p>
-    Download and run
+    To install Rust, download and run
     <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p class="other-platforms-help">You appear to be running Windows 32 bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
+  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+  <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <p class="other-platforms-help">You appear to be running Windows 32-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
 <div id="platform-instructions-win64" class="instructions" style="display: none;">
   <p>
-    Download and run
+    To install Rust, download and run
     <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p class="other-platforms-help">You appear to be running Windows 64 bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
+  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+  <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <p class="other-platforms-help">You appear to be running Windows 64-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
 <div id="platform-instructions-unknown" class="instructions" style="display: none;">
@@ -74,8 +78,18 @@
 
   <div>
     <p>
-      If you are running Windows,<br/>download and run
-      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      If you are running Windows 64-bit,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+      then follow the onscreen instructions.
+    </p>
+  </div>
+
+  <hr/>
+
+  <div>
+    <p>
+      If you are running Windows 32-bit,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>
@@ -84,7 +98,8 @@
 
 <div id="platform-instructions-default" class="instructions">
   <div>
-    <p>If you are running Unix,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
+    <p>To install Rust, if you are running Unix,<br/>run the following
+    in your terminal, then follow the onscreen instructions.</p>
     <pre>curl https://sh.rustup.rs -sSf | sh</pre>
   </div>
 
@@ -92,8 +107,18 @@
 
   <div>
     <p>
-      If you are running Windows,<br/>download and run
-      <a class="windows-download" href="https://win.rustup.rs">rustup&#x2011;init.exe</a>
+      If you are running Windows 64-bit,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+      then follow the onscreen instructions.
+    </p>
+  </div>
+
+  <hr/>
+
+  <div>
+    <p>
+      If you are running Windows 32-bit,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -107,6 +107,8 @@ hr {
 }
 
 #platform-instructions-unix > pre,
+#platform-instructions-win32 > pre,
+#platform-instructions-win64 > pre,
 #platform-instructions-default > div > pre,
 #platform-instructions-unknown > div > pre {
     background-color: #515151;
@@ -120,7 +122,8 @@ hr {
     box-shadow: inset 0px 0px 20px 0px #333333;
 }
 
-#platform-instructions-win a.windows-download,
+#platform-instructions-win32 a.windows-download,
+#platform-instructions-win64 a.windows-download,
 #platform-instructions-default a.windows-download,
 #platform-instructions-unknown a.windows-download {
     display: block;

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -1,3 +1,5 @@
+// IF YOU CHANGE THIS FILE IT MUST BE CHANGED ON BOTH rust-www and rustup.rs
+
 var platforms = ["default", "unknown", "win32", "win64", "unix"];
 var platform_override = null;
 
@@ -23,7 +25,7 @@ function detect_platform() {
     if (navigator.platform == "Mac") {os = "unix";}
     if (navigator.platform == "Win32") {os = "win32";}
     if (navigator.platform == "Win64" ||
-        navigator.userAgent.indexOf("WOW64") != -1 || 
+        navigator.userAgent.indexOf("WOW64") != -1 ||
         navigator.userAgent.indexOf("Win64") != -1) { os = "win64"; }
     if (navigator.platform == "FreeBSD x86_64") {os = "unix";}
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}
@@ -36,6 +38,16 @@ function detect_platform() {
         if (navigator.appVersion.indexOf("Mac")!=-1) {os = "unix";}
         // rust-www/#692 - FreeBSD epiphany!
         if (navigator.appVersion.indexOf("FreeBSD")!=-1) {os = "unix";}
+    }
+
+    // Firefox Quantum likes to hide platform and appVersion but oscpu works
+    if (navigator.oscpu) {
+        if (navigator.oscpu.indexOf("Win32")!=-1) {os = "win32";}
+        if (navigator.oscpu.indexOf("Win64")!=-1) {os = "win64";}
+        if (navigator.oscpu.indexOf("Mac")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("Linux")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("FreeBSD")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("NetBSD")!=-1) {os = "unix";}
     }
 
     return os;
@@ -53,10 +65,42 @@ function adjust_for_platform() {
             platform_div.style.display = "block";
         }
     });
+
+    adjust_platform_specific_instrs(platform);
+}
+
+// NB: This has no effect on rustup.rs
+function adjust_platform_specific_instrs(platform) {
+    var platform_specific = document.getElementsByClassName("platform-specific");
+    for (var el of platform_specific) {
+        var el_is_not_win = el.className.indexOf("not-win") !== -1;
+        var el_is_inline = el.tagName.toLowerCase() == "span";
+        var el_visible_style = "block";
+        if (el_is_inline) {
+            el_visible_style = "inline";
+        }
+        if (platform == "win64" || platform == "win32") {
+            if (el_is_not_win) {
+                el.style.display = "none";
+            } else {
+                el.style.display = el_visible_style;
+            }
+        } else {
+            if (el_is_not_win) {
+                el.style.display = el_visible_style;
+            } else {
+                el.style.display = "none";
+            }
+        }
+    }
 }
 
 function cycle_platform() {
-    platform_override = (platform_override + 1) % platforms.length;
+    if (platform_override == null) {
+        platform_override = 0;
+    } else {
+        platform_override = (platform_override + 1) % platforms.length;
+    }
     adjust_for_platform();
 }
 
@@ -79,6 +123,7 @@ function set_up_cycle_button() {
             if (idx == key.length) {
                 cycle_button.style.display = "block";
                 unlocked = true;
+                cycle_platform();
             }
         } else if (event.key == key[0]) {
             idx = 1;
@@ -93,6 +138,7 @@ function go_to_default_platform() {
     adjust_for_platform();
 }
 
+// NB: This has no effect on rust-lang.org/install.html
 function set_up_default_platform_buttons() {
     var defaults_buttons = document.getElementsByClassName('default-platform-button');
     for (var i = 0; i < defaults_buttons.length; i++) {


### PR DESCRIPTION
This makes rustup.js the same as on rust-www, pulls in
some of the language from rust-www, pulls in some fixes
to platform detection, fixes some css.