### PR TITLE
Allow using inherited RUSTUP_UPDATE_ROOT variable in rustup-init.sh.

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -15,7 +15,9 @@
 
 set -u
 
-RUSTUP_UPDATE_ROOT="https://static.rust-lang.org/rustup/dist"
+if [ -z "$RUSTUP_UPDATE_ROOT" ]; then
+    RUSTUP_UPDATE_ROOT="https://static.rust-lang.org/rustup"
+fi
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
@@ -60,7 +62,7 @@ main() {
             ;;
     esac
 
-    local _url="$RUSTUP_UPDATE_ROOT/$_arch/rustup-init$_ext"
+    local _url="$RUSTUP_UPDATE_ROOT/dist/$_arch/rustup-init$_ext"
 
     local _dir="$(mktemp -d 2>/dev/null || ensure mktemp -d -t rustup)"
     local _file="$_dir/rustup-init$_ext"


### PR DESCRIPTION
This also makes the usage of the variable consistent with rust version by moving the "/dist" part to usage site.

For people in mainland China, Amazon web hosting and cdn services are inaccessible. Using this patch, we can set the `RUSTUP_UPDATE_ROOT` variable beforehand to ask `rustup-init.sh` to download rustup-init.exe from a mirror site.