### PR TITLE
Check for stray hash when installing a toolchain

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -507,6 +507,14 @@ pub fn update_from_dist<'a>(
     force_update: bool,
 ) -> Result<Option<String>> {
     let fresh_install = !prefix.path().exists();
+    let hash_exists = update_hash.map(Path::exists).unwrap_or(false);
+
+    // fresh_install means the toolchain isn't present, but hash_exists means there is a stray hash file
+    if fresh_install && hash_exists {
+        // It's ok to unwrap, because hash have to exist at this point
+        (download.notify_handler)(Notification::StrayHash(update_hash.unwrap()));
+        std::fs::remove_file(update_hash.unwrap())?;
+    }
 
     let res = update_from_dist_(
         download,

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -31,6 +31,7 @@ pub enum Notification<'a> {
     DownloadingLegacyManifest,
     ManifestChecksumFailedHack,
     ComponentUnavailable(&'a str, Option<&'a TargetTriple>),
+    StrayHash(&'a Path),
 }
 
 impl<'a> From<crate::utils::Notification<'a>> for Notification<'a> {
@@ -70,7 +71,8 @@ impl<'a> Notification<'a> {
             | ExtensionNotInstalled(_)
             | MissingInstalledComponent(_)
             | CachedFileChecksumFailed
-            | ComponentUnavailable(_, _) => NotificationLevel::Warn,
+            | ComponentUnavailable(_, _)
+            | StrayHash(_) => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
         }
     }
@@ -155,6 +157,11 @@ impl<'a> Display for Notification<'a> {
                     write!(f, "component '{}' is not available anymore", pkg)
                 }
             }
+            StrayHash(path) => write!(
+                f,
+                "removing stray hash found at '{}' in order to continue",
+                path.display()
+            ),
         }
     }
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -4,8 +4,8 @@
 pub mod mock;
 
 use crate::mock::clitools::{
-    self, expect_err, expect_not_stdout_ok, expect_ok, expect_ok_ex, expect_stderr_ok,
-    expect_stdout_ok, set_current_dist_date, this_host_triple, Config, Scenario,
+    self, expect_err, expect_not_stdout_ok, expect_ok, expect_stderr_ok, expect_stdout_ok,
+    set_current_dist_date, this_host_triple, Config, Scenario,
 };
 use std::fs;
 use std::io::Write;
@@ -827,14 +827,13 @@ fn warn_about_and_remove_stray_hash() {
         fs::create_dir_all(&hash_path).expect("Unable to make the update-hashes directory");
 
         hash_path.push(for_host!("nightly-{}"));
-        println!("Update-hash path: {}", hash_path.display());
 
         let mut file = fs::File::create(&hash_path).expect("Unable to open update-hash file");
         file.write_all(b"LEGITHASH")
             .expect("Unable to write update-hash");
         drop(file);
 
-        expect_ok_ex(
+        expect_stderr_ok(
             config,
             &[
                 "rustup",
@@ -843,34 +842,13 @@ fn warn_about_and_remove_stray_hash() {
                 "nightly",
                 "--no-self-update",
             ],
-            for_host!(
-                r"
-  nightly-{0} installed - 1.3.0 (hash-n-2)
-
-"
-            ),
             &format!(
-                r"{}
-{}",
-                format!(
-                    r"warning: removing stray hash found at '{}' in order to continue",
-                    hash_path.display()
-                ),
-                for_host!(
-                    r"info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-"
-                )
+                "removing stray hash found at '{}' in order to continue",
+                hash_path.display()
             ),
         );
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "1.3.0");
     });
 }
 


### PR DESCRIPTION
#1777 
As @kinnison explained - problem is in update-hash that is still present after manual removal of a toolchain. This resulted in the inability to install it again. To fix this problem we now check if there is a stray hash, and delete if so. This is WIP as a test must be written.