### PR TITLE
Document `--no-self-update` properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ info: checking for self-updates
 info: downloading self-updates
 ```
 
+**Note**: `rustup` will automatically update itself at the end of any toolchain
+installation as well.  You can prevent this automatic behaviour by passing the
+`--no-self-update` argument when running `rustup update` or `rustup toolchain install`.
+
 ## Working with nightly Rust
 
 Rustup gives you easy access to the nightly compiler and its

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -140,10 +140,9 @@ pub fn cli() -> App<'static, 'static> {
                 )
                 .arg(
                     Arg::with_name("no-self-update")
-                        .help("Don't perform self update when running the `rustup` command")
+                        .help("Don't perform self-update when running the `rustup install` command")
                         .long("no-self-update")
                         .takes_value(false)
-                        .hidden(true),
                 )
                 .arg(
                     Arg::with_name("force")
@@ -175,10 +174,9 @@ pub fn cli() -> App<'static, 'static> {
                 )
                 .arg(
                     Arg::with_name("no-self-update")
-                        .help("Don't perform self update when running the `rustup` command")
+                        .help("Don't perform self update when running the `rustup update` command")
                         .long("no-self-update")
                         .takes_value(false)
-                        .hidden(true),
                 )
                 .arg(
                     Arg::with_name("force")
@@ -217,10 +215,9 @@ pub fn cli() -> App<'static, 'static> {
                         )
                         .arg(
                             Arg::with_name("no-self-update")
-                                .help("Don't perform self update when running the `rustup` command")
+                                .help("Don't perform self update when running the `rustup toolchain install` command")
                                 .long("no-self-update")
                                 .takes_value(false)
-                                .hidden(true),
                         ),
                 )
                 .subcommand(


### PR DESCRIPTION
This PR unhides the `--no-self-update` help from the CLI and also mentions it in the README.

They combine to fix #1742 to the extent that we agreed.