### PR TITLE
Update inline help text for `rustup completions`

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -155,13 +155,12 @@ pub static DOC_HELP: &str = r"DISCUSSION:
 
 pub static COMPLETIONS_HELP: &str =
 r"DISCUSSION:
-    One can generate a completion script for `rustup` that is
-    compatible with a given shell. The script is output on `stdout`
-    allowing one to re-direct the output to the file of their
-    choosing. Where you place the file will depend on which shell, and
-    which operating system you are using. Your particular
-    configuration may also determine where these scripts need to be
-    placed.
+    Enable tab completion for Bash, Fish, Zsh, or PowerShell
+    The script is output on `stdout`, allowing one to re-direct the
+    output to the file of their choosing. Where you place the file
+    will depend on which shell, and which operating system you are
+    using. Your particular configuration may also determine where
+    these scripts need to be placed.
 
     Here are some common set ups for the three supported shells under
     Unix and similar operating systems (such as GNU/Linux).

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -511,7 +511,7 @@ pub fn cli() -> App<'static, 'static> {
 
     app.subcommand(
         SubCommand::with_name("completions")
-            .about("Generate completion scripts for your shell")
+            .about("Generate tab-completion scripts for your shell")
             .after_help(COMPLETIONS_HELP)
             .setting(AppSettings::ArgRequiredElseHelp)
             .arg(Arg::with_name("shell").possible_values(&Shell::variants()))


### PR DESCRIPTION
`$ rustup completions` will show the following updated help:

```rust
rustup-completions 
Generate tab-completion scripts for your shell

USAGE:
    rustup completions [ARGS]

...

DISCUSSION:
    Enable tab completion for Bash, Fish, Zsh, or PowerShell
    The script is output on `stdout`, allowing one to re-direct the
    output to the file of their choosing. Where you place the file
    will depend on which shell, and which operating system you are
    using. Your particular configuration may also determine where
    these scripts need to be placed.
```