### PR TITLE
Fix local bash completion directory path

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ but the gist is as simple as using one of the following:
 
 ```console
 # Bash
-$ rustup completions bash > ~/.local/share/bash_completion/completions/rustup
+$ rustup completions bash > ~/.local/share/bash-completion/completions/rustup
 
 # Bash (macOS/Homebrew)
 $ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -166,11 +166,11 @@ r"DISCUSSION:
 
     Completion files are commonly stored in `/etc/bash_completion.d/` for
     system-wide commands, but can be stored in in
-    `~/.local/share/bash_completion/completions` for user-specific commands.
+    `~/.local/share/bash-completion/completions` for user-specific commands.
     Run the command:
 
-        $ mkdir -p ~/.local/share/bash_completion/completions
-        $ rustup completions bash >> ~/.local/share/bash_completion/completions/rustup
+        $ mkdir -p ~/.local/share/bash-completion/completions
+        $ rustup completions bash >> ~/.local/share/bash-completion/completions/rustup
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take affect.
@@ -265,7 +265,7 @@ r"DISCUSSION:
 
     BASH:
 
-        $ rustup completions bash cargo >> ~/.local/share/bash_completion/completions/cargo
+        $ rustup completions bash cargo >> ~/.local/share/bash-completion/completions/cargo
 
     ZSH:
 


### PR DESCRIPTION
Per https://github.com/scop/bash-completion/blob/master/README.md's
"FAQ", bash looks for local completions in "bash-completion" (a "-"
instead of an "_", or  ~/.local/share/bash-completion/completions).