### PR TITLE
Deal cleanly with malformed default-host

### DIFF
--- a/src/rustup-cli/log.rs
+++ b/src/rustup-cli/log.rs
@@ -16,6 +16,10 @@ macro_rules! verbose {
     ( $ ( $ arg : tt ) * ) => ( $crate::log::verbose_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
+macro_rules! debug {
+    ( $ ( $ arg : tt ) * ) => ( $crate::log::debug_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+}
+
 pub fn warn_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_YELLOW);
@@ -53,4 +57,16 @@ pub fn verbose_fmt(args: fmt::Arguments) {
     let _ = t.reset();
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
+}
+
+pub fn debug_fmt(args: fmt::Arguments) {
+    if std::env::var("RUSTUP_DEBUG").is_ok() {
+        let mut t = term2::stderr();
+        let _ = t.fg(term2::color::BRIGHT_BLUE);
+        let _ = t.attr(term2::Attr::Bold);
+        let _ = write!(t, "verbose: ");
+        let _ = t.reset();
+        let _ = t.write_fmt(args);
+        let _ = write!(t, "\n");
+    }
 }

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -454,7 +454,7 @@ fn do_pre_install_sanity_checks() -> Result<()> {
             "delete `{}` to remove rustup.sh",
             rustup_sh_path.expect("").display()
         );
-        warn!("or, if you already rustup installed, you can run");
+        warn!("or, if you already have rustup installed, you can run");
         warn!("`rustup self update` and `rustup toolchain list` to upgrade");
         warn!("your directory structure");
         return Err("cannot install while rustup.sh is installed".into());

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -468,7 +468,12 @@ fn do_pre_install_options_sanity_checks(opts: &InstallOpts) -> Result<()> {
     // Verify that the installation options are vaguely sane
     (|| {
         let host_triple = dist::TargetTriple::from_str(&opts.default_host_triple);
-        let partial_channel = dist::PartialToolchainDesc::from_str(&opts.default_toolchain)?;
+        let toolchain_to_use = if opts.default_toolchain == "none" {
+            "stable"
+        } else {
+            &opts.default_toolchain
+        };
+        let partial_channel = dist::PartialToolchainDesc::from_str(toolchain_to_use)?;
         let resolved = partial_channel.resolve(&host_triple)?.to_string();
         debug!(
             "Successfully resolved installation toolchain as: {}",

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -478,9 +478,11 @@ impl Cfg {
     }
 
     pub fn set_default_host_triple(&self, host_triple: &str) -> Result<()> {
-        if dist::PartialTargetTriple::from_str(host_triple).is_none() {
-            return Err("Invalid host triple".into());
-        }
+        // Ensure that the provided host_triple is capable of resolving
+        // against the 'stable' toolchain.  This provides early errors
+        // if the supplied triple is insufficient / bad.
+        dist::PartialToolchainDesc::from_str("stable")?
+            .resolve(&dist::TargetTriple::from_str(host_triple))?;
         self.settings_file.with_mut(|s| {
             s.default_host_triple = Some(host_triple.to_owned());
             Ok(())

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -493,7 +493,7 @@ impl Cfg {
     pub fn resolve_toolchain(&self, name: &str) -> Result<String> {
         if let Ok(desc) = dist::PartialToolchainDesc::from_str(name) {
             let host = self.get_default_host_triple()?;
-            Ok(desc.resolve(&host).to_string())
+            Ok(desc.resolve(&host)?.to_string())
         } else {
             Ok(name.to_owned())
         }

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -99,7 +99,7 @@ impl Cfg {
         );
         let dist_root = dist_root_server.clone() + "/dist";
 
-        Ok(Cfg {
+        let cfg = Cfg {
             rustup_dir: rustup_dir,
             settings_file: settings_file,
             toolchains_dir: toolchains_dir,
@@ -111,7 +111,15 @@ impl Cfg {
             env_override: env_override,
             dist_root_url: dist_root,
             dist_root_server: dist_root_server,
-        })
+        };
+
+        // Run some basic checks against the constructed configuration
+        // For now, that means simply checking that 'stable' can resolve
+        // for the current configuration.
+        cfg.resolve_toolchain("stable")
+            .map_err(|e| format!("Unable parse configuration: {}", e))?;
+
+        Ok(cfg)
     }
 
     pub fn set_default(&self, toolchain: &str) -> Result<()> {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -900,7 +900,19 @@ fn set_default_host_invalid_triple() {
         expect_err(
             config,
             &["rustup", "set", "default-host", "foo"],
-            "Invalid host triple",
+            "error: Provided host 'foo' couldn't be converted to partial triple",
+        );
+    });
+}
+
+// #745
+#[test]
+fn set_default_host_invalid_triple_valid_partial() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "set", "default-host", "x86_64-msvc"],
+            "error: Provided host 'x86_64-msvc' did not specify an operating system",
         );
     });
 }


### PR DESCRIPTION
It is better to report errors cleanly rather than panic.  If the
default-host is set badly then we can end up panicking because
we're unable to parse it.  Since default-host is user input, it's
better we don't panic.

This PR will, when complete, add in some appropriate checks for default-host
and hopefully lead the user to resolution of the problem resulting in fixing #745

So far, all I've done is to change the `.expect()` into `.ok_or()` and propagate the `Result<...>`
properly.  This removes the panic but means that we get some very odd reports from things
like `rustup show`, hence the plan to add some proper earlier checks which can report errors more usefully.

If this approach seems sane, I'd appreciate any pointers possible on where to add appropriate checks, and in addition, where to add appropriate tests.