### PR TITLE
Size optimizations: Build with LTO and alloc_system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,7 @@ test = false # no unit tests
 name = "rustup-init"
 path = "src/rustup-cli/main.rs"
 test = false # no unit tests
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -14,11 +14,6 @@
 
 #![recursion_limit = "1024"]
 
-use std::alloc::System;
-
-#[global_allocator]
-static A: System = System;
-
 #[macro_use]
 extern crate error_chain;
 extern crate rustup_dist;
@@ -60,11 +55,16 @@ mod term2;
 mod errors;
 mod help;
 
+use std::alloc::System;
 use std::env;
 use std::path::PathBuf;
 use errors::*;
 use rustup_dist::dist::TargetTriple;
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
+
+// Always use the system allocator, to reduce binary size.
+#[global_allocator]
+static _ALLOCATOR: System = System;
 
 fn main() {
     if let Err(ref e) = run_rustup() {

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -14,6 +14,11 @@
 
 #![recursion_limit = "1024"]
 
+use std::alloc::System;
+
+#[global_allocator]
+static A: System = System;
+
 #[macro_use]
 extern crate error_chain;
 extern crate rustup_dist;


### PR DESCRIPTION
This reduces the size of the rustup-init binary by 36% (from 11.8 MB to 7.5 MB) when building in release mode on my Linux system with rustc 1.31.0-nightly (2bd5993ca 2018-10-02).

Fixes #982.