### PR TITLE
ci: Ensure rustup-init script run on CentOS 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,18 @@ matrix:
     - <<: *mac
       env: MACOSX_DEPLOYMENT_TARGET=10.7 TARGET=i686-apple-darwin
 
+    - name: rustup-init.sh on CentOS 6
+      language: minimal
+      install: true
+      script:
+        - docker run
+            --volume "$TRAVIS_BUILD_DIR":/checkout:ro
+            --workdir /checkout
+            --rm
+            -it
+            centos:6
+            sh ./ci/raw_init.sh
+
 install:
   - sh rustup-init.sh --default-toolchain=stable -y
   - export PATH="$PATH:$HOME/.cargo/bin"

--- a/ci/raw_init.sh
+++ b/ci/raw_init.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+set -ex
+
+sh ./rustup-init.sh --default-toolchain none -y
+. "$HOME"/.cargo/env
+rustup -Vv


### PR DESCRIPTION
I tried to run rustup-init script on CentOS 5 docker images, but got
a strage SSL error codes. Maybe preinstalled TLS certificates on it is all
deprecated.