### PR TITLE
Add test for dumb terminal

### DIFF
--- a/src/utils/tty.rs
+++ b/src/utils/tty.rs
@@ -1,45 +1,38 @@
 // Copied from rustc. atty crate did not work as expected
 #[cfg(unix)]
 pub fn stderr_isatty() -> bool {
-    unsafe { libc::isatty(libc::STDERR_FILENO) != 0 }
+    isatty(libc::STDERR_FILENO)
 }
 
 // FIXME: Unfortunately this doesn't detect msys terminals so rustup
 // is always colorless there (just like rustc and cargo).
 #[cfg(windows)]
 pub fn stderr_isatty() -> bool {
-    type DWORD = u32;
-    type BOOL = i32;
-    type HANDLE = *mut u8;
-    const STD_ERROR_HANDLE: DWORD = -12i32 as DWORD;
-    extern "system" {
-        fn GetStdHandle(which: DWORD) -> HANDLE;
-        fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *mut DWORD) -> BOOL;
-    }
-    unsafe {
-        let handle = GetStdHandle(STD_ERROR_HANDLE);
-        let mut out = 0;
-        GetConsoleMode(handle, &mut out) != 0
-    }
+    isatty(winapi::um::winbase::STD_ERROR_HANDLE)
 }
 
 #[cfg(unix)]
 pub fn stdout_isatty() -> bool {
-    unsafe { libc::isatty(libc::STDOUT_FILENO) != 0 }
+    isatty(libc::STDOUT_FILENO)
 }
 
 #[cfg(windows)]
 pub fn stdout_isatty() -> bool {
-    type DWORD = u32;
-    type BOOL = i32;
-    type HANDLE = *mut u8;
-    const STD_OUTPUT_HANDLE: DWORD = -11i32 as DWORD;
-    extern "system" {
-        fn GetStdHandle(which: DWORD) -> HANDLE;
-        fn GetConsoleMode(hConsoleHandle: HANDLE, lpMode: *mut DWORD) -> BOOL;
-    }
+    isatty(winapi::um::winbase::STD_OUTPUT_HANDLE)
+}
+
+#[inline]
+#[cfg(unix)]
+fn isatty(fd: libc::c_int) -> bool {
+    unsafe { libc::isatty(fd) == 1 }
+}
+
+#[inline]
+#[cfg(windows)]
+fn isatty(fd: winapi::shared::minwindef::DWORD) -> bool {
+    use winapi::um::{consoleapi::GetConsoleMode, processenv::GetStdHandle};
     unsafe {
-        let handle = GetStdHandle(STD_OUTPUT_HANDLE);
+        let handle = GetStdHandle(fd);
         let mut out = 0;
         GetConsoleMode(handle, &mut out) != 0
     }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -122,6 +122,17 @@ fn update_works_without_term() {
     });
 }
 
+// Issue #1738
+#[test]
+fn show_works_with_dumb_term() {
+    setup(&|config| {
+        let mut cmd = clitools::cmd(config, "rustup", &["show"]);
+        clitools::env(config, &mut cmd);
+        cmd.env("TERM", "dumb");
+        assert!(cmd.spawn().unwrap().wait().unwrap().success());
+    });
+}
+
 // Issue #140
 // Don't panic when `target`, `update` etc. are called without subcommands.
 #[test]


### PR DESCRIPTION
cc @kinnison 

Do we need to use [`isatty`] crate instead of manual hand code? But looks like 
its repo has been archived.

Test for #1747.

[`isatty`]: https://crates.io/crates/isatty`
