### PR TITLE
Improve build time of x86_64-linux-gnu target

### DIFF
--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,9 +1,6 @@
+# Source from https://github.com/rust-lang-deprecated/rust-buildbot/blob/master/slaves/dist/Dockerfile
 FROM alexcrichton/rust-slave-dist:2015-10-20b
 USER root
 
 WORKDIR /
-RUN curl https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz | tar xzf -
-WORKDIR /perl-5.28.0
-RUN ./configure.gnu
-RUN make -j$(nproc)
-RUN make install
+RUN curl -L https://github.com/lzutao/rustup.rs/releases/download/perl-5.28.0/perl-5.28.0.tar.gz | tar xzf - -C /


### PR DESCRIPTION
By using prebuilt perl, we could reduce build-time up to 3 minutes.