### PR TITLE
 self update after updating a specific toolchain 

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -200,30 +200,41 @@ fn show_channel_updates(
     Ok(())
 }
 
-pub fn update_all_channels(cfg: &Cfg, self_update: bool, force_update: bool) -> Result<()> {
+pub fn update_all_channels(cfg: &Cfg, do_self_update: bool, force_update: bool) -> Result<()> {
     let toolchains = cfg.update_all_channels(force_update)?;
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
     }
 
-    let setup_path = if self_update {
-        self_update::prepare_update()?
-    } else {
-        None
+    let show_channel_updates = || {
+        if !toolchains.is_empty() {
+            println!("");
+
+            show_channel_updates(cfg, toolchains)?;
+        }
+        Ok(())
     };
 
-    if !toolchains.is_empty() {
-        println!("");
-
-        show_channel_updates(cfg, toolchains)?;
+    if do_self_update {
+        self_update(show_channel_updates)
+    } else {
+        show_channel_updates()
     }
+}
+
+pub fn self_update<F>(before_restart: F) -> Result<()>
+    where F: FnOnce() -> Result<()>
+{
+    let setup_path = self_update::prepare_update()?;
+
+    before_restart()?;
 
     if let Some(ref setup_path) = setup_path {
         self_update::run_update(setup_path)?;
 
         unreachable!(); // update exits on success
-    } else if self_update {
+    } else {
         // Try again in case we emitted "tool `{}` is already installed" last time.
         self_update::install_proxies()?;
     }

--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -224,7 +224,8 @@ pub fn update_all_channels(cfg: &Cfg, do_self_update: bool, force_update: bool) 
 }
 
 pub fn self_update<F>(before_restart: F) -> Result<()>
-    where F: FnOnce() -> Result<()>
+where
+    F: FnOnce() -> Result<()>,
 {
     let setup_path = self_update::prepare_update()?;
 

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -132,6 +132,19 @@ pub fn cli() -> App<'static, 'static> {
                         .help(TOOLCHAIN_ARG_HELP)
                         .required(true)
                         .multiple(true),
+                )
+                .arg(
+                    Arg::with_name("no-self-update")
+                        .help("Don't perform self update when running the `rustup` command")
+                        .long("no-self-update")
+                        .takes_value(false)
+                        .hidden(true),
+                )
+                .arg(
+                    Arg::with_name("force")
+                        .help("Force an update, even if some components are missing")
+                        .long("force")
+                        .takes_value(false),
                 ),
         )
         .subcommand(
@@ -196,6 +209,13 @@ pub fn cli() -> App<'static, 'static> {
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .required(true)
                                 .multiple(true),
+                        )
+                        .arg(
+                            Arg::with_name("no-self-update")
+                                .help("Don't perform self update when running the `rustup` command")
+                                .long("no-self-update")
+                                .takes_value(false)
+                                .hidden(true),
                         ),
                 )
                 .subcommand(

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -620,11 +620,7 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
             common::self_update(|| Ok(()))?;
         }
     } else {
-        common::update_all_channels(
-            cfg,
-            self_update,
-            m.is_present("force"),
-        )?;
+        common::update_all_channels(cfg, self_update, m.is_present("force"))?;
     }
 
     Ok(())

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -577,6 +577,7 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 }
 
 fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
+    let self_update = !m.is_present("no-self-update") && !self_update::NEVER_SELF_UPDATE;
     if let Some(names) = m.values_of("toolchain") {
         for name in names {
             update_bare_triple_check(cfg, name)?;
@@ -595,10 +596,13 @@ fn update(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
                 common::show_channel_update(cfg, toolchain.name(), Ok(status))?;
             }
         }
+        if self_update {
+            common::self_update(|| Ok(()))?;
+        }
     } else {
         common::update_all_channels(
             cfg,
-            !m.is_present("no-self-update") && !self_update::NEVER_SELF_UPDATE,
+            self_update,
             m.is_present("force"),
         )?;
     }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -25,7 +25,7 @@ fn update() {
     setup(&|config| {
         expect_ok_ex(
             config,
-            &["rustup", "update", "nightly"],
+            &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
   nightly-{0} installed - 1.3.0 (hash-n-2)
@@ -52,10 +52,10 @@ info: installing component 'rust-docs'
 #[test]
 fn update_again() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok_ex(
             config,
-            &["rustup", "update", "nightly"],
+            &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
   nightly-{0} unchanged - 1.3.0 (hash-n-2)

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -133,7 +133,7 @@ fn upgrade_v2_metadata_to_v12() {
             &["rustc", "--version"],
             for_host!("toolchain 'nightly-{0}' is not installed"),
         );
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -185,7 +185,7 @@ fn update_all_no_update_whitespace() {
     setup(&|config| {
         expect_stdout_ok(
             config,
-            &["rustup", "update", "nightly"],
+            &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
   nightly-{} installed - 1.3.0 (hash-n-2)
@@ -200,7 +200,7 @@ fn update_all_no_update_whitespace() {
 #[test]
 fn update_works_without_term() {
     setup(&|config| {
-        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly"]);
+        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly", "--no-self-update"]);
         clitools::env(config, &mut cmd);
         cmd.env_remove("TERM");
 
@@ -295,13 +295,13 @@ fn custom_toolchain_cargo_fallback_proxy() {
         );
         expect_ok(config, &["rustup", "default", "mytoolchain"]);
 
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-s-2");
 
-        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-b-2");
 
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-n-2");
     });
 }
@@ -323,21 +323,21 @@ fn custom_toolchain_cargo_fallback_run() {
         );
         expect_ok(config, &["rustup", "default", "mytoolchain"]);
 
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
             "hash-s-2",
         );
 
-        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
             "hash-b-2",
         );
 
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
@@ -395,7 +395,7 @@ fn rustup_failed_path_search() {
 #[test]
 fn rustup_run_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "install", "stable"]);
+        expect_ok(config, &["rustup", "install", "stable", "--no-self-update"]);
         expect_err(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -407,7 +407,7 @@ fn rustup_run_not_installed() {
 #[test]
 fn rustup_run_install() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "install", "stable"]);
+        expect_ok(config, &["rustup", "install", "stable", "--no-self-update"]);
         expect_stderr_ok(
             config,
             &[
@@ -426,7 +426,7 @@ fn rustup_run_install() {
 #[test]
 fn multirust_env_compat() {
     setup(&|config| {
-        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly"]);
+        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly", "--no-self-update"]);
         clitools::env(config, &mut cmd);
         cmd.env_remove("RUSTUP_HOME");
         cmd.env("MULTIRUST_HOME", &config.rustupdir);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -260,7 +260,13 @@ fn rustup_xz() {
         set_current_dist_date(config, "2015-01-01");
         expect_stderr_ok(
             config,
-            &["rustup", "--verbose", "update", "nightly", "--no-self-update"],
+            &[
+                "rustup",
+                "--verbose",
+                "update",
+                "nightly",
+                "--no-self-update",
+            ],
             for_host!(r"dist/2015-01-01/rust-std-nightly-{0}.tar.xz"),
         );
     });
@@ -904,7 +910,10 @@ fn set_default_host_invalid_triple() {
 fn update_doesnt_update_non_tracking_channels() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "nightly-2015-01-01", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "update", "nightly-2015-01-01", "--no-self-update"],
+        );
         let mut cmd = clitools::cmd(config, "rustup", &["update"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -918,7 +927,16 @@ fn update_doesnt_update_non_tracking_channels() {
 #[test]
 fn toolchain_install_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -941,7 +959,16 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
 #[test]
 fn toolchain_update_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "update",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -978,7 +1005,16 @@ fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
 fn proxy_toolchain_shorthand() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "update",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+stable", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+nightly", "--version"], "hash-n-2");
@@ -1237,7 +1273,16 @@ fn multirust_upgrade_works_with_proxy() {
 fn file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
@@ -1253,7 +1298,16 @@ fn file_override() {
 fn file_override_subdir() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
@@ -1275,7 +1329,13 @@ fn file_override_with_archive() {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(
             config,
-            &["rustup", "toolchain", "install", "nightly-2015-01-01", "--no-self-update"],
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly-2015-01-01",
+                "--no-self-update",
+            ],
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
@@ -1292,8 +1352,20 @@ fn file_override_with_archive() {
 fn directory_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
@@ -1310,8 +1382,20 @@ fn directory_override_beats_file_override() {
 fn close_file_override_beats_far_directory_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
@@ -1334,7 +1418,10 @@ fn close_file_override_beats_far_directory_override() {
 fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
+        );
         // not installing nightly
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
@@ -1352,8 +1439,20 @@ fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
 fn env_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1372,8 +1471,20 @@ fn env_override_beats_file_override() {
 fn plus_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1417,7 +1528,16 @@ fn file_override_with_target_info() {
 fn docs_with_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
 
         let mut cmd = clitools::cmd(config, "rustup", &["doc", "--path"]);
         clitools::env(config, &mut cmd);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -31,7 +31,7 @@ pub fn setup(f: &Fn(&Config)) {
 fn rustup_stable() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(
             config,
@@ -67,7 +67,7 @@ info: installing component 'rust-docs'
 fn rustup_stable_no_change() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok_ex(
             config,
             &["rustup", "update", "--no-self-update"],
@@ -89,9 +89,9 @@ fn rustup_stable_no_change() {
 fn rustup_all_channels() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(
             config,
@@ -157,11 +157,11 @@ info: installing component 'rust-docs'
 fn rustup_some_channels_up_to_date() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_ok_ex(
             config,
             &["rustup", "update", "--no-self-update"],
@@ -212,7 +212,7 @@ info: installing component 'rust-docs'
 #[test]
 fn rustup_no_channels() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
         expect_ok_ex(
             config,
@@ -260,7 +260,7 @@ fn rustup_xz() {
         set_current_dist_date(config, "2015-01-01");
         expect_stderr_ok(
             config,
-            &["rustup", "--verbose", "update", "nightly"],
+            &["rustup", "--verbose", "update", "nightly", "--no-self-update"],
             for_host!(r"dist/2015-01-01/rust-std-nightly-{0}.tar.xz"),
         );
     });
@@ -367,7 +367,7 @@ fn add_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(
             config,
             &[
@@ -391,7 +391,7 @@ fn remove_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(
             config,
             &[
@@ -422,7 +422,7 @@ fn remove_target_explicit() {
 #[test]
 fn list_targets_explicit() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "target", "list", "--toolchain", "nightly"],
@@ -440,7 +440,7 @@ fn link() {
         expect_ok(config, &["rustup", "default", "custom"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
         expect_stdout_ok(config, &["rustup", "show"], "custom (default)");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustup", "show"], "custom");
     });
@@ -465,7 +465,7 @@ fn fallback_cargo_calls_correct_rustc() {
         let path = path.to_string_lossy();
         expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
         expect_ok(config, &["rustup", "default", "custom"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
         expect_stdout_ok(config, &["cargo", "--version"], "hash-n-2");
 
@@ -519,7 +519,7 @@ nightly-{0} (default)
 fn show_multiple_toolchains() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok_ex(
             config,
             &["rustup", "show"],
@@ -612,6 +612,7 @@ fn show_multiple_toolchains_and_targets() {
                 "rustup",
                 "update",
                 &format!("stable-{}", clitools::MULTI_ARCH1),
+                "--no-self-update",
             ],
         );
         expect_ok_ex(
@@ -903,7 +904,7 @@ fn set_default_host_invalid_triple() {
 fn update_doesnt_update_non_tracking_channels() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "nightly-2015-01-01"]);
+        expect_ok(config, &["rustup", "update", "nightly-2015-01-01", "--no-self-update"]);
         let mut cmd = clitools::cmd(config, "rustup", &["update"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -917,7 +918,7 @@ fn update_doesnt_update_non_tracking_channels() {
 #[test]
 fn toolchain_install_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -931,7 +932,7 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {
         expect_err(
             config,
-            &["rustup", "toolchain", "install"],
+            &["rustup", "toolchain", "install", "--no-self-update"],
             "arguments were not provided",
         );
     });
@@ -940,7 +941,7 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
 #[test]
 fn toolchain_update_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -977,7 +978,7 @@ fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
 fn proxy_toolchain_shorthand() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+stable", "--version"], "hash-s-2");
         expect_stdout_ok(config, &["rustc", "+nightly", "--version"], "hash-n-2");
@@ -1236,7 +1237,7 @@ fn multirust_upgrade_works_with_proxy() {
 fn file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
@@ -1252,7 +1253,7 @@ fn file_override() {
 fn file_override_subdir() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
 
@@ -1274,7 +1275,7 @@ fn file_override_with_archive() {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(
             config,
-            &["rustup", "toolchain", "install", "nightly-2015-01-01"],
+            &["rustup", "toolchain", "install", "nightly-2015-01-01", "--no-self-update"],
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
@@ -1291,8 +1292,8 @@ fn file_override_with_archive() {
 fn directory_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
@@ -1309,8 +1310,8 @@ fn directory_override_beats_file_override() {
 fn close_file_override_beats_far_directory_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
@@ -1333,7 +1334,7 @@ fn close_file_override_beats_far_directory_override() {
 fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
         // not installing nightly
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
@@ -1351,8 +1352,8 @@ fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
 fn env_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1371,8 +1372,8 @@ fn env_override_beats_file_override() {
 fn plus_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1416,7 +1417,7 @@ fn file_override_with_target_info() {
 fn docs_with_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly", "--no-self-update"]);
 
         let mut cmd = clitools::cmd(config, "rustup", &["doc", "--path"]);
         clitools::env(config, &mut cmd);

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -716,6 +716,38 @@ fn rustup_self_updates() {
 }
 
 #[test]
+fn rustup_self_updates_with_specified_toolchain() {
+    update_setup(&|config, _| {
+        expect_ok(config, &["rustup-init", "-y"]);
+
+        let ref bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let before_hash = calc_hash(bin);
+
+        expect_ok(config, &["rustup", "update", "stable"]);
+
+        let after_hash = calc_hash(bin);
+
+        assert_ne!(before_hash, after_hash);
+    })
+}
+
+#[test]
+fn rustup_no_self_update_with_specified_toolchain() {
+    update_setup(&|config, _| {
+        expect_ok(config, &["rustup-init", "-y"]);
+
+        let ref bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let before_hash = calc_hash(bin);
+
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+
+        let after_hash = calc_hash(bin);
+
+        assert_eq!(before_hash, after_hash);
+    })
+}
+
+#[test]
 fn rustup_self_update_exact() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y"]);

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -763,7 +763,7 @@ fn updater_is_deleted_after_running_rustup() {
         expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "self", "update"]);
 
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
 
         let setup = config
             .cargodir

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -73,7 +73,7 @@ fn install_toolchain_from_version() {
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stderr_ok(
             config,
             &["rustup", "default", "nightly"],
@@ -89,7 +89,7 @@ fn update_channel() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -97,8 +97,8 @@ fn update_channel() {
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta-2015-01-01", "--no-self-update"]);
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
     });
@@ -118,7 +118,7 @@ fn list_toolchains_with_none() {
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "list"]);
         expect_stdout_ok(
@@ -320,8 +320,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_stdout_ok(config, &["rustup", "update", "nightly", "--no-self-update"], "unchanged");
     });
 }
 
@@ -332,7 +332,7 @@ fn update_on_channel_when_date_has_changed() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -340,7 +340,7 @@ fn update_on_channel_when_date_has_changed() {
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_stdout_ok(
             config,
@@ -356,7 +356,7 @@ fn remove_toolchain_then_add_again() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -98,7 +98,10 @@ fn update_channel() {
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
+        );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
     });
@@ -321,7 +324,11 @@ fn remove_override_with_multiple_overrides() {
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly", "--no-self-update"], "unchanged");
+        expect_stdout_ok(
+            config,
+            &["rustup", "update", "nightly", "--no-self-update"],
+            "unchanged",
+        );
     });
 }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -873,6 +873,9 @@ fn update_unavailable_force() {
                 trip
             ),
         );
-        expect_ok(config, &["rustup", "update", "nightly", "--force", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "update", "nightly", "--force", "--no-self-update"],
+        );
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -75,7 +75,7 @@ fn install_toolchain_from_version() {
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stderr_ok(
             config,
             &["rustup", "default", "nightly"],
@@ -91,7 +91,7 @@ fn update_channel() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -99,8 +99,8 @@ fn update_channel() {
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta-2015-01-01", "--no-self-update"]);
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
     });
@@ -110,7 +110,7 @@ fn list_toolchains() {
 fn list_toolchains_with_bogus_file() {
     // #520
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
 
         let name = "bogus_regular_file.txt";
         let path = config.rustupdir.join("toolchains").join(name);
@@ -134,7 +134,7 @@ fn list_toolchains_with_none() {
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "list"]);
         expect_stdout_ok(
@@ -152,7 +152,7 @@ fn add_remove_multiple_toolchains() {
             let tch1 = "beta";
             let tch2 = "nightly";
 
-            expect_ok(config, &["rustup", "toolchain", add, tch1, tch2]);
+            expect_ok(config, &["rustup", "toolchain", add, tch1, tch2, "--no-self-update"]);
             expect_ok(config, &["rustup", "toolchain", "list"]);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
@@ -417,8 +417,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_stdout_ok(config, &["rustup", "update", "nightly", "--no-self-update"], "unchanged");
     });
 }
 
@@ -429,7 +429,7 @@ fn update_on_channel_when_date_has_changed() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -437,7 +437,7 @@ fn update_on_channel_when_date_has_changed() {
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_stdout_ok(
             config,
@@ -453,7 +453,7 @@ fn remove_toolchain_then_add_again() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }
@@ -466,7 +466,7 @@ fn upgrade_v1_to_v2() {
         fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
         expect_ok(config, &["rustup", "default", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
     });
 }
@@ -500,7 +500,7 @@ fn list_targets_no_toolchain() {
 #[test]
 fn list_targets_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_err(
             config,
             &["rustup", "target", "list", "--toolchain=nightly"],
@@ -581,7 +581,7 @@ fn add_target_bogus() {
 #[test]
 fn add_target_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_err(
             config,
             &[
@@ -792,7 +792,7 @@ fn remove_target_host() {
 // Issue #304
 fn remove_target_missing_update_hash() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
 
         let file_name = format!("nightly-{}", this_host_triple());
         fs::remove_file(config.rustupdir.join("update-hashes").join(file_name)).unwrap();
@@ -829,7 +829,7 @@ fn update_unavailable_std() {
         make_component_unavailable(config, "rust-std", trip);
         expect_err(
             config,
-            &["rustup", "update", "nightly"],
+            &["rustup", "update", "nightly", "--no-self-update"],
             &format!(
                 "component 'rust-std' for target '{}' is unavailable for download",
                 trip
@@ -842,7 +842,7 @@ fn update_unavailable_std() {
 fn update_unavailable_force() {
     setup(&|config| {
         let ref trip = TargetTriple::from_build();
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(
             config,
             &[
@@ -857,12 +857,12 @@ fn update_unavailable_force() {
         make_component_unavailable(config, "rls-preview", trip);
         expect_err(
             config,
-            &["rustup", "update", "nightly"],
+            &["rustup", "update", "nightly", "--no-self-update"],
             &format!(
                 "component 'rls' for target '{}' is unavailable for download",
                 trip
             ),
         );
-        expect_ok(config, &["rustup", "update", "nightly", "--force"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--force", "--no-self-update"]);
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -100,7 +100,10 @@ fn update_channel() {
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01", "--no-self-update"]);
+        expect_ok(
+            config,
+            &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
+        );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
     });
@@ -152,7 +155,10 @@ fn add_remove_multiple_toolchains() {
             let tch1 = "beta";
             let tch2 = "nightly";
 
-            expect_ok(config, &["rustup", "toolchain", add, tch1, tch2, "--no-self-update"]);
+            expect_ok(
+                config,
+                &["rustup", "toolchain", add, tch1, tch2, "--no-self-update"],
+            );
             expect_ok(config, &["rustup", "toolchain", "list"]);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
@@ -418,7 +424,11 @@ fn remove_override_with_multiple_overrides() {
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly", "--no-self-update"], "unchanged");
+        expect_stdout_ok(
+            config,
+            &["rustup", "update", "nightly", "--no-self-update"],
+            "unchanged",
+        );
     });
 }
 


### PR DESCRIPTION
r? @alexcrichton 

This will make sure people who do `rustup update stable` still get a new rustup