### PR TITLE
Clear line properly for download progress

### DIFF
--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -130,6 +130,10 @@ impl DownloadTracker {
         let speed = if len > 0 { sum / len as f64 } else { 0. };
         let speed_h = HumanReadable(speed);
 
+        // First, move to the start of the current line and clear it.
+        let _ = self.term.as_mut().unwrap().carriage_return();
+        let _ = self.term.as_mut().unwrap().delete_line();
+
         match self.content_len {
             Some(content_len) => {
                 let content_len = content_len as f64;
@@ -156,11 +160,9 @@ impl DownloadTracker {
                 );
             }
         }
-        // delete_line() doesn't seem to clear the line properly.
-        // Instead, let's just print some whitespace to clear it.
-        let _ = write!(self.term.as_mut().unwrap(), "                ");
+
+        // Since stdout is typically line-buffered and we don't print a newline, we manually flush.
         let _ = self.term.as_mut().unwrap().flush();
-        let _ = self.term.as_mut().unwrap().carriage_return();
         self.displayed_progress = true;
     }
 }


### PR DESCRIPTION
The workaround here that was printing many spaces did not work properly if the line length got very long and then very short again. I noticed this problem on an old version of rustup that still suffered from #1696, so it might not technically be reproducible anymore, but I figured we might as well fix this for the future anyway!

I suspect the comment saying `delete_line()` didn't clear the line properly was attempting to call it *after* printing the current download progress, but [the `term` crate docs](https://docs.rs/term/0.5.2/term/trait.Terminal.html#tymethod.delete_line) say it deletes from the cursor
position to the end of the line.

To deal with that, we instead jump to the start of the line *before* printing the current download progress and call `delete_line()` there.