### PR TITLE
Display RUSTUP_HOME in `rustup show` and `rustup show home`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -43,6 +43,7 @@ pub fn main() -> Result<()> {
         ("dump-testament", _) => common::dump_testament(),
         ("show", Some(c)) => match c.subcommand() {
             ("active-toolchain", Some(_)) => handle_epipe(show_active_toolchain(cfg))?,
+            ("home", Some(_)) => handle_epipe(show_rustup_home(cfg))?,
             (_, _) => handle_epipe(show(cfg))?,
         },
         ("install", Some(m)) => update(cfg, m)?,
@@ -132,7 +133,11 @@ pub fn cli() -> App<'static, 'static> {
                     SubCommand::with_name("active-toolchain")
                         .about("Show the active toolchain")
                         .after_help(SHOW_ACTIVE_TOOLCHAIN_HELP),
-                ),
+                )
+                .subcommand(
+                    SubCommand::with_name("home")
+                        .about("Display the computed value of RUSTUP_HOME"),
+                )
         )
         .subcommand(
             SubCommand::with_name("install")
@@ -720,6 +725,15 @@ fn show(cfg: &Cfg) -> Result<()> {
         write!(t, "Default host: ")?;
         t.reset()?;
         writeln!(t, "{}", cfg.get_default_host_triple()?)?;
+    }
+
+    // Print rustup home directory
+    {
+        let mut t = term2::stdout();
+        t.attr(term2::Attr::Bold)?;
+        write!(t, "rustup home:  ")?;
+        t.reset()?;
+        writeln!(t, "{}", cfg.rustup_dir.display())?;
         writeln!(t)?;
     }
 
@@ -856,6 +870,11 @@ fn show_active_toolchain(cfg: &Cfg) -> Result<()> {
             println!("{} (default)", toolchain.name());
         }
     }
+    Ok(())
+}
+
+fn show_rustup_home(cfg: &Cfg) -> Result<()> {
+    println!("{}", cfg.rustup_dir.display());
     Ok(())
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -523,7 +523,7 @@ fn show_home() {
             &["rustup", "show", "home"],
             &format!(
                 r"{}
-", 
+",
                 config.rustupdir.display()
             ),
             r"",
@@ -537,7 +537,8 @@ fn show_toolchain_none() {
         expect_ok_ex(
             config,
             &["rustup", "show"],
-            &for_host_and_home!(config,
+            &for_host_and_home!(
+                config,
                 r"Default host: {0}
 rustup home:  {1}
 
@@ -556,7 +557,8 @@ fn show_toolchain_default() {
         expect_ok_ex(
             config,
             &["rustup", "show"],
-            for_host_and_home!(config,
+            for_host_and_home!(
+                config,
                 r"Default host: {0}
 rustup home:  {1}
 
@@ -577,7 +579,8 @@ fn show_multiple_toolchains() {
         expect_ok_ex(
             config,
             &["rustup", "show"],
-            for_host_and_home!(config,
+            for_host_and_home!(
+                config,
                 r"Default host: {0}
 rustup home:  {1}
 
@@ -923,7 +926,8 @@ fn show_toolchain_env() {
         let stdout = String::from_utf8(out.stdout).unwrap();
         assert_eq!(
             &stdout,
-            for_host_and_home!(config,
+            for_host_and_home!(
+                config,
                 r"Default host: {0}
 rustup home:  {1}
 


### PR DESCRIPTION
This PR patches `rustup show` to also display the RUSTUP_HOME path:
```
$ rustup show
Default host: x86_64-unknown-linux-gnu
rustup home:  /home/fisher/.rustup
```
It also adds a new subcommand, `rustup show home` that directly prints the path:
```
$ rustup show home
/home/fisher/.rustup
```

This closes #1627.