### PR TITLE
ci: Run rustfmt on x86_64-linux only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,26 +68,30 @@ matrix:
 
 install:
   - sh rustup-init.sh --default-toolchain=stable -y
-  - export PATH="$PATH:$HOME/.cargo/bin"
+  - . "$HOME"/.cargo/env
   - if [ -z "$NO_ADD" ]; then rustup target add "$TARGET"; fi
-  - rustup component add rustfmt
 
 script:
   - mkdir -p target/"$TARGET";
   - >
       case "$TARGET" in
-        *-linux-android)     DOCKER=android ;; # Android uses a local docker image
-        *-linux-androideabi) DOCKER=android ;;
-        *-apple-darwin)                     ;;
-        *)                   DOCKER=$TARGET ;;
+        *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
+        *-apple-darwin)                    ;;
+        *)                DOCKER="$TARGET" ;;
       esac;
       if [ -n "$DOCKER" ]; then
-          sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
+        sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
       else
-          PATH="$HOME/rust/bin:$PATH" sh ci/run.sh;
+        sh ci/run.sh;
       fi
+
+  # Check the formatting last because test failures are more interesting to have
+  # discovered for contributors lacking some platform access for testing beforehand
   - if [ "${TARGET}" = x86_64-unknown-linux-gnu ]; then
       shellcheck -s dash -e SC1090 -- rustup-init.sh ci/*.sh;
+      rustup component add rustfmt;
+      rustfmt -vV;
+      cargo fmt --all -- --check;
     fi
 
 before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -57,21 +57,16 @@ install:
   # add mingw to PATH if necessary
   - if defined MINGW_DIR set PATH=C:\msys64\%MINGW_DIR%\bin;C:\msys64\usr\bin;%PATH%
 
-  # Add rustfmt support
-  - rustup component add rustfmt
-
   # let's see what we got
   - where gcc rustc cargo
   - rustc -vV
   - cargo -vV
-  - rustfmt -vV
 
 build: false
 
 test_script:
   - cargo build --release --target %TARGET% --locked
   - cargo test --release --target %TARGET%
-  - cargo fmt --all -- --check
 
 notifications:
   - provider: Webhook

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -4,7 +4,6 @@ set -ex
 
 rustc -vV
 cargo -vV
-rustfmt -vV
 
 cargo build --locked -v --release --target "$TARGET" --features vendored-openssl
 
@@ -12,7 +11,3 @@ if [ -z "$SKIP_TESTS" ]; then
   cargo test --release -p download --target "$TARGET" --features vendored-openssl
   cargo test --release --target "$TARGET" --features vendored-openssl
 fi
-
-# Check the formatting last because test failures are more interesting to have
-# discovered for contributors lacking some platform access for testing beforehand
-cargo fmt --all -- --check


### PR DESCRIPTION
Also removing obsolete `PATH="$HOME/rust/bin:$PATH"`.