### PR TITLE
clitools: Clean up tests once run

### DIFF
--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -81,11 +81,15 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     }
     let test_dir = exe_dir.parent().unwrap().join("tests");
     fs::create_dir_all(&test_dir).unwrap();
+    let test_dir = tempfile::Builder::new()
+        .prefix("running-test-")
+        .tempdir_in(test_dir)
+        .unwrap();
 
-    fn tempdir_in_with_prefix(path: &Path, prefix: &str) -> PathBuf {
+    fn tempdir_in_with_prefix<P: AsRef<Path>>(path: P, prefix: &str) -> PathBuf {
         tempfile::Builder::new()
             .prefix(prefix)
-            .tempdir_in(path)
+            .tempdir_in(path.as_ref())
             .unwrap()
             .into_path()
     }


### PR DESCRIPTION
This reduces the waste in the target/ directory which could otherwise
run a system out of disk space.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>