### PR TITLE
Replace link to #rust-beginners IRC channel

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -125,7 +125,15 @@
 </div>
 
 <p>
-  Need help? <a href="https://client00.chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust-beginners">Ask on #rust-beginners</a>.
+  <!-- To regenerate the Discord invite link:
+     1. Open discord
+     2. Click on the invite button on the side of the #beginners channel
+     3. Make sure the link is set to **never expire**
+     4. Alternatively, we can always use the link: https://discord.gg/rust-lang
+        This link does not point them to any particular channel.
+  -->
+  Need help?<br>Ask on <a href="https://discord.gg/nJDDewm">#beginners in the Rust Discord</a><br>
+  or in the <a href="https://users.rust-lang.org">Rust Users Forum</a>.
 </p>
 
 <p id="about">

--- a/www/index.html
+++ b/www/index.html
@@ -125,14 +125,7 @@
 </div>
 
 <p>
-  <!-- To regenerate the Discord invite link:
-     1. Open discord
-     2. Click on the invite button on the side of the #beginners channel
-     3. Make sure the link is set to **never expire**
-     4. Alternatively, we can always use the link: https://discord.gg/rust-lang
-        This link does not point them to any particular channel.
-  -->
-  Need help?<br>Ask on <a href="https://discord.gg/nJDDewm">#beginners in the Rust Discord</a><br>
+  Need help?<br>Ask on <a href="https://discord.gg/rust-lang">#beginners in the Rust Discord</a><br>
   or in the <a href="https://users.rust-lang.org">Rust Users Forum</a>.
 </p>
 


### PR DESCRIPTION
Fixes #1859.

Here's a screenshot of how this looks:

![Screenshot from 2019-05-19 17-27-48](https://user-images.githubusercontent.com/530939/57988375-8a27fd80-7a5b-11e9-96f2-66f8d001c7f5.png)

There's more text now than before, so it looked really bad on one line. I added line breaks at logical places to make it look a bit better.

The link to the Discord should never expire, but I added some instructions in a comment in case we ever need to regenerate it.