### PR TITLE
Various version statement fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,9 @@ Rustup is distributed. The steps for a release are:
 5. While you wait for green CI, double-check the `rustup-init.sh` functionality
    and `rustup-init` just in case.
 6. Ensure all of CI is green on the `stable` branch.
+   Once it is, check through a representative proportion of the builds looking
+   for the reported version statements to ensure that we definitely built something
+   cleanly which reports as the right version number when run `--version`.
 7. Ping someone in the release team to perform the actual release.
    They can find instructions in `ci/sync-dist.py`
    Note: Some manual testing occurs here, so hopefully they'll catch

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,6 +67,7 @@ build: false
 
 test_script:
   - cargo build --release --target %TARGET% --locked
+  - cargo run --release --target %TARGET% --locked -- --dump-testament
   - cargo test --release --target %TARGET%
 
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ install:
   - appveyor-retry appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host=x86_64-pc-windows-msvc
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - del rustup-init.exe
 
   # Install the target we're compiling for
   - if NOT "%TARGET%" == "x86_64-pc-windows-msvc" rustup target add %TARGET%

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,6 +8,7 @@ cargo -vV
 cargo build --locked -v --release --target "$TARGET" --features vendored-openssl
 
 if [ -z "$SKIP_TESTS" ]; then
+  cargo run --locked --release --target "$TARGET" --features vendored-openssl -- --dump-testament
   cargo test --release -p download --target "$TARGET" --features vendored-openssl
   cargo test --release --target "$TARGET" --features vendored-openssl
 fi

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -431,6 +431,30 @@ pub fn version() -> &'static str {
     &RENDERED
 }
 
+pub fn dump_testament() {
+    use git_testament::GitModification::*;
+    println!("Rustup version renders as: {}", version());
+    println!("Current crate version: {}", env!("CARGO_PKG_VERSION"));
+    if TESTAMENT.branch_name.is_some() {
+        println!("Built from branch: {}", TESTAMENT.branch_name.unwrap());
+    } else {
+        println!("Branch information missing");
+    }
+    println!("Commit info: {}", TESTAMENT.commit);
+    if TESTAMENT.modifications.is_empty() {
+        println!("Working tree is clean");
+    } else {
+        for fmod in TESTAMENT.modifications {
+            match fmod {
+                Added(f) => println!("Added: {}", String::from_utf8_lossy(f)),
+                Removed(f) => println!("Removed: {}", String::from_utf8_lossy(f)),
+                Modified(f) => println!("Modified: {}", String::from_utf8_lossy(f)),
+                Untracked(f) => println!("Untracked: {}", String::from_utf8_lossy(f)),
+            }
+        }
+    }
+}
+
 pub fn report_error(e: &Error) {
     err!("{}", e);
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -39,6 +39,7 @@ pub fn main() -> Result<()> {
     cfg.check_metadata_version()?;
 
     match matches.subcommand() {
+        ("dump-testament", _) => common::dump_testament(),
         ("show", Some(c)) => match c.subcommand() {
             ("active-toolchain", Some(_)) => handle_epipe(show_active_toolchain(cfg))?,
             (_, _) => handle_epipe(show(cfg))?,
@@ -114,6 +115,11 @@ pub fn cli() -> App<'static, 'static> {
                 .help("Enable verbose output")
                 .short("v")
                 .long("verbose"),
+        )
+        .subcommand(
+            SubCommand::with_name("dump-testament")
+                .about("Dump information about the build")
+                .setting(AppSettings::Hidden) // Not for users, only CI
         )
         .subcommand(
             SubCommand::with_name("show")

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -13,6 +13,13 @@ pub fn main() -> Result<()> {
     if arg1 == Some("--self-replace") {
         return self_update::self_replace();
     }
+
+    // Internal testament dump used during CI.  Not for users.
+    if arg1 == Some("--dump-testament") {
+        common::dump_testament();
+        return Ok(());
+    }
+
     // XXX: If you change anything here, please make the same changes in rustup-init.sh
     let cli = App::new("rustup-init")
         .version(common::version())


### PR DESCRIPTION
This PR rolls up an addition of a hidden flag/command to dump the version testament which can be used if in the future a user receives an unexpectedly unclean version of rustup-init.

We use that in the CI pipeline to dump the version which would be displayed so that we can check it during our stable release process.

Also this includes a commit to remove a dirtying step (or rather to clean up after it) in our appveyor builds.