### PR TITLE
Fixed panic when no toolchain was configured

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -344,8 +344,11 @@ impl Cfg {
     }
 
     pub fn get_default(&self) -> Result<String> {
-        self.settings_file
-            .with(|s| Ok(s.default_toolchain.clone().unwrap()))
+        self.settings_file.with(|s| {
+            s.default_toolchain
+                .clone()
+                .ok_or_else(|| "no default toolchain configured".into())
+        })
     }
 
     pub fn list_toolchains(&self) -> Result<Vec<String>> {

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -413,6 +413,17 @@ fn toolchains_are_resolved_early() {
     });
 }
 
+#[test]
+fn no_panic_on_default_toolchain_missing() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &["rustup", "default"],
+            "no default toolchain configured",
+        );
+    });
+}
+
 // #190
 #[test]
 fn proxies_pass_empty_args() {


### PR DESCRIPTION
Fixed panic when no toolchain was configured and user run
`rustup default`.
