### PR TITLE
Add listing of installed targets

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -320,6 +320,23 @@ pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<()> {
     Ok(())
 }
 
+pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<()> {
+    let mut t = term2::stdout();
+    for component in toolchain.list_components()? {
+        if component.component.short_name_in_manifest() == "rust-std" {
+            let target = component
+                .component
+                .target
+                .as_ref()
+                .expect("rust-std should have a target");
+            if component.installed {
+                writeln!(t, "{}", target)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
     for component in toolchain.list_components()? {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -253,6 +253,11 @@ pub fn cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .about("List installed and available targets")
                         .arg(
+                            Arg::with_name("installed")
+                                .long("--installed")
+                                .help("List only installed targets"),
+                        )
+                        .arg(
                             Arg::with_name("toolchain")
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .long("toolchain")
@@ -829,7 +834,11 @@ fn show_active_toolchain(cfg: &Cfg) -> Result<()> {
 fn target_list(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
-    common::list_targets(&toolchain)
+    if m.is_present("installed") {
+        common::list_installed_targets(&toolchain)
+    } else {
+        common::list_targets(&toolchain)
+    }
 }
 
 fn target_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -371,6 +371,31 @@ fn list_targets() {
 }
 
 #[test]
+fn list_installed_targets() {
+    setup(&|config| {
+        let trip = this_host_triple();
+        let mut sorted = vec![
+            trip,
+            clitools::CROSS_ARCH1.to_string(),
+            clitools::CROSS_ARCH2.to_string(),
+        ];
+        sorted.sort();
+
+        let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
+
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        expect_ok_ex(
+            config,
+            &["rustup", "target", "list", "--installed"],
+            &expected,
+            r"",
+        );
+    });
+}
+
+#[test]
 fn cross_install_indicates_target() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -380,6 +380,16 @@ fn list_targets() {
 }
 
 #[test]
+fn list_installed_targets() {
+    setup(&|config| {
+        let trip = this_host_triple();
+
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_stdout_ok(config, &["rustup", "target", "list", "--installed"], &trip);
+    });
+}
+
+#[test]
 fn add_target_explicit() {
     setup(&|config| {
         let path = format!(

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -544,6 +544,16 @@ fn list_targets() {
 }
 
 #[test]
+fn list_installed_targets() {
+    setup(&|config| {
+        let trip = this_host_triple();
+
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_stdout_ok(config, &["rustup", "target", "list", "--installed"], &trip);
+    });
+}
+
+#[test]
 fn add_target() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);


### PR DESCRIPTION
This feature adds the ability to list installed `targets` only.

I'm playing with cross-compilation a lot and I need a way to list only the installed `targets`.
