### PR TITLE
Bring output of `rustup show active-toolchain` and `rustup default` into line with rest of rustup

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -783,8 +783,12 @@ fn show(cfg: &Cfg) -> Result<()> {
 
 fn show_active_toolchain(cfg: &Cfg) -> Result<()> {
     let ref cwd = utils::current_dir()?;
-    if let Some((toolchain, _)) = cfg.find_override_toolchain_or_default(cwd)? {
-        writeln!(term2::stdout(), "{}", toolchain.name())?
+    if let Some((toolchain, reason)) = cfg.find_override_toolchain_or_default(cwd)? {
+        if reason.is_some() {
+            println!("{} ({})", toolchain.name(), reason.unwrap());
+        } else {
+            println!("{} (default)", toolchain.name());
+        }
     }
     Ok(())
 }

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -592,17 +592,7 @@ fn default_(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
             common::show_channel_update(cfg, toolchain.name(), Ok(status))?;
         }
     } else {
-        let installed_toolchains = cfg.list_toolchains()?;
-        if installed_toolchains.len() > 0 {
-            let default_toolchain = cfg.get_default()?;
-            if default_toolchain != "" {
-                let mut t = term2::stdout();
-                let _ = t.attr(term2::Attr::Bold);
-                let _ = write!(t, "Default toolchain: ");
-                let _ = t.reset();
-                println!("{}", default_toolchain);
-            }
-        }
+        println!("{} (default)", cfg.get_default()?);
     }
 
     Ok(())

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -861,7 +861,7 @@ fn show_active_toolchain() {
             config,
             &["rustup", "show", "active-toolchain"],
             for_host!(
-                r"nightly-{0}
+                r"nightly-{0} (default)
 "
             ),
             r"",

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -870,6 +870,20 @@ fn show_active_toolchain() {
 }
 
 #[test]
+fn show_active_toolchain_with_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "override", "set", "stable"]);
+        expect_stdout_ok(
+            config,
+            &["rustup", "show", "active-toolchain"],
+            for_host!("stable-{0} (directory override for"),
+        );
+    });
+}
+
+#[test]
 fn show_active_toolchain_none() {
     setup(&|config| {
         expect_ok_ex(config, &["rustup", "show", "active-toolchain"], r"", r"");


### PR DESCRIPTION
This resolves: #1406, and brings into line the fix for #1633 

#1406 seems to just be the result of the `rustup show active-toolchain` command not producing the same output as `rustup show`, which includes the override reason. This has been changed so that if `active-toolchain` returns an override, it states the reason for the override. The change to `rustup default` is just to bring its output into line with the rest of rustup in using the "\<toolchain\> (\<status\>)" format.

Previous behavior of `rustup show active-toolchain` while nightly override is set:

```shell
canis@latrans:~/rustup.rs$ rustup show active-toolchain
nightly-x86_64-unknown-linux-gnu
```

New behavior:

```shell
canis@latrans:~/rustup.rs$ rustup show active-toolchain
nightly-x86_64-unknown-linux-gnu (directory override for '/home/canis/rustup.rs')
```