### PR TITLE
Fixup ci errors. Clippy on beta channel is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,7 @@ matrix:
       language: minimal
       install:
         - |
-          sh ./rustup-init.sh --default-toolchain=beta -y;
+          sh ./rustup-init.sh --default-toolchain=nightly -y;
           . "$HOME"/.cargo/env;
           rustup component add clippy;
       script:


### PR DESCRIPTION
Clippy on beta is broken and reports like:
```
error: cannot find macro `pre_install_msg_template!` in this scope
  --> src/cli/self_update.rs:98:9
   |
98 |         pre_install_msg_template!(
   |         ^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find macro `pre_install_msg_template!` in this scope
   --> src/cli/self_update.rs:109:9
    |
109 |         pre_install_msg_template!(
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

error: cannot find macro `pre_install_msg_template!` in this scope
   --> src/cli/self_update.rs:118:9
    |
118 |         pre_install_msg_template!(
    |         ^^^^^^^^^^^^^^^^^^^^^^^^

warning: unused macro definition
  --> src/cli/self_update.rs:62:1
   |
62 | / macro_rules! pre_install_msg_template {
63 | |     ($platform_msg: expr) => {
64 | |         concat!(
65 | |             r"
...  |
93 | |     };
94 | | }
   | |_^
   |
   = note: `#[warn(unused_macros)]` on by default
```

This does not happens on neither stable nor nightly channel.