### PR TITLE
Use official component availability page

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -134,7 +134,7 @@
   <br/>
   <a href="https://github.com/rust-lang/rustup.rs/#other-installation-methods">other installation options</a>
   &nbsp;&middot;&nbsp;
-  <a href="https://rust-lang-nursery.github.io/rust-toolstate/">component availability</a>
+  <a href="https://rust-lang.github.io/rustup-components-history/">component availability</a>
   &nbsp;&middot;&nbsp;
   <a href="https://github.com/rust-lang/rustup.rs">about rustup</a>
 </p>


### PR DESCRIPTION
Now that rustup-components-history is accepted[1] to the offical repository,
it makes sense to link to it directly from rustup.rs front page.

[1]: https://internals.rust-lang.org/t/solved-proposal-add-components-availability-history-into-nursery/9161/6