### PR TITLE
Make suggestions based on Damerau-Levenshtein distance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1249,6 +1249,7 @@ dependencies = [
  "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tar 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1428,6 +1429,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "strsim"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "strsim"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2044,6 +2050,7 @@ dependencies = [
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum strsim 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "032c03039aae92b350aad2e3779c352e104d919cb192ba2fabbd7b831ce4f0f6"
 "checksum syn 0.15.33 (registry+https://github.com/rust-lang/crates.io-index)" = "ec52cd796e5f01d0067225a5392e70084acc4c0013fa71d55166d38a8b307836"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum tar 0.4.24 (registry+https://github.com/rust-lang/crates.io-index)" = "2dd071a2604c8fd8902ca42908856821ed7a06e3cd846f84d75873c978dec7fb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ same-file = "1"
 scopeguard = "1"
 semver = "0.9"
 sha2 = "0.8"
+strsim = "0.9.1"
 tar = "0.4"
 tempdir = "0.3.4"
 # FIXME(issue #1788)

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -448,4 +448,11 @@ impl Component {
             pkg.to_string()
         }
     }
+    pub fn target(&self) -> String {
+        if let Some(ref t) = self.target {
+            format!("{}", t)
+        } else {
+            format!("")
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -303,9 +303,13 @@ error_chain! {
             description("toolchain does not support components")
             display("toolchain '{}' does not support components", t)
         }
-        UnknownComponent(t: String, c: String, s: String) {
+        UnknownComponent(t: String, c: String, s: Option<String>) {
             description("toolchain does not contain component")
-            display("toolchain '{}' does not contain component {}; did you mean '{}'?", t, c, s)
+            display("toolchain '{}' does not contain component {}{}", t, c, if let Some(suggestion) = s {
+                format!("; did you mean '{}'?", suggestion)
+            } else {
+                "".to_string()
+            })
         }
         AddingRequiredComponent(t: String, c: String) {
             description("required component cannot be added")

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -303,9 +303,9 @@ error_chain! {
             description("toolchain does not support components")
             display("toolchain '{}' does not support components", t)
         }
-        UnknownComponent(t: String, c: String) {
+        UnknownComponent(t: String, c: String, s: String) {
             description("toolchain does not contain component")
-            display("toolchain '{}' does not contain component {}", t, c)
+            display("toolchain '{}' does not contain component {}; did you mean '{}'?", t, c, s)
         }
         AddingRequiredComponent(t: String, c: String) {
             description("required component cannot be added")

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -935,6 +935,11 @@ fn add_component_suggest_best_match() {
             &["rustup", "component", "add", "rsl-preview"],
             "did you mean 'rls-preview'?",
         );
+        expect_err(
+            config,
+            &["rustup", "component", "add", "rustd"],
+            "did you mean 'rustc'?",
+        );
         expect_not_stderr_ok(
             config,
             &["rustup", "component", "add", "potato"],
@@ -964,6 +969,11 @@ fn remove_component_suggest_best_match() {
             &["rustup", "component", "add", "rsl-preview"],
             "did you mean 'rls-preview'?",
         );
+        expect_err(
+            config,
+            &["rustup", "component", "remove", "rustd"],
+            "did you mean 'rustc'?",
+        );
     });
 }
 
@@ -977,7 +987,7 @@ fn add_target_suggest_best_match() {
                 "rustup",
                 "target",
                 "add",
-                &clitools::CROSS_ARCH1.replace("x", "y"),
+                &format!("{}a", clitools::CROSS_ARCH1)[..],
             ],
             &format!("did you mean '{}'", clitools::CROSS_ARCH1),
         );
@@ -1010,7 +1020,7 @@ fn remove_target_suggest_best_match() {
                 "rustup",
                 "target",
                 "remove",
-                &clitools::CROSS_ARCH1.replace("x", "y"),
+                &format!("{}a", clitools::CROSS_ARCH1)[..],
             ],
             &format!("did you mean '{}'", clitools::CROSS_ARCH1),
         );

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -207,6 +207,16 @@ pub fn expect_not_stdout_ok(config: &Config, args: &[&str], expected: &str) {
     }
 }
 
+pub fn expect_not_stderr_ok(config: &Config, args: &[&str], expected: &str) {
+    let out = run(config, args[0], &args[1..], &[]);
+    if out.ok || out.stderr.contains(expected) {
+        print_command(args, &out);
+        println!("expected.ok: false");
+        print_indented("expected.stderr.does_not_contain", expected);
+        panic!();
+    }
+}
+
 pub fn expect_stderr_ok(config: &Config, args: &[&str], expected: &str) {
     let out = run(config, args[0], &args[1..], &[]);
     if !out.ok || !out.stderr.contains(expected) {


### PR DESCRIPTION
#1816
The only change that I'd suggest is to use Damerau-Levenshtein distance instead of Levenshtein distance, because the former adds transpositions to list of the basic operations. And as we know a lot of misspellings are made that way, even the example from issue is of this kind of error.