### PR TITLE
Switch issue templates to use subheadings instead of bold text

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,21 +6,21 @@ labels: bug
 
 <!-- Thanks for filing a 🐛 bug report 😄! -->
 
-**Problem**
+## Problem
 <!-- A clear and concise description of what the bug is. -->
 <!-- including what currently happens and what you expected to happen. -->
 
-**Steps**
+## Steps
 <!-- The steps to reproduce the bug. -->
 1.
 2.
 3.
 
-**Possible Solution(s)**
+## Possible Solution(s)
 <!-- Not obligatory, but suggest a fix/reason for the bug, -->
 <!-- or ideas how to implement the addition or change -->
 
-**Notes**
-
+## Notes
 Output of `rustup --version`:
+
 Output of `rustup show`:

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -6,11 +6,11 @@ labels: enhancement
 
 <!-- Thanks for filing an 🙋 enhancement request 😄! -->
 
-**Describe the problem you are trying to solve**
+## Describe the problem you are trying to solve
 <!-- A clear and concise description of the problem this enhancement request is trying to solve. -->
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 <!-- A clear and concise description of what you want to happen. -->
 
-**Notes**
+## Notes
 <!-- Any additional context or information you feel may be relevant to the issue. -->


### PR DESCRIPTION
Minor change. Using Markdown sub-headings instead of just bold text helps sections stand out a bit more by default. I left the rest of the templates untouched.