### PR TITLE
Implement verbose option for "rustup toolchain list"

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -424,8 +424,13 @@ pub fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<()> {
     Ok(())
 }
 
-pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
+pub fn list_toolchains(cfg: &Cfg, is_verbose: bool) -> Result<()> {
     let toolchains = cfg.list_toolchains()?;
+    let toolchain_info = if is_verbose {
+        format!("\t{}", &cfg.rustup_dir.display())
+    } else {
+        String::from("")
+    };
 
     if toolchains.is_empty() {
         println!("no installed toolchains");
@@ -436,11 +441,11 @@ pub fn list_toolchains(cfg: &Cfg) -> Result<()> {
             } else {
                 ""
             };
-            println!("{}{}", &toolchain, if_default);
+            println!("{}{}{}", &toolchain, if_default, toolchain_info);
         }
     } else {
         for toolchain in toolchains {
-            println!("{}", &toolchain);
+            println!("{}{}", &toolchain, toolchain_info);
         }
     }
     Ok(())

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -53,7 +53,7 @@ pub fn main() -> Result<()> {
         ("default", Some(m)) => default_(cfg, m)?,
         ("toolchain", Some(c)) => match c.subcommand() {
             ("install", Some(m)) => update(cfg, m)?,
-            ("list", Some(_)) => handle_epipe(common::list_toolchains(cfg))?,
+            ("list", Some(m)) => handle_epipe(toolchain_list(cfg, m))?,
             ("link", Some(m)) => toolchain_link(cfg, m)?,
             ("uninstall", Some(m)) => toolchain_remove(cfg, m)?,
             (_, _) => unreachable!(),
@@ -217,7 +217,17 @@ pub fn cli() -> App<'static, 'static> {
                 .setting(AppSettings::VersionlessSubcommands)
                 .setting(AppSettings::DeriveDisplayOrder)
                 .setting(AppSettings::SubcommandRequiredElseHelp)
-                .subcommand(SubCommand::with_name("list").about("List installed toolchains"))
+                .subcommand(
+                    SubCommand::with_name("list")
+                        .about("List installed toolchains")
+                        .arg(
+                            Arg::with_name("verbose")
+                                .help("Enable verbose output with toolchain information")
+                                .takes_value(false)
+                                .short("v")
+                                .long("verbose"),
+                        )
+                )
                 .subcommand(
                     SubCommand::with_name("install")
                         .about("Install or update a given toolchain")
@@ -1018,6 +1028,10 @@ fn explicit_or_dir_toolchain<'a>(cfg: &'a Cfg, m: &ArgMatches<'_>) -> Result<Too
     let (toolchain, _) = cfg.toolchain_for_dir(&cwd)?;
 
     Ok(toolchain)
+}
+
+fn toolchain_list(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
+    common::list_toolchains(cfg, m.is_present("verbose"))
 }
 
 fn toolchain_link(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -99,7 +99,19 @@ fn list_toolchains() {
             &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "(default)\t",
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "--verbose"],
+            "(default)\t",
+        );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "\t");
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "--verbose"], "\t");
     });
 }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -102,7 +102,19 @@ fn list_toolchains() {
             &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "(default)\t",
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "--verbose"],
+            "(default)\t",
+        );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "\t");
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "--verbose"], "\t");
     });
 }
 


### PR DESCRIPTION
This PR resolves #1479.

##### local test

```sh
→ rustup toolchain list -v
stable-x86_64-apple-darwin (default)	/Users/bchen/.rustup
nightly-2019-09-05-x86_64-apple-darwin	/Users/bchen/.rustup
nightly-x86_64-apple-darwin	/Users/bchen/.rustup
```

```sh
→ rustup toolchain list --verbose
stable-x86_64-apple-darwin (default)	/Users/bchen/.rustup
nightly-2019-09-05-x86_64-apple-darwin	/Users/bchen/.rustup
nightly-x86_64-apple-darwin	/Users/bchen/.rustup
```

```sh
→ rustup toolchain list -h
rustup-toolchain-list
List installed toolchains

USAGE:
    rustup toolchain list [FLAGS]

FLAGS:
    -h, --help       Prints help information
    -v, --verbose    Enable verbose output with toolchain infomation
```