### PR TITLE
Add more detail error messages when installing with some components has failed.

### DIFF
--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -5,6 +5,10 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use toml;
 
+pub const TOOLSTATE_MSG: &str = "if you require these components, please install and use the latest successful build version, \
+                                which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.\n\
+                                rustup install nightly-2018-12-27";
+
 error_chain! {
     links {
         Utils(rustup_utils::Error, rustup_utils::ErrorKind);
@@ -127,11 +131,21 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest) -> String {
         if same_target {
             let mut cs_strs = cs.iter().map(|c| format!("'{}'", c.short_name(manifest)));
             let cs_str = cs_strs.join(", ");
-            let _ = write!(buf, "some components unavailable for download: {}", cs_str);
+            let _ = write!(
+                    buf,
+                    "some components unavailable for download: {}\n{}",
+                    cs_str,
+                    TOOLSTATE_MSG,
+                );
         } else {
             let mut cs_strs = cs.iter().map(|c| c.description(manifest));
             let cs_str = cs_strs.join(", ");
-            let _ = write!(buf, "some components unavailable for download: {}", cs_str);
+            let _ = write!(
+                    buf,
+                    "some components unavailable for download: {}\n{}",
+                    cs_str,
+                    TOOLSTATE_MSG,
+                );
         }
     }
 

--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -5,9 +5,10 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use toml;
 
-pub const TOOLSTATE_MSG: &str = "if you require these components, please install and use the latest successful build version, \
-                                which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.\n\
-                                rustup install nightly-2018-12-27";
+pub const TOOLSTATE_MSG: &str =
+    "if you require these components, please install and use the latest successful build version, \
+     which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.\n\
+     rustup install nightly-2018-12-27";
 
 error_chain! {
     links {
@@ -132,20 +133,18 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest) -> String {
             let mut cs_strs = cs.iter().map(|c| format!("'{}'", c.short_name(manifest)));
             let cs_str = cs_strs.join(", ");
             let _ = write!(
-                    buf,
-                    "some components unavailable for download: {}\n{}",
-                    cs_str,
-                    TOOLSTATE_MSG,
-                );
+                buf,
+                "some components unavailable for download: {}\n{}",
+                cs_str, TOOLSTATE_MSG,
+            );
         } else {
             let mut cs_strs = cs.iter().map(|c| c.description(manifest));
             let cs_str = cs_strs.join(", ");
             let _ = write!(
-                    buf,
-                    "some components unavailable for download: {}\n{}",
-                    cs_str,
-                    TOOLSTATE_MSG,
-                );
+                buf,
+                "some components unavailable for download: {}\n{}",
+                cs_str, TOOLSTATE_MSG,
+            );
         }
     }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -12,6 +12,7 @@ use rustup_mock::clitools::{
     expect_timeout_ok, run, set_current_dist_date, this_host_triple, Config, Scenario,
 };
 use rustup_utils::{raw, utils};
+use rustup_dist::errors::{TOOLSTATE_MSG};
 
 use std::env::consts::EXE_SUFFIX;
 use std::ops::Add;
@@ -808,7 +809,10 @@ fn update_unavailable_rustc() {
         expect_err(
             config,
             &["rustup", "update", "nightly"],
-            "some components unavailable for download: 'rustc', 'cargo'",
+            format!(
+                "some components unavailable for download: 'rustc', 'cargo'\n{}",
+                TOOLSTATE_MSG
+            ).as_str(),
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -7,12 +7,12 @@ extern crate rustup_utils;
 extern crate tempdir;
 extern crate time;
 
+use rustup_dist::errors::TOOLSTATE_MSG;
 use rustup_mock::clitools::{
     self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok, expect_stdout_ok,
     expect_timeout_ok, run, set_current_dist_date, this_host_triple, Config, Scenario,
 };
 use rustup_utils::{raw, utils};
-use rustup_dist::errors::{TOOLSTATE_MSG};
 
 use std::env::consts::EXE_SUFFIX;
 use std::ops::Add;
@@ -812,7 +812,8 @@ fn update_unavailable_rustc() {
             format!(
                 "some components unavailable for download: 'rustc', 'cargo'\n{}",
                 TOOLSTATE_MSG
-            ).as_str(),
+            )
+            .as_str(),
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");


### PR DESCRIPTION
Error message that we get when installing with some components failed may seem unkind for beginners.
Many users create issue at component's repository.
For example,
https://github.com/rust-lang/rls/issues/1186
https://github.com/rust-lang/rls/issues/641
https://github.com/rust-lang/rustfmt/issues/3244
https://github.com/rust-lang/rust-clippy/issues/2869

So I might want to add more information.
(But there may be more suitable message.)