### PR TITLE
Add subcommands to "rustup show" for active-toolchain and it's version

### DIFF
--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -17,6 +17,15 @@ pub static SHOW_HELP: &'static str = r"DISCUSSION:
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.";
 
+pub static SHOW_ACTIVE_TOOLCHAIN_HELP: &'static str = r"DISCUSSION:
+    Shows the name of the active toolchain.
+
+    This is useful for figuring out the active tool chain from
+    scripts.
+
+    You should use `rustc --print sysroot` to get the sysroot, or
+    `rustc --version` to get the toolchain version.";
+
 pub static UPDATE_HELP: &'static str = r"DISCUSSION:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -31,7 +31,6 @@ pub fn main() -> Result<()> {
     match matches.subcommand() {
         ("show", Some(c)) => match c.subcommand() {
             ("active-toolchain", Some(_)) => show_active_toolchain(cfg)?,
-            ("active-toolchain-version", Some(_)) => show_active_toolchain_version(cfg)?,
             (_, _) => show(cfg)?
         },
         ("install", Some(m)) => update(cfg, m)?,
@@ -119,9 +118,7 @@ pub fn cli() -> App<'static, 'static> {
                 .setting(AppSettings::DeriveDisplayOrder)
                 .subcommand(SubCommand::with_name("active-toolchain")
                     .about("Show the active toolchain")
-                )
-                .subcommand(SubCommand::with_name("active-toolchain-version")
-                    .about("Show the active toolchain version")
+                    .after_help(SHOW_ACTIVE_TOOLCHAIN_HELP)
                 ),
         )
         .subcommand(
@@ -750,19 +747,6 @@ fn show_active_toolchain(cfg: &Cfg) -> Result<()> {
     match cfg.find_override_toolchain_or_default(cwd)? {
         Some((ref toolchain, _)) => {
             println!("{}", toolchain.name());
-        },
-        None => {
-            // Print nothing
-        }
-    }
-    Ok(())
-}
-
-fn show_active_toolchain_version(cfg: &Cfg) -> Result<()> {
-    let ref cwd = utils::current_dir()?;
-    match cfg.find_override_toolchain_or_default(cwd)? {
-        Some((ref toolchain, _)) => {
-            println!("{}", common::rustc_version(toolchain));
         },
         None => {
             // Print nothing

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -873,32 +873,6 @@ fn show_active_toolchain_none() {
     });
 }
 
-#[test]
-fn show_active_toolchain_version() {
-    setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok_ex(
-            config,
-            &["rustup", "show", "active-toolchain-version"],
-            r"1.3.0 (hash-n-2)
-",
-            r"",
-        );
-    });
-}
-
-#[test]
-fn show_active_toolchain_version_none() {
-    setup(&|config| {
-        expect_ok_ex(
-            config,
-            &["rustup", "show", "active-toolchain-version"],
-            r"",
-            r"",
-        );
-    });
-}
-
 // #846
 #[test]
 fn set_default_host() {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -845,6 +845,60 @@ fn show_toolchain_env_not_installed() {
     });
 }
 
+#[test]
+fn show_active_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok_ex(
+            config,
+            &["rustup", "show", "active-toolchain"],
+            for_host!(
+                r"nightly-{0}
+"
+            ),
+            r"",
+        );
+    });
+}
+
+#[test]
+fn show_active_toolchain_none() {
+    setup(&|config| {
+        expect_ok_ex(
+            config,
+            &["rustup", "show", "active-toolchain"],
+            r"",
+            r"",
+        );
+    });
+}
+
+#[test]
+fn show_active_toolchain_version() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok_ex(
+            config,
+            &["rustup", "show", "active-toolchain-version"],
+            r"1.3.0 (hash-n-2)
+",
+            r"",
+        );
+    });
+}
+
+#[test]
+fn show_active_toolchain_version_none() {
+    setup(&|config| {
+        expect_ok_ex(
+            config,
+            &["rustup", "show", "active-toolchain-version"],
+            r"",
+            r"",
+        );
+    });
+}
+
 // #846
 #[test]
 fn set_default_host() {


### PR DESCRIPTION
This should be useful to shell scripts (via command substitution) and other programs that need this information.

Do note that the new commands currently succeed and print nothing when there is no active tool chain. I'm not sure if that's the proper behavior.

Related: #450