### PR TITLE
Add --path flag to 'rustup doc'

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -361,6 +361,11 @@ pub fn cli() -> App<'static, 'static> {
                 .about("Open the documentation for the current toolchain")
                 .after_help(DOC_HELP)
                 .arg(
+                    Arg::with_name("path")
+                        .long("path")
+                        .help("Only print the path to the documentation"),
+                )
+                .arg(
                     Arg::with_name("book")
                         .long("book")
                         .help("The Rust Programming Language book"),
@@ -929,7 +934,14 @@ fn doc(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
         "index.html"
     };
 
-    Ok(cfg.open_docs_for_dir(&utils::current_dir()?, doc_url)?)
+    let cwd = &utils::current_dir()?;
+    if m.is_present("path") {
+        let doc_path = try!(cfg.doc_path_for_dir(cwd, doc_url));
+        println!("{}", doc_path.display());
+        Ok(())
+    } else {
+        Ok(cfg.open_docs_for_dir(cwd, doc_url)?)
+    }
 }
 
 fn man(cfg: &Cfg, m: &ArgMatches) -> Result<()> {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -7,6 +7,7 @@ extern crate tempdir;
 
 use std::fs;
 use std::env::consts::EXE_SUFFIX;
+use std::path::MAIN_SEPARATOR;
 use std::process;
 use rustup_utils::raw;
 use rustup_mock::clitools::{self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok,
@@ -1401,6 +1402,8 @@ fn docs_with_path() {
         let out = cmd.output().unwrap();
 
         let stdout = String::from_utf8(out.stdout).unwrap();
-        assert!(stdout.contains("share/doc/rust/html"));
+        let path = format!("share{}doc{}rust{}html",
+            MAIN_SEPARATOR, MAIN_SEPARATOR, MAIN_SEPARATOR);
+        assert!(stdout.contains(path.as_str()));
     });
 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1390,3 +1390,17 @@ fn file_override_with_target_info() {
         );
     });
 }
+
+#[test]
+fn docs_with_path() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+
+        let mut cmd = clitools::cmd(config, "rustup", &["doc", "--path"]);
+        clitools::env(config, &mut cmd);
+        let out = cmd.output().unwrap();
+
+        let stdout = String::from_utf8(out.stdout).unwrap();
+        assert!(stdout.contains("share/doc/rust/html"));
+    });
+}


### PR DESCRIPTION
This is a rebase of #1311 originally by @joerivanruth. 

This change will be helpful when used by editor plugins such as [rhysd/rust-doc.vim](https://github.com/rhysd/rust-doc.vim).