### PR TITLE
Add '/home' to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea/
 *~
 /**/target
+/home


### PR DESCRIPTION
The README suggests creating this directory for local rustup
development, but anybody who tries to do so will immediately find a
whole lot of files in their git status. This prevents that.