### PR TITLE
Add Listing of Installed Components

### DIFF
--- a/src/rustup-cli/common.rs
+++ b/src/rustup-cli/common.rs
@@ -323,18 +323,28 @@ pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
     for component in toolchain.list_components()? {
         let name = component.name;
         if component.required {
-            let _ = t.attr(term2::Attr::Bold);
-            let _ = writeln!(t, "{} (default)", name);
-            let _ = t.reset();
+            t.attr(term2::Attr::Bold)?;
+            writeln!(t, "{} (default)", name)?;
+            t.reset()?;
         } else if component.installed {
-            let _ = t.attr(term2::Attr::Bold);
-            let _ = writeln!(t, "{} (installed)", name);
-            let _ = t.reset();
+            t.attr(term2::Attr::Bold)?;
+            writeln!(t, "{} (installed)", name)?;
+            t.reset()?;
         } else if component.available {
-            let _ = writeln!(t, "{}", name);
+            writeln!(t, "{}", name)?;
         }
     }
 
+    Ok(())
+}
+
+pub fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<()> {
+    let mut t = term2::stdout();
+    for component in toolchain.list_components()? {
+        if component.installed {
+            writeln!(t, "{}", component.name)?;
+        }
+    }
     Ok(())
 }
 

--- a/src/rustup-cli/rustup_mode.rs
+++ b/src/rustup-cli/rustup_mode.rs
@@ -294,6 +294,11 @@ pub fn cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .about("List installed and available components")
                         .arg(
+                            Arg::with_name("installed")
+                                .long("--installed")
+                                .help("List only installed components"),
+                        )
+                        .arg(
                             Arg::with_name("toolchain")
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .long("toolchain")
@@ -823,7 +828,11 @@ fn target_remove(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
 fn component_list(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
-    common::list_components(&toolchain)
+    if m.is_present("installed") {
+        common::list_installed_components(&toolchain)
+    } else {
+        common::list_components(&toolchain)
+    }
 }
 
 fn component_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {


### PR DESCRIPTION
This feature adds the ability to only list installed components rather than all available components.

My use-case is described in #1658; I'm writing automation around `rustup` and I need to be able to view only installed components so I can selectively install them.

Closes #1658.