### PR TITLE
CI: Update run.sh and appveyor config for tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,7 +71,23 @@ build: false
 test_script:
   - cargo build --release --target %TARGET% --locked
   - cargo run --release --target %TARGET% --locked -- --dump-testament
-  - cargo test --release --target %TARGET%
+  # The rest of this relies on the set of things to test not changing
+  # because I have no idea how to script it.  TODO: Get someone to script it?
+  - cargo test --release --target %TARGET% -p download
+  - cargo test --release --target %TARGET% --bin rustup-init
+  - cargo test --release --target %TARGET% --lib --all
+  - cargo test --release --target %TARGET% --doc --all
+  - cargo test --release --target %TARGET% --test cli-exact
+  - cargo test --release --target %TARGET% --test cli-inst-interactive
+  - cargo test --release --target %TARGET% --test cli-misc
+  - cargo test --release --target %TARGET% --test cli-rustup
+  - cargo test --release --target %TARGET% --test cli-self-upd
+  - cargo test --release --target %TARGET% --test cli-v1
+  - cargo test --release --target %TARGET% --test cli-v2
+  - cargo test --release --target %TARGET% --test dist_install
+  - cargo test --release --target %TARGET% --test dist_manifest
+  - cargo test --release --target %TARGET% --test dist -- --test-threads 1
+  - cargo test --release --target %TARGET% --test dist_transactions
 
 notifications:
   - provider: Webhook

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -767,13 +767,14 @@ mod tests {
     #[test]
     fn test_cargo_home() {
         // CARGO_HOME unset, we'll get the default ending in /.cargo
+        env::remove_var("CARGO_HOME");
         let cargo_home1 = cargo_home();
         let ch = format!("{}", cargo_home1.unwrap().display());
-        assert!(ch.contains("/.cargo"));
+        assert!(ch.contains("/.cargo") || ch.contains("\\.cargo"));
 
         env::set_var("CARGO_HOME", "/test");
         let cargo_home2 = cargo_home();
-        assert_eq!("/test", format!("{}", cargo_home2.unwrap().display()));
+        assert!(format!("{}", cargo_home2.unwrap().display()).contains("/test"));
     }
 
     #[test]


### PR DESCRIPTION
In order that we might succeed in getting through our tests,
until we can properly diagnose and correct for whatever causes the
dist tests alone to fail in such spectacular ways, limit the dist
tests to a single thread to reduce the chance that they fail on
Windows CI.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>