### PR TITLE
Add rust-gdbgui to the list of proxied tools

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub static TOOLS: &[&str] = &[
     "cargo",
     "rust-lldb",
     "rust-gdb",
+    "rust-gdbgui",
     "rls",
     "cargo-clippy",
     "clippy-driver",


### PR DESCRIPTION
Currently, a link for `rust-gdbgui` in Cargo's bin directory isn't created by `rustup`. This adds `rust-gdbgui` to the list of tools that are proxied by `rustup` so that a link is created and we can run `rust-gdbgui` directly.

Please let me know if the tests in [tests/cli-self-upd.rs](https://github.com/rust-lang/rustup.rs/blob/master/tests/cli-self-upd.rs) should be updated to include `rust-gdbgui` as well. I am guessing wherever a test involves `rust-gdb`, it should also involve `rust-gdbgui` in a similar way?