### PR TITLE
 build: Use rustc docker for android targets 

### DIFF
--- a/ci/docker/android/Dockerfile
+++ b/ci/docker/android/Dockerfile
@@ -1,52 +1,61 @@
+# Based on https://github.com/rust-lang/rust/blob/master/src/ci/docker/dist-android/Dockerfile
 FROM ubuntu:18.04
 USER root
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates \
-    cmake \
-    curl \
-    gcc \
-    libc6-dev \
-    make \
-    pkg-config
-
 COPY ci/docker/scripts/sccache.bash /scripts/
-RUN bash /scripts/sccache.bash
 
-RUN apt-get install -y --no-install-recommends \
-    unzip \
-    python && \
-    curl -O https://dl.google.com/android/repository/android-ndk-r13b-linux-x86_64.zip && \
-    unzip -q android-ndk-r13b-linux-x86_64.zip && \
-    ./android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+RUN apt-get update -qq && \
+    apt-get install -qq --no-install-recommends \
+        ca-certificates \
+        cmake \
+        curl \
+        g++ \
+        libc6-dev \
+        make \
+        pkg-config \
+        python2.7 \
+        unzip \
+        xz-utils && \
+    bash /scripts/sccache.bash && \
+    ANDROID_EMU_URL=https://dl.google.com/android/repository && \
+    ANDROID_NDK_FILE=android-ndk-r15c-linux-x86_64.zip && \
+    curl -fO "${ANDROID_EMU_URL}/${ANDROID_NDK_FILE}" && \
+    unzip -q "./${ANDROID_NDK_FILE}" && \
+    rm "${ANDROID_NDK_FILE}" && \
+    mv android-ndk-* ndk && \
+    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
         --install-dir /android-ndk/arm \
         --arch arm \
         --api 21 && \
-    ./android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
         --install-dir /android-ndk/arm64 \
         --arch arm64 \
         --api 21 && \
-    ./android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
         --install-dir /android-ndk/x86 \
         --arch x86 \
         --api 21 && \
-    ./android-ndk-r13b/build/tools/make_standalone_toolchain.py \
+    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
         --install-dir /android-ndk/x86_64 \
         --arch x86_64 \
         --api 21 && \
-    rm -rf ./android-ndk-r13b-linux-x86_64.zip ./android-ndk-r13b && \
-    apt-get purge --auto-remove -y unzip python
+    rm -rf ./ndk
 
-ENV PATH=$PATH:/android-ndk/arm/bin
-ENV PATH=$PATH:/android-ndk/arm64/bin
-ENV PATH=$PATH:/android-ndk/x86/bin
-ENV PATH=$PATH:/android-ndk/x86_64/bin
-
-ENV CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc
-ENV CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-gcc
-ENV CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-gcc
-ENV CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-gcc
-ENV CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-gcc
+ENV PATH=$PATH:/android-ndk/arm/bin:/android-ndk/arm64/bin:/android-ndk/x86/bin:/android-ndk/x86_64/bin \
+    CC_arm_linux_androideabi=arm-linux-androideabi-clang \
+    CC_armv7_linux_androideabi=arm-linux-androideabi-clang \
+    CC_aarch64_linux_android=aarch64-linux-android-clang \
+    CC_i686_linux_android=i686-linux-android-clang \
+    CC_x86_64_linux_android=x86_64-linux-android-clang \
+    CXX_arm_linux_androideabi=arm-linux-androideabi-clang++ \
+    CXX_armv7_linux_androideabi=arm-linux-androideabi-clang++ \
+    CXX_aarch64_linux_android=aarch64-linux-android-clang++ \
+    CXX_i686_linux_android=i686-linux-android-clang++ \
+    CXX_x86_64_linux_android=x86_64-linux-android-clang++ \
+    CARGO_TARGET_ARM_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-clang \
+    CARGO_TARGET_ARMV7_LINUX_ANDROIDEABI_LINKER=arm-linux-androideabi-clang \
+    CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-clang \
+    CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-clang \
+    CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-clang
 
 WORKDIR /buildslave

--- a/ci/docker/android/Dockerfile
+++ b/ci/docker/android/Dockerfile
@@ -1,47 +1,6 @@
-# Based on https://github.com/rust-lang/rust/blob/master/src/ci/docker/dist-android/Dockerfile
-FROM ubuntu:18.04
-USER root
+FROM rust-android
 
-COPY ci/docker/scripts/sccache.bash /scripts/
-
-RUN apt-get update -qq && \
-    apt-get install -qq --no-install-recommends \
-        ca-certificates \
-        cmake \
-        curl \
-        g++ \
-        libc6-dev \
-        make \
-        pkg-config \
-        python2.7 \
-        unzip \
-        xz-utils && \
-    bash /scripts/sccache.bash && \
-    ANDROID_EMU_URL=https://dl.google.com/android/repository && \
-    ANDROID_NDK_FILE=android-ndk-r15c-linux-x86_64.zip && \
-    curl -fO "${ANDROID_EMU_URL}/${ANDROID_NDK_FILE}" && \
-    unzip -q "./${ANDROID_NDK_FILE}" && \
-    rm "${ANDROID_NDK_FILE}" && \
-    mv android-ndk-* ndk && \
-    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
-        --install-dir /android-ndk/arm \
-        --arch arm \
-        --api 21 && \
-    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
-        --install-dir /android-ndk/arm64 \
-        --arch arm64 \
-        --api 21 && \
-    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
-        --install-dir /android-ndk/x86 \
-        --arch x86 \
-        --api 21 && \
-    python2.7 ./ndk/build/tools/make_standalone_toolchain.py \
-        --install-dir /android-ndk/x86_64 \
-        --arch x86_64 \
-        --api 21 && \
-    rm -rf ./ndk
-
-ENV PATH=$PATH:/android-ndk/arm/bin:/android-ndk/arm64/bin:/android-ndk/x86/bin:/android-ndk/x86_64/bin \
+ENV PATH=$PATH:/android/ndk/arm-14/bin:/android/ndk/arm64-21/bin:/android/ndk/x86-14/bin:/android/ndk/x86_64-21/bin \
     CC_arm_linux_androideabi=arm-linux-androideabi-clang \
     CC_armv7_linux_androideabi=arm-linux-androideabi-clang \
     CC_aarch64_linux_android=aarch64-linux-android-clang \
@@ -57,5 +16,3 @@ ENV PATH=$PATH:/android-ndk/arm/bin:/android-ndk/arm64/bin:/android-ndk/x86/bin:
     CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=aarch64-linux-android-clang \
     CARGO_TARGET_I686_LINUX_ANDROID_LINKER=i686-linux-android-clang \
     CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=x86_64-linux-android-clang
-
-WORKDIR /buildslave

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -12,6 +12,11 @@ if [ "$TRAVIS_OS_NAME" != "windows" ]; then
   FEATURES=('--features' 'vendored-openssl')
 fi
 
+# rustc only supports armv7: https://forge.rust-lang.org/platform-support.html
+if [ "$TARGET" = arm-linux-androideabi ]; then
+  export CFLAGS='-march=armv7'
+fi
+
 cargo build --locked -v --release --target "$TARGET" "${FEATURES[@]}"
 
 runtest () {


### PR DESCRIPTION
There are two commits here. The first commit doesn't use rustc docker images but handwritten
one. The second one replaces it with rustc docker images. The rationale for the first commit
is to revert to it when we need in the future.

The first commit when I measure have a longer build time than second one. Probably due to
the installation time of android ndk.