### PR TITLE
Shell completions for Cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ but the gist is as simple as using one of the following:
 
 ```
 # Bash
-$ rustup completions bash > /etc/bash_completion.d/rustup.bash-completion
+$ rustup completions bash > ~/.local/share/bash_completion/completions/rustup
 
 # Bash (macOS/Homebrew)
 $ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -1,8 +1,11 @@
 #![allow(dead_code)]
 
+use crate::rustup_mode::CompletionCommand;
+
 use std::io;
 use std::path::PathBuf;
 
+use clap::Shell;
 use error_chain::error_chain;
 use error_chain::error_chain_processing;
 use error_chain::{impl_error_chain_kind, impl_error_chain_processed, impl_extract_backtrace};
@@ -45,6 +48,10 @@ error_chain! {
         }
         WindowsUninstallMadness {
             description("failure during windows uninstall")
+        }
+        UnsupportedCompletionShell(shell: Shell, cmd: CompletionCommand) {
+            description("completion script for shell not yet supported for tool")
+            display("{} does not currently support completions for {}", cmd, shell)
         }
     }
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -164,10 +164,12 @@ r"DISCUSSION:
 
     BASH:
 
-    Completion files are commonly stored in `/etc/bash_completion.d/`.
+    Completion files are commonly stored in `/etc/bash_completion.d/` for
+    system-wide commands, but can be stored in in
+    `~/.local/share/bash_completion/completions` for user-specific commands.
     Run the command:
 
-        $ rustup completions bash > /etc/bash_completion.d/rustup.bash-completion
+        $ rustup completions bash >> ~/.local/share/bash_completion/completions/rustup
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take affect.

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -251,7 +251,22 @@ r"DISCUSSION:
     into a separate file and source it inside our profile. To save the
     completions into our profile simply use
 
-        PS C:\> rustup completions powershell >> ${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1";
+        PS C:\> rustup completions powershell >> ${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+
+    CARGO:
+
+    Rustup can also generate a completion script for `cargo`. The script output
+    by `rustup` will source the completion script distributed with your default
+    toolchain. Not all shells are currently supported. Here are examples for
+    the currently supported shells.
+
+    BASH:
+
+        $ rustup completions bash cargo >> ~/.local/share/bash_completion/completions/cargo
+
+    ZSH:
+
+        $ rustup completions zsh cargo > ~/.zfunc/_cargo";
 
 pub static TOOLCHAIN_ARG_HELP: &'static str = "Toolchain name, such as 'stable', 'nightly', \
                                                or '1.8.0'. For more information see `rustup \

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -9,7 +9,7 @@ use rustup::dist::manifest::Component;
 use rustup::utils::utils::{self, ExitCode};
 use rustup::{command, Cfg, Toolchain};
 use std::error::Error;
-use std::io::{self, Write};
+use std::io::Write;
 use std::iter;
 use std::path::Path;
 use std::process::{self, Command};
@@ -1138,7 +1138,7 @@ impl FromStr for CompletionCommand {
 fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<()> {
     match command {
         CompletionCommand::Rustup => {
-            cli().gen_completions_to("rustup", shell, &mut io::stdout());
+            cli().gen_completions_to("rustup", shell, &mut term2::stdout());
         }
         CompletionCommand::Cargo => {
             let script = match shell {
@@ -1149,13 +1149,13 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
 
             if let Some(script) = script {
                 writeln!(
-                    &mut io::stdout(),
+                    &mut term2::stdout(),
                     "source $(rustc --print sysroot){}",
                     script,
                 )?;
             } else {
                 writeln!(
-                    &mut io::stderr(),
+                    &mut term2::stderr(),
                     "Cargo does not currently support completions for {}.",
                     shell,
                 )?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1153,6 +1153,12 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
                     "source $(rustc --print sysroot){}",
                     script,
                 )?;
+            } else {
+                writeln!(
+                    &mut io::stderr(),
+                    "Cargo does not currently support completions for {}.",
+                    shell,
+                )?;
             }
         }
     }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1117,9 +1117,14 @@ enum CompletionCommand {
     Cargo,
 }
 
+static COMPLETIONS: &[(&'static str, CompletionCommand)] = &[
+    ("rustup", CompletionCommand::Rustup),
+    ("cargo", CompletionCommand::Cargo),
+];
+
 impl CompletionCommand {
-    fn variants() -> [&'static str; 2] {
-        ["rustup", "cargo"]
+    fn variants() -> Vec<&'static str> {
+        COMPLETIONS.iter().map(|&(s, _)| s).collect::<Vec<_>>()
     }
 }
 
@@ -1127,10 +1132,13 @@ impl FromStr for CompletionCommand {
     type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        match s {
-            _ if s.eq_ignore_ascii_case("rustup") => Ok(CompletionCommand::Rustup),
-            _ if s.eq_ignore_ascii_case("cargo") => Ok(CompletionCommand::Cargo),
-            _ => Err(String::from("[valid values: rustup, cargo]")),
+        match COMPLETIONS
+            .iter()
+            .filter(|&(val, _)| val.eq_ignore_ascii_case(s))
+            .next()
+        {
+            Some(&(_, cmd)) => Ok(cmd),
+            None => Err(String::from("[valid values: rustup, cargo]")),
         }
     }
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -85,34 +85,7 @@ pub fn main() -> Result<()> {
         },
         ("completions", Some(c)) => {
             if let Some(shell) = c.value_of("shell") {
-                let shell = shell.parse::<Shell>().unwrap();
-                let prefix = "~/.rustup/toolchains/$(rustup toolchain list --default)";
-
-                cli().gen_completions_to(
-                    "rustup",
-                    shell,
-                    &mut io::stdout(),
-                );
-
-                match shell {
-                    Shell::Bash => {
-                        writeln!(
-                            &mut io::stdout(),
-                            "\n. {}{}",
-                            prefix,
-                            "/etc/bash_completion.d/cargo"
-                        );
-                    }
-                    Shell::Zsh => {
-                        writeln!(
-                            &mut io::stdout(),
-                            "\n. {}{}",
-                            prefix,
-                            "/share/zsh/site-functions/_cargo"
-                        );
-                    }
-                    _ => (),
-                };
+                output_completion_script(shell.parse::<Shell>().unwrap())?;
             }
         }
         (_, _) => unreachable!(),
@@ -1071,5 +1044,36 @@ fn self_uninstall(m: &ArgMatches<'_>) -> Result<()> {
 
 fn set_default_host_triple(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     cfg.set_default_host_triple(m.value_of("host_triple").expect(""))?;
+    Ok(())
+}
+
+fn output_completion_script(shell: Shell) -> Result<()> {
+    cli().gen_completions_to(
+        "rustup",
+        shell,
+        &mut io::stdout(),
+    );
+
+    let prefix = "$(rustc --print sysroot)";
+    match shell {
+        Shell::Bash => {
+            writeln!(
+                &mut io::stdout(),
+                "{}{}",
+                prefix,
+                "/etc/bash_completion.d/cargo"
+            )?;
+        }
+        Shell::Zsh => {
+            writeln!(
+                &mut io::stdout(),
+                "{}{}",
+                prefix,
+                "/share/zsh/site-functions/_cargo"
+            )?;
+        }
+        _ => {}
+    };
+
     Ok(())
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -85,11 +85,34 @@ pub fn main() -> Result<()> {
         },
         ("completions", Some(c)) => {
             if let Some(shell) = c.value_of("shell") {
+                let shell = shell.parse::<Shell>().unwrap();
+                let prefix = "~/.rustup/toolchains/$(rustup toolchain list --default)";
+
                 cli().gen_completions_to(
                     "rustup",
-                    shell.parse::<Shell>().unwrap(),
+                    shell,
                     &mut io::stdout(),
                 );
+
+                match shell {
+                    Shell::Bash => {
+                        writeln!(
+                            &mut io::stdout(),
+                            "\n. {}{}",
+                            prefix,
+                            "/etc/bash_completion.d/cargo"
+                        );
+                    }
+                    Shell::Zsh => {
+                        writeln!(
+                            &mut io::stdout(),
+                            "\n. {}{}",
+                            prefix,
+                            "/share/zsh/site-functions/_cargo"
+                        );
+                    }
+                    _ => (),
+                };
             }
         }
         (_, _) => unreachable!(),

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1141,26 +1141,19 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
             cli().gen_completions_to("rustup", shell, &mut io::stdout());
         }
         CompletionCommand::Cargo => {
-            let prefix = "$(rustc --print sysroot)";
-            match shell {
-                Shell::Bash => {
-                    writeln!(
-                        &mut io::stdout(),
-                        "{}{}",
-                        prefix,
-                        "/etc/bash_completion.d/cargo"
-                    )?;
-                }
-                Shell::Zsh => {
-                    writeln!(
-                        &mut io::stdout(),
-                        "{}{}",
-                        prefix,
-                        "/share/zsh/site-functions/_cargo"
-                    )?;
-                }
-                _ => {}
+            let script = match shell {
+                Shell::Bash => Some("/etc/bash_completion.d/cargo"),
+                Shell::Zsh => Some("/share/zsh/site-functions/_cargo"),
+                _ => None,
             };
+
+            if let Some(script) = script {
+                writeln!(
+                    &mut io::stdout(),
+                    "source $(rustc --print sysroot){}",
+                    script,
+                )?;
+            }
         }
     }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -4,8 +4,8 @@
 pub mod mock;
 
 use crate::mock::clitools::{
-    self, expect_err, expect_ok, expect_ok_ex, expect_stderr_ok, expect_stdout_ok, run,
-    set_current_dist_date, this_host_triple, Config, Scenario,
+    self, expect_err, expect_ok, expect_ok_eq, expect_ok_ex, expect_stderr_ok, expect_stdout_ok,
+    run, set_current_dist_date, this_host_triple, Config, Scenario,
 };
 use rustup::dist::errors::TOOLSTATE_MSG;
 use rustup::utils::{raw, utils};
@@ -787,5 +787,68 @@ fn update_unavailable_rustc() {
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+    });
+}
+
+#[test]
+fn completion_rustup() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "completions", "bash", "rustup"]);
+    });
+}
+
+#[test]
+fn completion_cargo() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "completions", "bash", "cargo"]);
+    });
+}
+
+#[test]
+fn completion_default() {
+    setup(&|config| {
+        expect_ok_eq(
+            config,
+            &["rustup", "completions", "bash"],
+            &["rustup", "completions", "bash", "rustup"],
+        );
+    });
+}
+
+#[test]
+fn completion_bad_shell() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "completions", "fake"],
+            "error: 'fake' isn't a valid value for '<shell>'",
+        );
+        expect_err(
+            config,
+            &["rustup", "completions", "fake", "cargo"],
+            "error: 'fake' isn't a valid value for '<shell>'",
+        );
+    });
+}
+
+#[test]
+fn completion_bad_tool() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "completions", "bash", "fake"],
+            "error: 'fake' isn't a valid value for '<command>'",
+        );
+    });
+}
+
+#[test]
+fn completion_cargo_unsupported_shell() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "completions", "fish", "cargo"],
+            "error: cargo does not currently support completions for ",
+        );
     });
 }

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -253,6 +253,18 @@ pub fn expect_ok_contains(config: &Config, args: &[&str], stdout: &str, stderr: 
     }
 }
 
+pub fn expect_ok_eq(config: &Config, args1: &[&str], args2: &[&str]) {
+    let out1 = run(config, args1[0], &args1[1..], &[]);
+    let out2 = run(config, args2[0], &args2[1..], &[]);
+    if !out1.ok || !out2.ok || out1.stdout != out2.stdout || out1.stderr != out2.stderr {
+        print_command(args1, &out1);
+        println!("expected.ok: {}", true);
+        print_command(args2, &out2);
+        println!("expected.ok: {}", true);
+        panic!();
+    }
+}
+
 fn print_command(args: &[&str], out: &SanitizedOutput) {
     print!("\n>");
     for arg in args {


### PR DESCRIPTION
This is a cleanup of a prior PR (#1425) by @ricvelozo.

- Adds the ability to output shell completions for cargo using the command `rustup completions <shell> cargo`
- Updates the completion instructions to mention and suggest placing bash completions in the home directory.