### PR TITLE
rustup check

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -679,7 +679,7 @@ fn update_from_dist_<'a>(
     }
 }
 
-fn dl_v2_manifest<'a>(
+pub fn dl_v2_manifest<'a>(
     download: DownloadCfg<'a>,
     update_hash: Option<&Path>,
     toolchain: &ToolchainDesc,

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -46,7 +46,7 @@ fn rustup_stable() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -108,7 +108,7 @@ fn rustup_all_channels() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -122,7 +122,7 @@ info: installing component 'cargo'
 info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'beta-{0}'
-info: latest update on 2015-01-02, rust version 1.2.0
+info: latest update on 2015-01-02, rust version 1.2.0 (hash-b-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -136,7 +136,7 @@ info: installing component 'cargo'
 info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -177,7 +177,7 @@ fn rustup_some_channels_up_to_date() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -192,7 +192,7 @@ info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'beta-{0}'
 info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -240,7 +240,7 @@ fn default() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -869,7 +869,7 @@ fn first_install_exact() {
 ",
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -50,7 +50,7 @@ pub fn create_mock_channel(
 
     packages.push(MockPackage {
         name: "rust",
-        version: "1.0.0",
+        version: "1.0.0".to_string(),
         targets: vec![
             MockTargetedPackage {
                 target: "x86_64-apple-darwin".to_string(),
@@ -113,7 +113,7 @@ pub fn create_mock_channel(
         let pkg = &bin[4..];
         packages.push(MockPackage {
             name: pkg,
-            version: "1.0.0",
+            version: "1.0.0".to_string(),
             targets: vec![
                 MockTargetedPackage {
                     target: "x86_64-apple-darwin".to_string(),
@@ -138,7 +138,7 @@ pub fn create_mock_channel(
 
     packages.push(MockPackage {
         name: "rust-std",
-        version: "1.0.0",
+        version: "1.0.0".to_string(),
         targets: vec![
             MockTargetedPackage {
                 target: "x86_64-apple-darwin".to_string(),
@@ -203,7 +203,7 @@ pub fn create_mock_channel(
 fn bonus_component(name: &'static str, contents: Arc<Vec<u8>>) -> MockPackage {
     MockPackage {
         name,
-        version: "1.0.0",
+        version: "1.0.0".to_string(),
         targets: vec![MockTargetedPackage {
             target: "x86_64-apple-darwin".to_string(),
             available: true,

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -485,7 +485,7 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
         chans.extend(vec![c1, c2, c3]);
     }
     let c4 = if s == Scenario::Unavailable {
-        build_mock_unavailable_channel("nightly", "2015-01-02", "1.3.0")
+        build_mock_unavailable_channel("nightly", "2015-01-02", "1.3.0", "hash-n-2")
     } else {
         build_mock_channel(
             s,
@@ -693,7 +693,7 @@ fn build_mock_channel(
 
         MockPackage {
             name,
-            version,
+            version: format!("{} ({})", version, version_hash),
             targets: target_pkgs.collect(),
         }
     });
@@ -773,7 +773,12 @@ fn build_mock_channel(
     }
 }
 
-fn build_mock_unavailable_channel(channel: &str, date: &str, version: &'static str) -> MockChannel {
+fn build_mock_unavailable_channel(
+    channel: &str,
+    date: &str,
+    version: &str,
+    version_hash: &str,
+) -> MockChannel {
     let host_triple = this_host_triple();
 
     let packages = [
@@ -789,7 +794,7 @@ fn build_mock_unavailable_channel(channel: &str, date: &str, version: &'static s
         .iter()
         .map(|name| MockPackage {
             name,
-            version,
+            version: format!("{} ({})", version, version_hash),
             targets: vec![MockTargetedPackage {
                 target: host_triple.clone(),
                 available: false,

--- a/tests/mock/dist.rs
+++ b/tests/mock/dist.rs
@@ -80,7 +80,7 @@ pub struct MockChannel {
 pub struct MockPackage {
     // rust, rustc, rust-std-$triple, rust-doc, etc.
     pub name: &'static str,
-    pub version: &'static str,
+    pub version: String,
     pub targets: Vec<MockTargetedPackage>,
 }
 


### PR DESCRIPTION
Hi, I was interested in being able to check for updates before running an update, and found that there was already a ticket open for this: #1249. I have had a go at implementing this feature in this PR.

The new command is `rustup check` and the output looks like this:
`stable-x86_64-unknown-linux-gnu - Up to date : 1.37.0 (eae3437df 2019-08-13)`
`beta-x86_64-unknown-linux-gnu - Up to date : 1.38.0-beta.3 (72bfc3753 2019-08-27)`
`nightly-x86_64-unknown-linux-gnu - Update available : 1.39.0-nightly (fba38ac27 2019-08-31) -> 1.39.0-nightly (dfd43f0fd 2019-09-01)`

The implementation gets the versions from the current local manifest and the downloaded manifest from the dist server. I added some test cases to the `cli-rustup` tests, I had to tweak the construction of the version string in the mock manifests to get this to work properly though.

I would appreciate any feedback you can give, some things to highlight:
- I made some assumptions that since the ticket was open and I also wanted the feature, then you guys would too... so I hope you think it is still a useful feature!
- I am not familiar with the history of the codebase, so I am not sure if the approach I have taken is a 'good' one
- This only works if there is a V2 manifest, I'm not sure what a V1 manifest is TBH
- I am quite new to rust, so I might have missed some idiomatic rust ways to do things
- I wasn't sure whether I needed to add a `handle_epipe` around the `check_updates` function call and add a new `ErrorKind`, do you think this is necessary?

Thanks in advance for your comments.

Preview:
![rustup_check](https://user-images.githubusercontent.com/7167073/64131055-6d26f880-cdc6-11e9-8fe4-29d5b9976ebd.png)
