### PR TITLE
Add --path option to 'rustup override set'

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -12,7 +12,7 @@ use std::error::Error;
 use std::fmt;
 use std::io::Write;
 use std::iter;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{self, Command};
 use std::str::FromStr;
 
@@ -351,6 +351,12 @@ pub fn cli() -> App<'static, 'static> {
                             Arg::with_name("toolchain")
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .required(true),
+                        )
+                        .arg(
+                            Arg::with_name("path")
+                                .long("path")
+                                .takes_value(true)
+                                .help("Path to the directory"),
                         ),
                 )
                 .subcommand(
@@ -992,7 +998,12 @@ fn override_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
         None
     };
 
-    toolchain.make_override(&utils::current_dir()?)?;
+    let path = if let Some(path) = m.value_of("path") {
+        PathBuf::from(path)
+    } else {
+        utils::current_dir()?
+    };
+    toolchain.make_override(&path)?;
 
     if let Some(status) = status {
         println!();

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -848,7 +848,7 @@ fn override_set_unset_with_path() {
         expect_ok_ex(
             config,
             &["rustup", "override", "list"],
-            &format!("{}\tnightly-x86_64-unknown-linux-gnu\n", &workdir),
+            &format!("{}\tnightly-{}\n", &workdir, this_host_triple()),
             r"",
         );
         config.change_dir(&config.emptydir, &|| {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -835,6 +835,35 @@ fn show_toolchain_override_not_installed() {
 }
 
 #[test]
+fn override_set_unset_with_path() {
+    setup(&|config| {
+        let workdir = config.current_dir();
+        let workdir = workdir.to_string_lossy();
+        config.change_dir(&config.emptydir, &|| {
+            expect_ok(
+                config,
+                &["rustup", "override", "set", "nightly", "--path", &workdir],
+            );
+        });
+        expect_ok_ex(
+            config,
+            &["rustup", "override", "list"],
+            &format!("{}\tnightly-x86_64-unknown-linux-gnu\n", &workdir),
+            r"",
+        );
+        config.change_dir(&config.emptydir, &|| {
+            expect_ok(config, &["rustup", "override", "unset", "--path", &workdir]);
+        });
+        expect_ok_ex(
+            config,
+            &["rustup", "override", "list"],
+            &"no overrides\n",
+            r"",
+        );
+    });
+}
+
+#[test]
 fn show_toolchain_env() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);


### PR DESCRIPTION
Same as --path in 'rustup override unset'