### PR TITLE
Add miri to rustup

### DIFF
--- a/src/rustup-win-installer/src/lib.rs
+++ b/src/rustup-win-installer/src/lib.rs
@@ -27,6 +27,7 @@ static TOOLS: &'static [&'static str] = &[
     "rustfmt",
     "cargo-fmt",
     "cargo-clippy",
+    "cargo-miri",
 ];
 
 #[no_mangle]

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -31,6 +31,7 @@ pub static TOOLS: &'static [&'static str] = &[
     "rust-gdb",
     "rls",
     "cargo-clippy",
+    "cargo-miri",
 ];
 
 // Tools which are commonly installed by Cargo as well as rustup. We take a bit
@@ -54,6 +55,7 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
         "rust-gdb" => Some("gdb-preview"),
         "rls" => Some("rls"),
         "cargo-clippy" => Some("clippy"),
+        "cargo-miri" => Some("miri"),
         "rustfmt" | "cargo-fmt" => Some("rustfmt"),
         _ => None,
     }


### PR DESCRIPTION
It was just added to the distribution in https://github.com/rust-lang/rust/pull/57086

This PR enables calling `cargo miri` after installing the `miri` component