### PR TITLE
rustup-utils: Remove unused import

### DIFF
--- a/src/rustup-utils/src/utils.rs
+++ b/src/rustup-utils/src/utils.rs
@@ -9,7 +9,6 @@ use std::fs::{self, File};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 use url::Url;
 
 #[cfg(windows)]


### PR DESCRIPTION
Trivial warning fix

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>