### PR TITLE
Reformat the entire codebase using `cargo fmt`

### DIFF
--- a/src/download/src/lib.rs
+++ b/src/download/src/lib.rs
@@ -10,8 +10,8 @@ extern crate lazy_static;
 #[cfg(feature = "reqwest-backend")]
 extern crate reqwest;
 
-use url::Url;
 use std::path::Path;
+use url::Url;
 
 mod errors;
 pub use crate::errors::*;
@@ -122,7 +122,7 @@ pub fn download_to_path_with_backend(
 
         Ok(())
     }()
-        .map_err(|e| {
+    .map_err(|e| {
         // TODO is there any point clearing up here? What kind of errors will leave us with an unusable partial?
         e
     })
@@ -136,12 +136,12 @@ pub mod curl {
     extern crate curl;
 
     use self::curl::easy::Easy;
+    use super::Event;
     use crate::errors::*;
     use std::cell::RefCell;
     use std::str;
     use std::time::Duration;
     use url::Url;
-    use super::Event;
 
     pub fn download(url: &Url, resume_from: u64, callback: &Fn(Event) -> Result<()>) -> Result<()> {
         // Fetch either a cached libcurl handle (which will preserve open
@@ -254,12 +254,12 @@ pub mod curl {
 pub mod reqwest_be {
     extern crate env_proxy;
 
+    use super::Event;
+    use crate::errors::*;
+    use reqwest::{header, Client, Proxy, Response};
     use std::io;
     use std::time::Duration;
-    use crate::errors::*;
     use url::Url;
-    use super::Event;
-    use reqwest::{header, Client, Proxy, Response};
 
     pub fn download(url: &Url, resume_from: u64, callback: &Fn(Event) -> Result<()>) -> Result<()> {
         // Short-circuit reqwest for the "file:" URL scheme
@@ -339,7 +339,8 @@ pub mod reqwest_be {
 
         // The file scheme is mostly for use by tests to mock the dist server
         if url.scheme() == "file" {
-            let src = url.to_file_path()
+            let src = url
+                .to_file_path()
                 .map_err(|_| Error::from(format!("bogus file url: '{}'", url)))?;
             if !src.is_file() {
                 // Because some of rustup's logic depends on checking
@@ -372,9 +373,9 @@ pub mod reqwest_be {
 #[cfg(not(feature = "curl-backend"))]
 pub mod curl {
 
+    use super::Event;
     use errors::*;
     use url::Url;
-    use super::Event;
 
     pub fn download(
         _url: &Url,
@@ -388,9 +389,9 @@ pub mod curl {
 #[cfg(not(feature = "reqwest-backend"))]
 pub mod reqwest_be {
 
+    use super::Event;
     use errors::*;
     use url::Url;
-    use super::Event;
 
     pub fn download(
         _url: &Url,

--- a/src/download/tests/download-curl-resume.rs
+++ b/src/download/tests/download-curl-resume.rs
@@ -59,14 +59,17 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
                     assert!(flag.is_none());
                     *flag = Some(len);
                 }
-                Event::DownloadDataReceived(data) => for b in data.iter() {
-                    received_in_callback.lock().unwrap().push(b.clone());
-                },
+                Event::DownloadDataReceived(data) => {
+                    for b in data.iter() {
+                        received_in_callback.lock().unwrap().push(b.clone());
+                    }
+                }
             }
 
             Ok(())
         }),
-    ).expect("Test download failed");
+    )
+    .expect("Test download failed");
 
     assert!(*callback_partial.lock().unwrap());
     assert_eq!(*callback_len.lock().unwrap(), Some(5));

--- a/src/download/tests/download-reqwest-resume.rs
+++ b/src/download/tests/download-reqwest-resume.rs
@@ -59,14 +59,17 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
                     assert!(flag.is_none());
                     *flag = Some(len);
                 }
-                Event::DownloadDataReceived(data) => for b in data.iter() {
-                    received_in_callback.lock().unwrap().push(b.clone());
-                },
+                Event::DownloadDataReceived(data) => {
+                    for b in data.iter() {
+                        received_in_callback.lock().unwrap().push(b.clone());
+                    }
+                }
             }
 
             Ok(())
         }),
-    ).expect("Test download failed");
+    )
+    .expect("Test download failed");
 
     assert!(*callback_partial.lock().unwrap());
     assert_eq!(*callback_len.lock().unwrap(), Some(5));

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -1,19 +1,19 @@
 //! Just a dumping ground for cli stuff
 
-use rustup::{self, Cfg, Notification, Toolchain, UpdateStatus};
-use rustup::telemetry_analysis::TelemetryAnalysis;
 use crate::errors::*;
-use rustup_utils::utils;
-use rustup_utils::notify::NotificationLevel;
 use crate::self_update;
+use crate::term2;
+use rustup::telemetry_analysis::TelemetryAnalysis;
+use rustup::{self, Cfg, Notification, Toolchain, UpdateStatus};
+use rustup_utils::notify::NotificationLevel;
+use rustup_utils::utils;
+use std;
 use std::io::{BufRead, BufReader, Write};
-use std::process::{Command, Stdio};
 use std::path::Path;
-use std::{cmp, iter};
+use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
-use std;
-use crate::term2;
+use std::{cmp, iter};
 use wait_timeout::ChildExt;
 
 pub fn confirm(question: &str, default: bool) -> Result<bool> {
@@ -178,7 +178,8 @@ fn show_channel_updates(
     let mut t = term2::stdout();
 
     let data: Vec<_> = data.collect();
-    let max_width = data.iter()
+    let max_width = data
+        .iter()
         .fold(0, |a, &(_, _, width, _, _)| cmp::max(a, width));
 
     for (name, banner, width, color, version) in data {
@@ -365,11 +366,8 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
             }
             println!(
                 "{:<40}\t{:<20}",
-                utils::format_path_for_display(&k) + if dir_exists {
-                    ""
-                } else {
-                    " (not a directory)"
-                },
+                utils::format_path_for_display(&k)
+                    + if dir_exists { "" } else { " (not a directory)" },
                 v
             )
         }

--- a/src/rustup-cli/download_tracker.rs
+++ b/src/rustup-cli/download_tracker.rs
@@ -1,11 +1,11 @@
+use rustup::Notification;
+use rustup_dist::Notification as In;
+use rustup_utils::tty;
+use rustup_utils::Notification as Un;
 use std::collections::VecDeque;
 use std::fmt;
 use term;
 use time::precise_time_s;
-use rustup::Notification;
-use rustup_dist::Notification as In;
-use rustup_utils::Notification as Un;
-use rustup_utils::tty;
 
 /// Keep track of this many past download amounts
 const DOWNLOAD_TRACK_COUNT: usize = 5;
@@ -123,7 +123,8 @@ impl DownloadTracker {
     /// Display the tracked download information to the terminal.
     fn display(&mut self) {
         let total_h = HumanReadable(self.total_downloaded as f64);
-        let sum = self.downloaded_last_few_secs
+        let sum = self
+            .downloaded_last_few_secs
             .iter()
             .fold(0., |a, &v| a + v as f64);
         let len = self.downloaded_last_few_secs.len();

--- a/src/rustup-cli/job.rs
+++ b/src/rustup-cli/job.rs
@@ -44,8 +44,8 @@ mod imp {
     use self::winapi::um::handleapi::*;
     use self::winapi::um::jobapi2::*;
     use self::winapi::um::processthreadsapi::*;
-    use self::winapi::um::winnt::*;
     use self::winapi::um::winnt::HANDLE;
+    use self::winapi::um::winnt::*;
 
     pub struct Setup {
         job: Handle,

--- a/src/rustup-cli/main.rs
+++ b/src/rustup-cli/main.rs
@@ -46,21 +46,21 @@ extern crate winreg;
 mod log;
 mod common;
 mod download_tracker;
-mod proxy_mode;
-mod setup_mode;
-mod rustup_mode;
-mod self_update;
-mod job;
-mod term2;
 mod errors;
 mod help;
+mod job;
+mod proxy_mode;
+mod rustup_mode;
+mod self_update;
+mod setup_mode;
+mod term2;
 
+use crate::errors::*;
+use rustup::env_var::RUST_RECURSION_COUNT_MAX;
+use rustup_dist::dist::TargetTriple;
 use std::alloc::System;
 use std::env;
 use std::path::PathBuf;
-use crate::errors::*;
-use rustup_dist::dist::TargetTriple;
-use rustup::env_var::RUST_RECURSION_COUNT_MAX;
 
 // Always use the system allocator, to reduce binary size.
 #[global_allocator]
@@ -83,14 +83,16 @@ fn run_rustup() -> Result<()> {
 
     // The name of arg0 determines how the program is going to behave
     let arg0 = env::args().next().map(PathBuf::from);
-    let name = arg0.as_ref()
+    let name = arg0
+        .as_ref()
         .and_then(|a| a.file_stem())
         .and_then(|a| a.to_str());
 
     match name {
         Some("rustup") => rustup_mode::main(),
         Some(n)
-            if n.starts_with("multirust-setup") || n.starts_with("rustup-setup")
+            if n.starts_with("multirust-setup")
+                || n.starts_with("rustup-setup")
                 || n.starts_with("rustup-init") =>
         {
             // NB: The above check is only for the prefix of the file
@@ -171,8 +173,8 @@ fn make_environment_compatible() {
 // REG_SZ type, when it should be REG_EXPAND_SZ. Silently fix it.
 #[cfg(windows)]
 fn fix_windows_reg_key() {
-    use winreg::RegKey;
     use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+    use winreg::RegKey;
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let env = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE);

--- a/src/rustup-cli/proxy_mode.rs
+++ b/src/rustup-cli/proxy_mode.rs
@@ -1,13 +1,13 @@
 use crate::common::set_globals;
-use rustup::Cfg;
 use crate::errors::*;
-use rustup_utils::utils::{self, ExitCode};
+use crate::job;
 use rustup::command::run_command_for_dir;
+use rustup::Cfg;
+use rustup_utils::utils::{self, ExitCode};
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
-use crate::job;
 
 pub fn main() -> Result<()> {
     crate::self_update::cleanup_self_updater()?;
@@ -18,7 +18,8 @@ pub fn main() -> Result<()> {
         let mut args = env::args();
 
         let arg0 = args.next().map(PathBuf::from);
-        let arg0 = arg0.as_ref()
+        let arg0 = arg0
+            .as_ref()
             .and_then(|a| a.file_name())
             .and_then(|a| a.to_str());
         let ref arg0 = arg0.ok_or(ErrorKind::NoExeName)?;
@@ -48,7 +49,12 @@ pub fn main() -> Result<()> {
     process::exit(c)
 }
 
-fn direct_proxy(cfg: &Cfg, arg0: &str, toolchain: Option<&str>, args: &[OsString]) -> Result<ExitCode> {
+fn direct_proxy(
+    cfg: &Cfg,
+    arg0: &str,
+    toolchain: Option<&str>,
+    args: &[OsString],
+) -> Result<ExitCode> {
     let cmd = match toolchain {
         None => cfg.create_command_for_dir(&utils::current_dir()?, arg0)?,
         Some(tc) => cfg.create_command_for_toolchain(tc, false, arg0)?,

--- a/src/rustup-cli/setup_mode.rs
+++ b/src/rustup-cli/setup_mode.rs
@@ -1,9 +1,9 @@
-use std::env;
-use crate::self_update::{self, InstallOpts};
+use crate::common;
 use crate::errors::*;
+use crate::self_update::{self, InstallOpts};
 use clap::{App, AppSettings, Arg};
 use rustup_dist::dist::TargetTriple;
-use crate::common;
+use std::env;
 
 pub fn main() -> Result<()> {
     let args: Vec<_> = env::args().collect();

--- a/src/rustup-cli/term2.rs
+++ b/src/rustup-cli/term2.rs
@@ -2,11 +2,11 @@
 //! that does not fail if `StdoutTerminal` etc can't be constructed, which happens
 //! if TERM isn't defined.
 
+use markdown::tokenize;
+use markdown::{Block, ListItem, Span};
+use rustup_utils::tty;
 use std::io;
 use term;
-use rustup_utils::tty;
-use markdown::{Block, ListItem, Span};
-use markdown::tokenize;
 
 pub use term::color;
 pub use term::Attr;
@@ -212,9 +212,11 @@ impl<'a, T: Instantiable + Isatty + io::Write + 'a> LineFormatter<'a, T> {
                         ListItem::Simple(spans) => {
                             self.do_spans(spans);
                         }
-                        ListItem::Paragraph(blocks) => for block in blocks {
-                            self.do_block(block);
-                        },
+                        ListItem::Paragraph(blocks) => {
+                            for block in blocks {
+                                self.do_block(block);
+                            }
+                        }
                     }
                     self.wrapper.write_line();
                     self.wrapper.indent -= 2;

--- a/src/rustup-dist/src/component/mod.rs
+++ b/src/rustup-dist/src/component/mod.rs
@@ -1,10 +1,9 @@
+pub use self::components::*;
+pub use self::package::*;
 /// An interpreter for the rust-installer [1] installation format.
 ///
 /// https://github.com/rust-lang/rust-installer
-
 pub use self::transaction::*;
-pub use self::components::*;
-pub use self::package::*;
 
 // Transactional file system tools
 mod transaction;

--- a/src/rustup-dist/src/component/package.rs
+++ b/src/rustup-dist/src/component/package.rs
@@ -10,14 +10,14 @@ use crate::component::components::*;
 use crate::component::transaction::*;
 
 use crate::errors::*;
-use rustup_utils::utils;
 use crate::temp;
+use rustup_utils::utils;
 
-use std::path::{Path, PathBuf};
 use std::collections::HashSet;
 use std::fmt;
-use std::io::Read;
 use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
 
 /// The current metadata revision used by rust-installer
 pub const INSTALLER_VERSION: &'static str = "3";
@@ -66,11 +66,12 @@ fn validate_installer_version(path: &Path) -> Result<()> {
 
 impl Package for DirectoryPackage {
     fn contains(&self, component: &str, short_name: Option<&str>) -> bool {
-        self.components.contains(component) || if let Some(n) = short_name {
-            self.components.contains(n)
-        } else {
-            false
-        }
+        self.components.contains(component)
+            || if let Some(n) = short_name {
+                self.components.contains(n)
+            } else {
+                false
+            }
     }
     fn install<'a>(
         &self,
@@ -157,7 +158,8 @@ fn set_file_perms(dest_path: &Path, src_path: &Path) -> Result<()> {
                 .chain_err(|| ErrorKind::ComponentFilePermissionsFailed)?;
         }
     } else {
-        let meta = fs::metadata(dest_path).chain_err(|| ErrorKind::ComponentFilePermissionsFailed)?;
+        let meta =
+            fs::metadata(dest_path).chain_err(|| ErrorKind::ComponentFilePermissionsFailed)?;
         let mut perm = meta.permissions();
         perm.set_mode(if is_bin || needs_x(&meta) {
             0o755

--- a/src/rustup-dist/src/component/transaction.rs
+++ b/src/rustup-dist/src/component/transaction.rs
@@ -9,11 +9,11 @@
 //! FIXME: This uses ensure_dir_exists in some places but rollback
 //! does not remove any dirs created by it.
 
-use rustup_utils::utils;
-use crate::temp;
-use crate::prefix::InstallPrefix;
 use crate::errors::*;
 use crate::notifications::*;
+use crate::prefix::InstallPrefix;
+use crate::temp;
+use rustup_utils::utils;
 
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -201,7 +201,8 @@ impl<'a> ChangedItem<'a> {
             Err(ErrorKind::ComponentConflict {
                 name: component.to_owned(),
                 path: relpath.clone(),
-            }.into())
+            }
+            .into())
         } else {
             if let Some(p) = abs_path.parent() {
                 utils::ensure_dir_exists("component", p, &|_| ())?;
@@ -223,7 +224,8 @@ impl<'a> ChangedItem<'a> {
             Err(ErrorKind::ComponentConflict {
                 name: component.to_owned(),
                 path: relpath.clone(),
-            }.into())
+            }
+            .into())
         } else {
             if let Some(p) = abs_path.parent() {
                 utils::ensure_dir_exists("component", p, &|_| ())?;
@@ -243,7 +245,8 @@ impl<'a> ChangedItem<'a> {
             Err(ErrorKind::ComponentConflict {
                 name: component.to_owned(),
                 path: relpath.clone(),
-            }.into())
+            }
+            .into())
         } else {
             if let Some(p) = abs_path.parent() {
                 utils::ensure_dir_exists("component", p, &|_| ())?;
@@ -264,7 +267,8 @@ impl<'a> ChangedItem<'a> {
             Err(ErrorKind::ComponentMissingFile {
                 name: component.to_owned(),
                 path: relpath.clone(),
-            }.into())
+            }
+            .into())
         } else {
             utils::rename_file("component", &abs_path, &backup)?;
             Ok(ChangedItem::RemovedFile(relpath, backup))
@@ -282,7 +286,8 @@ impl<'a> ChangedItem<'a> {
             Err(ErrorKind::ComponentMissingDir {
                 name: component.to_owned(),
                 path: relpath.clone(),
-            }.into())
+            }
+            .into())
         } else {
             utils::rename_dir("component", &abs_path, &backup.join("bk"))?;
             Ok(ChangedItem::RemovedDir(relpath, backup))

--- a/src/rustup-dist/src/config.rs
+++ b/src/rustup-dist/src/config.rs
@@ -1,8 +1,8 @@
 use toml;
 
-use rustup_utils::toml_utils::*;
-use crate::errors::*;
 use super::manifest::Component;
+use crate::errors::*;
+use rustup_utils::toml_utils::*;
 
 pub const SUPPORTED_CONFIG_VERSIONS: [&'static str; 1] = ["1"];
 pub const DEFAULT_CONFIG_VERSION: &'static str = "1";

--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -1,16 +1,16 @@
-use crate::temp;
+use crate::download::DownloadCfg;
 use crate::errors::*;
-use crate::notifications::*;
-use rustup_utils::{self, utils};
-use crate::prefix::InstallPrefix;
 use crate::manifest::Component;
 use crate::manifest::Manifest as ManifestV2;
 use crate::manifestation::{Changes, Manifestation, UpdateStatus};
-use crate::download::DownloadCfg;
+use crate::notifications::*;
+use crate::prefix::InstallPrefix;
+use crate::temp;
+use rustup_utils::{self, utils};
 
-use std::path::Path;
-use std::fmt;
 use std::env;
+use std::fmt;
+use std::path::Path;
 
 use regex::Regex;
 
@@ -125,8 +125,8 @@ impl TargetTriple {
     pub fn from_host() -> Option<Self> {
         #[cfg(windows)]
         fn inner() -> Option<TargetTriple> {
-            use winapi::um::sysinfoapi::GetNativeSystemInfo;
             use std::mem;
+            use winapi::um::sysinfoapi::GetNativeSystemInfo;
 
             // First detect architecture
             const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
@@ -152,8 +152,8 @@ impl TargetTriple {
         #[cfg(not(windows))]
         fn inner() -> Option<TargetTriple> {
             use libc;
-            use std::mem;
             use std::ffi::CStr;
+            use std::mem;
 
             let mut sys_info;
             let (sysname, machine) = unsafe {
@@ -582,14 +582,13 @@ pub fn update_from_dist_<'a>(
     ) {
         Ok(None) => Ok(None),
         Ok(Some(hash)) => Ok(Some(hash)),
-        e @ Err(Error(ErrorKind::Utils(rustup_utils::ErrorKind::DownloadNotExists { .. }), _)) => {
-            e.chain_err(|| {
+        e @ Err(Error(ErrorKind::Utils(rustup_utils::ErrorKind::DownloadNotExists { .. }), _)) => e
+            .chain_err(|| {
                 format!(
                     "could not download nonexistent rust version `{}`",
                     toolchain_str
                 )
-            })
-        }
+            }),
         Err(e) => Err(e),
     }
 }

--- a/src/rustup-dist/src/download.rs
+++ b/src/rustup-dist/src/download.rs
@@ -1,13 +1,13 @@
-use rustup_utils::utils;
 use crate::errors::*;
-use crate::temp;
 use crate::notifications::*;
+use crate::temp;
+use rustup_utils::utils;
 use sha2::{Digest, Sha256};
 use url::Url;
 
-use std::path::{Path, PathBuf};
 use std::fs;
 use std::ops;
+use std::path::{Path, PathBuf};
 
 const UPDATE_HASH_LEN: usize = 20;
 
@@ -59,7 +59,8 @@ impl<'a> DownloadCfg<'a> {
                 .file_name()
                 .map(|s| s.to_str().unwrap_or("_"))
                 .unwrap_or("_")
-                .to_owned() + ".partial",
+                .to_owned()
+                + ".partial",
         );
 
         let mut hasher = Sha256::new();
@@ -80,7 +81,8 @@ impl<'a> DownloadCfg<'a> {
                 url: url.to_string(),
                 expected: hash.to_string(),
                 calculated: actual_hash,
-            }.into());
+            }
+            .into());
         } else {
             (self.notify_handler)(Notification::ChecksumValid(&url.to_string()));
 
@@ -152,7 +154,8 @@ impl<'a> DownloadCfg<'a> {
                 url: url_str.to_owned(),
                 expected: hash,
                 calculated: actual_hash,
-            }.into());
+            }
+            .into());
         } else {
             (self.notify_handler)(Notification::ChecksumValid(url_str));
         }

--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
-use std::io::{self, Write};
-use crate::temp;
-use toml;
-use rustup_utils;
 use crate::manifest::{Component, Manifest};
+use crate::temp;
+use rustup_utils;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use toml;
 
 error_chain! {
     links {
@@ -121,7 +121,8 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest) -> String {
         );
     } else {
         use itertools::Itertools;
-        let same_target = cs.iter()
+        let same_target = cs
+            .iter()
             .all(|c| c.target == cs[0].target || c.target.is_none());
         if same_target {
             let mut cs_strs = cs.iter().map(|c| format!("'{}'", c.short_name(manifest)));

--- a/src/rustup-dist/src/lib.rs
+++ b/src/rustup-dist/src/lib.rs
@@ -24,12 +24,12 @@ pub use crate::notifications::Notification;
 
 pub mod temp;
 
+pub mod component;
+pub mod config;
 pub mod dist;
+pub mod download;
 pub mod errors;
+pub mod manifest;
+pub mod manifestation;
 pub mod notifications;
 pub mod prefix;
-pub mod component;
-pub mod manifestation;
-pub mod download;
-pub mod manifest;
-pub mod config;

--- a/src/rustup-dist/src/manifest.rs
+++ b/src/rustup-dist/src/manifest.rs
@@ -11,11 +11,11 @@
 //! See tests/channel-rust-nightly-example.toml for an example.
 
 use crate::errors::*;
-use toml;
 use rustup_utils::toml_utils::*;
+use toml;
 
-use std::collections::HashMap;
 use crate::dist::TargetTriple;
+use std::collections::HashMap;
 
 pub const SUPPORTED_MANIFEST_VERSIONS: [&'static str; 1] = ["2"];
 pub const DEFAULT_MANIFEST_VERSION: &'static str = "2";
@@ -169,9 +169,11 @@ impl Manifest {
 
     fn validate_targeted_package(&self, tpkg: &TargetedPackage) -> Result<()> {
         for c in tpkg.components.iter().chain(tpkg.extensions.iter()) {
-            let cpkg = self.get_package(&c.pkg)
+            let cpkg = self
+                .get_package(&c.pkg)
                 .chain_err(|| ErrorKind::MissingPackageForComponent(c.short_name(self)))?;
-            let _ctpkg = cpkg.get_target(c.target.as_ref())
+            let _ctpkg = cpkg
+                .get_target(c.target.as_ref())
                 .chain_err(|| ErrorKind::MissingPackageForComponent(c.short_name(self)))?;
         }
         Ok(())
@@ -184,9 +186,11 @@ impl Manifest {
                 PackageTargets::Wildcard(ref tpkg) => {
                     self.validate_targeted_package(tpkg)?;
                 }
-                PackageTargets::Targeted(ref tpkgs) => for (_, tpkg) in tpkgs {
-                    self.validate_targeted_package(tpkg)?;
-                },
+                PackageTargets::Targeted(ref tpkgs) => {
+                    for (_, tpkg) in tpkgs {
+                        self.validate_targeted_package(tpkg)?;
+                    }
+                }
             }
         }
 
@@ -235,8 +239,7 @@ impl Package {
 
         if let Some(toml::Value::Table(t)) = target_table.remove("*") {
             Ok(PackageTargets::Wildcard(TargetedPackage::from_toml(
-                t,
-                &path,
+                t, &path,
             )?))
         } else {
             let mut result = HashMap::new();
@@ -257,9 +260,11 @@ impl Package {
             PackageTargets::Wildcard(tpkg) => {
                 result.insert("*".to_owned(), toml::Value::Table(tpkg.to_toml()));
             }
-            PackageTargets::Targeted(tpkgs) => for (k, v) in tpkgs {
-                result.insert(k.to_string(), toml::Value::Table(v.to_toml()));
-            },
+            PackageTargets::Targeted(tpkgs) => {
+                for (k, v) in tpkgs {
+                    result.insert(k.to_string(), toml::Value::Table(v.to_toml()));
+                }
+            }
         }
         result
     }

--- a/src/rustup-dist/src/notifications.rs
+++ b/src/rustup-dist/src/notifications.rs
@@ -1,10 +1,10 @@
-use std::path::Path;
-use std::fmt::{self, Display};
+use crate::dist::TargetTriple;
+use crate::errors::*;
 use crate::temp;
 use rustup_utils;
 use rustup_utils::notify::NotificationLevel;
-use crate::dist::TargetTriple;
-use crate::errors::*;
+use std::fmt::{self, Display};
+use std::path::Path;
 
 #[derive(Debug)]
 pub enum Notification<'a> {
@@ -82,9 +82,7 @@ impl<'a> Display for Notification<'a> {
             Temp(ref n) => n.fmt(f),
             Utils(ref n) => n.fmt(f),
             Extracting(_, _) => write!(f, "extracting..."),
-            ComponentAlreadyInstalled(ref c) => {
-                write!(f, "component {} is up to date", c)
-            }
+            ComponentAlreadyInstalled(ref c) => write!(f, "component {} is up to date", c),
             CantReadUpdateHash(path) => write!(
                 f,
                 "can't read update hash file: '{}', can't skip update...",

--- a/src/rustup-dist/src/temp.rs
+++ b/src/rustup-dist/src/temp.rs
@@ -1,12 +1,12 @@
 extern crate remove_dir_all;
 
+use rustup_utils::raw;
 use std::error;
+use std::fmt::{self, Display};
 use std::fs;
-use std::path::{Path, PathBuf};
 use std::io;
 use std::ops;
-use std::fmt::{self, Display};
-use rustup_utils::raw;
+use std::path::{Path, PathBuf};
 
 use rustup_utils::notify::NotificationLevel;
 
@@ -140,7 +140,8 @@ impl Cfg {
     pub fn create_root(&self) -> Result<bool> {
         raw::ensure_dir_exists(&self.root_directory, |p| {
             (self.notify_handler)(Notification::CreatingRoot(p));
-        }).map_err(|e| Error::CreatingRoot {
+        })
+        .map_err(|e| Error::CreatingRoot {
             path: PathBuf::from(&self.root_directory),
             error: e,
         })

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -12,25 +12,25 @@ extern crate toml;
 extern crate url;
 extern crate walkdir;
 
-use rustup_mock::dist::*;
-use rustup_mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};
-use rustup_dist::prefix::InstallPrefix;
-use rustup_dist::ErrorKind;
-use rustup_dist::errors::Result;
 use rustup_dist::dist::{TargetTriple, ToolchainDesc, DEFAULT_DIST_SERVER};
 use rustup_dist::download::DownloadCfg;
-use rustup_dist::Notification;
-use rustup_utils::utils;
-use rustup_utils::raw as utils_raw;
-use rustup_dist::temp;
-use rustup_dist::manifestation::{Changes, Manifestation, UpdateStatus};
+use rustup_dist::errors::Result;
 use rustup_dist::manifest::{Component, Manifest};
-use url::Url;
+use rustup_dist::manifestation::{Changes, Manifestation, UpdateStatus};
+use rustup_dist::prefix::InstallPrefix;
+use rustup_dist::temp;
+use rustup_dist::ErrorKind;
+use rustup_dist::Notification;
+use rustup_mock::dist::*;
+use rustup_mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};
+use rustup_utils::raw as utils_raw;
+use rustup_utils::utils;
 use std::cell::Cell;
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use url::Url;
 
 use tempdir::TempDir;
 
@@ -126,12 +126,10 @@ pub fn create_mock_channel(
                     components: vec![],
                     extensions: vec![],
                     installer: MockInstallerBuilder {
-                        components: vec![
-                            MockComponentBuilder {
-                                name: pkg.to_string(),
-                                files: vec![MockFile::new_arc(*bin, contents.clone())],
-                            },
-                        ],
+                        components: vec![MockComponentBuilder {
+                            name: pkg.to_string(),
+                            files: vec![MockFile::new_arc(*bin, contents.clone())],
+                        }],
                     },
                 },
                 MockTargetedPackage {
@@ -155,12 +153,10 @@ pub fn create_mock_channel(
                 components: vec![],
                 extensions: vec![],
                 installer: MockInstallerBuilder {
-                    components: vec![
-                        MockComponentBuilder {
-                            name: "rust-std-x86_64-apple-darwin".to_string(),
-                            files: vec![MockFile::new_arc("lib/libstd.rlib", contents.clone())],
-                        },
-                    ],
+                    components: vec![MockComponentBuilder {
+                        name: "rust-std-x86_64-apple-darwin".to_string(),
+                        files: vec![MockFile::new_arc("lib/libstd.rlib", contents.clone())],
+                    }],
                 },
             },
             MockTargetedPackage {
@@ -169,17 +165,13 @@ pub fn create_mock_channel(
                 components: vec![],
                 extensions: vec![],
                 installer: MockInstallerBuilder {
-                    components: vec![
-                        MockComponentBuilder {
-                            name: "rust-std-i686-apple-darwin".to_string(),
-                            files: vec![
-                                MockFile::new_arc(
-                                    "lib/i686-apple-darwin/libstd.rlib",
-                                    contents.clone(),
-                                ),
-                            ],
-                        },
-                    ],
+                    components: vec![MockComponentBuilder {
+                        name: "rust-std-i686-apple-darwin".to_string(),
+                        files: vec![MockFile::new_arc(
+                            "lib/i686-apple-darwin/libstd.rlib",
+                            contents.clone(),
+                        )],
+                    }],
                 },
             },
             MockTargetedPackage {
@@ -188,17 +180,13 @@ pub fn create_mock_channel(
                 components: vec![],
                 extensions: vec![],
                 installer: MockInstallerBuilder {
-                    components: vec![
-                        MockComponentBuilder {
-                            name: "rust-std-i686-unknown-linux-gnu".to_string(),
-                            files: vec![
-                                MockFile::new_arc(
-                                    "lib/i686-unknown-linux-gnu/libstd.rlib",
-                                    contents.clone(),
-                                ),
-                            ],
-                        },
-                    ],
+                    components: vec![MockComponentBuilder {
+                        name: "rust-std-i686-unknown-linux-gnu".to_string(),
+                        files: vec![MockFile::new_arc(
+                            "lib/i686-unknown-linux-gnu/libstd.rlib",
+                            contents.clone(),
+                        )],
+                    }],
                 },
             },
         ],
@@ -224,22 +212,18 @@ fn bonus_component(name: &'static str, contents: Arc<Vec<u8>>) -> MockPackage {
     MockPackage {
         name: name,
         version: "1.0.0",
-        targets: vec![
-            MockTargetedPackage {
-                target: "x86_64-apple-darwin".to_string(),
-                available: true,
-                components: vec![],
-                extensions: vec![],
-                installer: MockInstallerBuilder {
-                    components: vec![
-                        MockComponentBuilder {
-                            name: format!("{}-x86_64-apple-darwin", name),
-                            files: vec![MockFile::new_arc("bin/bonus", contents)],
-                        },
-                    ],
-                },
+        targets: vec![MockTargetedPackage {
+            target: "x86_64-apple-darwin".to_string(),
+            available: true,
+            components: vec![],
+            extensions: vec![],
+            installer: MockInstallerBuilder {
+                components: vec![MockComponentBuilder {
+                    name: format!("{}-x86_64-apple-darwin", name),
+                    files: vec![MockFile::new_arc("bin/bonus", contents)],
+                }],
             },
-        ],
+        }],
     }
 }
 
@@ -253,9 +237,9 @@ fn mock_dist_server_smoke_test() {
     assert!(utils::path_exists(path.join(
         "dist/2016-02-01/rustc-nightly-x86_64-apple-darwin.tar.gz"
     )));
-    assert!(utils::path_exists(path.join(
-        "dist/2016-02-01/rustc-nightly-i686-apple-darwin.tar.gz"
-    )));
+    assert!(utils::path_exists(
+        path.join("dist/2016-02-01/rustc-nightly-i686-apple-darwin.tar.gz")
+    ));
     assert!(utils::path_exists(path.join(
         "dist/2016-02-01/rust-std-nightly-x86_64-apple-darwin.tar.gz"
     )));
@@ -274,12 +258,12 @@ fn mock_dist_server_smoke_test() {
     assert!(utils::path_exists(path.join(
         "dist/2016-02-01/rust-std-nightly-i686-apple-darwin.tar.gz.sha256"
     )));
-    assert!(utils::path_exists(path.join(
-        "dist/channel-rust-nightly.toml"
-    )));
-    assert!(utils::path_exists(path.join(
-        "dist/channel-rust-nightly.toml.sha256"
-    )));
+    assert!(utils::path_exists(
+        path.join("dist/channel-rust-nightly.toml")
+    ));
+    assert!(utils::path_exists(
+        path.join("dist/channel-rust-nightly.toml.sha256")
+    ));
 }
 
 // Test that a standard rename works - the component is installed with the old name, then renamed
@@ -567,9 +551,13 @@ fn uninstall_removes_config_file() {
                          download_cfg,
                          temp_cfg| {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
-        assert!(utils::path_exists(&prefix.manifest_file("multirust-config.toml")));
+        assert!(utils::path_exists(
+            &prefix.manifest_file("multirust-config.toml")
+        ));
         uninstall(toolchain, prefix, temp_cfg, &|_| ()).unwrap();
-        assert!(!utils::path_exists(&prefix.manifest_file("multirust-config.toml")));
+        assert!(!utils::path_exists(
+            &prefix.manifest_file("multirust-config.toml")
+        ));
     });
 }
 
@@ -713,22 +701,22 @@ fn update_preserves_extensions() {
         change_channel_date(url, "nightly", "2016-02-01");
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
 
         change_channel_date(url, "nightly", "2016-02-02");
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -762,12 +750,10 @@ fn update_preserves_extensions_that_became_components() {
         Some(edit),
         false,
         &|url, toolchain, prefix, download_cfg, temp_cfg| {
-            let ref adds = vec![
-                Component::new(
-                    "bonus".to_string(),
-                    Some(TargetTriple::from_str("x86_64-apple-darwin")),
-                ),
-            ];
+            let ref adds = vec![Component::new(
+                "bonus".to_string(),
+                Some(TargetTriple::from_str("x86_64-apple-darwin")),
+            )];
 
             change_channel_date(url, "nightly", "2016-02-01");
             update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
@@ -856,12 +842,12 @@ fn add_extensions_for_initial_install() {
         ];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -887,12 +873,12 @@ fn add_extensions_for_same_manifest() {
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -922,12 +908,12 @@ fn add_extensions_for_upgrade() {
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -939,12 +925,10 @@ fn add_extension_not_in_manifest() {
                          prefix,
                          download_cfg,
                          temp_cfg| {
-        let ref adds = vec![
-            Component::new(
-                "rust-bogus".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-bogus".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
     });
@@ -958,12 +942,10 @@ fn add_extension_that_is_required_component() {
                          prefix,
                          download_cfg,
                          temp_cfg| {
-        let ref adds = vec![
-            Component::new(
-                "rustc".to_string(),
-                Some(TargetTriple::from_str("x86_64-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rustc".to_string(),
+            Some(TargetTriple::from_str("x86_64-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
     });
@@ -986,12 +968,10 @@ fn add_extensions_does_not_remove_other_components() {
                          temp_cfg| {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
 
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
@@ -1008,12 +988,10 @@ fn remove_extensions_for_initial_install() {
                          prefix,
                          download_cfg,
                          temp_cfg| {
-        let ref removes = vec![
-            Component::new(
-                "rustc".to_string(),
-                Some(TargetTriple::from_str("x86_64-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rustc".to_string(),
+            Some(TargetTriple::from_str("x86_64-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
     });
@@ -1039,21 +1017,19 @@ fn remove_extensions_for_same_manifest() {
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
 
-        assert!(!utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(!utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -1081,21 +1057,19 @@ fn remove_extensions_for_upgrade() {
 
         change_channel_date(url, "nightly", "2016-02-02");
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
 
-        assert!(!utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(!utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -1113,12 +1087,10 @@ fn remove_extension_not_in_manifest() {
 
         change_channel_date(url, "nightly", "2016-02-02");
 
-        let ref removes = vec![
-            Component::new(
-                "rust-bogus".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-bogus".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
     });
@@ -1149,23 +1121,19 @@ fn remove_extension_not_in_manifest_but_is_already_installed() {
         &|url, toolchain, prefix, download_cfg, temp_cfg| {
             change_channel_date(url, "nightly", "2016-02-01");
 
-            let ref adds = vec![
-                Component::new(
-                    "bonus".to_string(),
-                    Some(TargetTriple::from_str("x86_64-apple-darwin")),
-                ),
-            ];
+            let ref adds = vec![Component::new(
+                "bonus".to_string(),
+                Some(TargetTriple::from_str("x86_64-apple-darwin")),
+            )];
             update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
             assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
 
             change_channel_date(url, "nightly", "2016-02-02");
 
-            let ref removes = vec![
-                Component::new(
-                    "bonus".to_string(),
-                    Some(TargetTriple::from_str("x86_64-apple-darwin")),
-                ),
-            ];
+            let ref removes = vec![Component::new(
+                "bonus".to_string(),
+                Some(TargetTriple::from_str("x86_64-apple-darwin")),
+            )];
             update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
         },
     );
@@ -1181,12 +1149,10 @@ fn remove_extension_that_is_required_component() {
                          temp_cfg| {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
 
-        let ref removes = vec![
-            Component::new(
-                "rustc".to_string(),
-                Some(TargetTriple::from_str("x86_64-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rustc".to_string(),
+            Some(TargetTriple::from_str("x86_64-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
     });
@@ -1202,12 +1168,10 @@ fn remove_extension_not_installed() {
                          temp_cfg| {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
     });
@@ -1224,21 +1188,17 @@ fn remove_extensions_does_not_remove_other_components() {
                          prefix,
                          download_cfg,
                          temp_cfg| {
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
         update_from_dist(url, toolchain, prefix, &[], removes, download_cfg, temp_cfg).unwrap();
 
@@ -1255,30 +1215,24 @@ fn add_and_remove_for_upgrade() {
                          temp_cfg| {
         change_channel_date(url, "nightly", "2016-02-01");
 
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
         change_channel_date(url, "nightly", "2016-02-02");
 
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
+        )];
 
         update_from_dist(
             url,
@@ -1288,14 +1242,15 @@ fn add_and_remove_for_upgrade() {
             removes,
             download_cfg,
             temp_cfg,
-        ).unwrap();
+        )
+        .unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(!utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(!utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -1306,28 +1261,22 @@ fn add_and_remove() {
                          prefix,
                          download_cfg,
                          temp_cfg| {
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
+        )];
 
         update_from_dist(url, toolchain, prefix, adds, &[], download_cfg, temp_cfg).unwrap();
 
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-unknown-linux-gnu")),
+        )];
 
         update_from_dist(
             url,
@@ -1337,14 +1286,15 @@ fn add_and_remove() {
             removes,
             download_cfg,
             temp_cfg,
-        ).unwrap();
+        )
+        .unwrap();
 
-        assert!(utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-apple-darwin/libstd.rlib")));
-        assert!(!utils::path_exists(&prefix
-            .path()
-            .join("lib/i686-unknown-linux-gnu/libstd.rlib")));
+        assert!(utils::path_exists(
+            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+        ));
+        assert!(!utils::path_exists(
+            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+        ));
     });
 }
 
@@ -1358,19 +1308,15 @@ fn add_and_remove_same_component() {
                          temp_cfg| {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
 
-        let ref adds = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple-darwin")),
-            ),
-        ];
+        let ref adds = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple-darwin")),
+        )];
 
-        let ref removes = vec![
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTriple::from_str("i686-apple_darwin")),
-            ),
-        ];
+        let ref removes = vec![Component::new(
+            "rust-std".to_string(),
+            Some(TargetTriple::from_str("i686-apple_darwin")),
+        )];
 
         update_from_dist(
             url,
@@ -1380,7 +1326,8 @@ fn add_and_remove_same_component() {
             removes,
             download_cfg,
             temp_cfg,
-        ).unwrap();
+        )
+        .unwrap();
     });
 }
 
@@ -1481,7 +1428,8 @@ fn checks_files_hashes_before_reuse() {
         let target_hash = utils::read_file(
             "target hash",
             &path.join("dist/2016-02-02/rustc-nightly-x86_64-apple-darwin.tar.gz.sha256"),
-        ).unwrap()[..64]
+        )
+        .unwrap()[..64]
             .to_owned();
         let prev_download = download_cfg.download_dir.join(target_hash);
         utils::ensure_dir_exists("download dir", &download_cfg.download_dir, &|_| {}).unwrap();

--- a/src/rustup-dist/tests/install.rs
+++ b/src/rustup-dist/tests/install.rs
@@ -4,18 +4,18 @@ extern crate rustup_utils;
 extern crate tempdir;
 
 use rustup_dist::component::Components;
-use rustup_dist::component::{DirectoryPackage, Package};
 use rustup_dist::component::Transaction;
+use rustup_dist::component::{DirectoryPackage, Package};
 use rustup_dist::dist::DEFAULT_DIST_SERVER;
+use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::temp;
 use rustup_dist::ErrorKind;
 use rustup_dist::Notification;
+use rustup_mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};
 use rustup_utils::utils;
-use rustup_dist::prefix::InstallPrefix;
 use std::fs::File;
 use std::io::Write;
 use tempdir::TempDir;
-use rustup_mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};
 
 // Just testing that the mocks work
 #[test]
@@ -80,12 +80,10 @@ fn package_bad_version() {
     let tempdir = TempDir::new("rustup").unwrap();
 
     let mock = MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "mycomponent".to_string(),
-                files: vec![MockFile::new("bin/foo", b"foo")],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "mycomponent".to_string(),
+            files: vec![MockFile::new("bin/foo", b"foo")],
+        }],
     };
 
     mock.build(tempdir.path());
@@ -101,16 +99,14 @@ fn basic_install() {
     let pkgdir = TempDir::new("rustup").unwrap();
 
     let mock = MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "mycomponent".to_string(),
-                files: vec![
-                    MockFile::new("bin/foo", b"foo"),
-                    MockFile::new("lib/bar", b"bar"),
-                    MockFile::new_dir("doc/stuff", &[("doc1", b"", false), ("doc2", b"", false)]),
-                ],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "mycomponent".to_string(),
+            files: vec![
+                MockFile::new("bin/foo", b"foo"),
+                MockFile::new("lib/bar", b"bar"),
+                MockFile::new_dir("doc/stuff", &[("doc1", b"", false), ("doc2", b"", false)]),
+            ],
+        }],
     };
 
     mock.build(pkgdir.path());
@@ -260,12 +256,10 @@ fn component_bad_version() {
     let pkgdir = TempDir::new("rustup").unwrap();
 
     let mock = MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "mycomponent".to_string(),
-                files: vec![MockFile::new("bin/foo", b"foo")],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "mycomponent".to_string(),
+            files: vec![MockFile::new("bin/foo", b"foo")],
+        }],
     };
 
     mock.build(pkgdir.path());
@@ -305,30 +299,28 @@ fn component_bad_version() {
 #[test]
 #[cfg(unix)]
 fn unix_permissions() {
-    use std::os::unix::fs::PermissionsExt;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
 
     let pkgdir = TempDir::new("rustup").unwrap();
 
     let mock = MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "mycomponent".to_string(),
-                files: vec![
-                    MockFile::new("bin/foo", b"foo"),
-                    MockFile::new("lib/bar", b"bar"),
-                    MockFile::new("lib/foobar", b"foobar").executable(true),
-                    MockFile::new_dir(
-                        "doc/stuff",
-                        &[
-                            ("doc1", b"", false),
-                            ("morestuff/doc2", b"", false),
-                            ("morestuff/tool", b"", true),
-                        ],
-                    ),
-                ],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "mycomponent".to_string(),
+            files: vec![
+                MockFile::new("bin/foo", b"foo"),
+                MockFile::new("lib/bar", b"bar"),
+                MockFile::new("lib/foobar", b"foobar").executable(true),
+                MockFile::new_dir(
+                    "doc/stuff",
+                    &[
+                        ("doc1", b"", false),
+                        ("morestuff/doc2", b"", false),
+                        ("morestuff/tool", b"", true),
+                    ],
+                ),
+            ],
+        }],
     };
 
     mock.build(pkgdir.path());
@@ -408,12 +400,10 @@ fn install_to_prefix_that_does_not_exist() {
     let pkgdir = TempDir::new("rustup").unwrap();
 
     let mock = MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "mycomponent".to_string(),
-                files: vec![MockFile::new("bin/foo", b"foo")],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "mycomponent".to_string(),
+            files: vec![MockFile::new("bin/foo", b"foo")],
+        }],
     };
 
     mock.build(pkgdir.path());

--- a/src/rustup-dist/tests/manifest.rs
+++ b/src/rustup-dist/tests/manifest.rs
@@ -1,8 +1,8 @@
 extern crate rustup_dist;
 
+use rustup_dist::dist::TargetTriple;
 use rustup_dist::manifest::Manifest;
 use rustup_dist::ErrorKind;
-use rustup_dist::dist::TargetTriple;
 
 // Example manifest from https://public.etherpad-mozilla.org/p/Rust-infra-work-week
 static EXAMPLE: &'static str = include_str!("channel-rust-nightly-example.toml");

--- a/src/rustup-dist/tests/transactions.rs
+++ b/src/rustup-dist/tests/transactions.rs
@@ -2,18 +2,18 @@ extern crate rustup_dist;
 extern crate rustup_utils;
 extern crate tempdir;
 
-use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::component::Transaction;
 use rustup_dist::dist::DEFAULT_DIST_SERVER;
+use rustup_dist::prefix::InstallPrefix;
 use rustup_dist::temp;
-use rustup_dist::Notification;
 use rustup_dist::ErrorKind;
-use rustup_utils::utils;
+use rustup_dist::Notification;
 use rustup_utils::raw as utils_raw;
-use tempdir::TempDir;
+use rustup_utils::utils;
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
+use tempdir::TempDir;
 
 #[test]
 fn add_file() {
@@ -172,7 +172,8 @@ fn copy_file_that_exists() {
     fs::create_dir_all(&prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
 
-    let err = tx.copy_file("c", PathBuf::from("foo/bar"), &srcpath)
+    let err = tx
+        .copy_file("c", PathBuf::from("foo/bar"), &srcpath)
         .unwrap_err();
 
     match err.0 {
@@ -271,7 +272,8 @@ fn copy_dir_that_exists() {
 
     fs::create_dir_all(prefix.path().join("a")).unwrap();
 
-    let err = tx.copy_dir("c", PathBuf::from("a"), srcdir.path())
+    let err = tx
+        .copy_dir("c", PathBuf::from("a"), srcdir.path())
         .unwrap_err();
 
     match err.0 {
@@ -508,7 +510,8 @@ fn write_file_that_exists() {
 
     let content = "hi".to_string();
     utils_raw::write_file(&prefix.path().join("a"), &content).unwrap();
-    let err = tx.write_file("c", PathBuf::from("a"), content.clone())
+    let err = tx
+        .write_file("c", PathBuf::from("a"), content.clone())
         .unwrap_err();
 
     match err.0 {

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -1,10 +1,15 @@
 //! A mock distribution server used by tests/cli-v1.rs and
 //! tests/cli-v2.rs
 
+use crate::dist::{
+    change_channel_date, ManifestVersion, MockChannel, MockComponent, MockDistServer, MockPackage,
+    MockTargetedPackage,
+};
+use crate::{MockComponentBuilder, MockFile, MockInstallerBuilder};
 use std::cell::RefCell;
 use std::collections::HashMap;
-use std::env::consts::EXE_SUFFIX;
 use std::env;
+use std::env::consts::EXE_SUFFIX;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::mem;
@@ -13,9 +18,6 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 use std::time::Duration;
 use tempdir::TempDir;
-use crate::{MockComponentBuilder, MockFile, MockInstallerBuilder};
-use crate::dist::{change_channel_date, ManifestVersion, MockChannel, MockComponent, MockDistServer,
-           MockPackage, MockTargetedPackage};
 use url::Url;
 use wait_timeout::ChildExt;
 
@@ -393,7 +395,8 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
     MockDistServer {
         path: path.to_owned(),
         channels: chans,
-    }.write(vs, true);
+    }
+    .write(vs, true);
 
     // Also create the manifests for stable releases by version
     if dates_count > 1 {
@@ -424,14 +427,16 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
                 host_triple
             )),
             path.join(format!("dist/rust-1.0.0-{}.tar.gz", host_triple)),
-        ).unwrap();
+        )
+        .unwrap();
         hard_link(
             path.join(format!(
                 "dist/2015-01-01/rust-stable-{}.tar.gz.sha256",
                 host_triple
             )),
             path.join(format!("dist/rust-1.0.0-{}.tar.gz.sha256", host_triple)),
-        ).unwrap();
+        )
+        .unwrap();
     }
     hard_link(
         path.join(format!(
@@ -439,14 +444,16 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
             host_triple
         )),
         path.join(format!("dist/rust-1.1.0-{}.tar.gz", host_triple)),
-    ).unwrap();
+    )
+    .unwrap();
     hard_link(
         path.join(format!(
             "dist/2015-01-02/rust-stable-{}.tar.gz.sha256",
             host_triple
         )),
         path.join(format!("dist/rust-1.1.0-{}.tar.gz.sha256", host_triple)),
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 fn build_mock_channel(
@@ -642,15 +649,13 @@ fn build_mock_unavailable_channel(channel: &str, date: &str, version: &'static s
         .map(|name| MockPackage {
             name,
             version,
-            targets: vec![
-                MockTargetedPackage {
-                    target: host_triple.clone(),
-                    available: false,
-                    components: vec![],
-                    extensions: vec![],
-                    installer: MockInstallerBuilder { components: vec![] },
-                },
-            ],
+            targets: vec![MockTargetedPackage {
+                target: host_triple.clone(),
+                available: false,
+                components: vec![],
+                extensions: vec![],
+                installer: MockInstallerBuilder { components: vec![] },
+            }],
         })
         .collect();
 
@@ -700,28 +705,25 @@ pub fn this_host_triple() -> String {
 
 fn build_mock_std_installer(trip: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: format!("rust-std-{}", trip.clone()),
-                files: vec![
-                    MockFile::new(format!("lib/rustlib/{}/libstd.rlib", trip), b""),
-                ],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: format!("rust-std-{}", trip.clone()),
+            files: vec![MockFile::new(
+                format!("lib/rustlib/{}/libstd.rlib", trip),
+                b"",
+            )],
+        }],
     }
 }
 
 fn build_mock_cross_std_installer(target: &str, date: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: format!("rust-std-{}", target.clone()),
-                files: vec![
-                    MockFile::new(format!("lib/rustlib/{}/lib/libstd.rlib", target), b""),
-                    MockFile::new(format!("lib/rustlib/{}/lib/{}", target, date), b""),
-                ],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: format!("rust-std-{}", target.clone()),
+            files: vec![
+                MockFile::new(format!("lib/rustlib/{}/lib/libstd.rlib", target), b""),
+                MockFile::new(format!("lib/rustlib/{}/lib/{}", target, date), b""),
+            ],
+        }],
     }
 }
 
@@ -741,23 +743,19 @@ fn build_mock_rustc_installer(
     }
 
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "rustc".to_string(),
-                files: mock_bin("rustc", version, &version_hash),
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "rustc".to_string(),
+            files: mock_bin("rustc", version, &version_hash),
+        }],
     }
 }
 
 fn build_mock_cargo_installer(version: &str, version_hash: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "cargo".to_string(),
-                files: mock_bin("cargo", version, &version_hash),
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "cargo".to_string(),
+            files: mock_bin("cargo", version, &version_hash),
+        }],
     }
 }
 
@@ -767,51 +765,44 @@ fn build_mock_rls_installer(
     preview: bool,
 ) -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: if preview {
-                    "rls-preview".to_string()
-                } else {
-                    "rls".to_string()
-                },
-                files: mock_bin("rls", version, version_hash),
+        components: vec![MockComponentBuilder {
+            name: if preview {
+                "rls-preview".to_string()
+            } else {
+                "rls".to_string()
             },
-        ],
+            files: mock_bin("rls", version, version_hash),
+        }],
     }
 }
 
 fn build_mock_rust_doc_installer() -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "rust-docs".to_string(),
-                files: vec![MockFile::new("share/doc/rust/html/index.html", b"")],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "rust-docs".to_string(),
+            files: vec![MockFile::new("share/doc/rust/html/index.html", b"")],
+        }],
     }
 }
 
 fn build_mock_rust_analysis_installer(trip: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: format!("rust-analysis-{}", trip),
-                files: vec![
-                    MockFile::new(format!("lib/rustlib/{}/analysis/libfoo.json", trip), b""),
-                ],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: format!("rust-analysis-{}", trip),
+            files: vec![MockFile::new(
+                format!("lib/rustlib/{}/analysis/libfoo.json", trip),
+                b"",
+            )],
+        }],
     }
 }
 
 fn build_mock_rust_src_installer() -> MockInstallerBuilder {
     MockInstallerBuilder {
-        components: vec![
-            MockComponentBuilder {
-                name: "rust-src".to_string(),
-                files: vec![MockFile::new("lib/rustlib/src/rust-src/foo.rs", b"")],
-            },
-        ],
+        components: vec![MockComponentBuilder {
+            name: "rust-src".to_string(),
+            files: vec![MockFile::new("lib/rustlib/src/rust-src/foo.rs", b"")],
+        }],
     }
 }
 

--- a/src/rustup-mock/src/dist.rs
+++ b/src/rustup-mock/src/dist.rs
@@ -2,19 +2,19 @@
 //! distribution server, with v1 and v2 manifests.
 
 use crate::MockInstallerBuilder;
-use url::Url;
+use flate2;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use tempdir::TempDir;
-use sha2::{Digest, Sha256};
-use toml;
-use flate2;
-use xz2;
 use tar;
+use tempdir::TempDir;
+use toml;
+use url::Url;
 use walkdir;
+use xz2;
 
 use crate::clitools::hard_link;
 
@@ -204,8 +204,7 @@ impl MockDistServer {
         // Tarball creation can be super slow, so cache created tarballs
         // globally to avoid recreating and recompressing tons of tarballs.
         lazy_static! {
-            static ref TARBALLS: Mutex<HashMap<(String, MockTargetedPackage, String),
-                                               (Vec<u8>, String)>> =
+            static ref TARBALLS: Mutex<HashMap<(String, MockTargetedPackage, String), (Vec<u8>, String)>> =
                 Mutex::new(HashMap::new());
         }
 
@@ -327,7 +326,8 @@ impl MockDistServer {
                 } else {
                     format!("{}-{}.tar.gz", package.name, channel.name)
                 };
-                let path = self.path
+                let path = self
+                    .path
                     .join("dist")
                     .join(&channel.date)
                     .join(package_file_name);
@@ -415,7 +415,8 @@ impl MockDistServer {
         let ref archive_manifest_path = self.path.join(format!("{}.toml", archive_manifest_name));
         hard_link(manifest_path, archive_manifest_path).unwrap();
 
-        let ref archive_hash_path = self.path
+        let ref archive_hash_path = self
+            .path
             .join(format!("{}.toml.sha256", archive_manifest_name));
         hard_link(hash_path, archive_hash_path).unwrap();
     }

--- a/src/rustup-mock/src/lib.rs
+++ b/src/rustup-mock/src/lib.rs
@@ -17,8 +17,8 @@ extern crate winapi;
 #[cfg(windows)]
 extern crate winreg;
 
-pub mod dist;
 pub mod clitools;
+pub mod dist;
 
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
@@ -144,10 +144,12 @@ impl MockFile {
     pub fn build(&self, path: &Path) {
         let path = path.join(&self.path);
         match self.contents {
-            Contents::Dir(ref files) => for &(ref name, ref contents) in files {
-                let fname = path.join(name);
-                contents.build(&fname);
-            },
+            Contents::Dir(ref files) => {
+                for &(ref name, ref contents) in files {
+                    let fname = path.join(name);
+                    contents.build(&fname);
+                }
+            }
             Contents::File(ref contents) => contents.build(&path),
         }
     }
@@ -176,11 +178,12 @@ impl MockContents {
 
 #[cfg(windows)]
 pub fn get_path() -> Option<String> {
-    use winreg::RegKey;
     use winreg::enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+    use winreg::RegKey;
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
-    let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
+    let environment = root
+        .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
         .unwrap();
 
     environment.get_value("PATH").ok()
@@ -188,11 +191,12 @@ pub fn get_path() -> Option<String> {
 
 #[cfg(windows)]
 pub fn restore_path(p: &Option<String>) {
-    use winreg::{RegKey, RegValue};
     use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+    use winreg::{RegKey, RegValue};
 
     let root = RegKey::predef(HKEY_CURRENT_USER);
-    let environment = root.open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
+    let environment = root
+        .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
         .unwrap();
 
     if let Some(p) = p.as_ref() {

--- a/src/rustup-utils/src/errors.rs
+++ b/src/rustup-utils/src/errors.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
-use std::ffi::OsString;
-use url::Url;
 use download;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use url::Url;
 
 error_chain! {
     links {

--- a/src/rustup-utils/src/lib.rs
+++ b/src/rustup-utils/src/lib.rs
@@ -21,9 +21,9 @@ extern crate libc;
 pub mod errors;
 pub mod notifications;
 pub mod raw;
+pub mod toml_utils;
 pub mod tty;
 pub mod utils;
-pub mod toml_utils;
 
 pub use crate::errors::*;
 pub use crate::notifications::Notification;

--- a/src/rustup-utils/src/notifications.rs
+++ b/src/rustup-utils/src/notifications.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use std::fmt::{self, Display};
+use std::path::Path;
 
 use url::Url;
 

--- a/src/rustup-utils/src/raw.rs
+++ b/src/rustup-utils/src/raw.rs
@@ -6,8 +6,8 @@ use std::error;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs;
-use std::io::Write;
 use std::io;
+use std::io::Write;
 use std::path::Path;
 use std::process::{Command, ExitStatus};
 use std::str;
@@ -176,14 +176,14 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
 #[cfg(windows)]
 #[allow(non_snake_case)]
 fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt;
+    use std::ptr;
     use winapi::shared::minwindef::*;
     use winapi::um::fileapi::*;
     use winapi::um::ioapiset::*;
     use winapi::um::winbase::*;
     use winapi::um::winioctl::FSCTL_SET_REPARSE_POINT;
     use winapi::um::winnt::*;
-    use std::ptr;
-    use std::os::windows::ffi::OsStrExt;
 
     const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
 
@@ -359,8 +359,8 @@ pub fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
 pub fn open_browser(path: &Path) -> io::Result<bool> {
     #[cfg(not(windows))]
     fn inner(path: &Path) -> io::Result<bool> {
-        use std::process::Stdio;
         use std::env;
+        use std::process::Stdio;
 
         let env_browser = env::var_os("BROWSER").map(|b| env::split_paths(&b).collect::<Vec<_>>());
         let env_commands = env_browser
@@ -389,11 +389,11 @@ pub fn open_browser(path: &Path) -> io::Result<bool> {
     }
     #[cfg(windows)]
     fn inner(path: &Path) -> io::Result<bool> {
-        use winapi::ctypes;
-        use winapi::shared::windef::HWND;
-        use winapi::shared::ntdef::LPCWSTR;
-        use winapi::shared::minwindef::HINSTANCE;
         use std::ptr;
+        use winapi::ctypes;
+        use winapi::shared::minwindef::HINSTANCE;
+        use winapi::shared::ntdef::LPCWSTR;
+        use winapi::shared::windef::HWND;
 
         // FIXME: When winapi has this function, use their version
         extern "system" {
@@ -427,14 +427,14 @@ pub fn open_browser(path: &Path) -> io::Result<bool> {
 
 #[cfg(windows)]
 pub mod windows {
-    use winapi::um::{combaseapi, shlobj, shtypes};
-    use winapi::shared::guiddef::GUID;
+    use std::ffi::{OsStr, OsString};
     use std::io;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
     use std::path::PathBuf;
     use std::ptr;
     use std::slice;
-    use std::ffi::{OsStr, OsString};
-    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+    use winapi::shared::guiddef::GUID;
+    use winapi::um::{combaseapi, shlobj, shtypes};
 
     #[allow(non_upper_case_globals)]
     pub const FOLDERID_LocalAppData: GUID = GUID {

--- a/src/rustup-utils/src/toml_utils.rs
+++ b/src/rustup-utils/src/toml_utils.rs
@@ -1,5 +1,5 @@
-use toml;
 use crate::errors::*;
+use toml;
 
 pub fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {
     table

--- a/src/rustup-win-installer/build.rs
+++ b/src/rustup-win-installer/build.rs
@@ -1,7 +1,7 @@
 extern crate gcc;
 
-use std::env;
 use gcc::windows_registry::{self, VsVers};
+use std::env;
 
 fn main() {
     println!("cargo:rustc-link-lib=dylib=msi");

--- a/src/rustup-win-installer/src/lib.rs
+++ b/src/rustup-win-installer/src/lib.rs
@@ -3,12 +3,12 @@
 extern crate rustup;
 extern crate winapi;
 
+use std::collections::HashMap;
 use std::ffi::CString;
 use std::path::PathBuf;
-use std::collections::HashMap;
 
-use winapi::shared::ntdef::{HRESULT, LPCWSTR, LPWSTR, PCSTR};
 use winapi::shared::minwindef::{LPVOID, UINT};
+use winapi::shared::ntdef::{HRESULT, LPCWSTR, LPWSTR, PCSTR};
 
 pub type MSIHANDLE = u32;
 

--- a/src/rustup/command.rs
+++ b/src/rustup/command.rs
@@ -1,16 +1,16 @@
+use regex::Regex;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{self, BufRead, BufReader, Seek, SeekFrom, Write};
 use std::process::{self, Command, Stdio};
 use std::time::Instant;
-use regex::Regex;
 use tempfile::tempfile;
 
-use crate::Cfg;
 use crate::errors::*;
 use crate::notifications::*;
-use rustup_utils::{self, utils::ExitCode};
 use crate::telemetry::{Telemetry, TelemetryEvent};
+use crate::Cfg;
+use rustup_utils::{self, utils::ExitCode};
 
 pub fn run_command_for_dir<S: AsRef<OsStr>>(
     cmd: Command,
@@ -62,7 +62,8 @@ fn telemetry_rustc<S: AsRef<OsStr>>(
 
     // FIXME rust-lang/rust#32254. It's not clear to me
     // when and why this is needed.
-    let mut cmd = cmd.stdin(Stdio::inherit())
+    let mut cmd = cmd
+        .stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
         .stderr(cmd_err_stdio)
         .spawn()

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -1,18 +1,18 @@
-use std::path::{Path, PathBuf};
 use std::borrow::Cow;
 use std::env;
-use std::io;
-use std::process::Command;
 use std::fmt::{self, Display};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 
 use crate::errors::*;
 use crate::notifications::*;
+use crate::settings::{Settings, SettingsFile, TelemetryMode, DEFAULT_METADATA_VERSION};
+use crate::telemetry_analysis::*;
+use crate::toolchain::{Toolchain, UpdateStatus};
 use rustup_dist::{dist, temp};
 use rustup_utils::utils;
-use crate::toolchain::{Toolchain, UpdateStatus};
-use crate::telemetry_analysis::*;
-use crate::settings::{Settings, SettingsFile, TelemetryMode, DEFAULT_METADATA_VERSION};
 
 #[derive(Debug)]
 pub enum OverrideReason {
@@ -210,11 +210,13 @@ impl Cfg {
     }
 
     pub fn find_default(&self) -> Result<Option<Toolchain>> {
-        let opt_name = self.settings_file
+        let opt_name = self
+            .settings_file
             .with(|s| Ok(s.default_toolchain.clone()))?;
 
         if let Some(name) = opt_name {
-            let toolchain = self.verify_toolchain(&name)
+            let toolchain = self
+                .verify_toolchain(&name)
                 .chain_err(|| ErrorKind::ToolchainNotInstalled(name.to_string()))?;
 
             Ok(Some(toolchain))
@@ -478,7 +480,8 @@ impl Cfg {
     }
 
     pub fn get_default_host_triple(&self) -> Result<dist::TargetTriple> {
-        Ok(self.settings_file
+        Ok(self
+            .settings_file
             .with(|s| {
                 Ok(s.default_host_triple
                     .as_ref()

--- a/src/rustup/errors.rs
+++ b/src/rustup/errors.rs
@@ -1,6 +1,6 @@
+use crate::component_for_bin;
 use rustup_dist::{self, temp};
 use rustup_utils;
-use crate::component_for_bin;
 use toml;
 
 error_chain! {

--- a/src/rustup/install.rs
+++ b/src/rustup/install.rs
@@ -1,14 +1,14 @@
 //! Installation and upgrade of both distribution-managed and local
 //! toolchains
 
-use rustup_dist::Notification;
-use rustup_dist::prefix::InstallPrefix;
-use rustup_utils::utils;
-use rustup_dist::temp;
+use crate::errors::Result;
+use rustup_dist::component::{Components, Package, TarGzPackage, Transaction};
 use rustup_dist::dist;
 use rustup_dist::download::DownloadCfg;
-use rustup_dist::component::{Components, Package, TarGzPackage, Transaction};
-use crate::errors::Result;
+use rustup_dist::prefix::InstallPrefix;
+use rustup_dist::temp;
+use rustup_dist::Notification;
+use rustup_utils::utils;
 use std::path::Path;
 
 #[derive(Copy, Clone)]

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -16,16 +16,22 @@ extern crate time;
 extern crate toml;
 extern crate url;
 
+pub use crate::config::*;
 pub use crate::errors::*;
 pub use crate::notifications::*;
-pub use crate::config::*;
 pub use crate::toolchain::*;
 pub use rustup_utils::{notify, toml_utils, utils};
 
-
 // A list of all binaries which Rustup will proxy.
-pub static TOOLS: &'static [&'static str] =
-    &["rustc", "rustdoc", "cargo", "rust-lldb", "rust-gdb", "rls", "cargo-clippy"];
+pub static TOOLS: &'static [&'static str] = &[
+    "rustc",
+    "rustdoc",
+    "cargo",
+    "rust-lldb",
+    "rust-gdb",
+    "rls",
+    "cargo-clippy",
+];
 
 // Tools which are commonly installed by Cargo as well as rustup. We take a bit
 // more care with these to ensure we don't overwrite the user's previous
@@ -45,13 +51,13 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
     }
 }
 
-mod errors;
-mod notifications;
-mod toolchain;
+pub mod command;
 mod config;
+pub mod env_var;
+mod errors;
 mod install;
+mod notifications;
 pub mod settings;
 pub mod telemetry;
-pub mod command;
 pub mod telemetry_analysis;
-pub mod env_var;
+mod toolchain;

--- a/src/rustup/notifications.rs
+++ b/src/rustup/notifications.rs
@@ -1,5 +1,5 @@
-use std::path::{Path, PathBuf};
 use std::fmt::{self, Display};
+use std::path::{Path, PathBuf};
 
 use crate::errors::*;
 

--- a/src/rustup/settings.rs
+++ b/src/rustup/settings.rs
@@ -2,11 +2,11 @@ use crate::errors::*;
 use crate::notifications::*;
 use crate::toml_utils::*;
 use crate::utils;
-use toml;
+use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
-use std::cell::RefCell;
 use std::str::FromStr;
+use toml;
 
 pub const SUPPORTED_METADATA_VERSIONS: [&'static str; 2] = ["2", "12"];
 pub const DEFAULT_METADATA_VERSION: &'static str = "12";

--- a/src/rustup/telemetry.rs
+++ b/src/rustup/telemetry.rs
@@ -1,7 +1,7 @@
 use crate::errors::*;
-use time;
 use rustup_utils::{raw, utils};
 use serde_json;
+use time;
 
 use std::fs;
 use std::path::PathBuf;

--- a/src/rustup/telemetry_analysis.rs
+++ b/src/rustup/telemetry_analysis.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::fs::File;
-use std::io::BufReader;
 use std::io::BufRead;
+use std::io::BufReader;
 use std::path::PathBuf;
 
 use itertools::Itertools;
@@ -119,7 +119,8 @@ impl TelemetryAnalysis {
 
     pub fn import_telemery(&mut self) -> Result<Vec<TelemetryEvent>> {
         let mut events: Vec<TelemetryEvent> = Vec::new();
-        let contents = self.telemetry_dir
+        let contents = self
+            .telemetry_dir
             .read_dir()
             .chain_err(|| ErrorKind::TelemetryAnalysisError)?;
 
@@ -189,7 +190,8 @@ impl TelemetryAnalysis {
                     self.rustc_statistics.rustc_execution_count += 1;
                     rustc_durations.push(duration_ms);
 
-                    let exit_count = self.rustc_statistics
+                    let exit_count = self
+                        .rustc_statistics
                         .exit_codes_with_count
                         .entry(*exit_code)
                         .or_insert(0);
@@ -243,7 +245,8 @@ impl TelemetryAnalysis {
         let error_list = Itertools::flatten(error_list.into_iter());
 
         for e in error_list {
-            let error_count = self.rustc_statistics
+            let error_count = self
+                .rustc_statistics
                 .error_codes_with_counts
                 .entry(e)
                 .or_insert(0);

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -1,24 +1,24 @@
-use crate::errors::*;
-use crate::notifications::*;
-use rustup_dist;
-use rustup_dist::download::DownloadCfg;
-use rustup_utils::utils;
-use rustup_dist::prefix::InstallPrefix;
-use rustup_dist::dist::ToolchainDesc;
-use rustup_dist::manifestation::{Changes, Manifestation};
-use rustup_dist::manifest::Component;
 use crate::config::Cfg;
 use crate::env_var;
+use crate::errors::*;
 use crate::install::{self, InstallMethod};
+use crate::notifications::*;
 use crate::telemetry;
 use crate::telemetry::{Telemetry, TelemetryEvent};
+use rustup_dist;
+use rustup_dist::dist::ToolchainDesc;
+use rustup_dist::download::DownloadCfg;
+use rustup_dist::manifest::Component;
+use rustup_dist::manifestation::{Changes, Manifestation};
+use rustup_dist::prefix::InstallPrefix;
+use rustup_utils::utils;
 
-use std::env::consts::EXE_SUFFIX;
-use std::ffi::OsString;
-use std::process::Command;
-use std::path::{Path, PathBuf};
-use std::ffi::OsStr;
 use std::env;
+use std::env::consts::EXE_SUFFIX;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use url::Url;
 
@@ -226,7 +226,8 @@ impl<'a> Toolchain<'a> {
     pub fn is_tracking(&self) -> bool {
         ToolchainDesc::from_str(&self.name)
             .ok()
-            .map(|d| d.is_tracking()) == Some(true)
+            .map(|d| d.is_tracking())
+            == Some(true)
     }
 
     fn ensure_custom(&self) -> Result<()> {
@@ -234,7 +235,8 @@ impl<'a> Toolchain<'a> {
             Err(
                 ErrorKind::Dist(::rustup_dist::ErrorKind::InvalidCustomToolchainName(
                     self.name.to_string(),
-                )).into(),
+                ))
+                .into(),
             )
         } else {
             Ok(())
@@ -344,7 +346,8 @@ impl<'a> Toolchain<'a> {
                 return Err(ErrorKind::BinaryNotFound(
                     self.name.clone(),
                     binary.to_string_lossy().into(),
-                ).into());
+                )
+                .into());
             }
             Path::new(&binary)
         };
@@ -390,7 +393,8 @@ impl<'a> Toolchain<'a> {
                 .chain_err(|| "unable to create dir to hold fallback exe")?;
             let fallback_file = fallback_dir.join("cargo.exe");
             if fallback_file.exists() {
-                fs::remove_file(&fallback_file).chain_err(|| "unable to unlink old fallback exe")?;
+                fs::remove_file(&fallback_file)
+                    .chain_err(|| "unable to unlink old fallback exe")?;
             }
             fs::hard_link(&src_file, &fallback_file)
                 .chain_err(|| "unable to hard link fallback exe")?;
@@ -513,10 +517,12 @@ impl<'a> Toolchain<'a> {
                     .unwrap_or(false);
 
                 // Get the component so we can check if it is available
-                let component_pkg = manifest.get_package(&component.short_name_in_manifest()).expect(&format!(
-                    "manifest should contain component {}",
-                    &component.short_name(&manifest)
-                ));
+                let component_pkg = manifest
+                    .get_package(&component.short_name_in_manifest())
+                    .expect(&format!(
+                        "manifest should contain component {}",
+                        &component.short_name(&manifest)
+                    ));
                 let component_target_pkg = component_pkg
                     .targets
                     .get(&toolchain.target)
@@ -538,10 +544,12 @@ impl<'a> Toolchain<'a> {
                     .unwrap_or(false);
 
                 // Get the component so we can check if it is available
-                let extension_pkg = manifest.get_package(&extension.short_name_in_manifest()).expect(&format!(
-                    "manifest should contain extension {}",
-                    &extension.short_name(&manifest)
-                ));
+                let extension_pkg = manifest
+                    .get_package(&extension.short_name_in_manifest())
+                    .expect(&format!(
+                        "manifest should contain extension {}",
+                        &extension.short_name(&manifest)
+                    ));
                 let extension_target_pkg = extension_pkg
                     .targets
                     .get(&toolchain.target)
@@ -651,12 +659,11 @@ impl<'a> Toolchain<'a> {
                 if targ_pkg.extensions.contains(&wildcard_component) {
                     component = wildcard_component;
                 } else {
-                    return Err(
-                        ErrorKind::UnknownComponent(
-                            self.name.to_string(),
-                            component.description(&manifest),
-                        ).into(),
-                    );
+                    return Err(ErrorKind::UnknownComponent(
+                        self.name.to_string(),
+                        component.description(&manifest),
+                    )
+                    .into());
                 }
             }
 
@@ -708,12 +715,11 @@ impl<'a> Toolchain<'a> {
                 .expect("installed manifest should have a known target");
 
             if targ_pkg.components.contains(&component) {
-                return Err(
-                    ErrorKind::RemovingRequiredComponent(
-                        self.name.to_string(),
-                        component.description(&manifest),
-                    ).into(),
-                );
+                return Err(ErrorKind::RemovingRequiredComponent(
+                    self.name.to_string(),
+                    component.description(&manifest),
+                )
+                .into());
             }
 
             let dist_config = manifestation.read_config()?.unwrap();
@@ -722,12 +728,11 @@ impl<'a> Toolchain<'a> {
                 if dist_config.components.contains(&wildcard_component) {
                     component = wildcard_component;
                 } else {
-                    return Err(
-                        ErrorKind::UnknownComponent(
-                            self.name.to_string(),
-                            component.description(&manifest),
-                        ).into(),
-                    );
+                    return Err(ErrorKind::UnknownComponent(
+                        self.name.to_string(),
+                        component.description(&manifest),
+                    )
+                    .into());
                 }
             }
 

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -6,10 +6,15 @@ extern crate rustup_mock;
 extern crate rustup_utils;
 extern crate tempdir;
 
-use rustup_mock::clitools::{self, expect_err_ex, expect_ok, expect_ok_ex, this_host_triple,
-                            Config, Scenario};
+use rustup_mock::clitools::{
+    self, expect_err_ex, expect_ok, expect_ok_ex, this_host_triple, Config, Scenario,
+};
 
-macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
+macro_rules! for_host {
+    ($s: expr) => {
+        &format!($s, this_host_triple())
+    };
+}
 
 fn setup(f: &Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV2, f);

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -6,11 +6,11 @@ extern crate rustup_mock;
 extern crate rustup_utils;
 extern crate scopeguard;
 
-use std::sync::Mutex;
-use std::process::Stdio;
-use std::io::Write;
 use rustup_mock::clitools::{self, expect_stdout_ok, Config, SanitizedOutput, Scenario};
 use rustup_mock::{get_path, restore_path};
+use std::io::Write;
+use std::process::Stdio;
+use std::sync::Mutex;
 
 pub fn setup(f: &Fn(&Config)) {
     clitools::setup(Scenario::SimpleV2, &|config| {
@@ -130,10 +130,9 @@ fn with_no_modify_path() {
     setup(&|config| {
         let out = run_input(config, &["rustup-init", "--no-modify-path"], "\n\n");
         assert!(out.ok);
-        assert!(
-            out.stdout
-                .contains("This path needs to be in your PATH environment variable")
-        );
+        assert!(out
+            .stdout
+            .contains("This path needs to be in your PATH environment variable"));
 
         if cfg!(unix) {
             assert!(!config.homedir.join(".profile").exists());

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -7,19 +7,24 @@ extern crate rustup_utils;
 extern crate tempdir;
 extern crate time;
 
-use rustup_mock::clitools::{self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok,
-                            expect_stdout_ok, expect_timeout_ok, run, set_current_dist_date,
-                            this_host_triple, Config, Scenario};
+use rustup_mock::clitools::{
+    self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok, expect_stdout_ok,
+    expect_timeout_ok, run, set_current_dist_date, this_host_triple, Config, Scenario,
+};
 use rustup_utils::{raw, utils};
 
+use std::env::consts::EXE_SUFFIX;
 use std::ops::Add;
 use std::ops::Sub;
 use std::time::Duration as StdDuration;
-use std::env::consts::EXE_SUFFIX;
 use tempdir::TempDir;
 use time::Duration;
 
-macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
+macro_rules! for_host {
+    ($s: expr) => {
+        &format!($s, this_host_triple())
+    };
+}
 
 pub fn setup(f: &Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV2, f);
@@ -147,21 +152,21 @@ fn upgrade_toml_settings() {
             "rustup's metadata is out of date. run `rustup self upgrade-data`",
         );
         // Replace the metadata version
-        assert!(!rustup_utils::raw::is_file(&config
-            .rustupdir
-            .join("version")));
-        assert!(!rustup_utils::raw::is_file(&config
-            .rustupdir
-            .join("default")));
-        assert!(!rustup_utils::raw::is_file(&config
-            .rustupdir
-            .join("overrides")));
-        assert!(!rustup_utils::raw::is_file(&config
-            .rustupdir
-            .join("telemetry-on")));
-        assert!(rustup_utils::raw::is_file(&config
-            .rustupdir
-            .join("settings.toml")));
+        assert!(!rustup_utils::raw::is_file(
+            &config.rustupdir.join("version")
+        ));
+        assert!(!rustup_utils::raw::is_file(
+            &config.rustupdir.join("default")
+        ));
+        assert!(!rustup_utils::raw::is_file(
+            &config.rustupdir.join("overrides")
+        ));
+        assert!(!rustup_utils::raw::is_file(
+            &config.rustupdir.join("telemetry-on")
+        ));
+        assert!(rustup_utils::raw::is_file(
+            &config.rustupdir.join("settings.toml")
+        ));
 
         let content =
             rustup_utils::raw::read_file(&config.rustupdir.join("settings.toml")).unwrap();
@@ -613,12 +618,7 @@ fn rename_rls_list() {
         expect_ok(config, &["rustup", "update", "--no-self-update"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
-        let out = run(
-            config,
-            "rustup",
-            &["component", "list"],
-            &[],
-        );
+        let out = run(config, "rustup", &["component", "list"], &[]);
         assert!(out.ok);
         assert!(out.stdout.contains(&format!("rls-{}", this_host_triple())));
     });
@@ -634,12 +634,7 @@ fn rename_rls_preview_list() {
         expect_ok(config, &["rustup", "update", "--no-self-update"]);
         expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
 
-        let out = run(
-            config,
-            "rustup",
-            &["component", "list"],
-            &[],
-        );
+        let out = run(config, "rustup", &["component", "list"], &[]);
         assert!(out.ok);
         assert!(out.stdout.contains(&format!("rls-{}", this_host_triple())));
     });
@@ -657,12 +652,20 @@ fn rename_rls_remove() {
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
         expect_ok(config, &["rustup", "component", "remove", "rls"]);
-        expect_err(config, &["rls", "--version"], &format!("'rls{}' is not installed", EXE_SUFFIX));
+        expect_err(
+            config,
+            &["rls", "--version"],
+            &format!("'rls{}' is not installed", EXE_SUFFIX),
+        );
 
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
         expect_ok(config, &["rustup", "component", "remove", "rls-preview"]);
-        expect_err(config, &["rls", "--version"], &format!("'rls{}' is not installed", EXE_SUFFIX));
+        expect_err(
+            config,
+            &["rls", "--version"],
+            &format!("'rls{}' is not installed", EXE_SUFFIX),
+        );
     });
 }
 
@@ -685,14 +688,12 @@ fn install_stops_if_rustc_exists() {
             ],
         );
         assert!(!out.ok);
-        assert!(
-            out.stderr
-                .contains("it looks like you have an existing installation of Rust at:")
-        );
-        assert!(
-            out.stderr
-                .contains("if this is what you want, restart the installation with `-y'")
-        );
+        assert!(out
+            .stderr
+            .contains("it looks like you have an existing installation of Rust at:"));
+        assert!(out
+            .stderr
+            .contains("if this is what you want, restart the installation with `-y'"));
     });
 }
 
@@ -715,14 +716,12 @@ fn install_stops_if_cargo_exists() {
             ],
         );
         assert!(!out.ok);
-        assert!(
-            out.stderr
-                .contains("it looks like you have an existing installation of Rust at:")
-        );
-        assert!(
-            out.stderr
-                .contains("if this is what you want, restart the installation with `-y'")
-        );
+        assert!(out
+            .stderr
+            .contains("it looks like you have an existing installation of Rust at:"));
+        assert!(out
+            .stderr
+            .contains("if this is what you want, restart the installation with `-y'"));
     });
 }
 
@@ -752,8 +751,8 @@ fn with_no_prompt_install_succeeds_if_rustc_exists() {
 #[test]
 #[cfg(any(unix, windows))]
 fn toolchain_broken_symlink() {
-    use std::path::Path;
     use std::fs;
+    use std::path::Path;
 
     #[cfg(unix)]
     fn create_symlink_dir<P: AsRef<Path>, Q: AsRef<Path>>(src: P, dst: Q) {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -5,16 +5,21 @@ extern crate rustup_mock;
 extern crate rustup_utils;
 extern crate tempdir;
 
-use std::fs;
+use rustup_mock::clitools::{
+    self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok, expect_stdout_ok,
+    set_current_dist_date, this_host_triple, Config, Scenario,
+};
+use rustup_utils::raw;
 use std::env::consts::EXE_SUFFIX;
+use std::fs;
 use std::path::MAIN_SEPARATOR;
 use std::process;
-use rustup_utils::raw;
-use rustup_mock::clitools::{self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok,
-                            expect_stdout_ok, set_current_dist_date, this_host_triple, Config,
-                            Scenario};
 
-macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
+macro_rules! for_host {
+    ($s: expr) => {
+        &format!($s, this_host_triple())
+    };
+}
 
 pub fn setup(f: &Fn(&Config)) {
     clitools::setup(Scenario::ArchivesV2, &|config| {
@@ -865,12 +870,7 @@ fn show_active_toolchain() {
 #[test]
 fn show_active_toolchain_none() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
-            &["rustup", "show", "active-toolchain"],
-            r"",
-            r"",
-        );
+        expect_ok_ex(config, &["rustup", "show", "active-toolchain"], r"", r"");
     });
 }
 
@@ -1092,12 +1092,10 @@ fn multirust_dir_upgrade_rename_multirust_dir_to_rustup() {
         assert!(String::from_utf8(out.stdout).unwrap().contains("stable"));
 
         assert!(multirust_dir.exists());
-        assert!(
-            fs::symlink_metadata(&multirust_dir)
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
+        assert!(fs::symlink_metadata(&multirust_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert!(rustup_dir.exists());
     });
 }
@@ -1140,12 +1138,10 @@ fn multirust_dir_upgrade_old_rustup_exists() {
         assert!(String::from_utf8(out.stdout).unwrap().contains("stable"));
 
         assert!(multirust_dir.exists());
-        assert!(
-            fs::symlink_metadata(&multirust_dir)
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
+        assert!(fs::symlink_metadata(&multirust_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert!(rustup_dir.exists());
         assert!(!old_rustup_sh_version_file.exists());
         assert!(new_rustup_sh_version_file.exists());
@@ -1201,12 +1197,10 @@ fn multirust_dir_upgrade_old_rustup_existsand_new_rustup_sh_exists() {
 
         // .multirust is now a symlink to .rustup
         assert!(multirust_dir.exists());
-        assert!(
-            fs::symlink_metadata(&multirust_dir)
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
+        assert!(fs::symlink_metadata(&multirust_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
 
         assert!(rustup_dir.exists());
         assert!(!old_rustup_sh_version_file.exists());
@@ -1230,12 +1224,10 @@ fn multirust_upgrade_works_with_proxy() {
         run_no_home(config, &["rustc", "--version"], &[]);
 
         assert!(multirust_dir.exists());
-        assert!(
-            fs::symlink_metadata(&multirust_dir)
-                .unwrap()
-                .file_type()
-                .is_symlink()
-        );
+        assert!(fs::symlink_metadata(&multirust_dir)
+            .unwrap()
+            .file_type()
+            .is_symlink());
         assert!(rustup_dir.exists());
     });
 }

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -6,12 +6,18 @@ extern crate rustup_mock;
 extern crate rustup_utils;
 extern crate tempdir;
 
+use rustup_mock::clitools::{
+    self, expect_err, expect_ok, expect_stderr_ok, expect_stdout_ok, set_current_dist_date,
+    this_host_triple, Config, Scenario,
+};
 use std::fs;
 use tempdir::TempDir;
-use rustup_mock::clitools::{self, expect_err, expect_ok, expect_stderr_ok, expect_stdout_ok,
-                            set_current_dist_date, this_host_triple, Config, Scenario};
 
-macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
+macro_rules! for_host {
+    ($s: expr) => {
+        &format!($s, this_host_triple())
+    };
+}
 
 pub fn setup(f: &Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV1, f);

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -6,15 +6,20 @@ extern crate rustup_mock;
 extern crate rustup_utils;
 extern crate tempdir;
 
+use rustup_mock::clitools::{
+    self, expect_err, expect_not_stdout_ok, expect_ok, expect_stderr_ok, expect_stdout_ok,
+    set_current_dist_date, this_host_triple, Config, Scenario,
+};
 use std::fs;
 use tempdir::TempDir;
-use rustup_mock::clitools::{self, expect_err, expect_not_stdout_ok, expect_ok, expect_stderr_ok,
-                            expect_stdout_ok, set_current_dist_date, this_host_triple, Config,
-                            Scenario};
 
 use rustup_dist::dist::TargetTriple;
 
-macro_rules! for_host { ($s: expr) => (&format!($s, this_host_triple())) }
+macro_rules! for_host {
+    ($s: expr) => {
+        &format!($s, this_host_triple())
+    };
+}
 
 pub fn setup(f: &Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV2, f);
@@ -787,7 +792,6 @@ fn remove_target_host() {
 // Issue #304
 fn remove_target_missing_update_hash() {
     setup(&|config| {
-
         expect_ok(config, &["rustup", "update", "nightly"]);
 
         let file_name = format!("nightly-{}", this_host_triple());


### PR DESCRIPTION
To make sure that people using editors which use rustfmt by default
on saving don't touch more lines than intended when working on the
rustup codebase, we'll take the hit to format it all once.


Please note, this depends on #1583 (as it effectively contains that commit also)