### PR TITLE
Force highest TLS version supported

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -376,9 +376,9 @@ downloader() {
     if [ "$1" = --check ]; then
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
-        curl -sSfL "$1" -o "$2"
+        curl --proto =https --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
     elif [ "$_dld" = wget ]; then
-        wget "$1" -O "$2"
+        wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
     else
         err "Unknown downloader"   # should not reach here
     fi

--- a/www/index.html
+++ b/www/index.html
@@ -36,7 +36,7 @@
     then follow the onscreen instructions.
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
-  <pre>curl https://sh.rustup.rs -sSf | sh</pre>
+  <pre>curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Windows 32-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 


### PR DESCRIPTION
The integrity and confidentiality of the installer script currently hinges on TLS. It is important to enforce the highest version of TLS in the instructions. Also, enforce the `https` scheme. Should redirects occur in the future, then each URL redirected to must be accessed using TLS 1.2 with HTTP, rather than allowing a plain HTTP link in the chain.