### PR TITLE
Switch to git-testament rather than old build.rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,16 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "chrono"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "clap"
 version = "2.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +506,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "git-testament"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "git-testament-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "git-testament-derive"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.30 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "h2"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +832,19 @@ dependencies = [
 [[package]]
 name = "nodrop"
 version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "num-integer"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1214,6 +1256,7 @@ dependencies = [
  "download 0.5.0",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-testament 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1886,6 +1929,7 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
 "checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
@@ -1922,6 +1966,8 @@ dependencies = [
 "checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
+"checksum git-testament 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74b588fea7d92320ed482f913b6639572078ef1d84b3325921984c50ef253382"
+"checksum git-testament-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca6d95dea8a5e77ccd93fd8f1ed3712d25eca4834216afaa378a5d632be3db3"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
@@ -1955,6 +2001,8 @@ dependencies = [
 "checksum native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ff8e08de0070bbf4c31f452ea2a70db092f36f6f2e4d897adf5674477d488fb2"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
+"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
+"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
 "checksum ole32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2c49021782e5233cd243168edfa8037574afed4eba4bbaf538b3d8d1789d8c"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ wait-timeout = "0.2"
 walkdir = "2"
 xz2 = "0.1.3"
 openssl = { version = "0.10", optional = true }
+git-testament = "0.1"
+lazy_static = "1"
 
 [target."cfg(windows)".dependencies]
 winapi = { version = "0.3", features = ["combaseapi", "errhandlingapi", "fileapi", "handleapi", "ioapiset", "jobapi", "jobapi2", "minwindef", "processthreadsapi", "psapi", "shlobj", "shtypes", "synchapi", "sysinfoapi", "tlhelp32", "userenv", "winbase", "winerror", "winioctl", "winnt", "winuser"] }

--- a/build.rs
+++ b/build.rs
@@ -1,57 +1,6 @@
 use std::env;
-use std::error::Error;
-use std::fs::File;
-use std::io::Write;
-use std::path::PathBuf;
-use std::process::Command;
-
-struct Ignore;
-
-impl<E> From<E> for Ignore
-where
-    E: Error,
-{
-    fn from(_: E) -> Ignore {
-        Ignore
-    }
-}
 
 fn main() {
     let target = env::var("TARGET").unwrap();
     println!("cargo:rustc-env=TARGET={}", target);
-
-    let out_dir = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    File::create(out_dir.join("commit-info.txt"))
-        .unwrap()
-        .write_all(commit_info().as_bytes())
-        .unwrap();
-
-    println!("cargo:rerun-if-changed=build.rs");
-}
-
-// Try to get hash and date of the last commit on a best effort basis. If anything goes wrong
-// (git not installed or if this is not a git repository) just return an empty string.
-fn commit_info() -> String {
-    match (commit_hash(), commit_date()) {
-        (Ok(hash), Ok(date)) => format!(" ({} {})", hash.trim_end(), date),
-        _ => String::new(),
-    }
-}
-
-fn commit_hash() -> Result<String, Ignore> {
-    Ok(String::from_utf8(
-        Command::new("git")
-            .args(&["rev-parse", "--short=9", "HEAD"])
-            .output()?
-            .stdout,
-    )?)
-}
-
-fn commit_date() -> Result<String, Ignore> {
-    Ok(String::from_utf8(
-        Command::new("git")
-            .args(&["log", "-1", "--date=short", "--pretty=format:%cd"])
-            .output()?
-            .stdout,
-    )?)
 }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -3,6 +3,8 @@
 use crate::errors::*;
 use crate::self_update;
 use crate::term2;
+use git_testament::{git_testament, render_testament};
+use lazy_static::lazy_static;
 use rustup::utils::notify::NotificationLevel;
 use rustup::utils::utils;
 use rustup::{Cfg, Notification, Toolchain, UpdateStatus};
@@ -402,11 +404,13 @@ pub fn list_overrides(cfg: &Cfg) -> Result<()> {
     Ok(())
 }
 
+git_testament!(TESTAMENT);
+
 pub fn version() -> &'static str {
-    concat!(
-        env!("CARGO_PKG_VERSION"),
-        include_str!(concat!(env!("OUT_DIR"), "/commit-info.txt"))
-    )
+    lazy_static! {
+        static ref RENDERED: String = render_testament!(TESTAMENT);
+    }
+    &RENDERED
 }
 
 pub fn report_error(e: &Error) {


### PR DESCRIPTION
Rather than the previous not-very-informative version string
which was generated by `build.rs` and then not updated unless
`build.rs` was touched, use the new `git-testament` crate which
does a more complete job at compile time via a proc-macro.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>