### PR TITLE
Version: Update git-testament to 0.1.4 and trust `stable`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,15 +507,15 @@ dependencies = [
 
 [[package]]
 name = "git-testament"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "git-testament-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-testament-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "git-testament-derive"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1256,7 +1256,7 @@ dependencies = [
  "download 0.5.0",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "git-testament 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "git-testament 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1966,8 +1966,8 @@ dependencies = [
 "checksum futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "62941eff9507c8177d448bd83a44d9b9760856e184081d8cd79ba9f03dd24981"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
-"checksum git-testament 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74b588fea7d92320ed482f913b6639572078ef1d84b3325921984c50ef253382"
-"checksum git-testament-derive 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca6d95dea8a5e77ccd93fd8f1ed3712d25eca4834216afaa378a5d632be3db3"
+"checksum git-testament 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b00f56c9844ed5d927a5cfccfe5d4a32fffa3b8a56f14c0634e70c613dc584b"
+"checksum git-testament-derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4abfb23d91a9da7cec4796bc94b3009fe87812d909035faea726681d2f3e3b5e"
 "checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ wait-timeout = "0.2"
 walkdir = "2"
 xz2 = "0.1.3"
 openssl = { version = "0.10", optional = true }
-git-testament = "0.1"
+git-testament = "0.1.4"
 lazy_static = "1"
 
 [target."cfg(windows)".dependencies]

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -406,7 +406,10 @@ git_testament!(TESTAMENT);
 
 pub fn version() -> &'static str {
     lazy_static! {
-        static ref RENDERED: String = render_testament!(TESTAMENT);
+        // Because we trust our `stable` branch given the careful release
+        // process, we mark it trusted here so that our version numbers look
+        // right when built from CI before the tag is pushed
+        static ref RENDERED: String = render_testament!(TESTAMENT, "stable");
     }
     &RENDERED
 }


### PR DESCRIPTION
In order that our CI process can continue to work, we need to
have a slightly newer version of `git-testament` which supports
indicating that the stable branch was the one used to build the
release binaries and so should trust the package version.

This also updates git-testament-derive to 0.1.5 which is more
reliable that 0.1.4 in the face of multiple branches at the same
commit.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>