### PR TITLE
Windows on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
 
     - &windows
       os: windows
-      env: TARGET=x86_64-pc-windows-msvc NO_ADD=1
+      env: TARGET=x86_64-pc-windows-msvc NO_ADD=1 EXE_EXT=.exe
       services: nil
       language: bash
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,35 +19,45 @@ matrix:
   include:
     # Linux builds use the `rust-slave-dist` image so we link them against a
     # "super old glibc" to ensure that it runs on as many platforms as possible.
-    - os: linux
+    # These builds always run.  PRs, master, staging, stable, etc.
+    - &linuxalways
+      os: linux
       env: TARGET=x86_64-unknown-linux-gnu NO_ADD=1
-    - &linux
+    # Most builds consuming this only run on the stable and staging branches
+    - &linuxstable
       os: linux
       env: TARGET=i686-unknown-linux-gnu
       if: branch != master
+    # These builds run on non-pull-requests, so master, staging, stable...
+    - &linuxmaster
+      os: linux
+      env: SKIP_TESTS=1 TARGET=aarch64-unknown-linux-gnu
+      if: type != pull_request
 
     # Cross builds happen in the `rust-slave-linux-cross` image to ensure that
     # we use the right cross compilers for these targets. That image should
     # bundle all the gcc cross compilers to enable us to build OpenSSL
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabi }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabihf }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-unknown-linux-gnueabihf }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-freebsd }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64le-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mipsel-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips64-unknown-linux-gnuabi64 }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips64el-unknown-linux-gnuabi64 }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=s390x-unknown-linux-gnu }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-linux-musl }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-linux-androideabi }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-linux-androideabi }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-linux-android }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=i686-linux-android }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-linux-android }
+    # Builds which occur only on stable (and staging branches) take linuxstable
+    # Those which occur on master or any other branch (but not PRs) linuxmaster
+    # And those which run always (PRs, master, staging, etc) linuxalways
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabi }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabihf }
+    - { <<: *linuxalways, env: SKIP_TESTS=1 TARGET=armv7-unknown-linux-gnueabihf }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=x86_64-unknown-freebsd }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=powerpc-unknown-linux-gnu }
+    - { <<: *linuxmaster, env: SKIP_TESTS=1 TARGET=powerpc64-unknown-linux-gnu }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=powerpc64le-unknown-linux-gnu }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=mips-unknown-linux-gnu }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=mipsel-unknown-linux-gnu }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=mips64-unknown-linux-gnuabi64 }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=mips64el-unknown-linux-gnuabi64 }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=s390x-unknown-linux-gnu }
+    - { <<: *linuxmaster, env: SKIP_TESTS=1 TARGET=x86_64-unknown-linux-musl }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=arm-linux-androideabi }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=armv7-linux-androideabi }
+    - { <<: *linuxalways, env: SKIP_TESTS=1 TARGET=aarch64-linux-android }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=i686-linux-android }
+    - { <<: *linuxstable, env: SKIP_TESTS=1 TARGET=x86_64-linux-android }
 
     # On OSX we want to target 10.7 so we ensure that the appropriate
     # environment variable is set to tell the linker what we want.
@@ -57,9 +67,10 @@ matrix:
     - &mac
       os: osx
       osx_image: xcode9.2
-      if: branch != master
+      if: type != pull_request
       env: MACOSX_DEPLOYMENT_TARGET=10.7 TARGET=x86_64-apple-darwin NO_ADD=1
     - <<: *mac
+      if: branch != master
       env: MACOSX_DEPLOYMENT_TARGET=10.7 TARGET=i686-apple-darwin
 
     - name: rustup-init.sh on CentOS 6

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,19 +77,32 @@ matrix:
       before_deploy:
       deploy:
 
+    - &windows
+      os: windows
+      env: TARGET=x86_64-pc-windows-msvc NO_ADD=1
+      services: nil
+      language: bash
+
 install:
   - sh rustup-init.sh --default-toolchain=stable -y
-  - . "$HOME"/.cargo/env
+  - |
+    if [ -r "$HOME/.cargo/env" ]; then
+      . "$HOME"/.cargo/env;
+    else
+      export PATH="$HOME/.cargo/bin:$PATH";
+    fi
   - if [ -z "$NO_ADD" ]; then rustup target add "$TARGET"; fi
 
 script:
   - mkdir -p target/"$TARGET";
-  - >
+  - |
     case "$TARGET" in
       *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
       *-apple-darwin)                    ;;
+      *-pc-windows-*)                    ;;
       *)                DOCKER="$TARGET" ;;
-    esac;
+    esac
+  - |
     if [ -n "$DOCKER" ]; then
       sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,25 +29,25 @@ matrix:
     # Cross builds happen in the `rust-slave-linux-cross` image to ensure that
     # we use the right cross compilers for these targets. That image should
     # bundle all the gcc cross compilers to enable us to build OpenSSL
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabi       }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabihf     }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-unknown-linux-gnueabihf   }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-unknown-linux-gnu       }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-freebsd          }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc-unknown-linux-gnu       }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64-unknown-linux-gnu     }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64le-unknown-linux-gnu   }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips-unknown-linux-gnu          }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mipsel-unknown-linux-gnu        }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips64-unknown-linux-gnuabi64   }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabi }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-unknown-linux-gnueabihf }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-unknown-linux-gnueabihf }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-freebsd }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=powerpc64le-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mipsel-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips64-unknown-linux-gnuabi64 }
     - { <<: *linux, env: SKIP_TESTS=1 TARGET=mips64el-unknown-linux-gnuabi64 }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=s390x-unknown-linux-gnu         }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-linux-musl       }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-linux-androideabi           }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-linux-androideabi         }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-linux-android           }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=i686-linux-android              }
-    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-linux-android            }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=s390x-unknown-linux-gnu }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-unknown-linux-musl }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=arm-linux-androideabi }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=armv7-linux-androideabi }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=aarch64-linux-android }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=i686-linux-android }
+    - { <<: *linux, env: SKIP_TESTS=1 TARGET=x86_64-linux-android }
 
     # On OSX we want to target 10.7 so we ensure that the appropriate
     # environment variable is set to tell the linker what we want.
@@ -66,7 +66,8 @@ matrix:
       language: minimal
       install:
       script:
-        - docker run
+        - >
+          docker run
             --volume "$TRAVIS_BUILD_DIR":/checkout:ro
             --workdir /checkout
             --rm
@@ -84,20 +85,21 @@ install:
 script:
   - mkdir -p target/"$TARGET";
   - >
-      case "$TARGET" in
-        *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
-        *-apple-darwin)                    ;;
-        *)                DOCKER="$TARGET" ;;
-      esac;
-      if [ -n "$DOCKER" ]; then
-        sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
-      else
-        sh ci/run.sh;
-      fi
+    case "$TARGET" in
+      *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
+      *-apple-darwin)                    ;;
+      *)                DOCKER="$TARGET" ;;
+    esac;
+    if [ -n "$DOCKER" ]; then
+      sh ci/build-run-docker.sh "$DOCKER" "$TARGET" "$SKIP_TESTS";
+    else
+      sh ci/run.sh;
+    fi
 
   # Check the formatting last because test failures are more interesting to have
   # discovered for contributors lacking some platform access for testing beforehand
-  - if [ "${TARGET}" = x86_64-unknown-linux-gnu ]; then
+  - >
+    if [ "${TARGET}" = x86_64-unknown-linux-gnu ]; then
       shellcheck -s dash -e SC1090 -- rustup-init.sh ci/*.sh;
       rustup component add rustfmt;
       rustfmt -vV;

--- a/ci/prepare-deploy-travis.sh
+++ b/ci/prepare-deploy-travis.sh
@@ -7,7 +7,7 @@ if [ "$TRAVIS_PULL_REQUEST" = "true" ] || [ "$TRAVIS_BRANCH" = "auto" ]; then
 fi
 
 # Copy rustup-init to rustup-setup for backwards compatibility
-cp target/"$TARGET"/release/rustup-init target/"$TARGET"/release/rustup-setup
+cp target/"$TARGET"/release/rustup-init$EXE_EXT target/"$TARGET"/release/rustup-setup$EXE_EXT
 
 # Generate hashes
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
@@ -22,10 +22,10 @@ dest="deploy"
 # Prepare bins for upload
 bindest="$dest/dist/$TARGET"
 mkdir -p "$bindest/"
-cp target/"$TARGET"/release/rustup-init "$bindest/"
-cp target/"$TARGET"/release/rustup-init.sha256 "$bindest/"
-cp target/"$TARGET"/release/rustup-setup "$bindest/"
-cp target/"$TARGET"/release/rustup-setup.sha256 "$bindest/"
+cp target/"$TARGET"/release/rustup-init"${EXE_EXT}" "$bindest/"
+cp target/"$TARGET"/release/rustup-init"${EXE_EXT}".sha256 "$bindest/"
+cp target/"$TARGET"/release/rustup-setup"${EXE_EXT}" "$bindest/"
+cp target/"$TARGET"/release/rustup-setup"${EXE_EXT}".sha256 "$bindest/"
 
 if [ "$TARGET" != "x86_64-unknown-linux-gnu" ]; then
     exit 0

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,10 +8,21 @@ export RUST_BACKTRACE
 rustc -vV
 cargo -vV
 
-cargo build --locked -v --release --target "$TARGET" --features vendored-openssl
+if [ "$TRAVIS_OS_NAME" = "windows" ]; then
+  FEATURES=""
+else
+  FEATURES="--features vendored-openssl"
+fi
+
+# Sadly we need word splitting for $FEATURES
+# shellcheck disable=SC2086
+cargo build --locked -v --release --target "$TARGET" $FEATURES
 
 if [ -z "$SKIP_TESTS" ]; then
-  cargo run --locked --release --target "$TARGET" --features vendored-openssl -- --dump-testament
-  cargo test --release -p download --target "$TARGET" --features vendored-openssl
-  cargo test --release --target "$TARGET" --features vendored-openssl
+  # shellcheck disable=SC2086
+  cargo run --locked --release --target "$TARGET" $FEATURES -- --dump-testament
+  # shellcheck disable=SC2086
+  cargo test --release -p download --target "$TARGET" $FEATURES
+  # shellcheck disable=SC2086
+  cargo test --release --target "$TARGET" $FEATURES
 fi


### PR DESCRIPTION
This alters the travis configuration to add Windows MSVC builds, and also to adjust which images we build on which branches.  The intent is as follows:

PRs, master, stable:

* x86_64 linux gnu
* armv7 linux gnueabihf
* aarch64 linux android
* windows msvc
* Mac OS x86_64
* CentOS 6 smoke test

master, stable:

The above, plus:

* x86_64 linux musl
* aarch64 linux gnu
* powerpc64 linux gnu

Everything else only on stable (and staging branches)