### PR TITLE
rustup-init.sh: Fix unset variable usage

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -15,9 +15,8 @@
 
 set -u
 
-if [ -z "$RUSTUP_UPDATE_ROOT" ]; then
-    RUSTUP_UPDATE_ROOT="https://static.rust-lang.org/rustup"
-fi
+# If RUSTUP_UPDATE_ROOT is unset or empty, default it.
+RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 
 #XXX: If you change anything here, please make the same changes in setup_mode.rs
 usage() {


### PR DESCRIPTION
```
With `set -u` our check for `RUSTUP_UPDATE_ROOT` being empty
needed an additional tweak for it being unset.
```

Lesson learned from 1.17.0 - even when Daniel *thinks* he has checked
`rustup-init.sh` he probably needs to check it again.

/cc @alexcrichton - thanks for the catch.

Fixes #1684