### PR TITLE
Bug 1870 - UI edition

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -36,6 +36,7 @@ use crate::markdown::md;
 use crate::term2;
 use rustup::dist::dist;
 use rustup::utils::utils;
+use rustup::utils::Notification;
 use rustup::{DUP_TOOLS, TOOLS};
 use same_file::Handle;
 use std::env;
@@ -613,7 +614,7 @@ fn install_bins() -> Result<()> {
     let this_exe_path = utils::current_exe()?;
     let rustup_path = bin_path.join(&format!("rustup{}", EXE_SUFFIX));
 
-    utils::ensure_dir_exists("bin", &bin_path, &|_| {})?;
+    utils::ensure_dir_exists("bin", &bin_path, &|_: Notification<'_>| {})?;
     // NB: Even on Linux we can't just copy the new binary over the (running)
     // old binary; we must unlink it first.
     if rustup_path.exists() {
@@ -760,7 +761,7 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
     // Delete RUSTUP_HOME
     let rustup_dir = utils::rustup_home()?;
     if rustup_dir.exists() {
-        utils::remove_dir("rustup_home", &rustup_dir, &|_| {})?;
+        utils::remove_dir("rustup_home", &rustup_dir, &|_: Notification<'_>| {})?;
     }
 
     let read_dir_err = "failure reading directory";
@@ -778,7 +779,7 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
         let dirent = dirent.chain_err(|| read_dir_err)?;
         if dirent.file_name().to_str() != Some("bin") {
             if dirent.path().is_dir() {
-                utils::remove_dir("cargo_home", &dirent.path(), &|_| {})?;
+                utils::remove_dir("cargo_home", &dirent.path(), &|_: Notification<'_>| {})?;
             } else {
                 utils::remove_file("cargo_home", &dirent.path())?;
             }
@@ -798,7 +799,7 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
         let file_is_tool = name.to_str().map(|n| tools.iter().any(|t| *t == n));
         if file_is_tool == Some(false) {
             if dirent.path().is_dir() {
-                utils::remove_dir("cargo_home", &dirent.path(), &|_| {})?;
+                utils::remove_dir("cargo_home", &dirent.path(), &|_: Notification<'_>| {})?;
             } else {
                 utils::remove_file("cargo_home", &dirent.path())?;
             }
@@ -946,7 +947,7 @@ pub fn complete_windows_uninstall() -> Result<()> {
 
     // Now that the parent has exited there are hopefully no more files open in CARGO_HOME
     let cargo_home = utils::cargo_home()?;
-    utils::remove_dir("cargo_home", &cargo_home, &|_| ())?;
+    utils::remove_dir("cargo_home", &cargo_home, &|_: Notification<'_>| ())?;
 
     // Now, run a *system* binary to inherit the DELETE_ON_CLOSE
     // handle to *this* process, then exit. The OS will delete the gc

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -821,7 +821,7 @@ pub fn uninstall(no_prompt: bool) -> Result<()> {
 #[cfg(unix)]
 fn delete_rustup_and_cargo_home() -> Result<()> {
     let cargo_home = utils::cargo_home()?;
-    utils::remove_dir("cargo_home", &cargo_home, &|_| ())?;
+    utils::remove_dir("cargo_home", &cargo_home, &|_: Notification<'_>| ())?;
 
     Ok(())
 }

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -194,7 +194,7 @@ impl Component {
         let temp = tx.temp().new_file()?;
         utils::filter_file("components", &abs_path, &temp, |l| (l != self.name))?;
         tx.modify_file(path)?;
-        utils::rename_file("components", &temp, &abs_path)?;
+        utils::rename_file("components", &temp, &abs_path, tx.notify_handler())?;
 
         // TODO: If this is the last component remove the components file
         // and the version file.

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -93,7 +93,13 @@ impl<'a> Transaction<'a> {
     /// Remove a file from a relative path to the install prefix.
     pub fn remove_file(&mut self, component: &str, relpath: PathBuf) -> Result<()> {
         assert!(relpath.is_relative());
-        let item = ChangedItem::remove_file(&self.prefix, component, relpath, &self.temp_cfg)?;
+        let item = ChangedItem::remove_file(
+            &self.prefix,
+            component,
+            relpath,
+            &self.temp_cfg,
+            self.notify_handler(),
+        )?;
         self.change(item);
         Ok(())
     }
@@ -102,7 +108,13 @@ impl<'a> Transaction<'a> {
     /// install prefix.
     pub fn remove_dir(&mut self, component: &str, relpath: PathBuf) -> Result<()> {
         assert!(relpath.is_relative());
-        let item = ChangedItem::remove_dir(&self.prefix, component, relpath, &self.temp_cfg)?;
+        let item = ChangedItem::remove_dir(
+            &self.prefix,
+            component,
+            relpath,
+            &self.temp_cfg,
+            self.notify_handler(),
+        )?;
         self.change(item);
         Ok(())
     }
@@ -136,7 +148,8 @@ impl<'a> Transaction<'a> {
     /// Move a file to a relative path of the install prefix.
     pub fn move_file(&mut self, component: &str, relpath: PathBuf, src: &Path) -> Result<()> {
         assert!(relpath.is_relative());
-        let item = ChangedItem::move_file(&self.prefix, component, relpath, src)?;
+        let item =
+            ChangedItem::move_file(&self.prefix, component, relpath, src, self.notify_handler())?;
         self.change(item);
         Ok(())
     }
@@ -144,7 +157,8 @@ impl<'a> Transaction<'a> {
     /// Recursively move a directory to a relative path of the install prefix.
     pub fn move_dir(&mut self, component: &str, relpath: PathBuf, src: &Path) -> Result<()> {
         assert!(relpath.is_relative());
-        let item = ChangedItem::move_dir(&self.prefix, component, relpath, src)?;
+        let item =
+            ChangedItem::move_dir(&self.prefix, component, relpath, src, self.notify_handler())?;
         self.change(item);
         Ok(())
     }
@@ -166,7 +180,7 @@ impl<'a> Drop for Transaction<'a> {
             for item in self.changes.iter().rev() {
                 // ok_ntfy!(self.notify_handler,
                 //          Notification::NonFatalError,
-                match item.roll_back(&self.prefix) {
+                match item.roll_back(&self.prefix, self.notify_handler()) {
                     Ok(()) => {}
                     Err(e) => {
                         (self.notify_handler)(Notification::NonFatalError(&e));
@@ -191,20 +205,20 @@ enum ChangedItem<'a> {
 }
 
 impl<'a> ChangedItem<'a> {
-    fn roll_back(&self, prefix: &InstallPrefix) -> Result<()> {
+    fn roll_back(
+        &self,
+        prefix: &InstallPrefix,
+        notify: &'a dyn Fn(Notification<'_>),
+    ) -> Result<()> {
         use self::ChangedItem::*;
         match self {
             AddedFile(path) => utils::remove_file("component", &prefix.abs_path(path))?,
-            AddedDir(path) => {
-                utils::remove_dir("component", &prefix.abs_path(path), &|_: Notification<
-                    '_,
-                >| ())?
-            }
+            AddedDir(path) => utils::remove_dir("component", &prefix.abs_path(path), notify)?,
             RemovedFile(path, tmp) | ModifiedFile(path, Some(tmp)) => {
-                utils::rename_file("component", &tmp, &prefix.abs_path(path))?
+                utils::rename_file("component", &tmp, &prefix.abs_path(path), notify)?
             }
             RemovedDir(path, tmp) => {
-                utils::rename_dir("component", &tmp.join("bk"), &prefix.abs_path(path))?
+                utils::rename_dir("component", &tmp.join("bk"), &prefix.abs_path(path), notify)?
             }
             ModifiedFile(path, None) => {
                 let abs_path = prefix.abs_path(path);
@@ -265,6 +279,7 @@ impl<'a> ChangedItem<'a> {
         component: &str,
         relpath: PathBuf,
         temp_cfg: &'a temp::Cfg,
+        notify: &'a dyn Fn(Notification<'_>),
     ) -> Result<Self> {
         let abs_path = prefix.abs_path(&relpath);
         let backup = temp_cfg.new_file()?;
@@ -275,7 +290,7 @@ impl<'a> ChangedItem<'a> {
             }
             .into())
         } else {
-            utils::rename_file("component", &abs_path, &backup)?;
+            utils::rename_file("component", &abs_path, &backup, notify)?;
             Ok(ChangedItem::RemovedFile(relpath, backup))
         }
     }
@@ -284,6 +299,7 @@ impl<'a> ChangedItem<'a> {
         component: &str,
         relpath: PathBuf,
         temp_cfg: &'a temp::Cfg,
+        notify: &'a dyn Fn(Notification<'_>),
     ) -> Result<Self> {
         let abs_path = prefix.abs_path(&relpath);
         let backup = temp_cfg.new_directory()?;
@@ -294,7 +310,7 @@ impl<'a> ChangedItem<'a> {
             }
             .into())
         } else {
-            utils::rename_dir("component", &abs_path, &backup.join("bk"))?;
+            utils::rename_dir("component", &abs_path, &backup.join("bk"), notify)?;
             Ok(ChangedItem::RemovedDir(relpath, backup))
         }
     }
@@ -321,9 +337,10 @@ impl<'a> ChangedItem<'a> {
         component: &str,
         relpath: PathBuf,
         src: &Path,
+        notify: &'a dyn Fn(Notification<'_>),
     ) -> Result<Self> {
         let abs_path = ChangedItem::dest_abs_path(prefix, component, &relpath)?;
-        utils::rename_file("component", src, &abs_path)?;
+        utils::rename_file("component", src, &abs_path, notify)?;
         Ok(ChangedItem::AddedFile(relpath))
     }
     fn move_dir(
@@ -331,9 +348,10 @@ impl<'a> ChangedItem<'a> {
         component: &str,
         relpath: PathBuf,
         src: &Path,
+        notify: &'a dyn Fn(Notification<'_>),
     ) -> Result<Self> {
         let abs_path = ChangedItem::dest_abs_path(prefix, component, &relpath)?;
-        utils::rename_dir("component", src, &abs_path)?;
+        utils::rename_dir("component", src, &abs_path, notify)?;
         Ok(ChangedItem::AddedDir(relpath))
     }
 }

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -536,9 +536,7 @@ pub fn update_from_dist<'a>(
     // Don't leave behind an empty / broken installation directory
     if res.is_err() && fresh_install {
         // FIXME Ignoring cascading errors
-        let _ = utils::remove_dir("toolchain", prefix.path(), &|n| {
-            (download.notify_handler)(n.into())
-        });
+        let _ = utils::remove_dir("toolchain", prefix.path(), download.notify_handler);
     }
 
     res

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -88,7 +88,12 @@ impl<'a> DownloadCfg<'a> {
         } else {
             (self.notify_handler)(Notification::ChecksumValid(&url.to_string()));
 
-            utils::rename_file("downloaded", &partial_file_path, &target_file)?;
+            utils::rename_file(
+                "downloaded",
+                &partial_file_path,
+                &target_file,
+                self.notify_handler,
+            )?;
             Ok(File { path: target_file })
         }
     }

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -37,9 +37,11 @@ impl<'a> DownloadCfg<'a> {
     /// target file already exists, then the hash is checked and it is returned
     /// immediately without re-downloading.
     pub fn download(&self, url: &Url, hash: &str) -> Result<File> {
-        utils::ensure_dir_exists("Download Directory", &self.download_dir, &|n| {
-            (self.notify_handler)(n.into())
-        })?;
+        utils::ensure_dir_exists(
+            "Download Directory",
+            &self.download_dir,
+            &self.notify_handler,
+        )?;
         let target_file = self.download_dir.join(Path::new(hash));
 
         if target_file.exists() {

--- a/src/install.rs
+++ b/src/install.rs
@@ -39,11 +39,11 @@ impl<'a> InstallMethod<'a> {
 
         match self {
             InstallMethod::Copy(src) => {
-                utils::copy_dir(src, path, &|n| notify_handler(n.into()))?;
+                utils::copy_dir(src, path, notify_handler)?;
                 Ok(true)
             }
             InstallMethod::Link(src) => {
-                utils::symlink_dir(src, &path, &|n| notify_handler(n.into()))?;
+                utils::symlink_dir(src, &path, notify_handler)?;
                 Ok(true)
             }
             InstallMethod::Installer(src, temp_cfg) => {
@@ -105,5 +105,5 @@ impl<'a> InstallMethod<'a> {
 }
 
 pub fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
-    utils::remove_dir("install", path, &|n| notify_handler(n.into()))
+    utils::remove_dir("install", path, notify_handler)
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -84,7 +84,7 @@ impl Default for Settings {
 impl Settings {
     fn path_to_key(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> String {
         if path.exists() {
-            utils::canonicalize_path(path, &|n| notify_handler(n.into()))
+            utils::canonicalize_path(path, notify_handler)
                 .display()
                 .to_string()
         } else {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -23,13 +23,16 @@ pub use crate::utils::utils::raw::{
 
 pub struct ExitCode(pub i32);
 
-pub fn ensure_dir_exists(
+pub fn ensure_dir_exists<'a, N>(
     name: &'static str,
-    path: &Path,
-    notify_handler: &dyn Fn(Notification<'_>),
-) -> Result<bool> {
-    raw::ensure_dir_exists(path, |p| {
-        notify_handler(Notification::CreatingDirectory(name, p))
+    path: &'a Path,
+    notify_handler: &'a dyn Fn(N),
+) -> Result<bool>
+where
+    N: From<Notification<'a>>,
+{
+    raw::ensure_dir_exists(path, |_| {
+        notify_handler(Notification::CreatingDirectory(name, path).into())
     })
     .chain_err(|| ErrorKind::CreatingDirectory {
         name,
@@ -104,9 +107,12 @@ pub fn match_file<T, F: FnMut(&str) -> Option<T>>(
     })
 }
 
-pub fn canonicalize_path(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> PathBuf {
+pub fn canonicalize_path<'a, N>(path: &'a Path, notify_handler: &dyn Fn(N)) -> PathBuf
+where
+    N: From<Notification<'a>>,
+{
     fs::canonicalize(path).unwrap_or_else(|_| {
-        notify_handler(Notification::NoCanonicalPath(path));
+        notify_handler(Notification::NoCanonicalPath(path).into());
         PathBuf::from(path)
     })
 }
@@ -249,12 +255,11 @@ pub fn assert_is_directory(path: &Path) -> Result<()> {
     }
 }
 
-pub fn symlink_dir(
-    src: &Path,
-    dest: &Path,
-    notify_handler: &dyn Fn(Notification<'_>),
-) -> Result<()> {
-    notify_handler(Notification::LinkingDirectory(src, dest));
+pub fn symlink_dir<'a, N>(src: &'a Path, dest: &'a Path, notify_handler: &dyn Fn(N)) -> Result<()>
+where
+    N: From<Notification<'a>>,
+{
+    notify_handler(Notification::LinkingDirectory(src, dest).into());
     raw::symlink_dir(src, dest).chain_err(|| ErrorKind::LinkingDirectory {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
@@ -293,8 +298,11 @@ pub fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
     .into())
 }
 
-pub fn copy_dir(src: &Path, dest: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
-    notify_handler(Notification::CopyingDirectory(src, dest));
+pub fn copy_dir<'a, N>(src: &'a Path, dest: &'a Path, notify_handler: &dyn Fn(N)) -> Result<()>
+where
+    N: From<Notification<'a>>,
+{
+    notify_handler(Notification::CopyingDirectory(src, dest).into());
     raw::copy_dir(src, dest).chain_err(|| ErrorKind::CopyingDirectory {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
@@ -318,12 +326,15 @@ pub fn copy_file(src: &Path, dest: &Path) -> Result<()> {
     }
 }
 
-pub fn remove_dir(
+pub fn remove_dir<'a, N>(
     name: &'static str,
-    path: &Path,
-    notify_handler: &dyn Fn(Notification<'_>),
-) -> Result<()> {
-    notify_handler(Notification::RemovingDirectory(name, path));
+    path: &'a Path,
+    notify_handler: &dyn Fn(N),
+) -> Result<()>
+where
+    N: From<Notification<'a>>,
+{
+    notify_handler(Notification::RemovingDirectory(name, path).into());
     raw::remove_dir(path).chain_err(|| ErrorKind::RemovingDirectory {
         name,
         path: PathBuf::from(path),

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -11,6 +11,7 @@ use crate::mock::{get_path, restore_path};
 use lazy_static::lazy_static;
 use remove_dir_all::remove_dir_all;
 use rustup::utils::{raw, utils};
+use rustup::Notification;
 use std::env;
 use std::env::consts::EXE_SUFFIX;
 use std::fs;
@@ -952,7 +953,7 @@ fn rustup_init_works_with_weird_names() {
     setup(&|config| {
         let old = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
         let new = config.exedir.join(&format!("rustup-init(2){}", EXE_SUFFIX));
-        utils::rename_file("test", &old, &new).unwrap();
+        utils::rename_file("test", &old, &new, &|_: Notification<'_>| {}).unwrap();
         expect_ok(config, &["rustup-init(2)", "-y"]);
         let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
         assert!(rustup.exists());

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -1417,7 +1417,12 @@ fn unable_to_download_component() {
 }
 
 fn prevent_installation(prefix: &InstallPrefix) {
-    utils::ensure_dir_exists("installation path", &prefix.path().join("lib"), &|_| {}).unwrap();
+    utils::ensure_dir_exists(
+        "installation path",
+        &prefix.path().join("lib"),
+        &|_: Notification<'_>| {},
+    )
+    .unwrap();
     let install_blocker = prefix.path().join("lib").join("rustlib");
     utils::write_file("install-blocker", &install_blocker, "fail-installation").unwrap();
 }
@@ -1475,7 +1480,12 @@ fn checks_files_hashes_before_reuse() {
         .unwrap()[..64]
             .to_owned();
         let prev_download = download_cfg.download_dir.join(target_hash);
-        utils::ensure_dir_exists("download dir", &download_cfg.download_dir, &|_| {}).unwrap();
+        utils::ensure_dir_exists(
+            "download dir",
+            &download_cfg.download_dir,
+            &|_: Notification<'_>| {},
+        )
+        .unwrap();
         utils::write_file("bad previous download", &prev_download, "bad content").unwrap();
         println!("wrote previous download to {}", prev_download.display());
 


### PR DESCRIPTION
Bug 1870's fix didn't show users what was going on and could stall for up to 30 seconds while waiting. This will show info: messages when that happens; perhaps a lot of them, but better on balance I think than absolutely nothing. Further refinement is of course possible but I think this is the minimum needed to make more releases sensible to do.