### PR TITLE
Snappy: Add support for snapcraft builds

### DIFF
--- a/.github/workflows/linux-builds-on-master.yaml
+++ b/.github/workflows/linux-builds-on-master.yaml
@@ -27,6 +27,11 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES
+            snap_arch: amd64
+          - target: aarch64-unknown-linux-gnu # skip-pr
+            snap_arch: arm64 # skip-pr
+          - target: armv7-unknown-linux-gnueabihf
+            snap_arch: armhf
     steps:
       - uses: actions/checkout@v2
         with:
@@ -134,6 +139,25 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      - name: Build a snapcraft configuration file
+        run: |
+          bash ci/snapcraft.bash
+        if: matrix.snap_arch != ''
+        env:
+          DO_SNAP: 1
+          SNAP_ARCH: ${{ matrix.snap_arch }}
+          SNAP_EDGE: 1 # skip-stable
+      - uses: snapcore/action-build@v1
+        id: snapcraftbuild
+        with:
+          path: snapcraft
+        if: matrix.snap_arch != ''
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAPCRAFT_TOKEN }}
+          snap: ${{ steps.snapcraftbuild.outputs.snap }}
+          release: edge # skip-pr skip-stable
+        if: matrix.snap_arch != '' # skip-pr
       - name: Clear the cargo caches
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean

--- a/.github/workflows/linux-builds-on-pr.yaml
+++ b/.github/workflows/linux-builds-on-pr.yaml
@@ -22,6 +22,9 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES
+            snap_arch: amd64
+          - target: armv7-unknown-linux-gnueabihf
+            snap_arch: armhf
     steps:
       - uses: actions/checkout@v2
         with:
@@ -129,6 +132,24 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      - name: Build a snapcraft configuration file
+        run: |
+          bash ci/snapcraft.bash
+        if: matrix.snap_arch != ''
+        env:
+          DO_SNAP: 1
+          SNAP_ARCH: ${{ matrix.snap_arch }}
+          SNAP_EDGE: 1 # skip-stable
+      - uses: snapcore/action-build@v1
+        id: snapcraftbuild
+        with:
+          path: snapcraft
+        if: matrix.snap_arch != ''
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAPCRAFT_TOKEN }}
+          snap: ${{ steps.snapcraftbuild.outputs.snap }}
+        if: matrix.snap_arch == 'not-for-prs' # skip-master skip-stable
       - name: Clear the cargo caches
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean

--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -41,6 +41,17 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES
+            snap_arch: amd64
+          - target: i686-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: i386  # skip-pr skip-master
+          - target: aarch64-unknown-linux-gnu # skip-pr
+            snap_arch: arm64 # skip-pr
+          - target: armv7-unknown-linux-gnueabihf
+            snap_arch: armhf
+          - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: ppc64el # skip-pr skip-master
+          - target: s390x-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: s390x # skip-pr skip-master
     steps:
       - uses: actions/checkout@v2
         with:
@@ -148,6 +159,24 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      - name: Build a snapcraft configuration file
+        run: |
+          bash ci/snapcraft.bash
+        if: matrix.snap_arch != ''
+        env:
+          DO_SNAP: 1
+          SNAP_ARCH: ${{ matrix.snap_arch }}
+      - uses: snapcore/action-build@v1
+        id: snapcraftbuild
+        with:
+          path: snapcraft
+        if: matrix.snap_arch != ''
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAPCRAFT_TOKEN }}
+          snap: ${{ steps.snapcraftbuild.outputs.snap }}
+          release: beta # skip-pr skip-master
+        if: matrix.snap_arch != '' # skip-pr
       - name: Clear the cargo caches
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /**/target
 /home
 /local-rustup
+/snapcraft

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -49,6 +49,17 @@ jobs:
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES
+            snap_arch: amd64
+          - target: i686-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: i386  # skip-pr skip-master
+          - target: aarch64-unknown-linux-gnu # skip-pr
+            snap_arch: arm64 # skip-pr
+          - target: armv7-unknown-linux-gnueabihf
+            snap_arch: armhf
+          - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: ppc64el # skip-pr skip-master
+          - target: s390x-unknown-linux-gnu # skip-pr skip-master
+            snap_arch: s390x # skip-pr skip-master
     steps:
       - uses: actions/checkout@v2
         with:
@@ -156,6 +167,27 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         if: github.event_name == 'push' && github.ref == 'refs/heads/stable'
+      - name: Build a snapcraft configuration file
+        run: |
+          bash ci/snapcraft.bash
+        if: matrix.snap_arch != ''
+        env:
+          DO_SNAP: 1
+          SNAP_ARCH: ${{ matrix.snap_arch }}
+          SNAP_EDGE: 1 # skip-stable
+      - uses: snapcore/action-build@v1
+        id: snapcraftbuild
+        with:
+          path: snapcraft
+        if: matrix.snap_arch != ''
+      - uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.SNAPCRAFT_TOKEN }}
+          snap: ${{ steps.snapcraftbuild.outputs.snap }}
+          release: edge # skip-pr skip-stable
+          release: beta # skip-pr skip-master
+        if: matrix.snap_arch != '' # skip-pr
+        if: matrix.snap_arch == 'not-for-prs' # skip-master skip-stable
       - name: Clear the cargo caches
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean

--- a/ci/snapcraft.bash
+++ b/ci/snapcraft.bash
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -efu
+
+set -o pipefail
+
+# This script encapsulates the job of preparing snapcract configuration for the
+# rustup snap.  We construct either an edge snap (builds on PRs or master)
+# or a beta snap if built from a non-master branch.
+
+# If built on master, we should publish the edge snap
+# If built on stable, we should publish the beta snap
+
+# To parameterise the build, the following environment variables are needed:
+# DO_SNAP=1  <-- without this, we don't run
+# SNAP_EDGE=1 <-- with this, we build an edge/devel snap, otherwise a release snap
+# SNAP_ARCH=... <-- without this we cannot build, this is the snap architecture we're building
+
+if [ -z "${DO_SNAP:-}" ]; then
+  echo "SNAP: Not attempting to snap"
+  exit 0
+fi
+
+if [ -z "${SNAP_ARCH:-}" ]; then
+  echo "SNAP: Unable to generate snap, architecture unset"
+  exit 1
+else
+  echo "SNAP: Constructing snap for architecture $SNAP_ARCH"
+fi
+
+if [ -n "${SNAP_EDGE:-}" ]; then
+  echo "SNAP: Generated snap will be an grade:devel snap"
+  GRADE=devel
+else
+  echo "SNAP: Generated snap will be a grade:stable snap"
+  GRADE=stable
+fi
+
+
+# This is the list of proxies which the snap will contain.  This needs to match
+# the set of aliases which the snap has been allocated.  If we add to this
+# list but don't get the aliases added, then people won't see the proxy except
+# as rustup.$PROXY.  If we have an alias which is not a supported proxy name
+# then rustup might get sad.
+
+PROXIES="cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rustc rustdoc rustfmt"
+
+# From now on, things should be automagic
+
+VERSION=$(grep "^version" Cargo.toml | head -1 | cut -d\" -f2)
+
+rm -rf snapcraft
+
+mkdir -p snapcraft/snap
+
+cd snapcraft
+
+cat > snap/snapcraft.yaml <<SNAP
+name: rustup
+version: $VERSION
+confinement: classic
+base: core18
+architectures:
+  - build-on: [amd64]
+    run-on: [$SNAP_ARCH]
+description: |
+  Rustup is the Rust Language's installer and primary front-end.  You probably
+  want this if you want to develop anything written in Rust.
+SNAP
+
+if [ -n "${SNAP_EDGE:-1}" ]; then
+  cat >> snap/snapcraft.yaml <<SNAP
+
+  Please note, this snap is experimental and functionality cannot be guaranteed
+  to be consistent with released snaps.
+summary: "EXPERIMENTAL: The Rust Language Installer"
+grade: $GRADE
+SNAP
+else
+  cat >> snap/snapcraft.yaml <<SNAP
+summary: "The Rust Language Installer"
+grade: $GRADE
+SNAP
+fi
+
+cat >> snap/snapcraft.yaml <<SNAP
+parts:
+  rustup:
+    plugin: nil
+    build-attributes: [no-patchelf]
+    source: inputs
+    override-build: |
+      mkdir -p \$SNAPCRAFT_PART_INSTALL/bin
+      cp rustup-init \$SNAPCRAFT_PART_INSTALL/bin/rustup
+SNAP
+
+for PROXY in $PROXIES; do
+  cat >> snap/snapcraft.yaml <<SNAP
+      ln \$SNAPCRAFT_PART_INSTALL/bin/rustup \$SNAPCRAFT_PART_INSTALL/bin/$PROXY
+SNAP
+done
+
+cat >> snap/snapcraft.yaml << 'SNAP'
+    prime:
+     - "-rustup-init"
+
+environment:
+  RUSTUP_HOME: "$SNAP_USER_COMMON/rustup"
+
+apps:
+  rustup:
+    command: bin/rustup
+SNAP
+
+for PROXY in $PROXIES; do
+  cat >> snap/snapcraft.yaml <<SNAP
+  $PROXY:
+    command: bin/$PROXY
+SNAP
+done
+
+mkdir inputs
+cp ../target/"$TARGET"/release/rustup-init inputs/
+
+ls -l snap/snapcraft.yaml


### PR DESCRIPTION
This commit enables building snaps for the various platforms supported by snapcraft.io

Currently the snap is under my personal page, and despite building it here, we'll keep that until after all-hands where I'll have a chat with t-release people about what we might do for an official snap.  So far I've had no joy looking at official methods of distributing rustup in other channels such as flatpak.