### PR TITLE
Switch to std::fs::read_to_string

### DIFF
--- a/download/tests/download-curl-resume.rs
+++ b/download/tests/download-curl-resume.rs
@@ -8,7 +8,7 @@ use url::Url;
 use download::*;
 
 mod support;
-use crate::support::{file_contents, serve_file, tmp_dir, write_file};
+use crate::support::{serve_file, tmp_dir, write_file};
 
 #[test]
 fn partially_downloaded_file_gets_resumed_from_byte_offset() {
@@ -23,7 +23,7 @@ fn partially_downloaded_file_gets_resumed_from_byte_offset() {
     download_to_path_with_backend(Backend::Curl, &from_url, &target_path, true, None)
         .expect("Test download failed");
 
-    assert_eq!(file_contents(&target_path), "12345");
+    assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }
 
 #[test]
@@ -72,5 +72,5 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
     assert_eq!(*callback_len.lock().unwrap(), Some(5));
     let observed_bytes = received_in_callback.into_inner().unwrap();
     assert_eq!(observed_bytes, vec![b'1', b'2', b'3', b'4', b'5']);
-    assert_eq!(file_contents(&target_path), "12345");
+    assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }

--- a/download/tests/download-reqwest-resume.rs
+++ b/download/tests/download-reqwest-resume.rs
@@ -8,7 +8,7 @@ use url::Url;
 use download::*;
 
 mod support;
-use crate::support::{file_contents, serve_file, tmp_dir, write_file};
+use crate::support::{serve_file, tmp_dir, write_file};
 
 #[test]
 fn resume_partial_from_file_url() {
@@ -23,7 +23,7 @@ fn resume_partial_from_file_url() {
     download_to_path_with_backend(Backend::Reqwest, &from_url, &target_path, true, None)
         .expect("Test download failed");
 
-    assert_eq!(file_contents(&target_path), "12345");
+    assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }
 
 #[test]
@@ -72,5 +72,5 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
     assert_eq!(*callback_len.lock().unwrap(), Some(5));
     let observed_bytes = received_in_callback.into_inner().unwrap();
     assert_eq!(observed_bytes, vec![b'1', b'2', b'3', b'4', b'5']);
-    assert_eq!(file_contents(&target_path), "12345");
+    assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }

--- a/download/tests/support/mod.rs
+++ b/download/tests/support/mod.rs
@@ -1,5 +1,5 @@
-use std::fs::{self, File};
-use std::io::{self, Read};
+use std::fs;
+use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
 
@@ -8,15 +8,6 @@ use tempdir::TempDir;
 
 pub fn tmp_dir() -> TempDir {
     TempDir::new("rustup-download-test-").expect("creating tempdir for test")
-}
-
-pub fn file_contents(path: &Path) -> String {
-    let mut result = String::new();
-    File::open(&path)
-        .unwrap()
-        .read_to_string(&mut result)
-        .expect("reading test result file");
-    result
 }
 
 pub fn write_file(path: &Path, contents: &str) {

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -64,16 +64,6 @@ pub fn write_file(path: &Path, contents: &str) -> io::Result<()> {
     Ok(())
 }
 
-pub fn read_file(path: &Path) -> io::Result<String> {
-    let mut file = fs::OpenOptions::new().read(true).open(path)?;
-
-    let mut contents = String::new();
-
-    io::Read::read_to_string(&mut file, &mut contents)?;
-
-    Ok(contents)
-}
-
 pub fn filter_file<F: FnMut(&str) -> bool>(
     src: &Path,
     dest: &Path,

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -41,7 +41,7 @@ where
 }
 
 pub fn read_file(name: &'static str, path: &Path) -> Result<String> {
-    raw::read_file(path).chain_err(|| ErrorKind::ReadingFile {
+    fs::read_to_string(path).chain_err(|| ErrorKind::ReadingFile {
         name,
         path: PathBuf::from(path),
     })

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -313,7 +313,7 @@ fn install_adds_path_to_rc(rcfile: &str) {
         raw::write_file(&rc, my_rc).unwrap();
         expect_ok(config, &["rustup-init", "-y"]);
 
-        let new_rc = raw::read_file(&rc).unwrap();
+        let new_rc = fs::read_to_string(&rc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#, config.cargodir.display());
         let expected = format!("{}\n{}\n", my_rc, addition);
         assert_eq!(new_rc, expected);
@@ -355,7 +355,7 @@ fn install_with_zsh_adds_path_to_zprofile() {
         cmd.env("SHELL", "zsh");
         assert!(cmd.output().unwrap().status.success());
 
-        let new_rc = raw::read_file(&rc).unwrap();
+        let new_rc = fs::read_to_string(&rc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#, config.cargodir.display());
         let expected = format!("{}\n{}\n", my_rc, addition);
         assert_eq!(new_rc, expected);
@@ -376,7 +376,7 @@ fn install_with_zsh_adds_path_to_zdotdir_zprofile() {
         cmd.env("ZDOTDIR", zdotdir.path());
         assert!(cmd.output().unwrap().status.success());
 
-        let new_rc = raw::read_file(&rc).unwrap();
+        let new_rc = fs::read_to_string(&rc).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#, config.cargodir.display());
         let expected = format!("{}\n{}\n", my_rc, addition);
         assert_eq!(new_rc, expected);
@@ -393,7 +393,7 @@ fn install_adds_path_to_rcfile_just_once() {
         expect_ok(config, &["rustup-init", "-y"]);
         expect_ok(config, &["rustup-init", "-y"]);
 
-        let new_profile = raw::read_file(&profile).unwrap();
+        let new_profile = fs::read_to_string(&profile).unwrap();
         let addition = format!(r#"export PATH="{}/bin:$PATH""#, config.cargodir.display());
         let expected = format!("{}\n{}\n", my_profile, addition);
         assert_eq!(new_profile, expected);
@@ -409,7 +409,7 @@ fn uninstall_removes_path_from_rc(rcfile: &str) {
         expect_ok(config, &["rustup-init", "-y"]);
         expect_ok(config, &["rustup", "self", "uninstall", "-y"]);
 
-        let new_rc = raw::read_file(&rc).unwrap();
+        let new_rc = fs::read_to_string(&rc).unwrap();
         assert_eq!(new_rc, my_rc);
     });
 }
@@ -437,7 +437,7 @@ fn uninstall_doesnt_touch_rc_files_that_dont_contain_cargo_home() {
         let profile = config.homedir.join(".profile");
         raw::write_file(&profile, my_rc).unwrap();
 
-        let profile = raw::read_file(&profile).unwrap();
+        let profile = fs::read_to_string(&profile).unwrap();
 
         assert_eq!(profile, my_rc);
     });
@@ -460,7 +460,7 @@ fn when_cargo_home_is_the_default_write_path_specially() {
         cmd.env_remove("CARGO_HOME");
         assert!(cmd.output().unwrap().status.success());
 
-        let new_profile = raw::read_file(&profile).unwrap();
+        let new_profile = fs::read_to_string(&profile).unwrap();
         let expected = format!("{}\nexport PATH=\"$HOME/.cargo/bin:$PATH\"\n", my_profile);
         assert_eq!(new_profile, expected);
 
@@ -468,7 +468,7 @@ fn when_cargo_home_is_the_default_write_path_specially() {
         cmd.env_remove("CARGO_HOME");
         assert!(cmd.output().unwrap().status.success());
 
-        let new_profile = raw::read_file(&profile).unwrap();
+        let new_profile = fs::read_to_string(&profile).unwrap();
         assert_eq!(new_profile, my_profile);
     });
 }
@@ -891,7 +891,7 @@ fn produces_env_file_on_unix() {
         cmd.env_remove("CARGO_HOME");
         assert!(cmd.output().unwrap().status.success());
         let envfile = config.homedir.join(".cargo/env");
-        let envfile = raw::read_file(&envfile).unwrap();
+        let envfile = fs::read_to_string(&envfile).unwrap();
         assert!(envfile.contains(r#"export PATH="$HOME/.cargo/bin:$PATH""#));
     });
 }

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -163,7 +163,7 @@ fn remove_override_toolchain_err_handling() {
 fn bad_sha_on_manifest() {
     setup(&|config| {
         let sha_file = config.distdir.join("dist/channel-rust-nightly.sha256");
-        let sha_str = rustup::utils::raw::read_file(&sha_file).unwrap();
+        let sha_str = fs::read_to_string(&sha_file).unwrap();
         let mut sha_bytes = sha_str.into_bytes();
         sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
         let sha_str = String::from_utf8(sha_bytes).unwrap();

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -235,7 +235,7 @@ fn bad_sha_on_manifest() {
     setup(&|config| {
         // Corrupt the sha
         let sha_file = config.distdir.join("dist/channel-rust-nightly.toml.sha256");
-        let sha_str = rustup::utils::raw::read_file(&sha_file).unwrap();
+        let sha_str = fs::read_to_string(&sha_file).unwrap();
         let mut sha_bytes = sha_str.into_bytes();
         sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
         let sha_str = String::from_utf8(sha_bytes).unwrap();
@@ -914,7 +914,7 @@ fn make_component_unavailable(config: &Config, name: &str, target: &TargetTriple
     use rustup::dist::manifest::Manifest;
 
     let manifest_path = config.distdir.join("dist/channel-rust-nightly.toml");
-    let manifest_str = rustup::utils::raw::read_file(&manifest_path).unwrap();
+    let manifest_str = fs::read_to_string(&manifest_path).unwrap();
     let mut manifest = Manifest::parse(&manifest_str).unwrap();
     {
         let std_pkg = manifest.packages.get_mut(name).unwrap();

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -543,13 +543,13 @@ fn upgrade() {
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
         assert_eq!(
             "2016-02-01",
-            utils_raw::read_file(&prefix.path().join("bin/rustc")).unwrap()
+            fs::read_to_string(&prefix.path().join("bin/rustc")).unwrap()
         );
         change_channel_date(url, "nightly", "2016-02-02");
         update_from_dist(url, toolchain, prefix, &[], &[], download_cfg, temp_cfg).unwrap();
         assert_eq!(
             "2016-02-02",
-            utils_raw::read_file(&prefix.path().join("bin/rustc")).unwrap()
+            fs::read_to_string(&prefix.path().join("bin/rustc")).unwrap()
         );
     });
 }

--- a/tests/dist_transactions.rs
+++ b/tests/dist_transactions.rs
@@ -34,7 +34,7 @@ fn add_file() {
     drop(file);
 
     assert_eq!(
-        utils_raw::read_file(&prefix.path().join("foo/bar")).unwrap(),
+        fs::read_to_string(&prefix.path().join("foo/bar")).unwrap(),
         "test"
     );
 }
@@ -460,7 +460,7 @@ fn write_file() {
 
     let path = prefix.path().join("foo/bar");
     assert!(utils::is_file(&path));
-    let file_content = utils_raw::read_file(&path).unwrap();
+    let file_content = fs::read_to_string(&path).unwrap();
     assert_eq!(content, file_content);
 }
 
@@ -566,7 +566,7 @@ fn modify_file_that_exists() {
     tx.modify_file(PathBuf::from("foo")).unwrap();
     tx.commit();
 
-    assert_eq!(utils_raw::read_file(&path).unwrap(), "wow");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "wow");
 }
 
 #[test]
@@ -613,7 +613,7 @@ fn modify_file_that_exists_then_rollback() {
     utils_raw::write_file(&path, "eww").unwrap();
     drop(tx);
 
-    assert_eq!(utils_raw::read_file(&path).unwrap(), "wow");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "wow");
 }
 
 // This is testing that the backup scheme is smart enough not
@@ -642,7 +642,7 @@ fn modify_twice_then_rollback() {
     utils_raw::write_file(&path, "ewww").unwrap();
     drop(tx);
 
-    assert_eq!(utils_raw::read_file(&path).unwrap(), "wow");
+    assert_eq!(fs::read_to_string(&path).unwrap(), "wow");
 }
 
 fn do_multiple_op_transaction(rollback: bool) {

--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -1,7 +1,7 @@
 use std::env::consts::EXE_SUFFIX;
 use std::env;
 use std::fs::File;
-use std::io::{self, Write, Read};
+use std::io::{self, Write};
 use std::path::{PathBuf, Path};
 use std::process::Command;
 
@@ -12,8 +12,6 @@ fn main() {
             let me = env::current_exe().unwrap();
             let mut version_file = PathBuf::from(format!("{}.version", me.display()));
             let mut hash_file = PathBuf::from(format!("{}.version-hash", me.display()));
-            let mut version = String::new();
-            let mut hash = String::new();
             if !version_file.exists() {
                 // There's a "MAJOR HACKS" statement in `toolchain.rs` right
                 // now where custom toolchains use a `cargo.exe` that's
@@ -42,8 +40,8 @@ fn main() {
                 version_file = format!("{}.version", path.display()).into();
                 hash_file = format!("{}.version-hash", path.display()).into();
             }
-            File::open(&version_file).unwrap().read_to_string(&mut version).unwrap();
-            File::open(&hash_file).unwrap().read_to_string(&mut hash).unwrap();
+            let version = std::fs::read_to_string(&version_file).unwrap();
+            let hash = std::fs::read_to_string(&hash_file).unwrap();
             println!("{} ({})", version, hash);
         }
         Some("--empty-arg-test") => {


### PR DESCRIPTION
According to [the doc][1]:  it is generally faster than reading into a string created with `String::new()`.

[1]: https://doc.rust-lang.org/nightly/std/fs/fn.read_to_string.html