### PR TITLE
Add support for `rustup target add all` to install all available targets

### DIFF
--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -49,5 +49,12 @@ error_chain! {
             description("completion script for shell not yet supported for tool")
             display("{} does not currently support completions for {}", cmd, shell)
         }
+        TargetAllSpecifiedWithTargets(t: Vec<String>) {
+            description(
+                "the `all` target, which installs all available targets, \
+                 cannot be combined with other targets"
+            )
+            display("`rustup target add {}` includes `all`", t.join(" "))
+        }
     }
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -866,6 +866,10 @@ fn target_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
         .collect();
 
     if targets.contains(&"all".to_string()) {
+        if targets.len() != 1 {
+            return Err(ErrorKind::TargetAllSpecifiedWithTargets(targets).into());
+        }
+
         targets.clear();
         for component in toolchain.list_components()? {
             if component.component.short_name_in_manifest() == "rust-std"

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -555,7 +555,7 @@ fn list_installed_targets() {
 }
 
 #[test]
-fn add_target() {
+fn add_target1() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
@@ -563,6 +563,40 @@ fn add_target() {
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
             clitools::CROSS_ARCH1
+        );
+        assert!(config.rustupdir.join(path).exists());
+    });
+}
+
+#[test]
+fn add_target2() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        let path = format!(
+            "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
+            this_host_triple(),
+            clitools::CROSS_ARCH2
+        );
+        assert!(config.rustupdir.join(path).exists());
+    });
+}
+
+#[test]
+fn add_all_targets() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "target", "add", "all"]);
+        let path = format!(
+            "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
+            this_host_triple(),
+            clitools::CROSS_ARCH1
+        );
+        assert!(config.rustupdir.join(path).exists());
+        let path = format!(
+            "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
+            this_host_triple(),
+            clitools::CROSS_ARCH2
         );
         assert!(config.rustupdir.join(path).exists());
     });

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -603,6 +603,29 @@ fn add_all_targets() {
 }
 
 #[test]
+fn add_all_targets_fail() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_err(
+            config,
+            &[
+                "rustup",
+                "target",
+                "add",
+                clitools::CROSS_ARCH1,
+                "all",
+                clitools::CROSS_ARCH2,
+            ],
+            &format!(
+                "`rustup target add {} all {}` includes `all`",
+                clitools::CROSS_ARCH1,
+                clitools::CROSS_ARCH2
+            ),
+        );
+    });
+}
+
+#[test]
 fn add_target_no_toolchain() {
     setup(&|config| {
         expect_err(


### PR DESCRIPTION
Closes #1653 .

---

EDIT: for context, the godbolt machines try to provide all available targets, either by manually hardcoding the ones available for each toolchain, or by parsing the components list (which isn't super machine friendly), and installing them manually. This would simplify things. 

I suspect that Rustup integration tests could also try to install all targets for all toolchains to discover issues (I've seen the installation of available components fail in the past). Sadly I cannot find where these integration tests live.