### PR TITLE
Turn on backtraces to improve CI usefulness

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,7 @@
 image: Visual Studio 2017
 environment:
   RUSTFLAGS: -Ctarget-feature=+crt-static
+  RUST_BACKTRACE: 1
   matrix:
   - TARGET: x86_64-pc-windows-msvc
     ALLOW_PR: 1

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -2,6 +2,9 @@
 
 set -ex
 
+RUST_BACKTRACE=1
+export RUST_BACKTRACE
+
 rustc -vV
 cargo -vV
 

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -69,6 +69,7 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     env::remove_var("RUSTUP_TOOLCHAIN");
     env::remove_var("SHELL");
     env::remove_var("ZDOTDIR");
+    env::remove_var("RUST_BACKTRACE");
 
     let current_exe_path = env::current_exe().map(PathBuf::from).unwrap();
     let mut exe_dir = current_exe_path.parent().unwrap();


### PR DESCRIPTION
This turns on backtraces in appveyor and the travis shell script in the hope that it might improve usefulness of panics when a test fails.