### PR TITLE
Fix most of clippy warnings

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -266,7 +266,7 @@ pub mod reqwest_be {
 
         if !res.status().is_success() {
             let code: u16 = res.status().into();
-            return Err(ErrorKind::HttpStatus(code as u32).into());
+            return Err(ErrorKind::HttpStatus(u32::from(code)).into());
         }
 
         let buffer_size = 0x10000;
@@ -345,13 +345,13 @@ pub mod reqwest_be {
                 return Err(ErrorKind::FileNotFound.into());
             }
 
-            let ref mut f = fs::File::open(src).chain_err(|| "unable to open downloaded file")?;
-            io::Seek::seek(f, io::SeekFrom::Start(resume_from))?;
+            let mut f = fs::File::open(src).chain_err(|| "unable to open downloaded file")?;
+            io::Seek::seek(&mut f, io::SeekFrom::Start(resume_from))?;
 
-            let ref mut buffer = vec![0u8; 0x10000];
+            let mut buffer = vec![0u8; 0x10000];
             loop {
-                let bytes_read =
-                    io::Read::read(f, buffer).chain_err(|| "unable to read downloaded file")?;
+                let bytes_read = io::Read::read(&mut f, &mut buffer)
+                    .chain_err(|| "unable to read downloaded file")?;
                 if bytes_read == 0 {
                     break;
                 }

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -105,7 +105,7 @@ impl DownloadTracker {
         if self.displayed_progress {
             // Display the finished state
             self.display();
-            let _ = writeln!(self.term.as_mut().unwrap(), "");
+            let _ = writeln!(self.term.as_mut().unwrap());
         }
         self.prepare_for_new_download();
     }

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -27,7 +27,7 @@ pub fn warn_fmt(args: fmt::Arguments<'_>) {
     let _ = write!(t, "warning: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
-    let _ = write!(t, "\n");
+    let _ = writeln!(t);
 }
 
 pub fn err_fmt(args: fmt::Arguments<'_>) {
@@ -37,7 +37,7 @@ pub fn err_fmt(args: fmt::Arguments<'_>) {
     let _ = write!(t, "error: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
-    let _ = write!(t, "\n");
+    let _ = writeln!(t);
 }
 
 pub fn info_fmt(args: fmt::Arguments<'_>) {
@@ -46,7 +46,7 @@ pub fn info_fmt(args: fmt::Arguments<'_>) {
     let _ = write!(t, "info: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
-    let _ = write!(t, "\n");
+    let _ = writeln!(t);
 }
 
 pub fn verbose_fmt(args: fmt::Arguments<'_>) {
@@ -56,7 +56,7 @@ pub fn verbose_fmt(args: fmt::Arguments<'_>) {
     let _ = write!(t, "verbose: ");
     let _ = t.reset();
     let _ = t.write_fmt(args);
-    let _ = write!(t, "\n");
+    let _ = writeln!(t);
 }
 
 pub fn debug_fmt(args: fmt::Arguments<'_>) {
@@ -67,6 +67,6 @@ pub fn debug_fmt(args: fmt::Arguments<'_>) {
         let _ = write!(t, "verbose: ");
         let _ = t.reset();
         let _ = t.write_fmt(args);
-        let _ = write!(t, "\n");
+        let _ = writeln!(t);
     }
 }

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -22,7 +22,7 @@ pub fn main() -> Result<()> {
             .as_ref()
             .and_then(|a| a.file_name())
             .and_then(|a| a.to_str());
-        let ref arg0 = arg0.ok_or(ErrorKind::NoExeName)?;
+        let arg0 = arg0.ok_or(ErrorKind::NoExeName)?;
 
         // Check for a toolchain specifier.
         let arg1 = args.next();
@@ -41,7 +41,7 @@ pub fn main() -> Result<()> {
 
         let cfg = set_globals(false)?;
         cfg.check_metadata_version()?;
-        direct_proxy(&cfg, arg0, toolchain, &cmd_args)?
+        direct_proxy(&cfg, &arg0, toolchain, &cmd_args)?
     };
 
     process::exit(c)

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -60,7 +60,7 @@ pub fn main() -> Result<()> {
     let opts = InstallOpts {
         default_host_triple: default_host,
         default_toolchain: default_toolchain.to_owned(),
-        no_modify_path: no_modify_path,
+        no_modify_path,
     };
 
     self_update::install(no_prompt, verbose, opts)?;

--- a/src/cli/term2.rs
+++ b/src/cli/term2.rs
@@ -67,7 +67,7 @@ struct LineWrapper<'a, T: io::Write> {
 impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
     // Just write a newline
     fn write_line(&mut self) {
-        let _ = writeln!(self.w, "");
+        let _ = writeln!(self.w);
         // Reset column position to start of line
         self.pos = 0;
     }
@@ -126,10 +126,10 @@ impl<'a, T: io::Write + 'a> LineWrapper<'a, T> {
     // Constructor
     fn new(w: &'a mut T, indent: u32, margin: u32) -> Self {
         LineWrapper {
-            indent: indent,
-            margin: margin,
+            indent,
+            margin,
             pos: indent,
-            w: w,
+            w,
         }
     }
 }

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -16,8 +16,8 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 
 /// The current metadata revision used by rust-installer
-pub const INSTALLER_VERSION: &'static str = "3";
-pub const VERSION_FILE: &'static str = "rust-installer-version";
+pub const INSTALLER_VERSION: &str = "3";
+pub const VERSION_FILE: &str = "rust-installer-version";
 
 pub trait Package: fmt::Debug {
     fn contains(&self, component: &str, short_name: Option<&str>) -> bool;
@@ -45,9 +45,9 @@ impl DirectoryPackage {
         let content = utils::read_file("package components", &path.join("components"))?;
         let components = content.lines().map(|l| l.to_owned()).collect();
         Ok(DirectoryPackage {
-            path: path,
-            components: components,
-            copy: copy,
+            path,
+            components,
+            copy,
         })
     }
 }

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -46,10 +46,10 @@ impl<'a> Transaction<'a> {
         notify_handler: &'a dyn Fn(Notification<'_>),
     ) -> Self {
         Transaction {
-            prefix: prefix,
+            prefix,
             changes: Vec::new(),
-            temp_cfg: temp_cfg,
-            notify_handler: notify_handler,
+            temp_cfg,
+            notify_handler,
             committed: false,
         }
     }

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -2,8 +2,8 @@ use super::manifest::Component;
 use crate::errors::*;
 use crate::utils::toml_utils::*;
 
-pub const SUPPORTED_CONFIG_VERSIONS: [&'static str; 1] = ["1"];
-pub const DEFAULT_CONFIG_VERSION: &'static str = "1";
+pub const SUPPORTED_CONFIG_VERSIONS: [&str; 1] = ["1"];
+pub const DEFAULT_CONFIG_VERSION: &str = "1";
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -24,10 +24,10 @@ impl Config {
 
         Ok(Config {
             config_version: version,
-            components: components,
+            components,
         })
     }
-    pub fn to_toml(self) -> toml::value::Table {
+    pub fn into_toml(self) -> toml::value::Table {
         let mut result = toml::value::Table::new();
         result.insert(
             "config_version".to_owned(),
@@ -46,7 +46,7 @@ impl Config {
     }
 
     pub fn stringify(self) -> String {
-        toml::Value::Table(self.to_toml()).to_string()
+        toml::Value::Table(self.into_toml()).to_string()
     }
 
     fn toml_to_components(arr: toml::value::Array, path: &str) -> Result<Vec<Component>> {
@@ -65,12 +65,18 @@ impl Config {
     fn components_to_toml(components: Vec<Component>) -> toml::value::Array {
         let mut result = toml::value::Array::new();
         for v in components {
-            result.push(toml::Value::Table(v.to_toml()));
+            result.push(toml::Value::Table(v.into_toml()));
         }
         result
     }
 
     pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
         Config {
             config_version: DEFAULT_CONFIG_VERSION.to_owned(),
             components: Vec::new(),

--- a/src/dist/prefix.rs
+++ b/src/dist/prefix.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
 
-const REL_MANIFEST_DIR: &'static str = "lib/rustlib";
+const REL_MANIFEST_DIR: &str = "lib/rustlib";
 
 #[derive(Clone, Debug)]
 pub struct InstallPrefix {
@@ -8,7 +8,7 @@ pub struct InstallPrefix {
 }
 impl InstallPrefix {
     pub fn from(path: PathBuf) -> Self {
-        InstallPrefix { path: path }
+        InstallPrefix { path }
     }
     pub fn path(&self) -> &Path {
         &self.path

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -109,13 +109,13 @@ impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> ::std::result::Result<(), fmt::Error> {
         use self::Error::*;
         match *self {
-            CreatingRoot { ref path, error: _ } => {
+            CreatingRoot { ref path, .. } => {
                 write!(f, "could not create temp root: {}", path.display())
             }
-            CreatingFile { ref path, error: _ } => {
+            CreatingFile { ref path, .. } => {
                 write!(f, "could not create temp file: {}", path.display())
             }
-            CreatingDirectory { ref path, error: _ } => {
+            CreatingDirectory { ref path, .. } => {
                 write!(f, "could not create temp directory: {}", path.display())
             }
         }
@@ -129,9 +129,9 @@ impl Cfg {
         notify_handler: Box<dyn Fn(Notification<'_>)>,
     ) -> Self {
         Cfg {
-            root_directory: root_directory,
+            root_directory,
             dist_server: dist_server.to_owned(),
-            notify_handler: notify_handler,
+            notify_handler,
         }
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -100,7 +100,5 @@ impl<'a> InstallMethod<'a> {
 }
 
 pub fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
-    Ok(utils::remove_dir("install", path, &|n| {
-        notify_handler(n.into())
-    })?)
+    utils::remove_dir("install", path, &|n| notify_handler(n.into()))
 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -686,7 +686,7 @@ fn list_default_toolchain() {
 }
 
 #[test]
-#[ignore(windows)] // FIXME Windows shows UNC paths
+#[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_override() {
     setup(&|config| {
         let cwd = config.current_dir();
@@ -709,7 +709,7 @@ nightly-{0} (directory override for '{1}')
 }
 
 #[test]
-#[ignore(windows)] // FIXME Windows shows UNC paths
+#[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_toolchain_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
@@ -748,7 +748,7 @@ nightly-{0} (overridden by '{1}')
 }
 
 #[test]
-#[ignore(windows)] // FIXME Windows shows UNC paths
+#[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_version_nested_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
@@ -792,7 +792,7 @@ nightly-{0} (overridden by '{1}')
 }
 
 #[test]
-#[ignore(windows)] // FIXME Windows shows UNC paths
+#[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_toolchain_file_override_not_installed() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -648,7 +648,7 @@ fn add_target_host() {
     setup(&|config| {
         let trip = TargetTriple::from_build();
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "target", "add", &trip.to_string()],
+        expect_stderr_ok(config, &["rustup", "target", "add", &trip.to_string()],
                    for_host!("component 'rust-std' for target '{0}' was automatically added because it is required for toolchain 'nightly-{0}'"));
     });
 }


### PR DESCRIPTION
Note: Feel free to squash this PR.

There are 3 remained warnings:
- large_enum_variant
- module_inception
- should_implement_trait

<details>
<summary>Remaining clippy warnings</summary>

```rust

warning: large size difference between variants
   --> src/errors.rs:17:1
    |
17  | / error_chain! {
18  | |     links {
19  | |         Download(download::Error, download::ErrorKind);
20  | |     }
...   |
322 | |     }
323 | | }
    | |_^
    |
    = note: #[warn(clippy::large_enum_variant)] on by default
help: consider boxing the large fields to reduce the total size of the enum
   --> src/errors.rs:17:1
    |
17  | / error_chain! {
18  | |     links {
19  | |         Download(download::Error, download::ErrorKind);
20  | |     }
...   |
322 | |     }
323 | | }
    | |_^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

warning: module has the same name as its containing module
 --> src/dist/mod.rs:9:1
  |
9 | pub mod dist;
  | ^^^^^^^^^^^^^
  |
  = note: #[warn(clippy::module_inception)] on by default
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception

warning: module has the same name as its containing module
 --> src/utils/mod.rs:6:1
  |
6 | pub mod utils;
  | ^^^^^^^^^^^^^^
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#module_inception


warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less ambiguous name
   --> src/dist/dist.rs:113:5
    |
113 | /     pub fn from_str(name: &str) -> Self {
114 | |         TargetTriple(name.to_string())
115 | |     }
    | |_____^
    |
    = note: #[warn(clippy::should_implement_trait)] on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less ambiguous name
   --> src/dist/dist.rs:213:5
    |
213 | /     pub fn from_str(name: &str) -> Option<Self> {
214 | |         if name.is_empty() {
215 | |             return Some(PartialTargetTriple {
216 | |                 arch: None,
...   |
248 | |         })
249 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less ambiguous name
   --> src/dist/dist.rs:253:5
    |
253 | /     pub fn from_str(name: &str) -> Result<Self> {
254 | |         let channels = [
255 | |             "nightly",
256 | |             "beta",
...   |
290 | |         }
291 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait

warning: defining a method called `from_str` on this type; consider implementing the `std::str::FromStr` trait or choosing a less ambiguous name
   --> src/dist/dist.rs:343:5
    |
343 | /     pub fn from_str(name: &str) -> Result<Self> {
344 | |         let channels = [
345 | |             "nightly",
346 | |             "beta",
...   |
374 | |             .ok_or(ErrorKind::InvalidToolchainName(name.to_string()).into())
375 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#should_implement_trait
</details>
