### PR TITLE
Change handling of renames

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -284,7 +284,7 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
 pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
     let mut t = term2::stdout();
     for component in toolchain.list_components()? {
-        if component.component.pkg == "rust-std" {
+        if component.component.name_in_manifest() == "rust-std" {
             let target = component
                 .component
                 .target
@@ -310,7 +310,7 @@ pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
 pub fn list_components(toolchain: &Toolchain) -> Result<()> {
     let mut t = term2::stdout();
     for component in toolchain.list_components()? {
-        let name = component.component.pkg;
+        let name = component.name;
         if component.required {
             let _ = t.attr(term2::Attr::Bold);
             let _ = writeln!(t, "{} (default)", name);

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -310,7 +310,7 @@ pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
 pub fn list_components(toolchain: &Toolchain) -> Result<()> {
     let mut t = term2::stdout();
     for component in toolchain.list_components()? {
-        let name = component.component.name();
+        let name = component.component.pkg;
         if component.required {
             let _ = t.attr(term2::Attr::Bold);
             let _ = writeln!(t, "{} (default)", name);

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -650,7 +650,7 @@ fn show(cfg: &Cfg) -> Result<()> {
             match t.list_components() {
                 Ok(cs_vec) => cs_vec
                     .into_iter()
-                    .filter(|c| c.component.pkg == "rust-std")
+                    .filter(|c| c.component.name_in_manifest() == "rust-std")
                     .filter(|c| c.installed)
                     .collect(),
                 Err(_) => vec![],
@@ -778,10 +778,7 @@ fn target_add(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
     for target in m.values_of("target").expect("") {
-        let new_component = Component {
-            pkg: "rust-std".to_string(),
-            target: Some(TargetTriple::from_str(target)),
-        };
+        let new_component = Component::new("rust-std".to_string(), Some(TargetTriple::from_str(target)));
 
         toolchain.add_component(new_component)?;
     }
@@ -793,10 +790,7 @@ fn target_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
     for target in m.values_of("target").expect("") {
-        let new_component = Component {
-            pkg: "rust-std".to_string(),
-            target: Some(TargetTriple::from_str(target)),
-        };
+        let new_component = Component::new("rust-std".to_string(), Some(TargetTriple::from_str(target)));
 
         toolchain.remove_component(new_component)?;
     }
@@ -823,10 +817,7 @@ fn component_add(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
         });
 
     for component in m.values_of("component").expect("") {
-        let new_component = Component {
-            pkg: component.to_string(),
-            target: target.clone(),
-        };
+        let new_component = Component::new(component.to_string(), target.clone());
 
         toolchain.add_component(new_component)?;
     }
@@ -847,10 +838,7 @@ fn component_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
         });
 
     for component in m.values_of("component").expect("") {
-        let new_component = Component {
-            pkg: component.to_string(),
-            target: target.clone(),
-        };
+        let new_component = Component::new(component.to_string(), target.clone());
 
         toolchain.remove_component(new_component)?;
     }

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -34,6 +34,7 @@ use common::{self, Confirm};
 use errors::*;
 use rustup_dist::dist;
 use rustup_utils::utils;
+use rustup::{TOOLS, DUP_TOOLS};
 use same_file::Handle;
 use std::env;
 use std::env::consts::EXE_SUFFIX;
@@ -191,14 +192,6 @@ If you will be targeting the GNU ABI or otherwise know what you are
 doing then it is fine to continue installation without the build
 tools, but otherwise, install the C++ build tools before proceeding.
 "#;
-
-static TOOLS: &'static [&'static str] =
-    &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls", "cargo-clippy"];
-
-// Tools which are commonly installed by Cargo as well as rustup. We take a bit
-// more care with these to ensure we don't overwrite the user's previous
-// installation.
-static DUP_TOOLS: &'static [&'static str] = &["rustfmt", "cargo-fmt"];
 
 static UPDATE_ROOT: &'static str = "https://static.rust-lang.org/rustup";
 

--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -99,9 +99,9 @@ error_chain! {
             description("unsupported manifest version")
             display("manifest version '{}' is not supported", v)
         }
-        MissingPackageForComponent(c: Component) {
+        MissingPackageForComponent(name: String) {
             description("missing package for component")
-            display("server sent a broken manifest: missing package for component {}", c.name())
+            display("server sent a broken manifest: missing package for component {}", name)
         }
         MissingPackageForRename(name: String) {
             description("missing package for the target of a rename")

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -126,7 +126,7 @@ impl Manifestation {
         }
 
         // Make sure we don't accidentally uninstall the essential components! (see #1297)
-        update.missing_essential_components(&self.target_triple)?;
+        update.missing_essential_components(&self.target_triple, new_manifest)?;
 
         // Validate that the requested components are available
         match update.unavailable_components(new_manifest) {
@@ -142,7 +142,7 @@ impl Manifestation {
         let mut things_downloaded: Vec<String> = Vec::new();
         for (component, format, url, hash) in update.components_urls_and_hashes(new_manifest)? {
             notify_handler(Notification::DownloadingComponent(
-                &component.pkg,
+                &component.short_name(new_manifest),
                 &self.target_triple,
                 component.target.as_ref(),
             ));
@@ -154,13 +154,13 @@ impl Manifestation {
 
             let url_url = utils::parse_url(&url)?;
 
-            let dowloaded_file = download_cfg
+            let downloaded_file = download_cfg
                 .download(&url_url, &hash)
-                .chain_err(|| ErrorKind::ComponentDownloadFailed(component.clone()))?;
+                .chain_err(|| ErrorKind::ComponentDownloadFailed(component.name(new_manifest)))?;
 
             things_downloaded.push(hash);
 
-            things_to_install.push((component, format, dowloaded_file));
+            things_to_install.push((component, format, downloaded_file));
         }
 
         // Begin transaction
@@ -174,7 +174,7 @@ impl Manifestation {
         // Uninstall components
         for component in update.components_to_uninstall {
             notify_handler(Notification::RemovingComponent(
-                &component.pkg,
+                &component.short_name(new_manifest),
                 &self.target_triple,
                 component.target.as_ref(),
             ));
@@ -184,8 +184,15 @@ impl Manifestation {
 
         // Install components
         for (component, format, installer_file) in things_to_install {
+            // For historical reasons, the rust-installer component
+            // names are not the same as the dist manifest component
+            // names. Some are just the component name some are the
+            // component name plus the target triple.
+            let ref name = component.name(new_manifest);
+            let short_name = component.short_name(new_manifest);
+
             notify_handler(Notification::InstallingComponent(
-                &component.pkg,
+                &short_name,
                 &self.target_triple,
                 component.target.as_ref(),
             ));
@@ -203,15 +210,8 @@ impl Manifestation {
                 }
             };
 
-            // For historical reasons, the rust-installer component
-            // names are not the same as the dist manifest component
-            // names. Some are just the component name some are the
-            // component name plus the target triple.
-            let ref name = component.name(new_manifest);
-            let short_name = component.short_name(new_manifest);
-
             // If the package doesn't contain the component that the
-            // manifest says it does the somebody must be playing a joke on us.
+            // manifest says it does then somebody must be playing a joke on us.
             if !package.contains(name, Some(&short_name)) {
                 return Err(ErrorKind::CorruptComponent(short_name).into());
             }
@@ -283,7 +283,7 @@ impl Manifestation {
         // names. Some are just the component name some are the
         // component name plus the target triple.
         let ref name = component.name(manifest);
-        let ref short_name = format!("{}", component.pkg);
+        let ref short_name = component.short_name(manifest);
         if let Some(c) = self.installation.find(&name)? {
             tx = c.uninstall(tx)?;
         } else if let Some(c) = self.installation.find(&short_name)? {
@@ -537,10 +537,7 @@ impl Update {
             if !is_removed {
                 // If there is a rename in the (new) manifest, then we uninstall the component with the
                 // old name and install a component with the new name
-                if new_manifest.renames.contains_key(&existing_component.pkg) {
-                    let mut renamed_component = existing_component.clone();
-                    renamed_component.pkg =
-                        new_manifest.renames[&existing_component.pkg].to_owned();
+                if let Some(renamed_component) = new_manifest.rename_component(&existing_component) {
                     let is_already_included =
                         self.final_component_list.contains(&renamed_component);
                     if !is_already_included {
@@ -563,7 +560,7 @@ impl Update {
                             self.components_to_uninstall
                                 .push(existing_component.clone());
                             notify_handler(Notification::ComponentUnavailable(
-                                &existing_component.pkg,
+                                &existing_component.short_name(new_manifest),
                                 existing_component.target.as_ref(),
                             ));
                         }
@@ -577,24 +574,21 @@ impl Update {
         self.components_to_uninstall.is_empty() && self.components_to_install.is_empty()
     }
 
-    fn missing_essential_components(&self, target_triple: &TargetTriple) -> Result<()> {
+    fn missing_essential_components(&self, target_triple: &TargetTriple, manifest: &Manifest) -> Result<()> {
         let missing_essential_components = ["rustc", "cargo"]
             .iter()
             .filter_map(|pkg| {
-                if self.final_component_list.iter().any(|c| &c.pkg == pkg) {
+                if self.final_component_list.iter().any(|c| &c.name_in_manifest() == pkg) {
                     None
                 } else {
-                    Some(Component {
-                        pkg: pkg.to_string(),
-                        target: Some(target_triple.clone()),
-                    })
+                    Some(Component::new(pkg.to_string(), Some(target_triple.clone())))
                 }
             })
             .collect::<Vec<_>>();
 
         if !missing_essential_components.is_empty() {
             return Err(
-                ErrorKind::RequestedComponentsUnavailable(missing_essential_components).into(),
+                ErrorKind::RequestedComponentsUnavailable(missing_essential_components, manifest.clone()).into(),
             );
         }
 
@@ -606,7 +600,7 @@ impl Update {
             .iter()
             .filter(|c| {
                 use manifest::*;
-                let pkg: Option<&Package> = new_manifest.get_package(&c.pkg).ok();
+                let pkg: Option<&Package> = new_manifest.get_package(&c.name_in_manifest()).ok();
                 let target_pkg: Option<&TargetedPackage> =
                     pkg.and_then(|p| p.get_target(c.target.as_ref()).ok());
                 target_pkg.map(|tp| tp.available()) != Some(true)
@@ -617,7 +611,7 @@ impl Update {
         unavailable_components.extend_from_slice(&self.missing_components);
 
         if !unavailable_components.is_empty() {
-            return Err(ErrorKind::RequestedComponentsUnavailable(unavailable_components).into());
+            return Err(ErrorKind::RequestedComponentsUnavailable(unavailable_components, new_manifest.clone()).into());
         }
 
         Ok(())
@@ -630,7 +624,7 @@ impl Update {
     ) -> Result<Vec<(Component, Format, String, String)>> {
         let mut components_urls_and_hashes = Vec::new();
         for component in &self.components_to_install {
-            let package = new_manifest.get_package(&component.pkg)?;
+            let package = new_manifest.get_package(&component.name_in_manifest())?;
             let target_package = package.get_target(component.target.as_ref())?;
 
             let bins = target_package.bins.as_ref().expect("components available");

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -212,8 +212,8 @@ impl Manifestation {
 
             // If the package doesn't contain the component that the
             // manifest says it does the somebody must be playing a joke on us.
-            if !package.contains(name, Some(short_name)) {
-                return Err(ErrorKind::CorruptComponent(component.pkg.clone()).into());
+            if !package.contains(name, Some(&short_name)) {
+                return Err(ErrorKind::CorruptComponent(short_name).into());
             }
 
             tx = package.install(&self.installation, name, Some(short_name), tx)?;

--- a/src/rustup-dist/src/notifications.rs
+++ b/src/rustup-dist/src/notifications.rs
@@ -3,7 +3,6 @@ use std::fmt::{self, Display};
 use temp;
 use rustup_utils;
 use rustup_utils::notify::NotificationLevel;
-use manifest::Component;
 use dist::TargetTriple;
 use errors::*;
 
@@ -13,7 +12,7 @@ pub enum Notification<'a> {
     Temp(temp::Notification<'a>),
 
     Extracting(&'a Path, &'a Path),
-    ComponentAlreadyInstalled(&'a Component),
+    ComponentAlreadyInstalled(&'a str),
     CantReadUpdateHash(&'a Path),
     NoUpdateHash(&'a Path),
     ChecksumValid(&'a str),
@@ -21,7 +20,7 @@ pub enum Notification<'a> {
     FileAlreadyDownloaded,
     CachedFileChecksumFailed,
     RollingBack,
-    ExtensionNotInstalled(&'a Component),
+    ExtensionNotInstalled(&'a str),
     NonFatalError(&'a Error),
     MissingInstalledComponent(&'a str),
     DownloadingComponent(&'a str, &'a TargetTriple, Option<&'a TargetTriple>),
@@ -84,7 +83,7 @@ impl<'a> Display for Notification<'a> {
             Utils(ref n) => n.fmt(f),
             Extracting(_, _) => write!(f, "extracting..."),
             ComponentAlreadyInstalled(ref c) => {
-                write!(f, "component {} is up to date", c.description())
+                write!(f, "component {} is up to date", c)
             }
             CantReadUpdateHash(path) => write!(
                 f,
@@ -97,7 +96,7 @@ impl<'a> Display for Notification<'a> {
             FileAlreadyDownloaded => write!(f, "reusing previously downloaded file"),
             CachedFileChecksumFailed => write!(f, "bad checksum for cached download"),
             RollingBack => write!(f, "rolling back changes"),
-            ExtensionNotInstalled(c) => write!(f, "extension '{}' was not installed", c.name()),
+            ExtensionNotInstalled(c) => write!(f, "extension '{}' was not installed", c),
             NonFatalError(e) => write!(f, "{}", e),
             MissingInstalledComponent(c) => {
                 write!(f, "during uninstall component {} was not found", c)

--- a/src/rustup-dist/tests/manifest.rs
+++ b/src/rustup-dist/tests/manifest.rs
@@ -33,11 +33,11 @@ fn parse_smoke_test() {
     assert_eq!(rust_target_pkg.bins.clone().unwrap().hash, "...");
 
     let ref component = rust_target_pkg.components[0];
-    assert_eq!(component.pkg, "rustc");
+    assert_eq!(component.name_in_manifest(), "rustc");
     assert_eq!(component.target.as_ref(), Some(&x86_64_unknown_linux_gnu));
 
     let ref component = rust_target_pkg.extensions[0];
-    assert_eq!(component.pkg, "rust-std");
+    assert_eq!(component.name_in_manifest(), "rust-std");
     assert_eq!(component.target.as_ref(), Some(&x86_64_unknown_linux_musl));
 
     let docs_pkg = pkg.get_package("rust-docs").unwrap();

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -485,11 +485,11 @@ fn build_mock_channel(
     ];
 
     if rename_rls {
+        let rls = build_mock_rls_installer(version, version_hash, true);
+        all.push(("rls-preview", vec![(rls, host_triple.clone())]));
+    } else {
         let rls = build_mock_rls_installer(version, version_hash, false);
         all.push(("rls", vec![(rls, host_triple.clone())]));
-    } else {
-        let rls_preview = build_mock_rls_installer(version, version_hash, true);
-        all.push(("rls-preview", vec![(rls_preview, host_triple.clone())]));
     }
 
     let more = vec![
@@ -526,11 +526,11 @@ fn build_mock_channel(
         all.extend(more);
 
         if rename_rls {
+            let rls = build_mock_rls_installer(version, version_hash, true);
+            all.push(("rls-preview", vec![(rls, triple.clone())]));
+        } else {
             let rls = build_mock_rls_installer(version, version_hash, false);
             all.push(("rls", vec![(rls, triple.clone())]));
-        } else {
-            let rls_preview = build_mock_rls_installer(version, version_hash, true);
-            all.push(("rls-preview", vec![(rls_preview, triple.clone())]));
         }
 
         let more = vec![
@@ -584,12 +584,12 @@ fn build_mock_channel(
             });
             if rename_rls {
                 target_pkg.extensions.push(MockComponent {
-                    name: "rls".to_string(),
+                    name: "rls-preview".to_string(),
                     target: target.to_string(),
                 });
             } else {
                 target_pkg.extensions.push(MockComponent {
-                    name: "rls-preview".to_string(),
+                    name: "rls".to_string(),
                     target: target.to_string(),
                 });
             }
@@ -614,7 +614,7 @@ fn build_mock_channel(
 
     let mut renames = HashMap::new();
     if rename_rls {
-        renames.insert("rls-preview".to_owned(), "rls".to_owned());
+        renames.insert("rls".to_owned(), "rls-preview".to_owned());
     }
 
     MockChannel {
@@ -634,7 +634,7 @@ fn build_mock_unavailable_channel(channel: &str, date: &str, version: &'static s
         "rust-docs",
         "rust-std",
         "rustc",
-        "rls-preview",
+        "rls",
         "rust-analysis",
     ];
     let packages = packages
@@ -764,13 +764,12 @@ fn build_mock_cargo_installer(version: &str, version_hash: &str) -> MockInstalle
 fn build_mock_rls_installer(
     version: &str,
     version_hash: &str,
-    preview: bool,
+    _preview: bool,
 ) -> MockInstallerBuilder {
-    let name = if preview { "rls-preview" } else { "rls" };
     MockInstallerBuilder {
         components: vec![
             MockComponentBuilder {
-                name: name.to_string(),
+                name: "rls".to_string(),
                 files: mock_bin("rls", version, version_hash),
             },
         ],

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -1,5 +1,6 @@
 use rustup_dist::{self, temp};
 use rustup_utils;
+use component_for_bin;
 use toml;
 
 error_chain! {
@@ -27,7 +28,7 @@ error_chain! {
         }
         BinaryNotFound(t: String, bin: String) {
             description("toolchain does not contain binary")
-            display("toolchain '{}' does not have the binary `{}`", t, bin)
+            display("'{}' is not installed for the toolchain '{}'{}", bin, t, install_msg(bin))
         }
         NeedMetadataUpgrade {
             description("rustup's metadata is out of date. run `rustup self upgrade-data`")
@@ -69,5 +70,12 @@ error_chain! {
         TelemetryAnalysisError {
             description("error analyzing telemetry files")
         }
+    }
+}
+
+fn install_msg(bin: &str) -> String {
+    match component_for_bin(bin) {
+        Some(c) => format!("\nTo install, run `rustup component add {}`", c),
+        None => String::new(),
     }
 }

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -1,6 +1,5 @@
 use rustup_dist::{self, temp};
 use rustup_utils;
-use rustup_dist::manifest::Component;
 use toml;
 
 error_chain! {
@@ -44,22 +43,22 @@ error_chain! {
             description("toolchain does not support components")
             display("toolchain '{}' does not support components", t)
         }
-        UnknownComponent(t: String, c: Component) {
+        UnknownComponent(t: String, c: String) {
             description("toolchain does not contain component")
-            display("toolchain '{}' does not contain component {}", t, c.description())
+            display("toolchain '{}' does not contain component {}", t, c)
         }
-        AddingRequiredComponent(t: String, c: Component) {
+        AddingRequiredComponent(t: String, c: String) {
             description("required component cannot be added")
             display("component {} was automatically added because it is required for toolchain '{}'",
-                    c.description(), t)
+                    c, t)
         }
         ParsingSettings(e: toml::de::Error) {
             description("error parsing settings")
         }
-        RemovingRequiredComponent(t: String, c: Component) {
+        RemovingRequiredComponent(t: String, c: String) {
             description("required component cannot be removed")
             display("component {} is required for toolchain '{}' and cannot be removed",
-                    c.description(), t)
+                    c, t)
         }
         NoExeName {
             description("couldn't determine self executable name")

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -22,6 +22,29 @@ pub use config::*;
 pub use toolchain::*;
 pub use rustup_utils::{notify, toml_utils, utils};
 
+
+// A list of all binaries which Rustup will proxy.
+pub static TOOLS: &'static [&'static str] =
+    &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls", "cargo-clippy"];
+
+// Tools which are commonly installed by Cargo as well as rustup. We take a bit
+// more care with these to ensure we don't overwrite the user's previous
+// installation.
+pub static DUP_TOOLS: &'static [&'static str] = &["rustfmt", "cargo-fmt"];
+
+fn component_for_bin(binary: &str) -> Option<&'static str> {
+    match binary {
+        "rustc" | "rustdoc" => Some("rustc"),
+        "cargo" => Some("cargo"),
+        "rust-lldb" => Some("lldb-preview"),
+        "rust-gdb" => Some("gdb-preview"),
+        "rls" => Some("rls"),
+        "cargo-clippy" => Some("clippy"),
+        "rustfmt" | "cargo-fmt" => Some("rustfmt"),
+        _ => None,
+    }
+}
+
 mod errors;
 mod notifications;
 mod toolchain;

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -617,6 +617,11 @@ impl<'a> Toolchain<'a> {
         let manifestation = Manifestation::open(prefix, toolchain.target.clone())?;
 
         if let Some(manifest) = manifestation.load_manifest()? {
+            // Rename the component if necessary.
+            if let Some(to) = manifest.renames.get(&component.pkg) {
+                component.pkg = to.to_owned();
+            }
+
             // Validate the component name
             let rust_pkg = manifest
                 .packages
@@ -679,6 +684,11 @@ impl<'a> Toolchain<'a> {
         let manifestation = Manifestation::open(prefix, toolchain.target.clone())?;
 
         if let Some(manifest) = manifestation.load_manifest()? {
+            // Rename the component if necessary.
+            if let Some(to) = manifest.renames.get(&component.pkg) {
+                component.pkg = to.to_owned();
+            }
+
             // Validate the component name
             let rust_pkg = manifest
                 .packages

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -521,10 +521,18 @@ impl<'a> Toolchain<'a> {
                     .get(&toolchain.target)
                     .expect("component should have target toolchain");
 
+                let mut component = component.clone();
+                // Rename components to the 'old' name. This may seem wrong, but
+                // it is a hack to name -preview versions of components back to
+                // their unsuffixed names.
+                if let Some(from) = manifest.reverse_renames.get(&component.pkg) {
+                    component.pkg = from.to_owned();
+                }
+
                 res.push(ComponentStatus {
-                    component: component.clone(),
+                    component,
                     required: true,
-                    installed: installed,
+                    installed,
                     available: component_target_pkg.available(),
                 });
             }
@@ -545,10 +553,15 @@ impl<'a> Toolchain<'a> {
                     .get(&toolchain.target)
                     .expect("extension should have target toolchain");
 
+                let mut component = extension.clone();
+                if let Some(from) = manifest.reverse_renames.get(&component.pkg) {
+                    component.pkg = from.to_owned();
+                }
+
                 res.push(ComponentStatus {
-                    component: extension.clone(),
+                    component,
                     required: false,
-                    installed: installed,
+                    installed,
                     available: extension_target_pkg.available(),
                 });
             }

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -647,7 +647,10 @@ impl<'a> Toolchain<'a> {
 
             if targ_pkg.components.contains(&component) {
                 return Err(
-                    ErrorKind::AddingRequiredComponent(self.name.to_string(), component).into(),
+                    ErrorKind::AddingRequiredComponent(
+                        self.name.to_string(),
+                        component.description(&manifest),
+                    ).into(),
                 );
             }
 
@@ -660,7 +663,10 @@ impl<'a> Toolchain<'a> {
                     component = wildcard_component;
                 } else {
                     return Err(
-                        ErrorKind::UnknownComponent(self.name.to_string(), component).into(),
+                        ErrorKind::UnknownComponent(
+                            self.name.to_string(),
+                            component.description(&manifest),
+                        ).into(),
                     );
                 }
             }
@@ -714,7 +720,10 @@ impl<'a> Toolchain<'a> {
 
             if targ_pkg.components.contains(&component) {
                 return Err(
-                    ErrorKind::RemovingRequiredComponent(self.name.to_string(), component).into(),
+                    ErrorKind::RemovingRequiredComponent(
+                        self.name.to_string(),
+                        component.description(&manifest),
+                    ).into(),
                 );
             }
 
@@ -728,7 +737,10 @@ impl<'a> Toolchain<'a> {
                     component = wildcard_component;
                 } else {
                     return Err(
-                        ErrorKind::UnknownComponent(self.name.to_string(), component).into(),
+                        ErrorKind::UnknownComponent(
+                            self.name.to_string(),
+                            component.description(&manifest),
+                        ).into(),
                     );
                 }
             }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -377,7 +377,7 @@ fn rustup_failed_path_search() {
             config,
             broken,
             &format!(
-                "toolchain 'custom' does not have the binary `fake_proxy{}`",
+                "'fake_proxy{}' is not installed for the toolchain 'custom'",
                 EXE_SUFFIX
             ),
         );
@@ -550,9 +550,9 @@ fn rls_does_not_exist_in_toolchain() {
             config,
             &["rls", "--version"],
             &format!(
-                "toolchain 'stable-{}' does not have the binary `rls{}`",
+                "'rls{}' is not installed for the toolchain 'stable-{}'",
+                EXE_SUFFIX,
                 this_host_triple(),
-                EXE_SUFFIX
             ),
         );
     });
@@ -659,12 +659,12 @@ fn rename_rls_remove() {
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
         expect_ok(config, &["rustup", "component", "remove", "rls"]);
-        expect_err(config, &["rls", "--version"], "does not have the binary `rls`");
+        expect_err(config, &["rls", "--version"], "'rls' is not installed");
 
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
         expect_ok(config, &["rustup", "component", "remove", "rls-preview"]);
-        expect_err(config, &["rls", "--version"], "does not have the binary `rls`");
+        expect_err(config, &["rls", "--version"], "'rls' is not installed");
     });
 }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -533,7 +533,7 @@ fn telemetry_cleanup_removes_old_files() {
 fn rls_exists_in_toolchain() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
         expect_ok(config, &["rls", "--version"]);
@@ -563,7 +563,7 @@ fn rename_rls_before() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "--no-self-update"]);
@@ -581,7 +581,7 @@ fn rename_rls_after() {
 
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "--no-self-update"]);
-        expect_ok(config, &["rustup", "component", "add", "rls"]);
+        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
 
         assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
         expect_ok(config, &["rls", "--version"]);

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -589,6 +589,86 @@ fn rename_rls_after() {
 }
 
 #[test]
+fn rename_rls_add_old_name() {
+    clitools::setup(Scenario::ArchivesV2, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        set_current_dist_date(config, "2015-01-02");
+        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+
+        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        expect_ok(config, &["rls", "--version"]);
+    });
+}
+
+#[test]
+fn rename_rls_list() {
+    clitools::setup(Scenario::ArchivesV2, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        set_current_dist_date(config, "2015-01-02");
+        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+
+        let out = run(
+            config,
+            "rustup",
+            &["component", "list"],
+            &[],
+        );
+        assert!(out.ok);
+        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple()))
+        );
+    });
+}
+
+#[test]
+fn rename_rls_preview_list() {
+    clitools::setup(Scenario::ArchivesV2, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        set_current_dist_date(config, "2015-01-02");
+        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
+
+        let out = run(
+            config,
+            "rustup",
+            &["component", "list"],
+            &[],
+        );
+        assert!(out.ok);
+        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple()))
+        );
+    });
+}
+
+#[test]
+fn rename_rls_remove() {
+    clitools::setup(Scenario::ArchivesV2, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        set_current_dist_date(config, "2015-01-02");
+        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+        expect_ok(config, &["rls", "--version"]);
+        expect_ok(config, &["rustup", "component", "remove", "rls"]);
+        expect_err(config, &["rls", "--version"], "does not have the binary `rls`");
+
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+        expect_ok(config, &["rls", "--version"]);
+        expect_ok(config, &["rustup", "component", "remove", "rls-preview"]);
+        expect_err(config, &["rls", "--version"], "does not have the binary `rls`");
+    });
+}
+
+#[test]
 fn install_stops_if_rustc_exists() {
     let temp_dir = TempDir::new("fakebin").unwrap();
     // Create fake executable

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -1306,9 +1306,9 @@ fn rls_proxy_set_up_after_install() {
             config,
             &["rls", "--version"],
             &format!(
-                "toolchain 'stable-{}' does not have the binary `rls{}`",
+                "'rls{}' is not installed for the toolchain 'stable-{}'",
+                EXE_SUFFIX,
                 this_host_triple(),
-                EXE_SUFFIX
             ),
         );
         expect_ok(config, &["rustup", "component", "add", "rls"]);

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -1311,7 +1311,7 @@ fn rls_proxy_set_up_after_install() {
                 EXE_SUFFIX
             ),
         );
-        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -827,7 +827,7 @@ fn update_unavailable_std() {
             config,
             &["rustup", "update", "nightly"],
             &format!(
-                "component 'rust-std' for '{}' is unavailable for download",
+                "component 'rust-std' for target '{}' is unavailable for download",
                 trip
             ),
         );


### PR DESCRIPTION
This PR makes handling of renamed components more flexible by allowing components to be added or removed based on either the 'before' or 'after' names. We always use the 'before' name when communicating with the user, but use the 'after' name internally (basically just in the manifest).

This is a backwards-compatible stop-gap. It means that for the edition we can talk about 'rls' rather than 'rls-preview'. (Assuming renames are from 'rls' to 'rls-preview', which is the current situation in the manifest).

The final commit adds an instruction for adding missing components to rustup's proxies.

Since Rustup is not distributed with Rust, this does not need to be part of the edition, timing-wise. However, it would be good to have this in the wild and tested somewhat so that new users will get the benefits when the edition is released.

r? @alexcrichton 

