### PR TITLE
Fixed according to warning of clippy

### DIFF
--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -98,7 +98,7 @@ pub fn setup(s: Scenario, f: &Fn(&mut Config)) {
         distdir: distdir.path().to_owned(),
         rustupdir: rustupdir.path().to_owned(),
         customdir: customdir.path().to_owned(),
-        cargodir: cargodir,
+        cargodir,
         homedir: homedir.path().to_owned(),
         emptydir: emptydir.path().to_owned(),
         workdir: RefCell::new(workdir.path().to_owned()),
@@ -559,12 +559,12 @@ fn build_mock_channel(
                 available: true,
                 components: vec![],
                 extensions: vec![],
-                installer: installer,
+                installer,
             });
 
         MockPackage {
-            name: name,
-            version: version,
+            name,
+            version,
             targets: target_pkgs.collect(),
         }
     });
@@ -629,7 +629,7 @@ fn build_mock_channel(
     MockChannel {
         name: channel.to_string(),
         date: date.to_string(),
-        packages: packages,
+        packages,
         renames,
     }
 }

--- a/src/rustup-mock/src/clitools.rs
+++ b/src/rustup-mock/src/clitools.rs
@@ -354,10 +354,12 @@ pub fn run(config: &Config, name: &str, args: &[&str], env: &[(&str, &str)]) -> 
         stdout: String::from_utf8(out.stdout).unwrap(),
         stderr: String::from_utf8(out.stderr).unwrap(),
     };
+
     println!("status: {}", out.status);
     println!("----- stdout\n{}", output.stdout);
     println!("----- stderr\n{}", output.stderr);
-    return output;
+
+    output
 }
 
 // Creates a mock dist server populated with some test data

--- a/src/rustup-mock/src/dist.rs
+++ b/src/rustup-mock/src/dist.rs
@@ -60,7 +60,7 @@ pub fn change_channel_date(dist_server: &Url, channel: &str, date: &str) {
 }
 
 // The manifest version created by this mock
-pub const MOCK_MANIFEST_VERSION: &'static str = "2";
+pub const MOCK_MANIFEST_VERSION: &str = "2";
 
 // A mock Rust v2 distribution server. Create it and and run `write`
 // to write its structure to a directory.

--- a/src/rustup-mock/src/dist.rs
+++ b/src/rustup-mock/src/dist.rs
@@ -167,7 +167,7 @@ impl MockDistServer {
             );
         }
 
-        return hashes;
+        hashes
     }
 
     // Returns the hash of the tarball

--- a/src/rustup-mock/src/lib.rs
+++ b/src/rustup-mock/src/lib.rs
@@ -105,9 +105,9 @@ impl MockFile {
 
     fn _new(path: String, contents: Arc<Vec<u8>>) -> MockFile {
         MockFile {
-            path: path,
+            path,
             contents: Contents::File(MockContents {
-                contents: contents,
+                contents,
                 executable: false,
             }),
         }


### PR DESCRIPTION
## Fixed according to warning of clippy

- Remove unnecessary return keywords
- Remove unnecessary name assignment
- Remove static lifetime keyword