### PR TITLE
Thread toolchain through to error message

### DIFF
--- a/src/rustup-dist/src/dist.rs
+++ b/src/rustup-dist/src/dist.rs
@@ -556,6 +556,7 @@ pub fn update_from_dist_<'a>(
                 force_update,
                 &download,
                 download.notify_handler.clone(),
+                &toolchain.manifest_name(),
             )? {
                 UpdateStatus::Unchanged => Ok(None),
                 UpdateStatus::Changed => Ok(Some(hash)),

--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -107,9 +107,9 @@ error_chain! {
             description("missing package for the target of a rename")
             display("server sent a broken manifest: missing package for the target of a rename {}", name)
         }
-        RequestedComponentsUnavailable(c: Vec<Component>, manifest: Manifest) {
+        RequestedComponentsUnavailable(c: Vec<Component>, manifest: Manifest, toolchain: String) {
             description("some requested components are unavailable to download")
-            display("{}", component_unavailable_msg(&c, &manifest))
+            display("{} for channel '{}'", component_unavailable_msg(&c, &manifest), toolchain)
         }
     }
 }

--- a/src/rustup-dist/tests/dist.rs
+++ b/src/rustup-dist/tests/dist.rs
@@ -422,6 +422,7 @@ fn update_from_dist_(
         force_update,
         download_cfg,
         download_cfg.notify_handler.clone(),
+        &toolchain.to_string(),
     )
 }
 

--- a/src/rustup/toolchain.rs
+++ b/src/rustup/toolchain.rs
@@ -594,6 +594,7 @@ impl<'a> Toolchain<'a> {
                 false,
                 &self.download_cfg(),
                 self.download_cfg().notify_handler.clone(),
+                &toolchain.manifest_name(),
             )?;
 
             Ok(())
@@ -663,6 +664,7 @@ impl<'a> Toolchain<'a> {
                 false,
                 &self.download_cfg(),
                 self.download_cfg().notify_handler.clone(),
+                &toolchain.manifest_name(),
             )?;
 
             Ok(())

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -836,8 +836,8 @@ fn update_unavailable_std() {
             config,
             &["rustup", "update", "nightly", "--no-self-update"],
             &format!(
-                "component 'rust-std' for target '{}' is unavailable for download",
-                trip
+                "component 'rust-std' for target '{}' is unavailable for download for channel 'nightly'",
+                trip,
             ),
         );
     });
@@ -864,8 +864,8 @@ fn update_unavailable_force() {
             config,
             &["rustup", "update", "nightly", "--no-self-update"],
             &format!(
-                "component 'rls' for target '{}' is unavailable for download",
-                trip
+                "component 'rls' for target '{}' is unavailable for download for channel 'nightly'",
+                trip,
             ),
         );
         expect_ok(


### PR DESCRIPTION
In the component-unavailable error case, we need to report the
full toolchain rather than just the component and target name.
This threads it through and reports it in the error message.

Fixes: #1596

This is not ideal right now, but it's a starting point for discussion.

Currently the error message ends up looking something like:

```
error: component 'rust-std' for target 'x86_64-unknown-linux-gnu' is unavailable for download for toolchain 'nightly-x86_64-unknown-linux-gnu'
```

Clearly the repetition of the target name in the toolchain name isn't ideal, I've been considering
reformatting the message but didn't want to do so without some further input on what might be better.