### PR TITLE
Add a PowerShell implementation for rustup-init

### DIFF
--- a/rustup-init.ps1
+++ b/rustup-init.ps1
@@ -1,0 +1,146 @@
+#!/usr/bin/pwsh
+
+# This is just a little script that can be downloaded from the internet to
+# install rustup. It just does platform detection, downloads the installer and
+# runs it.
+
+# XXX: If you change anything here, please make the same changes in
+# `src/cli/setup_mode.rs` and `rustup-init.sh`. This keeps the usage output of
+# the bootstrapping scripts consistent with the `rustup-init` executable.
+function Write-Usage {
+    Write-Host @'
+rustup-init 1.18.3 (435397f48 2019-05-22)
+The installer for rustup
+
+USAGE:
+    rustup-init.ps1 [FLAGS] [OPTIONS]
+
+FLAGS:
+    -v, --verbose           Enable verbose output
+    -y                      Disable confirmation prompt.
+        --no-modify-path    Don't configure the PATH environment variable
+    -h, --help              Prints help information
+    -V, --version           Prints version information
+
+OPTIONS:
+        --default-host <default-host>              Choose a default host triple
+        --default-toolchain <default-toolchain>    Choose a default toolchain to install
+'@
+}
+
+function Invoke-Main([AllowEmptyCollection()] [string[]]$Argv = @()) {
+    foreach ($arg in $Argv) {
+        if ("$arg" -eq "-h" -or "$arg" -eq "--help") {
+            Write-Usage
+            return
+        }
+    }
+
+    Install-Rustup $Argv
+}
+
+function Get-Architecture {
+    if (($IsWindows -eq $null) -or $IsWindows) {
+        $ostype = "pc-windows-msvc"
+    } elseif ($IsMacOS) {
+        $ostype = "apple-darwin"
+    } elseif ($IsLinux) {
+        $ostype = "unknown-linux-gnu"
+    } else {
+        Write-Failure "unrecognized OS type"
+    }
+
+    if ([System.IntPtr]::Size -eq 8) {
+        $cputype = "x86_64"
+    } elseif ([System.IntPtr]::Size -eq 4) {
+        $cputype = "i686"
+    } else {
+        Write-Failure "unknown CPU type"
+    }
+
+    $arch = "${cputype}-${ostype}"
+    Write-Verbose "Detected arch '$arch'"
+    $arch
+}
+
+# If RUSTUP_UPDATE_ROOT is unset, default it.
+function Get-RustupUpdateRoot {
+    $EnvVar = [System.Environment]::GetEnvironmentVariable("RUSTUP_UPDATE_ROOT")
+    if (($EnvVar -ne $null) -and (Test-Path -Path $EnvVar)) {
+        $EnvVar
+    } else {
+        "https://static.rust-lang.org/rustup"
+    }
+}
+
+function Install-Rustup([AllowEmptyCollection()] [string[]]$Argv) {
+    $arch = Get-Architecture
+    switch -Wildcard ($arch) {
+        "*windows*" { $ext = ".exe"; break }
+        default { $ext = "" }
+    }
+
+    $url = "$(Get-RustupUpdateRoot)/dist/$arch/rustup-init$ext"
+
+    $dir = New-TemporaryDirectory
+    $file = Join-Path $dir "rustup-init$ext"
+
+    try {
+        Write-Verbose "Downloading $url to $file"
+        Set-HighestEncryption
+        (New-Object System.Net.WebClient).DownloadFile($url, $file)
+
+        if ($IsMacOS -or $IsLinux) {
+            Write-Verbose "Setting execute permission on $file"
+            chmod u+x "$file"
+        }
+
+        Write-Verbose "Calling $file $Argv"
+        & "$file" @Argv
+    } finally {
+        Write-Verbose "Cleaning $dir"
+        Remove-Item "$dir" -Force -Recurse
+    }
+}
+
+function New-TemporaryDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    [string]$name = [System.Guid]::NewGuid()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function Set-HighestEncryption {
+    # Implementation adapted from the Chocolatey installer script,
+    # see: https://chocolatey.org/install.ps1
+
+    # Attempt to set highest encryption available for SecurityProtocol.
+    # PowerShell will not set this by default (until maybe .NET 4.6.x). This
+    # will typically produce a message for PowerShell v2 (just an info message
+    # though)
+    $OldSPM = [System.Net.ServicePointManager]::SecurityProtocol
+    try {
+        # Set TLS 1.2 (3072) which is currently the highest protocol enabled on
+        # static.rust-lang.org. Favor TLS 1.3 (12288) with a TLS 1.2 fallback
+        # when 1.3 is supported. Use integers because the enumeration values
+        # for TLS 1.2 won't exist in .NET 4.0, even though they are addressable
+        # if .NET 4.5+ is installed (.NET 4.5 is an in-place upgrade).
+        [System.Net.ServicePointManager]::SecurityProtocol = 3072
+    } catch {
+        Write-Failure @'
+rustup: Unable to set PowerShell to use TLS 1.2 due to old .NET Framework
+installed. If you see underlying connection closed or trust errors, you may
+need to do one or more of the following: (1) upgrade to .NET Framework 4.5+ and
+PowerShell v3+, (2) download an alternative install method from
+https://rustup.rs/.
+'@
+    } finally {
+        [System.Net.ServicePointManager]::SecurityProtocol = $OldSPM
+    }
+}
+
+function Write-Failure([string]$Message) {
+    Write-Warning "rustup: $Message"
+    throw
+}
+
+Invoke-Main $args

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -9,7 +9,9 @@ set -u
 # If RUSTUP_UPDATE_ROOT is unset or empty, default it.
 RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 
-#XXX: If you change anything here, please make the same changes in setup_mode.rs
+# XXX: If you change anything here, please make the same changes in
+# `src/cli/setup_mode.rs` and `rustup-init.sh`. This keeps the usage output of
+# the bootstrapping scripts consistent with the `rustup-init` executable.
 usage() {
     cat 1>&2 <<EOF
 rustup-init 1.18.3 (302899482 2019-05-22)

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -20,7 +20,9 @@ pub fn main() -> Result<()> {
         return Ok(());
     }
 
-    // XXX: If you change anything here, please make the same changes in rustup-init.sh
+    // XXX: If you change anything here, please make the same changes in `src/cli/setup_mode.rs`
+    // and `rustup-init.sh`. This keeps the usage output of the bootstrapping scripts consistent
+    // with the `rustup-init` executable.
     let cli = App::new("rustup-init")
         .version(common::version())
         .about("The installer for rustup")


### PR DESCRIPTION
This change adds a new PowerShell script (`rustup-init.ps1`) which
performs the same duties and behaviors as the existing Shell-based
script (`rustup-init.sh`).

It is primarily targeted at tier 1 supported Windows platforms, namely:

* `i686-pc-windows-gnu` (32-bit MinGW)
* `i686-pc-windows-msvc` (32-bit MSVC)
* `x86_64-pc-windows-gnu` (64-bit MinGW)
* `x86_64-pc-windows-msvc` (64-bit MSVC)

However, due to the recent portability of PowerShell releases on macOS
and Linux, this script also supports these targets which overlap with
PowerShell targets:

* `x86_64-apple-darwin` (64-bit OS X/macOS)
* `x86_64-unknown-linux-gnu` (64-bit Linux)

As much as possible, the behavior of the existing `rustup-init.sh` is
preserved, including:

* Accepting arguments to be passed through to
  `rustup.init`/`rustup-init.exe`
* Short-circuiting the `-h` and `--help` flags to display an inline
  usage
* Honor the `RUSTUP_UPDATE_ROOT` environment variable if set, and
  defaulting to `https://static.rust-lang.org/rustup`
* Attempting to force TLS v1.2 on Windows
* Download executable to a dedicated temporary directory under the
  system's temp path which is cleaned up on success and failure

For example, to install the latest nightly toolchain as the default in
an unattended scenario, a user can run the following in a PowerShell
session:

```powershell
.\rustup-init.ps1 -y --default-toolchain nightly
```

If `cmd.exe` is your current shell, you can still invoke the same by
running the above in a PowerShell session with:

```batch
powershell -Command ".\rustup-init.ps1 -y --default-toolchain nightly"
```

The script is written carefully to not call `exit` so that it can be
downloaded and used in much the same way as the Shell based "curl-bash"
strategy. Assuming that this script was available at
`https://ps1.rustup.rs` (or `https://pwsh.rustup.rs`,
`https://posh.rustup.rs`, etc.), and that no further arguments are
passed to the script, a user could invoke this script directly in a
PowerShell session with:

```powershell
iex ((New-Object System.Net.WebClient).DownloadString('https://ps1.rustup.rs'))
```
(For folks new to PowerShell, `iex` is an alias for the
`Invoke-Expression` cmdlet, similar to `eval` in other languages)

In order to pass arguments to the script, a slightly longer form can be
used. For example, to perform an unattended install of Rustup with no
default toolchain and no path modification, a user could run the
following in a PowerShell session:

```powershell
& ([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://ps1.rustup.rs'))) -y --default-toolchain none --no-modify-path
```

Yes, that's rather long, but I think that's as short a "code golf" as
you can get and it's on par with Chocolatey's `install.ps1` strategy.

---

## Additional Notes

* As I'm not as familiar with PowerShell as others, it's harder for me to attest to how far back this implementation supports as far as Windows releases go. I'm reasonably sure that this works with PowerShell 3.0, possibly even PowerShell 2.0 meaning this could support as far back as Windows 8 or 7. I would love any additional feedback if I've failed to keep things conservative and portable.
* I tested this on macOS/x86_64 10.14.4 with PowerShell 6.2.0 and Ubuntu/x86_64 18.04 in Docker (Linux 4.9.125-linuxkit) with PowerShell 6.2.1. I believe this covers the vast majority of off-Windows scenarios although any more feedback here would be great as well.
* In order to better test the "curl-bash" functionality, I have the identical code published in a Gist called [A Windows/Linux/macOS PowerShell Rustup Install Script](https://gist.github.com/fnichol/699d3c2930649a9932f71bab8a315b31) which anyone can try by running:
  ```powershell
  & ([scriptblock]::Create((New-Object System.Net.WebClient).DownloadString('https://gist.github.com/fnichol/699d3c2930649a9932f71bab8a315b31/raw/rustup-init.ps1')))
  ```
  I'm using this currently in a [CI setup](https://github.com/fnichol/mtoc/blob/0deec6953f7538169666712ee7c57f1afbeae8b4/.cirrus.yml#L90-L94) which has helped drive better consistency across Windows and non-Windows platforms (yay)
