### PR TITLE
A variety of fixes, and detection of snappy et al.

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -374,7 +374,7 @@ pub mod curl {
     pub fn download(
         _url: &Url,
         _resume_from: u64,
-        _callback: &Fn(Event) -> Result<()>,
+        _callback: &dyn Fn(Event<'_>) -> Result<()>,
     ) -> Result<()> {
         Err(ErrorKind::BackendUnavailable("curl").into())
     }
@@ -390,7 +390,7 @@ pub mod reqwest_be {
     pub fn download(
         _url: &Url,
         _resume_from: u64,
-        _callback: &Fn(Event) -> Result<()>,
+        _callback: &dyn Fn(Event<'_>) -> Result<()>,
     ) -> Result<()> {
         Err(ErrorKind::BackendUnavailable("reqwest").into())
     }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -669,6 +669,13 @@ fn update(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
                 println!();
                 common::show_channel_update(cfg, toolchain.name(), Ok(status))?;
             }
+
+            if cfg.get_default()?.is_none() {
+                use rustup::UpdateStatus;
+                if let Some(UpdateStatus::Installed) = status {
+                    toolchain.make_default()?;
+                }
+            }
         }
         if self_update {
             common::self_update(|| Ok(()))?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -641,7 +641,10 @@ fn default_(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
             );
         }
     } else {
-        println!("{} (default)", cfg.get_default()?);
+        let default_toolchain: Result<String> = cfg
+            .get_default()?
+            .ok_or_else(|| "no default toolchain configured".into());
+        println!("{} (default)", default_toolchain?);
     }
 
     Ok(())
@@ -755,7 +758,10 @@ fn show(cfg: &Cfg) -> Result<()> {
         if show_headers {
             print_header(&mut t, "installed toolchains")?;
         }
-        let default_name = cfg.get_default()?;
+        let default_name: Result<String> = cfg
+            .get_default()?
+            .ok_or_else(|| "no default toolchain configured".into());
+        let default_name = default_name?;
         for it in installed_toolchains {
             if default_name == it {
                 writeln!(t, "{} (default)", it)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -342,12 +342,8 @@ impl Cfg {
         )
     }
 
-    pub fn get_default(&self) -> Result<String> {
-        self.settings_file.with(|s| {
-            s.default_toolchain
-                .clone()
-                .ok_or_else(|| "no default toolchain configured".into())
-        })
+    pub fn get_default(&self) -> Result<Option<String>> {
+        self.settings_file.with(|s| Ok(s.default_toolchain.clone()))
     }
 
     pub fn list_toolchains(&self) -> Result<Vec<String>> {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -299,10 +299,11 @@ impl<'a> Toolchain<'a> {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(0);
             if recursion_count > env_var::RUST_RECURSION_COUNT_MAX - 1 {
+                let defaults = self.cfg.get_default()?;
                 return Err(ErrorKind::BinaryNotFound(
                     binary.to_string_lossy().into(),
                     self.name.clone(),
-                    Some(&self.name) == self.cfg.get_default().ok().as_ref(),
+                    Some(&self.name) == defaults.as_ref(),
                 )
                 .into());
             }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -38,6 +38,7 @@ pub struct ComponentStatus {
     pub available: bool,
 }
 
+#[derive(Clone, Copy, Debug)]
 pub enum UpdateStatus {
     Installed,
     Updated,

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -40,6 +40,7 @@ info: installing component 'rust-std'
 info: installing component 'rustc'
 info: installing component 'cargo'
 info: installing component 'rust-docs'
+info: default toolchain set to 'nightly-{0}'
 "
             ),
         );


### PR DESCRIPTION
In order to support running `rustup` from within snaps and other package managed environments, I wrote some patches.  Along the way I fixed some bugs too.