### PR TITLE
Run basic 2018 edition fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "rustup"
 version = "1.16.0"
+edition = "2018"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Manage multiple rust installations with ease"
 

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "download"
 version = "0.4.0"
+edition = "2018"
 authors = [ "Brian Anderson <banderson@mozilla.com>" ]
 
 license = "MIT/Apache-2.0"

--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -14,7 +14,7 @@ use url::Url;
 use std::path::Path;
 
 mod errors;
-pub use errors::*;
+pub use crate::errors::*;
 
 #[derive(Debug, Copy, Clone)]
 pub enum Backend {
@@ -136,7 +136,7 @@ pub mod curl {
     extern crate curl;
 
     use self::curl::easy::Easy;
-    use errors::*;
+    use crate::errors::*;
     use std::cell::RefCell;
     use std::str;
     use std::time::Duration;
@@ -256,7 +256,7 @@ pub mod reqwest_be {
 
     use std::io;
     use std::time::Duration;
-    use errors::*;
+    use crate::errors::*;
     use url::Url;
     use super::Event;
     use reqwest::{header, Client, Proxy, Response};

--- a/src/download/tests/download-curl-resume.rs
+++ b/src/download/tests/download-curl-resume.rs
@@ -10,7 +10,7 @@ use url::Url;
 use download::*;
 
 mod support;
-use support::{file_contents, serve_file, tmp_dir, write_file};
+use crate::support::{file_contents, serve_file, tmp_dir, write_file};
 
 #[test]
 fn partially_downloaded_file_gets_resumed_from_byte_offset() {

--- a/src/download/tests/download-reqwest-resume.rs
+++ b/src/download/tests/download-reqwest-resume.rs
@@ -10,7 +10,7 @@ use url::Url;
 use download::*;
 
 mod support;
-use support::{file_contents, serve_file, tmp_dir, write_file};
+use crate::support::{file_contents, serve_file, tmp_dir, write_file};
 
 #[test]
 fn resume_partial_from_file_url() {

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -2,10 +2,10 @@
 
 use rustup::{self, Cfg, Notification, Toolchain, UpdateStatus};
 use rustup::telemetry_analysis::TelemetryAnalysis;
-use errors::*;
+use crate::errors::*;
 use rustup_utils::utils;
 use rustup_utils::notify::NotificationLevel;
-use self_update;
+use crate::self_update;
 use std::io::{BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use std::path::Path;
@@ -13,7 +13,7 @@ use std::{cmp, iter};
 use std::sync::Arc;
 use std::time::Duration;
 use std;
-use term2;
+use crate::term2;
 use wait_timeout::ChildExt;
 
 pub fn confirm(question: &str, default: bool) -> Result<bool> {
@@ -104,7 +104,7 @@ pub fn read_line() -> Result<String> {
 }
 
 pub fn set_globals(verbose: bool) -> Result<Cfg> {
-    use download_tracker::DownloadTracker;
+    use crate::download_tracker::DownloadTracker;
     use std::cell::RefCell;
 
     let download_tracker = RefCell::new(DownloadTracker::new());

--- a/src/rustup-cli/log.rs
+++ b/src/rustup-cli/log.rs
@@ -1,4 +1,4 @@
-use term2;
+use crate::term2;
 use std::fmt;
 use std::io::Write;
 

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -58,7 +58,7 @@ mod help;
 use std::alloc::System;
 use std::env;
 use std::path::PathBuf;
-use errors::*;
+use crate::errors::*;
 use rustup_dist::dist::TargetTriple;
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
 

--- a/src/rustup-cli/proxy_mode.rs
+++ b/src/rustup-cli/proxy_mode.rs
@@ -1,16 +1,16 @@
-use common::set_globals;
+use crate::common::set_globals;
 use rustup::Cfg;
-use errors::*;
+use crate::errors::*;
 use rustup_utils::utils::{self, ExitCode};
 use rustup::command::run_command_for_dir;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
-use job;
+use crate::job;
 
 pub fn main() -> Result<()> {
-    ::self_update::cleanup_self_updater()?;
+    crate::self_update::cleanup_self_updater()?;
 
     let ExitCode(c) = {
         let _setup = job::setup();

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -1,22 +1,22 @@
 use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, Shell, SubCommand};
-use common;
+use crate::common;
 use rustup::{command, Cfg, Toolchain};
 use rustup::settings::TelemetryMode;
-use errors::*;
+use crate::errors::*;
 use rustup_dist::manifest::Component;
 use rustup_dist::dist::{PartialTargetTriple, PartialToolchainDesc, TargetTriple};
 use rustup_utils::utils::{self, ExitCode};
-use self_update;
+use crate::self_update;
 use std::path::Path;
 use std::process::{self, Command};
 use std::iter;
 use std::error::Error;
-use term2;
+use crate::term2;
 use std::io::{self, Write};
-use help::*;
+use crate::help::*;
 
 pub fn main() -> Result<()> {
-    ::self_update::cleanup_self_updater()?;
+    crate::self_update::cleanup_self_updater()?;
 
     let ref matches = cli().get_matches();
     let verbose = matches.is_present("verbose");

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -30,8 +30,8 @@
 //! Deleting the running binary during uninstall is tricky
 //! and racy on Windows.
 
-use common::{self, Confirm};
-use errors::*;
+use crate::common::{self, Confirm};
+use crate::errors::*;
 use rustup_dist::dist;
 use rustup_utils::utils;
 use rustup::{TOOLS, DUP_TOOLS};
@@ -42,7 +42,7 @@ use std::path::{Component, Path, PathBuf};
 use std::process::{self, Command};
 use std::fs;
 use tempdir::TempDir;
-use term2;
+use crate::term2;
 use regex::Regex;
 
 pub struct InstallOpts {

--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -1,9 +1,9 @@
 use std::env;
-use self_update::{self, InstallOpts};
-use errors::*;
+use crate::self_update::{self, InstallOpts};
+use crate::errors::*;
 use clap::{App, AppSettings, Arg};
 use rustup_dist::dist::TargetTriple;
-use common;
+use crate::common;
 
 pub fn main() -> Result<()> {
     let args: Vec<_> = env::args().collect();

--- a/src/rustup-dist/Cargo.toml
+++ b/src/rustup-dist/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "rustup-dist"
 version = "1.16.0"
+edition = "2018"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Installation from a Rust distribution server"
 build = "build.rs"

--- a/src/rustup-dist/src/component/components.rs
+++ b/src/rustup-dist/src/component/components.rs
@@ -3,11 +3,11 @@
 /// installation / uninstallation process.
 
 use rustup_utils::utils;
-use prefix::InstallPrefix;
-use errors::*;
+use crate::prefix::InstallPrefix;
+use crate::errors::*;
 
-use component::transaction::Transaction;
-use component::package::{INSTALLER_VERSION, VERSION_FILE};
+use crate::component::transaction::Transaction;
+use crate::component::package::{INSTALLER_VERSION, VERSION_FILE};
 
 use std::path::{Path, PathBuf};
 use std::fs::File;

--- a/src/rustup-dist/src/component/package.rs
+++ b/src/rustup-dist/src/component/package.rs
@@ -6,12 +6,12 @@ extern crate flate2;
 extern crate tar;
 extern crate xz2;
 
-use component::components::*;
-use component::transaction::*;
+use crate::component::components::*;
+use crate::component::transaction::*;
 
-use errors::*;
+use crate::errors::*;
 use rustup_utils::utils;
-use temp;
+use crate::temp;
 
 use std::path::{Path, PathBuf};
 use std::collections::HashSet;

--- a/src/rustup-dist/src/component/transaction.rs
+++ b/src/rustup-dist/src/component/transaction.rs
@@ -10,10 +10,10 @@
 //! does not remove any dirs created by it.
 
 use rustup_utils::utils;
-use temp;
-use prefix::InstallPrefix;
-use errors::*;
-use notifications::*;
+use crate::temp;
+use crate::prefix::InstallPrefix;
+use crate::errors::*;
+use crate::notifications::*;
 
 use std::fs::File;
 use std::path::{Path, PathBuf};

--- a/src/rustup-dist/src/config.rs
+++ b/src/rustup-dist/src/config.rs
@@ -1,7 +1,7 @@
 use toml;
 
 use rustup_utils::toml_utils::*;
-use errors::*;
+use crate::errors::*;
 use super::manifest::Component;
 
 pub const SUPPORTED_CONFIG_VERSIONS: [&'static str; 1] = ["1"];

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -1,12 +1,12 @@
-use temp;
-use errors::*;
-use notifications::*;
+use crate::temp;
+use crate::errors::*;
+use crate::notifications::*;
 use rustup_utils::{self, utils};
-use prefix::InstallPrefix;
-use manifest::Component;
-use manifest::Manifest as ManifestV2;
-use manifestation::{Changes, Manifestation, UpdateStatus};
-use download::DownloadCfg;
+use crate::prefix::InstallPrefix;
+use crate::manifest::Component;
+use crate::manifest::Manifest as ManifestV2;
+use crate::manifestation::{Changes, Manifestation, UpdateStatus};
+use crate::download::DownloadCfg;
 
 use std::path::Path;
 use std::fmt;

--- a/src/rustup-dist/src/download.rs
+++ b/src/rustup-dist/src/download.rs
@@ -1,7 +1,7 @@
 use rustup_utils::utils;
-use errors::*;
-use temp;
-use notifications::*;
+use crate::errors::*;
+use crate::temp;
+use crate::notifications::*;
 use sha2::{Digest, Sha256};
 use url::Url;
 

--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -1,9 +1,9 @@
 use std::path::PathBuf;
 use std::io::{self, Write};
-use temp;
+use crate::temp;
 use toml;
 use rustup_utils;
-use manifest::{Component, Manifest};
+use crate::manifest::{Component, Manifest};
 
 error_chain! {
     links {

--- a/src/rustup-dist/src/lib.rs
+++ b/src/rustup-dist/src/lib.rs
@@ -19,8 +19,8 @@ extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;
 
-pub use errors::*;
-pub use notifications::Notification;
+pub use crate::errors::*;
+pub use crate::notifications::Notification;
 
 pub mod temp;
 

--- a/src/rustup-dist/src/manifest.rs
+++ b/src/rustup-dist/src/manifest.rs
@@ -10,12 +10,12 @@
 //!
 //! See tests/channel-rust-nightly-example.toml for an example.
 
-use errors::*;
+use crate::errors::*;
 use toml;
 use rustup_utils::toml_utils::*;
 
 use std::collections::HashMap;
-use dist::TargetTriple;
+use crate::dist::TargetTriple;
 
 pub const SUPPORTED_MANIFEST_VERSIONS: [&'static str; 1] = ["2"];
 pub const DEFAULT_MANIFEST_VERSION: &'static str = "2";

--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -1,16 +1,16 @@
 //! Maintains a Rust installation by installing individual Rust
 //! platform components from a distribution server.
 
-use config::Config;
-use manifest::{Component, Manifest, TargetedPackage};
-use dist::{TargetTriple, DEFAULT_DIST_SERVER};
-use component::{Components, Package, TarGzPackage, TarXzPackage, Transaction};
-use temp;
-use errors::*;
-use notifications::*;
+use crate::config::Config;
+use crate::manifest::{Component, Manifest, TargetedPackage};
+use crate::dist::{TargetTriple, DEFAULT_DIST_SERVER};
+use crate::component::{Components, Package, TarGzPackage, TarXzPackage, Transaction};
+use crate::temp;
+use crate::errors::*;
+use crate::notifications::*;
 use rustup_utils::utils;
-use download::{DownloadCfg, File};
-use prefix::InstallPrefix;
+use crate::download::{DownloadCfg, File};
+use crate::prefix::InstallPrefix;
 use std::path::Path;
 
 pub const DIST_MANIFEST: &'static str = "multirust-channel-manifest.toml";
@@ -600,7 +600,7 @@ impl Update {
         let mut unavailable_components: Vec<Component> = self.components_to_install
             .iter()
             .filter(|c| {
-                use manifest::*;
+                use crate::manifest::*;
                 let pkg: Option<&Package> = new_manifest.get_package(&c.short_name_in_manifest()).ok();
                 let target_pkg: Option<&TargetedPackage> =
                     pkg.and_then(|p| p.get_target(c.target.as_ref()).ok());

--- a/src/rustup-dist/src/notifications.rs
+++ b/src/rustup-dist/src/notifications.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 use std::fmt::{self, Display};
-use temp;
+use crate::temp;
 use rustup_utils;
 use rustup_utils::notify::NotificationLevel;
-use dist::TargetTriple;
-use errors::*;
+use crate::dist::TargetTriple;
+use crate::errors::*;
 
 #[derive(Debug)]
 pub enum Notification<'a> {

--- a/src/rustup-mock/Cargo.toml
+++ b/src/rustup-mock/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "rustup-mock"
 version = "1.16.0"
+edition = "2018"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Test mocks for rustup"
 

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -13,8 +13,8 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 use tempdir::TempDir;
-use {MockComponentBuilder, MockFile, MockInstallerBuilder};
-use dist::{change_channel_date, ManifestVersion, MockChannel, MockComponent, MockDistServer,
+use crate::{MockComponentBuilder, MockFile, MockInstallerBuilder};
+use crate::dist::{change_channel_date, ManifestVersion, MockChannel, MockComponent, MockDistServer,
            MockPackage, MockTargetedPackage};
 use url::Url;
 use wait_timeout::ChildExt;

--- a/src/rustup-mock/src/dist.rs
+++ b/src/rustup-mock/src/dist.rs
@@ -1,7 +1,7 @@
 //! Tools for building and working with the filesystem of a mock Rust
 //! distribution server, with v1 and v2 manifests.
 
-use MockInstallerBuilder;
+use crate::MockInstallerBuilder;
 use url::Url;
 use std::collections::HashMap;
 use std::fs::{self, File};
@@ -16,7 +16,7 @@ use xz2;
 use tar;
 use walkdir;
 
-use clitools::hard_link;
+use crate::clitools::hard_link;
 
 // This function changes the mock manifest for a given channel to that
 // of a particular date. For advancing the build from e.g. 2016-02-1

--- a/src/rustup-utils/Cargo.toml
+++ b/src/rustup-utils/Cargo.toml
@@ -2,6 +2,7 @@
 
 name = "rustup-utils"
 version = "1.16.0"
+edition = "2018"
 authors = [ "Diggory Blake <diggsey@googlemail.com>" ]
 description = "Utility functions for rustup"
 

--- a/src/rustup-utils/src/lib.rs
+++ b/src/rustup-utils/src/lib.rs
@@ -25,6 +25,6 @@ pub mod tty;
 pub mod utils;
 pub mod toml_utils;
 
-pub use errors::*;
-pub use notifications::Notification;
+pub use crate::errors::*;
+pub use crate::notifications::Notification;
 pub mod notify;

--- a/src/rustup-utils/src/notifications.rs
+++ b/src/rustup-utils/src/notifications.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Display};
 
 use url::Url;
 
-use notify::NotificationLevel;
+use crate::notify::NotificationLevel;
 
 #[derive(Debug)]
 pub enum Notification<'a> {

--- a/src/rustup-utils/src/toml_utils.rs
+++ b/src/rustup-utils/src/toml_utils.rs
@@ -1,5 +1,5 @@
 use toml;
-use errors::*;
+use crate::errors::*;
 
 pub fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {
     table

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -1,4 +1,4 @@
-use errors::*;
+use crate::errors::*;
 use std::path::{Path, PathBuf};
 use std::fs::{self, File};
 use std::io::{self, Write};
@@ -7,8 +7,8 @@ use std::ffi::OsString;
 use std::env;
 use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use sha2::Sha256;
-use notifications::Notification;
-use raw;
+use crate::notifications::Notification;
+use crate::raw;
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;
 #[cfg(windows)]
@@ -16,7 +16,7 @@ use winreg;
 use std::cmp::Ord;
 use url::Url;
 
-pub use raw::{find_cmd, has_cmd, if_not_empty, is_directory, is_file, path_exists, prefix_arg,
+pub use crate::raw::{find_cmd, has_cmd, if_not_empty, is_directory, is_file, path_exists, prefix_arg,
               random_string};
 
 pub struct ExitCode(pub i32);

--- a/src/rustup/command.rs
+++ b/src/rustup/command.rs
@@ -6,11 +6,11 @@ use std::time::Instant;
 use regex::Regex;
 use tempfile::tempfile;
 
-use Cfg;
-use errors::*;
-use notifications::*;
+use crate::Cfg;
+use crate::errors::*;
+use crate::notifications::*;
 use rustup_utils::{self, utils::ExitCode};
-use telemetry::{Telemetry, TelemetryEvent};
+use crate::telemetry::{Telemetry, TelemetryEvent};
 
 pub fn run_command_for_dir<S: AsRef<OsStr>>(
     cmd: Command,

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -6,13 +6,13 @@ use std::process::Command;
 use std::fmt::{self, Display};
 use std::sync::Arc;
 
-use errors::*;
-use notifications::*;
+use crate::errors::*;
+use crate::notifications::*;
 use rustup_dist::{dist, temp};
 use rustup_utils::utils;
-use toolchain::{Toolchain, UpdateStatus};
-use telemetry_analysis::*;
-use settings::{Settings, SettingsFile, TelemetryMode, DEFAULT_METADATA_VERSION};
+use crate::toolchain::{Toolchain, UpdateStatus};
+use crate::telemetry_analysis::*;
+use crate::settings::{Settings, SettingsFile, TelemetryMode, DEFAULT_METADATA_VERSION};
 
 #[derive(Debug)]
 pub enum OverrideReason {

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -1,6 +1,6 @@
 use rustup_dist::{self, temp};
 use rustup_utils;
-use component_for_bin;
+use crate::component_for_bin;
 use toml;
 
 error_chain! {

--- a/src/rustup/install.rs
+++ b/src/rustup/install.rs
@@ -8,7 +8,7 @@ use rustup_dist::temp;
 use rustup_dist::dist;
 use rustup_dist::download::DownloadCfg;
 use rustup_dist::component::{Components, Package, TarGzPackage, Transaction};
-use errors::Result;
+use crate::errors::Result;
 use std::path::Path;
 
 #[derive(Copy, Clone)]

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -16,10 +16,10 @@ extern crate time;
 extern crate toml;
 extern crate url;
 
-pub use errors::*;
-pub use notifications::*;
-pub use config::*;
-pub use toolchain::*;
+pub use crate::errors::*;
+pub use crate::notifications::*;
+pub use crate::config::*;
+pub use crate::toolchain::*;
 pub use rustup_utils::{notify, toml_utils, utils};
 
 

--- a/src/rustup/notifications.rs
+++ b/src/rustup/notifications.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::fmt::{self, Display};
 
-use errors::*;
+use crate::errors::*;
 
 use rustup_dist::{self, temp};
 use rustup_utils;

--- a/src/rustup/settings.rs
+++ b/src/rustup/settings.rs
@@ -1,7 +1,7 @@
-use errors::*;
-use notifications::*;
-use toml_utils::*;
-use utils;
+use crate::errors::*;
+use crate::notifications::*;
+use crate::toml_utils::*;
+use crate::utils;
 use toml;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/src/rustup/telemetry.rs
+++ b/src/rustup/telemetry.rs
@@ -1,4 +1,4 @@
-use errors::*;
+use crate::errors::*;
 use time;
 use rustup_utils::{raw, utils};
 use serde_json;

--- a/src/rustup/telemetry_analysis.rs
+++ b/src/rustup/telemetry_analysis.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 use itertools::Itertools;
 use serde_json;
 
-use errors::*;
-use telemetry::{LogMessage, TelemetryEvent};
+use crate::errors::*;
+use crate::telemetry::{LogMessage, TelemetryEvent};
 
 pub struct TelemetryAnalysis {
     telemetry_dir: PathBuf,

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -1,5 +1,5 @@
-use errors::*;
-use notifications::*;
+use crate::errors::*;
+use crate::notifications::*;
 use rustup_dist;
 use rustup_dist::download::DownloadCfg;
 use rustup_utils::utils;
@@ -7,11 +7,11 @@ use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::dist::ToolchainDesc;
 use rustup_dist::manifestation::{Changes, Manifestation};
 use rustup_dist::manifest::Component;
-use config::Cfg;
-use env_var;
-use install::{self, InstallMethod};
-use telemetry;
-use telemetry::{Telemetry, TelemetryEvent};
+use crate::config::Cfg;
+use crate::env_var;
+use crate::install::{self, InstallMethod};
+use crate::telemetry;
+use crate::telemetry::{Telemetry, TelemetryEvent};
 
 use std::env::consts::EXE_SUFFIX;
 use std::ffi::OsString;


### PR DESCRIPTION
In order to use 2018 features we need the edition to be updated.
This commit is the result of running:

cargo fix --edition -p rustup -p rustup-dist -p rustup-mock -p rustup-utils -p download

And then adding 'edition = "2018"' to each requisite Cargo.toml