### PR TITLE
Do not list unavailable targets

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,4 +1,5 @@
 use crate::config::Cfg;
+use crate::dist::dist::TargetTriple;
 use crate::dist::dist::ToolchainDesc;
 use crate::dist::download::DownloadCfg;
 use crate::dist::manifest::Component;
@@ -529,6 +530,8 @@ impl<'a> Toolchain<'a> {
                     .map(|c| c.components.contains(extension))
                     .unwrap_or(false);
 
+                let extension_target = TargetTriple::new(&extension.target());
+
                 // Get the component so we can check if it is available
                 let extension_pkg = manifest
                     .get_package(&extension.short_name_in_manifest())
@@ -540,8 +543,8 @@ impl<'a> Toolchain<'a> {
                     });
                 let extension_target_pkg = extension_pkg
                     .targets
-                    .get(&toolchain.target)
-                    .expect("extension should have target toolchain");
+                    .get(&extension_target)
+                    .expect("extension should have listed toolchain");
 
                 res.push(ComponentStatus {
                     component: extension.clone(),

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1083,3 +1083,19 @@ fn remove_target_suggest_best_match() {
         );
     });
 }
+
+#[test]
+fn target_list_ignores_unavailable_targets() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        let target_list = &["rustup", "target", "list"];
+        expect_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
+        let trip = TargetTriple::new(clitools::CROSS_ARCH1);
+        make_component_unavailable(config, "rust-std", &trip);
+        expect_ok(
+            config,
+            &["rustup", "update", "nightly", "--force", "--no-self-update"],
+        );
+        expect_not_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
+    })
+}


### PR DESCRIPTION
We were mistakenly listing targets as available when they were not, resulting in confusion when running `rustup target add all`.

This change ensures that we do not do that, by ensuring we use extension targets rather than the toolchain's target, when checking availability.  We do not do this for components too at this time, since components are almost always the same arch as the rustc itself.
