### PR TITLE
Make the error more verbose

### DIFF
--- a/src/rustup-dist/src/errors.rs
+++ b/src/rustup-dist/src/errors.rs
@@ -72,7 +72,7 @@ error_chain! {
             display("component manifest for '{}' is corrupt", name)
         }
         ExtractingPackage {
-            description("failed to extract package")
+            description("failed to extract package (perhaps you ran out of disk space?)")
         }
         BadInstallerVersion(v: String) {
             description("unsupported installer version")


### PR DESCRIPTION
A small attempt to improve unclear errors. cf. #1617

I can branch/rebase/etc if this PR does not conform to Rust standards.
