### PR TITLE
Fold process of building Dockerfile in Travis log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,9 +64,9 @@ script:
         *)                   DOCKER=$TARGET ;;
       esac;
       if [ -n "$DOCKER" ]; then
-          sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
+          bash ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
       else
-          PATH="$HOME/rust/bin:$PATH" sh ci/run.sh;
+          PATH="$HOME/rust/bin:$PATH" bash ci/run.sh;
       fi
 
 before_deploy:

--- a/ci/build-run-docker.sh
+++ b/ci/build-run-docker.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-set -ex
+# Start loading environment before `set -x`
+script_dir=$(cd "$(dirname "$0")" && pwd)
+. "$script_dir/shared.bash"
+
+set -e
+# Disable cause it makes helper script failed to work properly.
+# set -x
 
 mkdir -p target
 
@@ -8,9 +14,18 @@ DOCKER="$1"
 TARGET="$2"
 SKIP_TESTS="$3"
 
-bash ci/fetch-rust-docker.sh "$TARGET"
+travis_fold start "fetch.image.${TARGET}"
+travis_time_start
+travis_do_cmd bash ci/fetch-rust-docker.sh "$TARGET"
+travis_time_finish
+travis_fold end "fetch.image.${TARGET}"
+
 if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-  docker build -t "$DOCKER" "ci/docker/$DOCKER/"
+  travis_fold start "Build.Dockerfile.${DOCKER}"
+  travis_time_start
+  travis_do_cmd docker build -t "$DOCKER" "ci/docker/$DOCKER/"
+  travis_time_finish
+  travis_fold end "Build.Dockerfile.${DOCKER}"
 fi
 
 docker run \

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -3,8 +3,4 @@ FROM alexcrichton/rust-slave-dist:2015-10-20b
 USER root
 
 WORKDIR /
-RUN curl https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz | tar xzf -
-WORKDIR /perl-5.28.0
-RUN ./configure.gnu
-RUN make -j$(nproc)
-RUN make install
+RUN curl -L https://github.com/lzutao/rustup.rs/releases/download/perl-5.28.0/perl-5.28.0.tar.gz | tar xzf - -C /

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,3 +1,4 @@
+# Source from https://github.com/rust-lang-deprecated/rust-buildbot/blob/master/slaves/dist/Dockerfile
 FROM alexcrichton/rust-slave-dist:2015-10-20b
 USER root
 

--- a/ci/fetch-rust-docker.sh
+++ b/ci/fetch-rust-docker.sh
@@ -7,26 +7,6 @@ TARGET="$1"
 RUST_REPO="https://github.com/rust-lang/rust"
 S3_BASE_URL="https://s3-us-west-1.amazonaws.com/rust-lang-ci2/rustc-builds"
 
-# See http://unix.stackexchange.com/questions/82598
-# Duplicated from rust-lang/rust/src/ci/shared.sh
-function retry {
-  echo "Attempting with retry:" "$@"
-  local n=1
-  local max=5
-  while true; do
-    "$@" && break || {
-      if [[ $n -lt $max ]]; then
-        sleep $n  # don't retry immediately
-        ((n++))
-        echo "Command failed. Attempt $n/$max:"
-      else
-        echo "The command has failed after $n attempts."
-        return 1
-      fi
-    }
-  done
-}
-
 # Use images from rustc master
 case "$TARGET" in
   mips-unknown-linux-gnu)          image=dist-mips-linux ;;
@@ -54,7 +34,7 @@ if ! docker tag "$digest" "rust-$TARGET"; then
   echo "Attempting to download $url"
   rm -f "$cache"
   set +e
-  retry curl -y 30 -Y 10 --connect-timeout 30 -f -L -C - -o "$cache" "$url"
+  travis_retry curl -y 30 -Y 10 --connect-timeout 30 -f -L -C - -o "$cache" "$url"
   docker load -i "$cache"
   set -e
   docker tag "$digest" "rust-$TARGET"

--- a/ci/shared.bash
+++ b/ci/shared.bash
@@ -1,0 +1,93 @@
+#!/bin/false
+#
+# This file is intended to be sourced, hence the invalid shebang and
+# not being marked as an executable file in git.
+
+# This is from
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_setup_env.bash
+travis_setup_env() {
+  export ANSI_RED='\e[31;1m'
+  export ANSI_GREEN='\e[32;1m'
+  export ANSI_YELLOW='\e[33;1m'
+  export ANSI_RESET='\e[0m'
+  export ANSI_CLEAR='\e[0K'
+}
+
+# This is from
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_fold.bash
+travis_fold() {
+  local action="${1}"
+  local name="${2}"
+  printf 'travis_fold:%s:%s\r'"${ANSI_CLEAR}" "${action}" "${name}"
+}
+
+# This is modified loop version of
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/travis_retry.bash
+travis_retry() {
+  local result=0
+  local count=1
+  local max=5
+  while [ "${count}" -le "${max}" ]; do
+    [ "${result}" -ne 0 ] && {
+      printf "${ANSI_RED}"'The command "%s" failed. Retrying, %s of %s.'"${ANSI_RESET}"'\n' "${*}" "${count}" "${max}" >&2
+    }
+    "${@}" && { result=0 && break; } || result="${?}"
+    ((count++))
+    sleep 1
+  done
+
+  [ "${count}" -gt "${max}" ] && {
+    printf "${ANSI_RED}"'The command "%s" failed %s times.'"${ANSI_RESET}"'\n' "${*}" "${max}" >&2
+  }
+
+  return "${result}"
+}
+
+# This is from
+# https://github.com/travis-ci/travis-build/blob/master/lib/travis/build/bash/
+travis_nanoseconds() {
+  local cmd='date'
+  local format='+%s%N'
+
+  if command -v gdate >/dev/null 2>&1; then
+    cmd='gdate'
+  elif [ "$(uname)" = Darwin ]; then
+    format='+%s000000000'
+  fi
+
+  "${cmd}" -u "${format}"
+}
+
+travis_time_start() {
+  TRAVIS_TIMER_ID="$(printf '%08x' $((RANDOM * RANDOM)))"
+  TRAVIS_TIMER_START_TIME="$(travis_nanoseconds)"
+  export TRAVIS_TIMER_ID TRAVIS_TIMER_START_TIME
+  printf 'travis_time:start:%s\r'"${ANSI_CLEAR}" "${TRAVIS_TIMER_ID}"
+}
+
+travis_time_finish() {
+  travis_timer_end_time="$(travis_nanoseconds)"
+  local duration="$((travis_timer_end_time - TRAVIS_TIMER_START_TIME))"
+  printf '\ntravis_time:end:%s:start=%s,finish=%s,duration=%s\r'"${ANSI_CLEAR}" \
+         "${TRAVIS_TIMER_ID}" "${TRAVIS_TIMER_START_TIME}" \
+         "${travis_timer_end_time}" "${duration}"
+}
+
+travis_do_cmd() {
+  echo "$ ${*}"
+  "${@}"
+  local result="$?"
+  export TRAVIS_TEST_RESULT=$((${TRAVIS_TEST_RESULT:-0} | $((result != 0))))
+
+  if [ "${result}" -eq 0 ]; then
+    printf '%b' "${ANSI_GREEN}"
+  else
+    printf '%b' "${ANSI_RED}"
+  fi
+  printf 'The command "%s" exited with %d.'"${ANSI_RESET}"'\n' "${*}" "${result}"
+  return "$result"
+}
+
+travis_setup_env
+
+export -f travis_retry travis_fold travis_time_start travis_time_finish travis_nanoseconds


### PR DESCRIPTION
The build log of Perl in Docker image is so long (about 5000 lines).
Now it should [look like this](https://travis-ci.com/rust-lang/rustup.rs/builds/108227392#L456):

![image](https://user-images.githubusercontent.com/15225902/56082812-89da8800-5e47-11e9-9f3e-36eea432274e.png)

r? @kinnison 