### PR TITLE
Deprecate cURL

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,9 +530,16 @@ If you need a more complex setup, rustup supports the convention used by
 the __curl__ program, documented in the ENVIRONMENT section of
 [its manual page][curlman].
 
-Note that some versions of `libcurl` apparently require you to drop the 
-`http://` or `https://` prefix in environment variables. For example, 
-`export http_proxy=proxy.example.com:1080` (and likewise for HTTPS). 
+The use of `curl` is presently **deprecated**, however it can still be used by
+providing the `RUSTUP_USE_CURL` environment variable, for example:
+
+```
+RUSTUP_USE_CURL=1 rustup update
+```
+
+Note that some versions of `libcurl` apparently require you to drop the
+`http://` or `https://` prefix in environment variables. For example,
+`export http_proxy=proxy.example.com:1080` (and likewise for HTTPS).
 If you are getting an SSL `unknown protocol` error from `rustup` via `libcurl`
 but the command-line `curl` command works fine, this may be the problem.
 

--- a/src/download/Cargo.toml
+++ b/src/download/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT/Apache-2.0"
 
 [features]
 
-default = ["curl-backend"]
+default = ["reqwest-backend"]
 
 curl-backend = ["curl"]
 reqwest-backend = ["reqwest", "env_proxy", "lazy_static"]

--- a/src/rustup-utils/src/notifications.rs
+++ b/src/rustup-utils/src/notifications.rs
@@ -64,10 +64,9 @@ impl<'a> Display for Notification<'a> {
             ResumingPartialDownload => write!(f, "resuming partial download"),
             UsingCurl => write!(f, "downloading with curl"),
             UsingReqwest => write!(f, "downloading with reqwest"),
-            UsingHyperDeprecated => f.write_str(
-                "RUSTUP_USE_HYPER environment variable is deprecated,\
-                 use RUSTUP_USE_REQWEST instead",
-            ),
+            UsingHyperDeprecated => {
+                f.write_str("RUSTUP_USE_HYPER environment variable is deprecated.")
+            }
         }
     }
 }

--- a/src/rustup-utils/src/notifications.rs
+++ b/src/rustup-utils/src/notifications.rs
@@ -22,7 +22,6 @@ pub enum Notification<'a> {
     ResumingPartialDownload,
     UsingCurl,
     UsingReqwest,
-    UsingHyperDeprecated,
 }
 
 impl<'a> Notification<'a> {
@@ -39,7 +38,7 @@ impl<'a> Notification<'a> {
             | ResumingPartialDownload
             | UsingCurl
             | UsingReqwest => NotificationLevel::Verbose,
-            UsingHyperDeprecated | NoCanonicalPath(_) => NotificationLevel::Warn,
+            NoCanonicalPath(_) => NotificationLevel::Warn,
         }
     }
 }
@@ -64,9 +63,6 @@ impl<'a> Display for Notification<'a> {
             ResumingPartialDownload => write!(f, "resuming partial download"),
             UsingCurl => write!(f, "downloading with curl"),
             UsingReqwest => write!(f, "downloading with reqwest"),
-            UsingHyperDeprecated => {
-                f.write_str("RUSTUP_USE_HYPER environment variable is deprecated.")
-            }
         }
     }
 }

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -210,11 +210,11 @@ fn download_file_(
     if use_hyper_backend && DEPRECATED_HYPER_WARNED.swap(true, Ordering::Relaxed) {
         notify_handler(Notification::UsingHyperDeprecated);
     }
-    let use_reqwest_backend = use_hyper_backend || env::var_os("RUSTUP_USE_REQWEST").is_some();
-    let (backend, notification) = if use_reqwest_backend {
-        (Backend::Reqwest, Notification::UsingReqwest)
-    } else {
+    let use_curl_backend = env::var_os("RUSTUP_USE_CURL").is_some();
+    let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)
+    } else {
+        (Backend::Reqwest, Notification::UsingReqwest)
     };
     notify_handler(notification);
     download_to_path_with_backend(backend, url, path, resume_from_partial, Some(callback))?;

--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -158,8 +158,6 @@ pub fn download_file_with_resume(
     }
 }
 
-static DEPRECATED_HYPER_WARNED: AtomicBool = ATOMIC_BOOL_INIT;
-
 fn download_file_(
     url: &Url,
     path: &Path,
@@ -206,10 +204,6 @@ fn download_file_(
     // Download the file
 
     // Keep the hyper env var around for a bit
-    let use_hyper_backend = env::var_os("RUSTUP_USE_HYPER").is_some();
-    if use_hyper_backend && DEPRECATED_HYPER_WARNED.swap(true, Ordering::Relaxed) {
-        notify_handler(Notification::UsingHyperDeprecated);
-    }
     let use_curl_backend = env::var_os("RUSTUP_USE_CURL").is_some();
     let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)


### PR DESCRIPTION
Part of the simplification project: #1611 

Deprecates cURL in favor of reqwest.

This is the preliminary step for the complete disuse of cURL by rustup; on-going discussion: #1657 

cc's from previous PR:
@dwijnand 
@brson 
@briansmith
@jnicholls
@seanmonstar 