### PR TITLE
Add `clippy-driver` as a proxy

### DIFF
--- a/src/rustup-win-installer/src/lib.rs
+++ b/src/rustup-win-installer/src/lib.rs
@@ -27,6 +27,7 @@ static TOOLS: &'static [&'static str] = &[
     "rustfmt",
     "cargo-fmt",
     "cargo-clippy",
+    "clippy-driver",
     "cargo-miri",
 ];
 

--- a/src/rustup/lib.rs
+++ b/src/rustup/lib.rs
@@ -15,6 +15,7 @@ pub static TOOLS: &'static [&'static str] = &[
     "rust-gdb",
     "rls",
     "cargo-clippy",
+    "clippy-driver",
     "cargo-miri",
 ];
 
@@ -39,6 +40,7 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
         "rust-gdb" => Some("gdb-preview"),
         "rls" => Some("rls"),
         "cargo-clippy" => Some("clippy"),
+        "clippy-driver" => Some("clippy"),
         "cargo-miri" => Some("miri"),
         "rustfmt" | "cargo-fmt" => Some("rustfmt"),
         _ => None,


### PR DESCRIPTION
The Cargo team are taking `cargo clippy` on-board and as such
will need `clippy-driver` as a general proxy.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>