### PR TITLE
Update target-not-found error message

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -275,7 +275,8 @@ impl Package {
                 if let Some(t) = target {
                     tpkgs
                         .get(t)
-                        .ok_or_else(|| format!("target not found: '{}'", t).into())
+                        .ok_or_else(|| format!("target '{}' not found in channel.  \
+                        Perhaps check https://forge.rust-lang.org/platform-support.html for available targets", t).into())
                 } else {
                     Err("no target specified".into())
                 }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -330,7 +330,7 @@ fn update_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0
-error: target not found: '2016-03-1'
+error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
 ",
         );
     });
@@ -345,7 +345,7 @@ fn default_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0
-error: target not found: '2016-03-1'
+error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
 ",
         );
     });


### PR DESCRIPTION
In an effort to make error messages clearer and more helpful,
this replaces the `target not found: 'foo'` message with the
more helpful `target 'foo' not found in channel.  Perhaps
check https://forge.rust-lang.org/platform-support.html for
available targets`.

This fixes #1741

/cc @paulbone