### PR TITLE
Use `renames` instead of `rename` to match the actual manifest

### DIFF
--- a/src/rustup-dist/src/manifest.rs
+++ b/src/rustup-dist/src/manifest.rs
@@ -98,7 +98,7 @@ impl Manifest {
         );
 
         let renames = Self::renames_to_table(self.renames);
-        result.insert("rename".to_owned(), toml::Value::Table(renames));
+        result.insert("renames".to_owned(), toml::Value::Table(renames));
 
         let packages = Self::packages_to_table(self.packages);
         result.insert("pkg".to_owned(), toml::Value::Table(packages));
@@ -135,9 +135,9 @@ impl Manifest {
     ) -> Result<(HashMap<String, String>, HashMap<String, String>)> {
         let mut renames = HashMap::new();
         let mut reverse_renames = HashMap::new();
-        let rename_table = get_table(table, "rename", path)?;
+        let renames_table = get_table(table, "renames", path)?;
 
-        for (k, v) in rename_table {
+        for (k, v) in renames_table {
             if let toml::Value::Table(mut t) = v {
                 let to = get_string(&mut t, "to", path)?;
                 renames.insert(k.to_owned(), to.clone());

--- a/src/rustup-dist/tests/channel-rust-nightly-example2.toml
+++ b/src/rustup-dist/tests/channel-rust-nightly-example2.toml
@@ -1,7 +1,7 @@
 manifest-version = "2"
 date = "2016-03-04"
 
-[rename.cargo-old]
+[renames.cargo-old]
 to = "cargo"
 
 [pkg.cargo]

--- a/src/rustup-dist/tests/manifest.rs
+++ b/src/rustup-dist/tests/manifest.rs
@@ -48,6 +48,15 @@ fn parse_smoke_test() {
 }
 
 #[test]
+fn renames() {
+    let manifest = Manifest::parse(EXAMPLE2).unwrap();
+    assert_eq!(1, manifest.renames.len());
+    assert_eq!(manifest.renames["cargo-old"], "cargo");
+    assert_eq!(1, manifest.reverse_renames.len());
+    assert_eq!(manifest.reverse_renames["cargo"], "cargo-old");
+}
+
+#[test]
 fn parse_round_trip() {
     let original = Manifest::parse(EXAMPLE).unwrap();
     let serialized = original.clone().stringify();

--- a/src/rustup-mock/src/dist.rs
+++ b/src/rustup-mock/src/dist.rs
@@ -401,7 +401,7 @@ impl MockDistServer {
             toml_rename.insert(String::from("to"), toml::Value::String(to.to_owned()));
             toml_renames.insert(from.to_owned(), toml::Value::Table(toml_rename));
         }
-        toml_manifest.insert(String::from("rename"), toml::Value::Table(toml_renames));
+        toml_manifest.insert(String::from("renames"), toml::Value::Table(toml_renames));
 
         let manifest_name = format!("dist/channel-rust-{}", channel.name);
         let ref manifest_path = self.path.join(format!("{}.toml", manifest_name));

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -620,8 +620,7 @@ fn rename_rls_list() {
             &[],
         );
         assert!(out.ok);
-        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple()))
-        );
+        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple())));
     });
 }
 
@@ -642,8 +641,7 @@ fn rename_rls_preview_list() {
             &[],
         );
         assert!(out.ok);
-        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple()))
-        );
+        assert!(out.stdout.contains(&format!("rls-{}", this_host_triple())));
     });
 }
 


### PR DESCRIPTION
Kind of worrying this didn't make any difference for a year. It would explain at least why renames had some unexpected behaviour which was not picked up by the tests, renames IRL have always been ignored.

r? @alexcrichton 