### PR TITLE
Don't set mtime on toolchain files

### DIFF
--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -247,7 +247,7 @@ fn unpack_without_first_dir<R: Read>(archive: &mut tar::Archive<R>, path: &Path)
             }
             _ => (),
         };
-
+        entry.set_preserve_mtime(false);
         entry
             .unpack(&full_path)
             .chain_err(|| ErrorKind::ExtractingPackage)?;


### PR DESCRIPTION
We don't depend on file times in the toolchains for any of our
operations, so making them match the time from the tar archive isn't
particularly useful. My bench machine here dropped from 31/32s for
rust-docs to 26/27s with this change.