### PR TITLE
Don't forget the Windows SDK!

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -177,6 +177,9 @@ tools:
 
     https://aka.ms/buildtools
 
+Please ensure the Windows 10 SDK component is included when installing
+the Visual C++ Build Tools.
+
 Alternately, you can install Visual Studio 2015 or Visual
 Studio 2013 and during install select the "C++ tools":
 


### PR DESCRIPTION
So many people encounter issues with Rust not working because they forgot this crucial bit.