### PR TITLE
Make error message more specific when the shell profile cannot be updated.

### DIFF
--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -57,5 +57,11 @@ error_chain! {
             )
             display("`rustup target add {}` includes `all`", t.join(" "))
         }
+        WritingShellProfile {
+            path: PathBuf,
+        } {
+            description("could not amend shell profile")
+            display("could not amend shell profile: '{}'", path.display())
+        }
     }
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1107,7 +1107,9 @@ fn do_add_to_path(methods: &[PathUpdateMethod]) -> Result<()> {
             };
             let addition = format!("\n{}", shell_export_string()?);
             if !file.contains(&addition) {
-                utils::append_file("rcfile", rcpath, &addition)?;
+                utils::append_file("rcfile", rcpath, &addition).chain_err(|| ErrorKind::WritingShellProfile {
+                    path: rcpath.to_path_buf(),
+                })?;
             }
         } else {
             unreachable!()

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1107,8 +1107,10 @@ fn do_add_to_path(methods: &[PathUpdateMethod]) -> Result<()> {
             };
             let addition = format!("\n{}", shell_export_string()?);
             if !file.contains(&addition) {
-                utils::append_file("rcfile", rcpath, &addition).chain_err(|| ErrorKind::WritingShellProfile {
-                    path: rcpath.to_path_buf(),
+                utils::append_file("rcfile", rcpath, &addition).chain_err(|| {
+                    ErrorKind::WritingShellProfile {
+                        path: rcpath.to_path_buf(),
+                    }
                 })?;
             }
         } else {

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -345,6 +345,24 @@ fn install_does_not_add_path_to_bash_profile_that_doesnt_exist() {
 
 #[test]
 #[cfg(unix)]
+fn install_errors_when_rc_file_cannot_be_updated() {
+    setup(&|config| {
+        let rc = config.homedir.join(".bash_profile");
+        fs::File::create(&rc).unwrap();
+        let mut perms = fs::metadata(&rc).unwrap().permissions();
+        perms.set_readonly(true);
+        fs::set_permissions(&rc, perms).unwrap();
+
+        expect_err(
+            config,
+            &["rustup-init", "-y"],
+            "amend shell",
+        );
+    });
+}
+
+#[test]
+#[cfg(unix)]
 fn install_with_zsh_adds_path_to_zprofile() {
     setup(&|config| {
         let my_rc = "foo\nbar\nbaz";

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -353,11 +353,7 @@ fn install_errors_when_rc_file_cannot_be_updated() {
         perms.set_readonly(true);
         fs::set_permissions(&rc, perms).unwrap();
 
-        expect_err(
-            config,
-            &["rustup-init", "-y"],
-            "amend shell",
-        );
+        expect_err(config, &["rustup-init", "-y"], "amend shell");
     });
 }
 


### PR DESCRIPTION
This is intended to close #292.

I went with the `error_chain` approach @kinnison suggested (thank you, by the way!), but am certainly open to changing that, as well as anything else (e.g. should tests be added for the other supported rc files?).