### PR TITLE
Bump home crate to v0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,10 +504,10 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.3.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1225,7 +1225,7 @@ dependencies = [
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "git-testament 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1926,7 +1926,7 @@ dependencies = [
 "checksum git-testament 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "42b8bfbe5a934d3968485e67c94c6cda85c476a8adabba323896c1210dd8a695"
 "checksum git-testament-derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "27f30c4ed1f7c17348dca7764adabc7ad24934e64f6dc7823e8a6776e2973f09"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
-"checksum home 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29302b90cfa76231a757a887d1e3153331a63c7f80b6c75f86366334cbe70708"
+"checksum home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c07c315e106bd6f83f026a20ddaeef2706782e490db1dcdd37caad38a0e895b3"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ download = { path = "download" }
 error-chain = "0.12"
 flate2 = "1"
 git-testament = "0.1.4"
-home = "0.3.4"
+home = "0.5"
 lazy_static = "1"
 libc = "0.2"
 markdown = "0.2"


### PR DESCRIPTION
This home release removes support for multirust folder used in old version of rustup.