### PR TITLE
Add link for component availability

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -134,6 +134,8 @@
   <br/>
   <a href="https://github.com/rust-lang/rustup.rs/#other-installation-methods">other installation options</a>
   &nbsp;&middot;&nbsp;
+  <a href="https://rust-lang-nursery.github.io/rust-toolstate/">component availability</a>
+  &nbsp;&middot;&nbsp;
   <a href="https://github.com/rust-lang/rustup.rs">about rustup</a>
 </p>
 


### PR DESCRIPTION
This link is a community-supported history of component availability in nightly releases.
(Generated automatically from each nightly release)

I always forget the link, so probably having it up visible on rustup.rs is a good idea.

wdyt?