### PR TITLE
Add extra HTTP headers to rustup.rs

### DIFF
--- a/www/website_config.json
+++ b/www/website_config.json
@@ -1,0 +1,9 @@
+{
+    "headers": {
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+        "X-Content-Type-Options": "nosniff",
+        "X-Frame-Options": "DENY",
+        "X-XSS-Protection": "1; mode=block",
+        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin"
+    }
+}


### PR DESCRIPTION
This PR adds the headers required to reach a B score on the [Mozilla Observatory](https://observatory.mozilla.org), as required by the [guidelines for hosting static websites on Rust infrastructure](https://github.com/rust-lang/infra-team/blob/master/guidelines/static-websites.md). The headers it adds are:

* **Strict-Transport-Security**: prevents users from visiting rustup.rs through HTTP on the client side
* **X-Content-Type-Options**: prevents browsers from misguessing (well, guessing at all) the MIME type of the returned files
* **X-Frame-Options**: prevents the website being embedded in a frame
* **X-XSS-Protection**: prevents XSS attacks on some older browsers
* **Referrer-Policy**: protects the privacy of our users by omitting the `Referer` header

A Content Security Policy will be implemented later.
cc https://github.com/rust-lang/rustup.rs/issues/180