### PR TITLE
Install some GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug
+---
+
+<!-- Thanks for filing a 🐛 bug report 😄! -->
+
+**Problem**
+<!-- A clear and concise description of what the bug is. -->
+<!-- including what currently happens and what you expected to happen. -->
+
+**Steps**
+<!-- The steps to reproduce the bug. -->
+1.
+2.
+3.
+
+**Possible Solution(s)**
+<!-- Not obligatory, but suggest a fix/reason for the bug, -->
+<!-- or ideas how to implement the addition or change -->
+
+**Notes**
+
+Output of `rustup --version`:
+Output of `rustup show`:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -1,0 +1,16 @@
+---
+name: Enhancement request
+about: Suggest an enhancement for this project
+labels: enhancement
+---
+
+<!-- Thanks for filing an 🙋 enhancement request 😄! -->
+
+**Describe the problem you are trying to solve**
+<!-- A clear and concise description of the problem this enhancement request is trying to solve. -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Notes**
+<!-- Any additional context or information you feel may be relevant to the issue. -->


### PR DESCRIPTION
I've had good experiences using issue templates, and these are derived from the ones established in the cargo repo.  WDYT?