### PR TITLE
Prevent uninstall of only remaining toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ Command | Description
 `rustup override set nightly-2015-04-01` | For the current directory, use a nightly from a specific date
 `rustup toolchain link my-toolchain "C:\RustInstallation"` | Install a custom toolchain by symlinking an existing installation
 `rustup show` | Show which toolchain will be used in the current directory
-`rustup toolchain uninstall nightly` | Uninstall a given toolchain
+`rustup toolchain uninstall nightly` | Uninstall a given toolchain (you cannot uninstall the only toolchain left installed)
 `rustup toolchain help` | Show the `help` page for a subcommand (like `toolchain`) to see what actions are available on it
 
 ## Environment variables

--- a/src/rustup-cli/errors.rs
+++ b/src/rustup-cli/errors.rs
@@ -27,6 +27,10 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        ToolchainUninstallOnly(t: String) {
+            description("attempting to uninstall only remaining toolchain")
+            display("'{}' is the only toolchain left", t)
+        }
         InvalidToolchainName(t: String) {
             description("invalid toolchain name")
             display("invalid toolchain name: '{}'", t)

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -896,6 +896,11 @@ fn toolchain_link(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 fn toolchain_remove(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
     for toolchain in m.values_of("toolchain").expect("") {
         let toolchain = cfg.get_toolchain(toolchain, false)?;
+        let installed_toolchains = cfg.list_toolchains()?;
+        if installed_toolchains.len() == 1 && toolchain.name() == installed_toolchains[0] {
+            // Do not allow removal of toolchain if it's the only toolchain
+            return Err(ErrorKind::ToolchainUninstallOnly(toolchain.name().to_string()).into());
+        }
         toolchain.remove()?;
     }
     Ok(())

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -773,12 +773,19 @@ fn toolchain_broken_symlink() {
         // We artifically create a broken symlink toolchain -- but this can also happen "legitimately"
         // by having a proper toolchain there, using "toolchain link", and later removing the directory.
         fs::create_dir(config.rustupdir.join("toolchains")).unwrap();
+        // Have to have at least one toolchain left before attempting to uninstall
+        expect_ok(config, &["rustup", "default", "stable"]);
         create_symlink_dir(
             config.rustupdir.join("this-directory-does-not-exist"),
             config.rustupdir.join("toolchains").join("test"),
         );
         // Make sure this "fake install" actually worked
-        expect_ok_ex(config, &["rustup", "toolchain", "list"], "test\n", "");
+        expect_ok_ex(
+            config,
+            &["rustup", "toolchain", "list"],
+            for_host!("stable-{0} (default)\ntest\n"),
+            "",
+        );
         // Now try to uninstall it.  That should work only once.
         expect_ok_ex(
             config,

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -213,13 +213,10 @@ info: installing component 'rust-docs'
 fn rustup_no_channels() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
-        expect_ok_ex(
+        expect_err(
             config,
-            &["rustup", "update", "--no-self-update"],
-            r"",
-            r"info: no updatable toolchains installed
-",
+            &["rustup", "toolchain", "remove", "stable"],
+            for_host!("error: 'stable-{0}' is the only toolchain left\n"),
         );
     })
 }
@@ -806,6 +803,8 @@ fn show_toolchain_toolchain_file_override_not_installed() {
 #[test]
 fn show_toolchain_override_not_installed() {
     setup(&|config| {
+        // Must have at least one toolchain installed after `remove nightly`
+        expect_ok(config, &["rustup", "override", "add", "stable"]);
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         let mut cmd = clitools::cmd(config, "rustup", &["show"]);

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -138,13 +138,14 @@ fn list_toolchains_with_none() {
 fn remove_toolchain() {
     setup(&|config| {
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "list"]);
-        expect_stdout_ok(
+        expect_err(
             config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
+            &["rustup", "toolchain", "remove", "nightly"],
+            for_host!("error: 'nightly-{0}' is the only toolchain left"),
         );
+        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "list"]);
     });
 }
 
@@ -154,15 +155,23 @@ fn add_remove_multiple_toolchains() {
         setup(&|config| {
             let tch1 = "beta";
             let tch2 = "nightly";
+            let tch3 = "stable";
 
             expect_ok(
                 config,
-                &["rustup", "toolchain", add, tch1, tch2, "--no-self-update"],
+                &[
+                    "rustup",
+                    "toolchain",
+                    add,
+                    tch1,
+                    tch2,
+                    tch3,
+                    "--no-self-update",
+                ],
             );
             expect_ok(config, &["rustup", "toolchain", "list"]);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
-
             expect_ok(config, &["rustup", "toolchain", rm, tch1, tch2]);
             expect_ok(config, &["rustup", "toolchain", "list"]);
             expect_not_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
@@ -181,11 +190,10 @@ fn add_remove_multiple_toolchains() {
 fn remove_default_toolchain_err_handling() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_err(
             config,
-            &["rustc"],
-            for_host!("toolchain 'nightly-{0}' is not installed"),
+            &["rustup", "toolchain", "remove", "nightly"],
+            for_host!("error: 'nightly-{0}' is the only toolchain left"),
         );
     });
 }
@@ -462,8 +470,16 @@ fn remove_toolchain_then_add_again() {
     // Issue brson/multirust #53
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        // Can't uninstall the only toolchain left
+        expect_err(
+            config,
+            &["rustup", "toolchain", "remove", "beta"],
+            for_host!("error: 'beta-{0}' is the only toolchain left\n"),
+        );
+        // Use nightly as second toolchain to pass this error
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }
@@ -802,6 +818,8 @@ fn remove_target_host() {
 // Issue #304
 fn remove_target_missing_update_hash() {
     setup(&|config| {
+        // Ensure there are at least two toolchains before removal
+        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
 
         let file_name = format!("nightly-{}", this_host_triple());


### PR DESCRIPTION
Behavior: should the user attempt to uninstall their only remaining toolkit, an error will be produced telling them this is not possible to do. If uninstall is allowed, rustup enters a bad state as demonstrated in #1631

This still allows for `--default-toolchain none` during install.