### PR TITLE
feat: --quiet option

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -20,6 +20,7 @@ USAGE:
 
 FLAGS:
     -v, --verbose           Enable verbose output
+    -q, --quiet             Disable progress output
     -y                      Disable confirmation prompt.
         --no-modify-path    Don't configure the PATH environment variable
     -h, --help              Prints help information

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -104,11 +104,11 @@ pub fn read_line() -> Result<String> {
         .ok_or_else(|| "unable to read from stdin for confirmation".into())
 }
 
-pub fn set_globals(verbose: bool) -> Result<Cfg> {
+pub fn set_globals(verbose: bool, quiet: bool) -> Result<Cfg> {
     use crate::download_tracker::DownloadTracker;
     use std::cell::RefCell;
 
-    let download_tracker = RefCell::new(DownloadTracker::new());
+    let download_tracker = RefCell::new(DownloadTracker::new().with_display_progress(!quiet));
 
     Ok(Cfg::from_env(Arc::new(move |n: Notification<'_>| {
         if download_tracker.borrow_mut().handle_notification(&n) {

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -44,6 +44,8 @@ pub struct DownloadTracker {
     displayed_charcount: Option<usize>,
     /// What units to show progress in
     units: Vec<String>,
+    /// Whether we display progress
+    display_progress: bool,
 }
 
 impl DownloadTracker {
@@ -59,7 +61,13 @@ impl DownloadTracker {
             term: term2::stdout(),
             displayed_charcount: None,
             units: vec!["B".into(); 1],
+            display_progress: true,
         }
+    }
+
+    pub fn with_display_progress(mut self, display_progress: bool) -> DownloadTracker {
+        self.display_progress = display_progress;
+        self
     }
 
     pub fn handle_notification(&mut self, n: &Notification<'_>) -> bool {
@@ -109,7 +117,9 @@ impl DownloadTracker {
             Some(prev) => {
                 let elapsed = current_time - prev;
                 if elapsed >= 1.0 {
-                    self.display();
+                    if self.display_progress {
+                        self.display();
+                    }
                     self.last_sec = Some(current_time);
                     if self.downloaded_last_few_secs.len() == DOWNLOAD_TRACK_COUNT {
                         self.downloaded_last_few_secs.pop_back();

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -39,7 +39,7 @@ pub fn main() -> Result<()> {
             env::args_os().skip(2).collect()
         };
 
-        let cfg = set_globals(false)?;
+        let cfg = set_globals(false, true)?;
         cfg.check_metadata_version()?;
         direct_proxy(&cfg, &arg0, toolchain, &cmd_args)?
     };

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -124,6 +124,7 @@ pub fn cli() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("quiet")
+                .conflicts_with("verbose")
                 .help("Disable progress output")
                 .short("q")
                 .long("quiet"),

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -31,7 +31,8 @@ pub fn main() -> Result<()> {
 
     let matches = cli().get_matches();
     let verbose = matches.is_present("verbose");
-    let cfg = &common::set_globals(verbose)?;
+    let quiet = matches.is_present("quiet");
+    let cfg = &common::set_globals(verbose, quiet)?;
 
     if maybe_upgrade_data(cfg, &matches)? {
         return Ok(());
@@ -120,6 +121,12 @@ pub fn cli() -> App<'static, 'static> {
                 .help("Enable verbose output")
                 .short("v")
                 .long("verbose"),
+        )
+        .arg(
+            Arg::with_name("quiet")
+                .help("Disable progress output")
+                .short("q")
+                .long("quiet"),
         )
         .subcommand(
             SubCommand::with_name("dump-testament")

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -232,7 +232,7 @@ fn canonical_cargo_home() -> Result<String> {
 /// Installing is a simple matter of copying the running binary to
 /// `CARGO_HOME`/bin, hard-linking the various Rust tools to it,
 /// and adding `CARGO_HOME`/bin to PATH.
-pub fn install(no_prompt: bool, verbose: bool, mut opts: InstallOpts) -> Result<()> {
+pub fn install(no_prompt: bool, verbose: bool, quiet: bool, mut opts: InstallOpts) -> Result<()> {
     do_pre_install_sanity_checks()?;
     do_pre_install_options_sanity_checks(&opts)?;
     check_existence_of_rustc_or_cargo_in_path(no_prompt)?;
@@ -284,6 +284,7 @@ pub fn install(no_prompt: bool, verbose: bool, mut opts: InstallOpts) -> Result<
             &opts.profile,
             &opts.default_host_triple,
             verbose,
+            quiet,
         )?;
 
         if cfg!(unix) {
@@ -737,8 +738,9 @@ fn maybe_install_rust(
     profile_str: &str,
     default_host_triple: &str,
     verbose: bool,
+    quiet: bool,
 ) -> Result<()> {
-    let cfg = common::set_globals(verbose)?;
+    let cfg = common::set_globals(verbose, quiet)?;
     cfg.set_profile(profile_str)?;
 
     // If there is already an install, then `toolchain_str` may not be

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -32,6 +32,12 @@ pub fn main() -> Result<()> {
                 .help("Enable verbose output"),
         )
         .arg(
+            Arg::with_name("quiet")
+                .short("q")
+                .long("quiet")
+                .help("Disable progress output"),
+        )
+        .arg(
             Arg::with_name("no-prompt")
                 .short("y")
                 .help("Disable confirmation prompt."),
@@ -63,6 +69,7 @@ pub fn main() -> Result<()> {
     let matches = cli.get_matches();
     let no_prompt = matches.is_present("no-prompt");
     let verbose = matches.is_present("verbose");
+    let quiet = matches.is_present("quiet");
     let default_host = matches
         .value_of("default-host")
         .map(std::borrow::ToOwned::to_owned)
@@ -80,7 +87,7 @@ pub fn main() -> Result<()> {
         no_modify_path,
     };
 
-    self_update::install(no_prompt, verbose, opts)?;
+    self_update::install(no_prompt, verbose, quiet, opts)?;
 
     Ok(())
 }

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -33,6 +33,7 @@ pub fn main() -> Result<()> {
         )
         .arg(
             Arg::with_name("quiet")
+                .conflicts_with("verbose")
                 .short("q")
                 .long("quiet")
                 .help("Disable progress output"),

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -66,6 +66,45 @@ info: installing component 'rust-docs'
 }
 
 #[test]
+fn rustup_stable_quiet() {
+    setup(&|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(
+            config,
+            &["rustup", "--quiet", "update", "stable", "--no-self-update"],
+        );
+        set_current_dist_date(config, "2015-01-02");
+        expect_ok_ex(
+            config,
+            &["rustup", "--quiet", "update", "--no-self-update"],
+            for_host!(
+                r"
+  stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+
+"
+            ),
+            for_host!(
+                r"info: syncing channel updates for 'stable-{0}'
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
+info: downloading component 'rustc'
+info: downloading component 'cargo'
+info: downloading component 'rust-std'
+info: downloading component 'rust-docs'
+info: removing previous version of component 'rustc'
+info: removing previous version of component 'cargo'
+info: removing previous version of component 'rust-std'
+info: removing previous version of component 'rust-docs'
+info: installing component 'rustc'
+info: installing component 'cargo'
+info: installing component 'rust-std'
+info: installing component 'rust-docs'
+"
+            ),
+        );
+    });
+}
+
+#[test]
 fn rustup_stable_no_change() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
@@ -1067,6 +1106,28 @@ fn toolchain_install_is_like_update() {
             config,
             &[
                 "rustup",
+                "toolchain",
+                "install",
+                "nightly",
+                "--no-self-update",
+            ],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "run", "nightly", "rustc", "--version"],
+            "hash-nightly-2",
+        );
+    });
+}
+
+#[test]
+fn toolchain_install_is_like_update_quiet() {
+    setup(&|config| {
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "--quiet",
                 "toolchain",
                 "install",
                 "nightly",


### PR DESCRIPTION
# PR Content

issue: #1928 

add `--quiet` option. it disables progress console output.

## TODO

- [x] write unit test for this new option.
- [x] verify default behavior in `proxy_mode.rs` is the right one.