### PR TITLE
Ensure formatting during CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,6 +132,7 @@ matrix:
 
 install:
   - if [ -z "$NO_ADD" ]; then rustup target add $TARGET; fi
+  - rustup component add rustfmt
 
 script:
   - mkdir -p target/$TARGET;

--- a/README.md
+++ b/README.md
@@ -728,6 +728,10 @@ affecting any existing installation. Remember to keep those two environment vari
 set when running your compiled `rustup-init` or the toolchains it installs, but _unset_
 when rebuilding `rustup` itself.
 
+We use `rustfmt` to keep our codebase consistently formatted.  Please ensure that
+you have correctly formatted your code (most editors will do this automatically
+when saving) or it may not pass the CI tests.
+
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as above, without any

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,9 @@ install:
   # add mingw to PATH if necessary
   - if defined MINGW_DIR set PATH=C:\msys64\%MINGW_DIR%\bin;C:\msys64\usr\bin;%PATH%
 
+  # Add rustfmt support
+  - rustup component add rustfmt
+
   # set cargo features for MSI if requested (otherwise empty string)
   - set FEATURES=
   - if defined BUILD_MSI set FEATURES=--features msi-installed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ install:
   - where gcc rustc cargo
   - rustc -vV
   - cargo -vV
+  - rustfmt -vV
 
 build: false
 
@@ -79,6 +80,7 @@ test_script:
   - cargo test --release --target %TARGET% %FEATURES%
   - if defined BUILD_MSI pushd src\rustup-win-installer && cargo build --release --target %TARGET% & popd
   - if defined BUILD_MSI pushd src\rustup-win-installer\msi && powershell .\build.ps1 -Target %TARGET% & popd
+  - cargo fmt --all -- --check
 
 notifications:
   - provider: Webhook

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -6,6 +6,7 @@ echo "toolchain versions\n------------------"
 
 rustc -vV
 cargo -vV
+rustfmt -vV
 
 cargo build --locked -v --release --target $TARGET --features vendored-openssl
 
@@ -14,3 +15,7 @@ if [ -z "$SKIP_TESTS" ]; then
   cargo test --release -p rustup-dist --target $TARGET --features vendored-openssl
   cargo test --release --target $TARGET --features vendored-openssl
 fi
+
+# Check the formatting last because test failures are more interesting to have
+# discovered for contributors lacking some platform access for testing beforehand
+cargo fmt --all -- --check


### PR DESCRIPTION
In order to ensure that we don't get odd formatting changes
mixed in with future PRs, verify the formatting during the CI
run if all tests pass.