### PR TITLE
Fix `utils::copy_file` for symlink.

### DIFF
--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -306,11 +306,7 @@ pub fn copy_file(src: &Path, dest: &Path) -> Result<()> {
         path: PathBuf::from(src),
     })?;
     if metadata.file_type().is_symlink() {
-        let link = fs::read_link(src).chain_err(|| ErrorKind::ReadingFile {
-            name: "link contents for",
-            path: PathBuf::from(src),
-        })?;
-        symlink_file(&link, dest).map(|_| ())
+        symlink_file(&src, dest).map(|_| ())
     } else {
         fs::copy(src, dest)
             .chain_err(|| ErrorKind::CopyingFile {


### PR DESCRIPTION
When `rustup-init` is a symlink, create a symlink to that symlink instead of resolving it first. This is also in line with [using the `no-self-update` feature](https://github.com/Homebrew/homebrew-core/pull/32701), to allow managing the `rustup` version with Homebrew.

Fixes https://github.com/rust-lang-nursery/rustup.rs/issues/1512.