### PR TITLE
alias `rustup date` to update

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -177,6 +177,7 @@ pub fn cli() -> App<'static, 'static> {
         .subcommand(
             SubCommand::with_name("update")
                 .about("Update Rust toolchains and rustup")
+                .aliases(&["date"])
                 .after_help(UPDATE_HELP)
                 .arg(
                     Arg::with_name("toolchain")


### PR DESCRIPTION
I keep typing `rustup date`, and it looks like it's easier to fix the code
to work around that than my brain.