### PR TITLE
More progress bars

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -207,7 +207,7 @@ impl Manifestation {
             let gz;
             let xz;
             let notification_converter = |notification: crate::utils::Notification<'_>| {
-                notify_handler(Notification::Utils(notification));
+                notify_handler(notification.into());
             };
             let reader =
                 utils::FileReaderWithProgress::new_file(&installer_file, &notification_converter)?;
@@ -402,7 +402,12 @@ impl Manifestation {
         }
 
         // Install all the components in the installer
-        let package = TarGzPackage::new_file(&installer_file, temp_cfg)?;
+        let notification_converter = |notification: crate::utils::Notification<'_>| {
+            notify_handler(notification.into());
+        };
+        let reader =
+            utils::FileReaderWithProgress::new_file(&installer_file, &notification_converter)?;
+        let package: &dyn Package = &TarGzPackage::new(reader, temp_cfg)?;
 
         for component in package.components() {
             tx = package.install(&self.installation, &component, None, tx)?;

--- a/src/install.rs
+++ b/src/install.rs
@@ -85,7 +85,11 @@ impl<'a> InstallMethod<'a> {
 
         let prefix = InstallPrefix::from(path.to_owned());
         let installation = Components::open(prefix.clone())?;
-        let package = TarGzPackage::new_file(src, temp_cfg)?;
+        let notification_converter = |notification: crate::utils::Notification<'_>| {
+            notify_handler(notification.into());
+        };
+        let reader = utils::FileReaderWithProgress::new_file(&src, &notification_converter)?;
+        let package: &dyn Package = &TarGzPackage::new(reader, temp_cfg)?;
 
         let mut tx = Transaction::new(prefix.clone(), temp_cfg, notify_handler);
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -695,7 +695,7 @@ impl<'a> std::io::Read for FileReaderWithProgress<'a> {
         match self.fh.read(buf) {
             Ok(nbytes) => {
                 self.nbytes += nbytes as u64;
-                if (nbytes != 0) {
+                if nbytes != 0 {
                     (self.notify_handler)(Notification::DownloadDataReceived(&buf[0..nbytes]));
                 }
                 if (nbytes == 0) || (self.flen == self.nbytes) {


### PR DESCRIPTION
The progress bar based file reader is relevant for v1 and tarball
packages but not being used - use it more broadly, which will also
improve performance due to the BufReader usage.

Also a drive by lint fix.