### PR TITLE
ci: Limit shellcheck to x86_64-linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ script:
       else
           PATH="$HOME/rust/bin:$PATH" sh ci/run.sh;
       fi
-  - if [ "${TRAVIS_OS_NAME}" = linux ]; then
+  - if [ "${TARGET}" = x86_64-unknown-linux-gnu ]; then
       shellcheck -s dash -e SC1090 -- rustup-init.sh ci/*.sh;
     fi
 


### PR DESCRIPTION
We only need to run this once.