### PR TITLE
Improve formatting of longer download times in download tracker

### DIFF
--- a/src/rustup-cli/download_tracker.rs
+++ b/src/rustup-cli/download_tracker.rs
@@ -176,10 +176,25 @@ impl fmt::Display for HumanReadable {
 
             if sec.is_infinite() {
                 write!(f, "Unknown")
-            } else if sec > 1e3 {
+            } else if sec > 48. * 3600. {
                 let sec = self.0 as u64;
-                let min = sec / 60;
-                let sec = sec % 60;
+                let d = sec / (24. * 3600.);
+                let h = sec % (24. * 3600.);
+                let min = sec % 3600.;
+                let sec = sec % 60.;
+
+                write!(f, "{:3} days {:2} h {:2} min {:2} s", d, h, min, sec) // XYZ days PQ h RS min TU s
+            } else if sec > 6_000. {
+                let sec = self.0 as u64;
+                let h = sec / 3600.;
+                let min = sec % 3600.;
+                let sec = sec % 60.;
+
+                write!(f, "{:3} h {:2} min {:2} s", h, min, sec) // XYZ h PQ min RS s
+            } else if sec > 100 {
+                let sec = self.0 as u64;
+                let min = sec / 60.;
+                let sec = sec % 60.;
 
                 write!(f, "{:3} min {:2} s", min, sec) // XYZ min PQ s
             } else {


### PR DESCRIPTION
Someone on twitter complained that on slow connections Rustup gives progress values like `1234 m 56 s`, which is kinda annoying to look at.

I changed it so that past 100 minutes we start counting hours, and past 2 days we start counting days. The days bit may not be necessary.

The cutoff values were taken from wget.