### PR TITLE
Nitpick: punctuation breaks url in terminals

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 pub const TOOLSTATE_MSG: &str =
     "If you require these components, please install and use the latest successful build version,\n\
-     which you can find at https://rust-lang-nursery.github.io/rust-toolstate.\n\nAfter determining \
+     which you can find at <https://rust-lang-nursery.github.io/rust-toolstate>.\n\nAfter determining \
      the correct date, install it with a command such as:\n\n    \
      rustup toolchain install nightly-2018-12-27\n\n\
      Then you can use the toolchain with commands such as:\n\n    \


### PR DESCRIPTION
The period after the URL confused me and my terminal for a moment, as it thought it was part of the URL and opened a 404 page in my browser. Hopefully this change isn't annoyingly small.