### PR TITLE
add path modification to .bashrc

### DIFF
--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -1175,6 +1175,14 @@ fn get_add_path_methods() -> Vec<PathUpdateMethod> {
         }
     }
 
+    if let Some(bashrc) = utils::home_dir().map(|p| p.join(".bashrc")) {
+        //Update .bashrc if it exists. Not updating .bashrc could cause PATH
+        //to not be loaded correctly on login.
+        if bashrc.exists() {
+            profiles.push(Some(bashrc));
+        }
+    }
+
     let rcfiles = profiles.into_iter().filter_map(|f| f);
     rcfiles.map(PathUpdateMethod::RcFile).collect()
 }
@@ -1305,8 +1313,9 @@ fn get_remove_path_methods() -> Result<Vec<PathUpdateMethod>> {
 
     let profile = utils::home_dir().map(|p| p.join(".profile"));
     let bash_profile = utils::home_dir().map(|p| p.join(".bash_profile"));
+    let bashrc = utils::home_dir().map(|p| p.join(".bashrc"));
 
-    let rcfiles = vec![profile, bash_profile];
+    let rcfiles = vec![profile, bash_profile, bashrc];
     let existing_rcfiles = rcfiles.into_iter().filter_map(|f| f).filter(|f| f.exists());
 
     let export_str = shell_export_string()?;

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -352,6 +352,23 @@ fn install_does_not_add_path_to_bash_profile_that_doesnt_exist() {
 
 #[test]
 #[cfg(unix)]
+fn install_adds_path_to_bashrc() {
+    install_adds_path_to_rc(".bashrc");
+}
+
+#[test]
+#[cfg(unix)]
+fn install_does_not_add_path_to_bashrc_that_doesnt_exist() {
+    setup(&|config| {
+        let ref rc = config.homedir.join(".bashrc");
+        expect_ok(config, &["rustup-init", "-y"]);
+
+        assert!(!rc.exists());
+    });
+}
+
+#[test]
+#[cfg(unix)]
 fn install_with_zsh_adds_path_to_zprofile() {
     setup(&|config| {
         let my_rc = "foo\nbar\nbaz";
@@ -431,6 +448,12 @@ fn uninstall_removes_path_from_profile() {
 #[cfg(unix)]
 fn uninstall_removes_path_from_bash_profile() {
     uninstall_removes_path_from_rc(".bash_profile");
+}
+
+#[test]
+#[cfg(unix)]
+fn uninstall_removes_path_from_bashrc() {
+    uninstall_removes_path_from_rc(".bashrc");
 }
 
 #[test]


### PR DESCRIPTION
Hi all!
I recently installed rust for the first time on my Ubuntu 18.04 machine and noticed that $HOME/.cargo/bin gets added to the .profile and .bash_profile files but not .bashrc. This caused me a little bit of headache figuring out why new terminals couldn't find the cargo command. To fix this I've added .bashrc to the files that get updated with the new PATH when installing rustup. This action will only be performed if the .bashrc file exists and works exactly the same as #1179. 

Thanks for taking a look!
