### PR TITLE
More tweeks to renames

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -284,7 +284,7 @@ pub fn rustc_version(toolchain: &Toolchain) -> String {
 pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
     let mut t = term2::stdout();
     for component in toolchain.list_components()? {
-        if component.component.name_in_manifest() == "rust-std" {
+        if component.component.short_name_in_manifest() == "rust-std" {
             let target = component
                 .component
                 .target

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -650,7 +650,7 @@ fn show(cfg: &Cfg) -> Result<()> {
             match t.list_components() {
                 Ok(cs_vec) => cs_vec
                     .into_iter()
-                    .filter(|c| c.component.name_in_manifest() == "rust-std")
+                    .filter(|c| c.component.short_name_in_manifest() == "rust-std")
                     .filter(|c| c.installed)
                     .collect(),
                 Err(_) => vec![],

--- a/src/rustup-dist/src/manifest.rs
+++ b/src/rustup-dist/src/manifest.rs
@@ -432,7 +432,15 @@ impl Component {
             format!("'{}'", pkg)
         }
     }
-    pub fn name_in_manifest(&self) -> &String {
+    pub fn short_name_in_manifest(&self) -> &String {
         &self.pkg
+    }
+    pub fn name_in_manifest(&self) -> String {
+        let pkg = self.short_name_in_manifest();
+        if let Some(ref t) = self.target {
+            format!("{}-{}", pkg, t)
+        } else {
+            format!("{}", pkg)
+        }
     }
 }

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -233,7 +233,7 @@ fn bonus_component(name: &'static str, contents: Arc<Vec<u8>>) -> MockPackage {
                 installer: MockInstallerBuilder {
                     components: vec![
                         MockComponentBuilder {
-                            name: "bonus-x86_64-apple-darwin".to_owned(),
+                            name: format!("{}-x86_64-apple-darwin", name),
                             files: vec![MockFile::new_arc("bin/bonus", contents)],
                         },
                     ],

--- a/src/rustup-dist/tests/manifest.rs
+++ b/src/rustup-dist/tests/manifest.rs
@@ -33,11 +33,11 @@ fn parse_smoke_test() {
     assert_eq!(rust_target_pkg.bins.clone().unwrap().hash, "...");
 
     let ref component = rust_target_pkg.components[0];
-    assert_eq!(component.name_in_manifest(), "rustc");
+    assert_eq!(component.short_name_in_manifest(), "rustc");
     assert_eq!(component.target.as_ref(), Some(&x86_64_unknown_linux_gnu));
 
     let ref component = rust_target_pkg.extensions[0];
-    assert_eq!(component.name_in_manifest(), "rust-std");
+    assert_eq!(component.short_name_in_manifest(), "rust-std");
     assert_eq!(component.target.as_ref(), Some(&x86_64_unknown_linux_musl));
 
     let docs_pkg = pkg.get_package("rust-docs").unwrap();

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -764,12 +764,16 @@ fn build_mock_cargo_installer(version: &str, version_hash: &str) -> MockInstalle
 fn build_mock_rls_installer(
     version: &str,
     version_hash: &str,
-    _preview: bool,
+    preview: bool,
 ) -> MockInstallerBuilder {
     MockInstallerBuilder {
         components: vec![
             MockComponentBuilder {
-                name: "rls".to_string(),
+                name: if preview {
+                    "rls-preview".to_string()
+                } else {
+                    "rls".to_string()
+                },
                 files: mock_bin("rls", version, version_hash),
             },
         ],

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -513,7 +513,7 @@ impl<'a> Toolchain<'a> {
                     .unwrap_or(false);
 
                 // Get the component so we can check if it is available
-                let component_pkg = manifest.get_package(&component.name_in_manifest()).expect(&format!(
+                let component_pkg = manifest.get_package(&component.short_name_in_manifest()).expect(&format!(
                     "manifest should contain component {}",
                     &component.short_name(&manifest)
                 ));
@@ -538,7 +538,7 @@ impl<'a> Toolchain<'a> {
                     .unwrap_or(false);
 
                 // Get the component so we can check if it is available
-                let extension_pkg = manifest.get_package(&extension.name_in_manifest()).expect(&format!(
+                let extension_pkg = manifest.get_package(&extension.short_name_in_manifest()).expect(&format!(
                     "manifest should contain extension {}",
                     &extension.short_name(&manifest)
                 ));


### PR DESCRIPTION
r? @alexcrichton 

This is mostly undoing some of the changes from previous PRs (with some renames). I had mistakenly made the tests unlike the actual packages downloaded, then made the code correct for the tests not real life. The actual meaningful change here is in src/rustup-dist/src/manifestation.rs, where we use the name of the component in the manifest to refer the name of a component in a package (where it matches the manifest, not the user-visible name).