### PR TITLE
Prevent de-installation of last toolkit

### DIFF
--- a/src/rustup-cli/errors.rs
+++ b/src/rustup-cli/errors.rs
@@ -27,6 +27,10 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        ToolchainUninstallOnly(t: String) {
+            description("attempting to uninstall only remaining toolchain")
+            display("'{}' is the only toolchain left", t)
+        }
         InvalidToolchainName(t: String) {
             description("invalid toolchain name")
             display("invalid toolchain name: '{}'", t)

--- a/src/rustup-cli/log.rs
+++ b/src/rustup-cli/log.rs
@@ -16,6 +16,10 @@ macro_rules! verbose {
     ( $ ( $ arg : tt ) * ) => ( $crate::log::verbose_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
+macro_rules! debug {
+    ( $ ( $ arg : tt ) * ) => ( $crate::log::debug_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+}
+
 pub fn warn_fmt(args: fmt::Arguments) {
     let mut t = term2::stderr();
     let _ = t.fg(term2::color::BRIGHT_YELLOW);
@@ -53,4 +57,16 @@ pub fn verbose_fmt(args: fmt::Arguments) {
     let _ = t.reset();
     let _ = t.write_fmt(args);
     let _ = write!(t, "\n");
+}
+
+pub fn debug_fmt(args: fmt::Arguments) {
+    if std::env::var("RUSTUP_DEBUG").is_ok() {
+        let mut t = term2::stderr();
+        let _ = t.fg(term2::color::BRIGHT_BLUE);
+        let _ = t.attr(term2::Attr::Bold);
+        let _ = write!(t, "verbose: ");
+        let _ = t.reset();
+        let _ = t.write_fmt(args);
+        let _ = write!(t, "\n");
+    }
 }

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -896,6 +896,11 @@ fn toolchain_link(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 fn toolchain_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     for toolchain in m.values_of("toolchain").expect("") {
         let toolchain = cfg.get_toolchain(toolchain, false)?;
+        let installed_toolchains = cfg.list_toolchains()?;
+        if installed_toolchains.len() == 1 && toolchain.name() == installed_toolchains[0] {
+            // Do not allow removal of toolchain if it's the only toolchain
+            return Err(ErrorKind::ToolchainUninstallOnly(toolchain.name().to_string()).into());
+        }
         toolchain.remove()?;
     }
     Ok(())

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -454,7 +454,7 @@ fn do_pre_install_sanity_checks() -> Result<()> {
             "delete `{}` to remove rustup.sh",
             rustup_sh_path.expect("").display()
         );
-        warn!("or, if you already rustup installed, you can run");
+        warn!("or, if you already have rustup installed, you can run");
         warn!("`rustup self update` and `rustup toolchain list` to upgrade");
         warn!("your directory structure");
         return Err("cannot install while rustup.sh is installed".into());

--- a/src/rustup-cli/self_update.rs
+++ b/src/rustup-cli/self_update.rs
@@ -468,7 +468,12 @@ fn do_pre_install_options_sanity_checks(opts: &InstallOpts) -> Result<()> {
     // Verify that the installation options are vaguely sane
     (|| {
         let host_triple = dist::TargetTriple::from_str(&opts.default_host_triple);
-        let partial_channel = dist::PartialToolchainDesc::from_str(&opts.default_toolchain)?;
+        let toolchain_to_use = if opts.default_toolchain == "none" {
+            "stable"
+        } else {
+            &opts.default_toolchain
+        };
+        let partial_channel = dist::PartialToolchainDesc::from_str(toolchain_to_use)?;
         let resolved = partial_channel.resolve(&host_triple)?.to_string();
         debug!(
             "Successfully resolved installation toolchain as: {}",

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -478,9 +478,11 @@ impl Cfg {
     }
 
     pub fn set_default_host_triple(&self, host_triple: &str) -> Result<()> {
-        if dist::PartialTargetTriple::from_str(host_triple).is_none() {
-            return Err("Invalid host triple".into());
-        }
+        // Ensure that the provided host_triple is capable of resolving
+        // against the 'stable' toolchain.  This provides early errors
+        // if the supplied triple is insufficient / bad.
+        dist::PartialToolchainDesc::from_str("stable")?
+            .resolve(&dist::TargetTriple::from_str(host_triple))?;
         self.settings_file.with_mut(|s| {
             s.default_host_triple = Some(host_triple.to_owned());
             Ok(())

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -493,7 +493,7 @@ impl Cfg {
     pub fn resolve_toolchain(&self, name: &str) -> Result<String> {
         if let Ok(desc) = dist::PartialToolchainDesc::from_str(name) {
             let host = self.get_default_host_triple()?;
-            Ok(desc.resolve(&host).to_string())
+            Ok(desc.resolve(&host)?.to_string())
         } else {
             Ok(name.to_owned())
         }

--- a/src/rustup/config.rs
+++ b/src/rustup/config.rs
@@ -99,7 +99,7 @@ impl Cfg {
         );
         let dist_root = dist_root_server.clone() + "/dist";
 
-        Ok(Cfg {
+        let cfg = Cfg {
             rustup_dir: rustup_dir,
             settings_file: settings_file,
             toolchains_dir: toolchains_dir,
@@ -111,7 +111,15 @@ impl Cfg {
             env_override: env_override,
             dist_root_url: dist_root,
             dist_root_server: dist_root_server,
-        })
+        };
+
+        // Run some basic checks against the constructed configuration
+        // For now, that means simply checking that 'stable' can resolve
+        // for the current configuration.
+        cfg.resolve_toolchain("stable")
+            .map_err(|e| format!("Unable parse configuration: {}", e))?;
+
+        Ok(cfg)
     }
 
     pub fn set_default(&self, toolchain: &str) -> Result<()> {

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -773,12 +773,19 @@ fn toolchain_broken_symlink() {
         // We artifically create a broken symlink toolchain -- but this can also happen "legitimately"
         // by having a proper toolchain there, using "toolchain link", and later removing the directory.
         fs::create_dir(config.rustupdir.join("toolchains")).unwrap();
+        // Have to have at least one toolchain left before attempting to uninstall
+        expect_ok(config, &["rustup", "default", "stable"]);
         create_symlink_dir(
             config.rustupdir.join("this-directory-does-not-exist"),
             config.rustupdir.join("toolchains").join("test"),
         );
         // Make sure this "fake install" actually worked
-        expect_ok_ex(config, &["rustup", "toolchain", "list"], "test\n", "");
+        expect_ok_ex(
+            config,
+            &["rustup", "toolchain", "list"],
+            for_host!("stable-{0} (default)\ntest\n"),
+            "",
+        );
         // Now try to uninstall it.  That should work only once.
         expect_ok_ex(
             config,

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -213,13 +213,10 @@ info: installing component 'rust-docs'
 fn rustup_no_channels() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
-        expect_ok_ex(
+        expect_err(
             config,
-            &["rustup", "update", "--no-self-update"],
-            r"",
-            r"info: no updatable toolchains installed
-",
+            &["rustup", "toolchain", "remove", "stable"],
+            for_host!("error: 'stable-{0}' is the only toolchain left\n"),
         );
     })
 }
@@ -806,6 +803,8 @@ fn show_toolchain_toolchain_file_override_not_installed() {
 #[test]
 fn show_toolchain_override_not_installed() {
     setup(&|config| {
+        // Must have at least one toolchain installed after `remove nightly`
+        expect_ok(config, &["rustup", "override", "add", "stable"]);
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         let mut cmd = clitools::cmd(config, "rustup", &["show"]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -900,7 +900,19 @@ fn set_default_host_invalid_triple() {
         expect_err(
             config,
             &["rustup", "set", "default-host", "foo"],
-            "Invalid host triple",
+            "error: Provided host 'foo' couldn't be converted to partial triple",
+        );
+    });
+}
+
+// #745
+#[test]
+fn set_default_host_invalid_triple_valid_partial() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "set", "default-host", "x86_64-msvc"],
+            "error: Provided host 'x86_64-msvc' did not specify an operating system",
         );
     });
 }

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -122,13 +122,12 @@ fn list_toolchains_with_none() {
 fn remove_toolchain() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "list"]);
-        expect_stdout_ok(
+        expect_err(
             config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
+            &["rustup", "toolchain", "remove", "nightly"],
+            for_host!("error: 'nightly-{0}' is the only toolchain left"),
         );
+        expect_ok(config, &["rustup", "toolchain", "list"]);
     });
 }
 
@@ -136,11 +135,10 @@ fn remove_toolchain() {
 fn remove_default_toolchain_err_handling() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_err(
             config,
-            &["rustc"],
-            for_host!("toolchain 'nightly-{0}' is not installed"),
+            &["rustup", "toolchain", "remove", "nightly"],
+            for_host!("error: 'nightly-{0}' is the only toolchain left"),
         );
     });
 }
@@ -362,8 +360,16 @@ fn remove_toolchain_then_add_again() {
     // Issue brson/multirust #53
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        // Can't uninstall the only toolkit left
+        expect_err(
+            config,
+            &["rustup", "toolchain", "remove", "beta"],
+            for_host!("error: 'beta-{0}' is the only toolchain left\n"),
+        );
+        // Use nightly as second toolchain to pass this error
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }


### PR DESCRIPTION
Behavior: should the user attempt to `uninstall` their only remaining toolkit, an error will be produced telling them this is not possible to do.

If something like this isn't done, rustup enters a bad state as demonstrated in #1631 

Edit: This still allows for `--default-toolchain none` during install.