### PR TITLE
Disable non-panic error backtraces when RUSTUP_NO_BACKTRACE is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,9 @@ Command                                                     | Description
 - `RUSTUP_UNPACK_RAM` *unstable* (default 400M, min 100M)
   Caps the amount of RAM rustup will use for IO tasks while unpacking.
 
+- `RUSTUP_NO_BACKTRACE`
+  Disables backtraces on non-panic errors even when `RUST_BACKTRACE` is set.
+
 ## Other installation methods
 
 The primary installation method, as described at https://rustup.rs, differs by platform:

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -536,6 +536,10 @@ pub fn report_error(e: &Error) {
     }
 
     fn show_backtrace() -> bool {
+        if let Ok(true) = env::var("RUSTUP_NO_BACKTRACE").map(|s| s == "1") {
+            return false;
+        }
+
         if let Ok(true) = env::var("RUST_BACKTRACE").map(|s| s == "1") {
             return true;
         }


### PR DESCRIPTION
Fixes #1956