### PR TITLE
Buffer reads from package tarfiles

### DIFF
--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -280,7 +280,6 @@ pub struct TarGzPackage<'a>(TarPackage<'a>);
 impl<'a> TarGzPackage<'a> {
     pub fn new<R: Read>(stream: R, temp_cfg: &'a temp::Cfg) -> Result<Self> {
         let stream = flate2::read::GzDecoder::new(stream);
-
         Ok(TarGzPackage(TarPackage::new(stream, temp_cfg)?))
     }
     pub fn new_file(path: &Path, temp_cfg: &'a temp::Cfg) -> Result<Self> {
@@ -313,7 +312,6 @@ pub struct TarXzPackage<'a>(TarPackage<'a>);
 impl<'a> TarXzPackage<'a> {
     pub fn new<R: Read>(stream: R, temp_cfg: &'a temp::Cfg) -> Result<Self> {
         let stream = xz2::read::XzDecoder::new(stream);
-
         Ok(TarXzPackage(TarPackage::new(stream, temp_cfg)?))
     }
     pub fn new_file(path: &Path, temp_cfg: &'a temp::Cfg) -> Result<Self> {


### PR DESCRIPTION
Buffer reads from package tarfiles

This has variable impact on extract - when plenty of buffer cache is
available no impact; but in low-cache situations this avoids contention
as rust-docs writes several hundred MB but needs read only 11MB of
archive. I've measured this at between 0 seconds and 12 seconds of
improvement accordingly, depending on the scenario. The buffer size of
8MB is chosen to be twice the block size of the largest SSD around
today, so hopefully triggering read-ahead, which can matter if our
rchives were to increase in size. 4MB could be chosen, or an adaptive
buffer used, if we need to run on embedded devices.

It may be still better to never write these tarfiles to disk,
but that is a substantially larger change and I'm confident enough that
this is beneficial to propose it now.

In order to do this either an additional handle was required, or we
could simplify FileReaderWithProgress length handling - sent_start was
never being toggled: we were notifying the download tracker on every
read that hit the progress adapter. Rather than having that logic in
read(), move it to new_file, as that is a more obvious place to have it
anyway.