### PR TITLE
rustup-dist: Use Download notifications to track install

### DIFF
--- a/src/rustup-dist/src/manifestation.rs
+++ b/src/rustup-dist/src/manifestation.rs
@@ -200,13 +200,18 @@ impl Manifestation {
 
             let gz;
             let xz;
+            let notification_converter = |notification: rustup_utils::Notification| {
+                notify_handler(Notification::Utils(notification));
+            };
+            let reader =
+                utils::FileReaderWithProgress::new_file(&installer_file, &notification_converter)?;
             let package: &Package = match format {
                 Format::Gz => {
-                    gz = TarGzPackage::new_file(&installer_file, temp_cfg)?;
+                    gz = TarGzPackage::new(reader, temp_cfg)?;
                     &gz
                 }
                 Format::Xz => {
-                    xz = TarXzPackage::new_file(&installer_file, temp_cfg)?;
+                    xz = TarXzPackage::new(reader, temp_cfg)?;
                     &xz
                 }
             };


### PR DESCRIPTION
People have requested some indication of progress for long-running
install steps.  This commit re-uses the download tracker logic to
provide a progress bar (the length is the compressed component
tarball but should be good enough) to provide such feedback.

Fixes: #1557