### PR TITLE
Fix generation of Cargo completions for ZSH (issue #1821)

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1248,6 +1248,10 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
             cli().gen_completions_to("rustup", shell, &mut term2::stdout());
         }
         CompletionCommand::Cargo => {
+            if let Shell::Zsh = shell {
+                writeln!(&mut term2::stdout(), "#compdef cargo")?;
+            }
+
             let script = match shell {
                 Shell::Bash => "/etc/bash_completion.d/cargo",
                 Shell::Zsh => "/share/zsh/site-functions/_cargo",


### PR DESCRIPTION
When `source`ing the original completion file, the `#compdef cargo` line at the start is ignored, and ZSH does not autoload the completions, so `rustup` must put it the generated `_cargo` as well.
<sub>I guess `rustup` does not create a symlink instead, because that would be less portable.</sub>