### PR TITLE
Remove duplicate std::env import

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -442,7 +442,6 @@ fn do_pre_install_options_sanity_checks(opts: &InstallOpts) -> Result<()> {
 fn do_anti_sudo_check(no_prompt: bool) -> Result<()> {
     #[cfg(unix)]
     pub fn home_mismatch() -> bool {
-        use std::env;
         use std::ffi::CStr;
         use std::mem;
         use std::ops::Deref;


### PR DESCRIPTION
This PR removes a duplicate import of `std::env` from `cli/self_update`.

I saw the duplicate import warning while working on #1808 and decided to tackle it in another PR