### PR TITLE
Add padding to left and right of install command

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -115,8 +115,8 @@ hr {
     color: white;
     margin-left: auto;
     margin-right: auto;
-    padding-top: 1rem;
-    padding-bottom: 1rem;
+    padding: 1rem;
+    width: 32rem;
     text-align: center;
     border-radius: 3px;
     box-shadow: inset 0px 0px 20px 0px #333333;


### PR DESCRIPTION
Since the install command is longer now (#1716), it hits the edge of the box it's in, which looks ugly. This commit adds 1rem of padding to the left and right of the text, which is the same as the padding above and below.

Before:

![image](https://user-images.githubusercontent.com/9433472/59770954-c5a72900-92a0-11e9-8235-54002fddf577.png)

After:

![image](https://user-images.githubusercontent.com/9433472/59770976-ce97fa80-92a0-11e9-9c61-0fc288da0527.png)