### PR TITLE
Copy Rustup binary into test environments

### DIFF
--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -1,6 +1,5 @@
 use std::env::consts::EXE_SUFFIX;
 use std::env;
-use std::fs::File;
 use std::io::{self, Write};
 use std::path::{PathBuf, Path};
 use std::process::Command;
@@ -79,6 +78,7 @@ fn equivalent(a: &Path, b: &Path) -> bool {
     use std::mem;
     use std::os::windows::prelude::*;
     use std::os::windows::raw::HANDLE;
+    use std::fs::File;
 
     extern "system" {
         fn GetFileInformationByHandle(a: HANDLE, b: *mut BY_HANDLE_FILE_INFORMATION)


### PR DESCRIPTION
In order to better run on NTFS and friends, this copies the rustup binary into place in the test environment rather than hard-linking it.  We (ab)use an RwLock to achieve this safely since otherwise forked but not-yet execd children of other tests might be holding a FD open resulting in Text-File-Busy type situations.