### PR TITLE
ci: Use rustc docker image for x86_64 and i686 linux

### DIFF
--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,9 +1,1 @@
-FROM alexcrichton/rust-slave-dist:2015-10-20b
-USER root
-
-WORKDIR /
-RUN curl https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz | tar xzf -
-WORKDIR /perl-5.28.0
-RUN ./configure.gnu
-RUN make -j$(nproc)
-RUN make install
+FROM rust-i686-unknown-linux-gnu

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,9 +1,1 @@
-FROM alexcrichton/rust-slave-dist:2015-10-20b
-USER root
-
-WORKDIR /
-RUN curl https://www.cpan.org/src/5.0/perl-5.28.0.tar.gz | tar xzf -
-WORKDIR /perl-5.28.0
-RUN ./configure.gnu
-RUN make -j$(nproc)
-RUN make install
+FROM rust-x86_64-unknown-linux-gnu

--- a/ci/fetch-rust-docker.sh
+++ b/ci/fetch-rust-docker.sh
@@ -22,6 +22,8 @@ case "$TARGET" in
   powerpc64-unknown-linux-gnu)     image=dist-powerpc64-linux ;;
   powerpc64le-unknown-linux-gnu)   image=dist-powerpc64le-linux ;;
   s390x-unknown-linux-gnu)         image=dist-s390x-linux ;;
+  x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;
+  i686-unknown-linux-gnu)          image=dist-i686-linux ;;
   *) exit ;;
 esac
 


### PR DESCRIPTION
cc @kinnison , @alexcrichton 
~So the effort of improving CI time is zero for now~ (#1760)
The next PR might be setting up sccache.