### PR TITLE
Fix fallout when zsh options `noequals` is unset (default)

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -376,7 +376,7 @@ downloader() {
     if [ "$1" = --check ]; then
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
-        curl --proto =https --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
+        curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
     elif [ "$_dld" = wget ]; then
         wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
     else

--- a/www/index.html
+++ b/www/index.html
@@ -36,7 +36,7 @@
     then follow the onscreen instructions.
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
-  <pre>curl --proto =https --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+  <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Windows 32-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 


### PR DESCRIPTION
This is introduced in #1716.
