### PR TITLE
Filtering of `component list` by available, required, and installed

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -320,9 +320,25 @@ pub fn list_targets(toolchain: &Toolchain) -> Result<()> {
     Ok(())
 }
 
-pub fn list_components(toolchain: &Toolchain) -> Result<()> {
+pub enum ComponentFilter {
+    Required,
+    Available,
+    Installed,
+    None,
+}
+
+pub fn list_components(toolchain: &Toolchain, filter: &ComponentFilter) -> Result<()> {
     let mut t = term2::stdout();
-    for component in toolchain.list_components()? {
+    let components = toolchain
+        .list_components()?
+        .into_iter()
+        .filter(|c| match filter {
+            ComponentFilter::Required => c.required,
+            ComponentFilter::Available => c.available && !c.installed,
+            ComponentFilter::Installed => c.installed,
+            ComponentFilter::None => c.required || c.available || c.installed,
+        });
+    for component in components {
         let name = component.name;
         if component.required {
             let _ = t.attr(term2::Attr::Bold);

--- a/src/rustup-cli/help.rs
+++ b/src/rustup-cli/help.rs
@@ -254,3 +254,6 @@ r"DISCUSSION:
 pub static TOOLCHAIN_ARG_HELP: &'static str = "Toolchain name, such as 'stable', 'nightly', \
                                                or '1.8.0'. For more information see `rustup \
                                                help toolchain`";
+
+pub static FILTER_ARG_HELP: &'static str =
+    "Component status: 'required', 'available', or 'installed'";

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -296,6 +296,12 @@ pub fn cli() -> App<'static, 'static> {
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .long("toolchain")
                                 .takes_value(true),
+                        )
+                        .arg(
+                            Arg::with_name("filter")
+                                .help(FILTER_ARG_HELP)
+                                .long("filter")
+                                .takes_value(true),
                         ),
                 )
                 .subcommand(
@@ -825,7 +831,13 @@ fn target_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 fn component_list(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
-    common::list_components(&toolchain)
+    let filter = match m.value_of("filter") {
+        Some("required") => common::ComponentFilter::Required,
+        Some("available") => common::ComponentFilter::Available,
+        Some("installed") => common::ComponentFilter::Installed,
+        _ => common::ComponentFilter::None,
+    };
+    common::list_components(&toolchain, &filter)
 }
 
 fn component_add(cfg: &Cfg, m: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
Allows filtering of `rustup component list` command.

Example output:
```console
canis@latrans$ rustup component add clippy
canis@latrans$ rustup component list --filter installed
cargo-x86_64-unknown-linux-gnu (default)
clippy-x86_64-unknown-linux-gnu (installed)
rust-docs-x86_64-unknown-linux-gnu (default)
rust-std-x86_64-unknown-linux-gnu (default)
rustc-x86_64-unknown-linux-gnu (default)
canis@latrans$ rustup component list --filter required
cargo-x86_64-unknown-linux-gnu (default)
rust-docs-x86_64-unknown-linux-gnu (default)
rust-std-x86_64-unknown-linux-gnu (default)
rustc-x86_64-unknown-linux-gnu (default)
canis@latrans$ rustup component list --filter available
llvm-tools-preview-x86_64-unknown-linux-gnu
rls-x86_64-unknown-linux-gnu
rust-analysis-x86_64-unknown-linux-gnu
rust-src
...
```