### PR TITLE
errors: Reorder component-unavailable message parts

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,9 +10,12 @@ use std::path::PathBuf;
 use url::Url;
 
 pub const TOOLSTATE_MSG: &str =
-    "if you require these components, please install and use the latest successful build version, \
-     which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.\n\
-     rustup install nightly-2018-12-27";
+    "If you require these components, please install and use the latest successful build version,\n\
+     which you can find at https://rust-lang-nursery.github.io/rust-toolstate.\n\nAfter determining \
+     the correct date, install it with a command such as:\n\n    \
+     rustup toolchain install nightly-2018-12-27\n\n\
+     Then you can use the toolchain with commands such as:\n\n    \
+     cargo +nightly-2018-12-27 build";
 
 error_chain! {
     links {
@@ -267,7 +270,7 @@ error_chain! {
         }
         RequestedComponentsUnavailable(c: Vec<Component>, manifest: Manifest, toolchain: String) {
             description("some requested components are unavailable to download")
-            display("{} for channel '{}'", component_unavailable_msg(&c, &manifest), toolchain)
+            display("{} for channel '{}'\n{}", component_unavailable_msg(&c, &manifest), toolchain, TOOLSTATE_MSG)
         }
         UnknownMetadataVersion(v: String) {
             description("unknown metadata version")
@@ -341,19 +344,11 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest) -> String {
         if same_target {
             let mut cs_strs = cs.iter().map(|c| format!("'{}'", c.short_name(manifest)));
             let cs_str = cs_strs.join(", ");
-            let _ = write!(
-                buf,
-                "some components unavailable for download: {}\n{}",
-                cs_str, TOOLSTATE_MSG,
-            );
+            let _ = write!(buf, "some components unavailable for download: {}", cs_str,);
         } else {
             let mut cs_strs = cs.iter().map(|c| c.description(manifest));
             let cs_str = cs_strs.join(", ");
-            let _ = write!(
-                buf,
-                "some components unavailable for download: {}\n{}",
-                cs_str, TOOLSTATE_MSG,
-            );
+            let _ = write!(buf, "some components unavailable for download: {}", cs_str,);
         }
     }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -699,7 +699,7 @@ fn update_unavailable_rustc() {
             config,
             &["rustup", "update", "nightly"],
             format!(
-                "some components unavailable for download: 'rustc', 'cargo'\n{}",
+                "some components unavailable for download: 'rustc', 'cargo' for channel 'nightly'\n{}",
                 TOOLSTATE_MSG
             )
             .as_str(),


### PR DESCRIPTION
The ordering of some of the parts of the component-unavailable
error message was unfortunate, resulting in confusion.  This
reorders those so that errors are slightly clearer.

Fixes: #1768

As an example, the old message form would be:

```
error: some components unavailable for download: 'rls', 'clippy'
if you require these components, please install and use the latest successful build version, which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.
rustup install nightly-2018-12-27 for channel 'nightly'
```

The new form is:

```
error: some components unavailable for download: 'rls', 'clippy' for channel 'nightly'
if you require these components, please install and use the latest successful build version, which you can find at https://rust-lang-nursery.github.io/rust-toolstate, for example.
rustup install nightly-2018-12-27
```

/cc @vi 