### PR TITLE
Link to rustup-components-history instead on missing component

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -9,7 +9,7 @@ use url::Url;
 
 pub const TOOLSTATE_MSG: &str =
     "If you require these components, please install and use the latest successful build version,\n\
-     which you can find at <https://rust-lang-nursery.github.io/rust-toolstate>.\n\nAfter determining \
+     which you can find at <https://rust-lang.github.io/rustup-components-history>.\n\nAfter determining \
      the correct date, install it with a command such as:\n\n    \
      rustup toolchain install nightly-2018-12-27\n\n\
      Then you can use the toolchain with commands such as:\n\n    \


### PR DESCRIPTION
The [rust-toolstate](https://rust-lang-nursery.github.io/rust-toolstate/) page records the status of the unpublished master branch, while [rustup-components-history](https://rust-lang.github.io/rustup-components-history) records the status of the published nightly builds. The latter is more accurate for rustup. Since the latter is now organized by us too, let's point the link there instead.