### PR TITLE
Add Content Security Policy to the website

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -13,7 +13,7 @@
 
 <body id="idx">
 
-<a id="platform-button" style="display: none;" href="#">
+<a id="platform-button" class="display-none" href="#">
   click or press "n" to cycle platforms
 </a>
 
@@ -23,13 +23,13 @@
   <a href="https://www.rust-lang.org">Rust</a>
 </p>
 
-<div id="platform-instructions-unix" class="instructions" style="display: none;">
+<div id="platform-instructions-unix" class="instructions display-none">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
   <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Unix. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
-<div id="platform-instructions-win32" class="instructions" style="display: none;">
+<div id="platform-instructions-win32" class="instructions display-none">
   <p>
     To install Rust, download and run
     <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
@@ -40,7 +40,7 @@
   <p class="other-platforms-help">You appear to be running Windows 32-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
-<div id="platform-instructions-win64" class="instructions" style="display: none;">
+<div id="platform-instructions-win64" class="instructions display-none">
   <p>
     To install Rust, download and run
     <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
@@ -51,7 +51,7 @@
   <p class="other-platforms-help">You appear to be running Windows 64-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
-<div id="platform-instructions-unknown" class="instructions" style="display: none;">
+<div id="platform-instructions-unknown" class="instructions display-none">
   <!-- unrecognized platform: ask for help -->
   <p>I don't recognize your platform.</p>
   <p>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -158,3 +158,15 @@ hr {
     margin-right: auto;
     padding: 1em;
 }
+
+.display-none {
+    display: none;
+}
+
+.display-block {
+    display: block;
+}
+
+.display-inline {
+    display: inline;
+}

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -53,6 +53,17 @@ function detect_platform() {
     return os;
 }
 
+function vis(elem, value) {
+    var possible = ["block", "inline", "none"];
+    for (var i = 0; i < possible.length; i++) {
+        if (possible[i] === value) {
+            elem.classList.add("display-" + possible[i]);
+        } else {
+            elem.classList.remove("display-" + possible[i]);
+        }
+    }
+}
+
 function adjust_for_platform() {
     "use strict";
 
@@ -60,9 +71,9 @@ function adjust_for_platform() {
 
     platforms.forEach(function (platform_elem) {
         var platform_div = document.getElementById("platform-instructions-" + platform_elem);
-        platform_div.style.display = "none";
+        vis(platform_div, "none");
         if (platform == platform_elem) {
-            platform_div.style.display = "block";
+            vis(platform_div, "block");
         }
     });
 
@@ -81,15 +92,15 @@ function adjust_platform_specific_instrs(platform) {
         }
         if (platform == "win64" || platform == "win32") {
             if (el_is_not_win) {
-                el.style.display = "none";
+                vis(el, "none");
             } else {
-                el.style.display = el_visible_style;
+                vis(el, el_visible_style);
             }
         } else {
             if (el_is_not_win) {
-                el.style.display = el_visible_style;
+                vis(el, el_visible_style);
             } else {
-                el.style.display = "none";
+                vis(el, "none");
             }
         }
     }
@@ -121,7 +132,7 @@ function set_up_cycle_button() {
             idx += 1;
 
             if (idx == key.length) {
-                cycle_button.style.display = "block";
+                vis(cycle_button, "block");
                 unlocked = true;
                 cycle_platform();
             }

--- a/www/website_config.json
+++ b/www/website_config.json
@@ -4,6 +4,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "X-XSS-Protection": "1; mode=block",
-        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin"
+        "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin",
+        "Content-Security-Policy": "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' https://www.rust-lang.org; font-src 'self'"
     }
 }


### PR DESCRIPTION
This PR adds the following CSP to the rustup.rs website:

```
default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' https://www.rust-lang.org; font-src 'self'
```

Along with the new header I had to tweak the platform detection script to use classes instead of applying styles directly (which would've required the `unsafe-inline` CSP directive).

Fixes https://github.com/rust-lang/rustup.rs/issues/1986
r? @kinnison 