### PR TITLE
Add x86_64-unknown-linux-musl build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,12 @@ matrix:
            DOCKER=s390x-unknown-linux-gnu
            SKIP_TESTS=1
       if: branch != master
+    - os: linux
+      env: TARGET=x86_64-unknown-linux-musl
+           DOCKER=x86_64-unknown-linux-musl
+           SKIP_TESTS=1
+      if: branch != master
+
 
     # Android use a local docker image
     - os: linux

--- a/README.md
+++ b/README.md
@@ -610,6 +610,7 @@ platform of your choice:
 - [x86_64-pc-windows-msvc](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)<sup>[†](#vs2015)</sup>
 - [x86_64-unknown-freebsd](https://static.rust-lang.org/rustup/dist/x86_64-unknown-freebsd/rustup-init)
 - [x86_64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init)
+- [x86_64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init)
 - [x86_64-unknown-netbsd](https://static.rust-lang.org/rustup/dist/x86_64-unknown-netbsd/rustup-init)
 
 <a name="vs2015">†</a>

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.8
+FROM ubuntu:16.04
 
-RUN apk update && \
-  apk add \
+RUN apt-get update && apt-get install -y \
+  musl-tools \
   curl \
   ca-certificates \
   perl \
   make \
   gcc
 
-ENV CC_x86_64_unknown_linux_musl=gcc
+ENV CC_x86_64_unknown_linux_musl=musl-gcc

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.8
+
+RUN apk update && \
+  apk add \
+  curl \
+  ca-certificates \
+  perl \
+  make \
+  gcc
+
+ENV CC_x86_64_unknown_linux_musl=gcc


### PR DESCRIPTION
A duplicate of #1517 on a different branch than master, to make Travis actually build the musl variant.

Please ignore.