### PR TITLE
Tell user if override is set in the environment after `rustup default`

### DIFF
--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -591,6 +591,12 @@ fn default_(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
             println!();
             common::show_channel_update(cfg, toolchain.name(), Ok(status))?;
         }
+
+        let cwd = utils::current_dir()?;
+        if let Some((toolchain, reason)) = cfg.find_override(&cwd)? {
+            info!("using override set by current environment");
+            info!("{} ({})", toolchain.name(), reason);
+        }
     } else {
         let installed_toolchains = cfg.list_toolchains()?;
         if installed_toolchains.len() > 0 {

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -594,8 +594,11 @@ fn default_(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
 
         let cwd = utils::current_dir()?;
         if let Some((toolchain, reason)) = cfg.find_override(&cwd)? {
-            info!("using override set by current environment");
-            info!("{} ({})", toolchain.name(), reason);
+            info!(
+                "note that the toolchain '{}' is currently in use ({})",
+                toolchain.name(),
+                reason
+            );
         }
     } else {
         let installed_toolchains = cfg.list_toolchains()?;

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -250,6 +250,24 @@ info: default toolchain set to 'nightly-{0}'
 }
 
 #[test]
+fn default_override() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "default", "stable"]);
+        expect_ok(config, &["rustup", "override", "set", "nightly"]);
+        expect_stderr_ok(
+            config,
+            &["rustup", "default", "stable"],
+            for_host!(
+                r"info: using existing install for 'stable-{0}'
+info: default toolchain set to 'stable-{0}'
+info: note that the toolchain 'nightly-{0}' is currently in use (directory override for"
+            ),
+        );
+    });
+}
+
+#[test]
 fn rustup_xz() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");


### PR DESCRIPTION
Resolves: #1648

Given: an environment with stable, beta, and nightly installed, and an override for beta set on the current working directory.

Previous Behavior:

```shell
canis@latrans:~/rustup.rs$ rustup default nightly
info: using existing install for 'nightly-x86_64-unknown-linux-gnu'
info: default toolchain set to 'nightly-x86_64-unknown-linux-gnu'

  nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.34.0-nightly (57d7cfc3c 2019-02-11)
```

New behavior:

```shell
canis@latrans:~/rustup.rs$ rustup default nightly
info: using existing install for 'nightly-x86_64-unknown-linux-gnu'
info: default toolchain set to 'nightly-x86_64-unknown-linux-gnu'

  nightly-x86_64-unknown-linux-gnu unchanged - rustc 1.34.0-nightly (57d7cfc3c 2019-02-11)

info: using override set by current environment
info: beta-x86_64-unknown-linux-gnu (directory override for '/home/canis/rustup.rs')

```