### PR TITLE
Update the sanity limit to 200M per file

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -32,8 +32,8 @@ if [ -z "$SKIP_TESTS" ]; then
 
   runtest --test dist -- --test-threads 1
 
-  find ./tests -maxdepth 1 -type f ! -path '*/dist.rs' -name '*.rs' \
-  | sed -E 's@\./tests/(.+)\.rs@\1@g' \
+  find tests -maxdepth 1 -type f ! -path '*/dist.rs' -name '*.rs' \
+  | sed -e 's@^tests/@@;s@\.rs$@@g' \
   | while read -r test; do
     runtest --test "${test}"
   done

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -277,7 +277,7 @@ fn unpack_without_first_dir<'a, R: Read>(
     let entries = archive
         .entries()
         .chain_err(|| ErrorKind::ExtractingPackage)?;
-    const MAX_FILE_SIZE: u64 = 100_000_000;
+    const MAX_FILE_SIZE: u64 = 200_000_000;
     let mut budget = MemoryBudget::new(MAX_FILE_SIZE as usize);
 
     let mut directories: HashMap<PathBuf, DirStatus> = HashMap::new();


### PR DESCRIPTION
This is needed because the stdlib .rlib files are now around 100M
and some targets exceed the old sanity limit.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>

/cc @rbtcollins 