### PR TITLE
Update to most recent viable nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,6 +1220,7 @@ name = "rustup"
 version = "1.19.0"
 dependencies = [
  "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "download 0.6.3",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ no-self-update = []
 
 # Sorted by alphabetic order
 [dependencies]
+chrono = "0.4"
 clap = "2"
 download = { path = "download" }
 error-chain = "0.12"

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -1,4 +1,5 @@
 use crate::dist::dist::TargetTriple;
+use crate::dist::manifest::Component;
 use crate::dist::temp;
 use crate::errors::*;
 use crate::utils::notify::NotificationLevel;
@@ -29,6 +30,7 @@ pub enum Notification<'a> {
     DownloadingManifest(&'a str),
     DownloadedManifest(&'a str, Option<&'a str>),
     DownloadingLegacyManifest,
+    SkippingNightlyMissingComponent(&'a [Component]),
     ManifestChecksumFailedHack,
     ComponentUnavailable(&'a str, Option<&'a TargetTriple>),
     StrayHash(&'a Path),
@@ -66,6 +68,7 @@ impl<'a> Notification<'a> {
             | ManifestChecksumFailedHack
             | RollingBack
             | DownloadingManifest(_)
+            | SkippingNightlyMissingComponent(_)
             | DownloadedManifest(_, _) => NotificationLevel::Info,
             CantReadUpdateHash(_)
             | ExtensionNotInstalled(_)
@@ -157,6 +160,11 @@ impl<'a> Display for Notification<'a> {
                 f,
                 "removing stray hash found at '{}' in order to continue",
                 path.display()
+            ),
+            SkippingNightlyMissingComponent(components) => write!(
+                f,
+                "skipping nightly which is missing installed component '{}'",
+                components[0].short_name_in_manifest()
             ),
         }
     }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -770,6 +770,23 @@ fn update_nightly_even_with_incompat() {
 }
 
 #[test]
+fn nightly_backtrack_skips_missing() {
+    clitools::setup(Scenario::Unavailable, &|config| {
+        set_current_dist_date(config, "2015-01-01");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+
+        // nightly is missing on latest
+        set_current_dist_date(config, "2015-01-02");
+
+        // update should not change nightly, and should not error
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+    });
+}
+
+#[test]
 fn completion_rustup() {
     setup(&|config| {
         expect_ok(config, &["rustup", "completions", "bash", "rustup"]);

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -8,7 +8,6 @@ use crate::mock::clitools::{
     expect_ok_eq, expect_ok_ex, expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date,
     this_host_triple, Config, Scenario,
 };
-use rustup::errors::TOOLSTATE_MSG;
 use rustup::utils::{raw, utils};
 
 use std::env::consts::EXE_SUFFIX;
@@ -741,18 +740,32 @@ fn update_unavailable_rustc() {
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
 
+        // latest nightly is unavailable
         set_current_dist_date(config, "2015-01-02");
-        expect_err(
-            config,
-            &["rustup", "update", "nightly"],
-            format!(
-                "some components unavailable for download for channel nightly: 'rustc', 'cargo', 'rust-std', 'rust-docs'\n{}",
-                TOOLSTATE_MSG
-            )
-            .as_str(),
-        );
+        // update should do nothing
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+    });
+}
+
+#[test]
+fn update_nightly_even_with_incompat() {
+    clitools::setup(Scenario::MissingComponent, &|config| {
+        set_current_dist_date(config, "2019-09-12");
+        expect_ok(config, &["rustup", "default", "nightly"]);
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_ok(config, &["rustup", "component", "add", "rls"]);
+        expect_component_executable(config, "rls");
+
+        // latest nightly is now one that does not have RLS
+        set_current_dist_date(config, "2019-09-14");
+
+        expect_component_executable(config, "rls");
+        // update should bring us to latest nightly that does
+        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_component_executable(config, "rls");
     });
 }
 


### PR DESCRIPTION
Previously, if the user had components installed on `nightly` which were not available for the latest nightly, `rustup update` would not update the user's nightly at all. With this patch, rustup will try progressively older nightlies until it finds a nightly that supports all the components the user has installed for their current nightly.

Fixes #1628.
Makes progress towards #1501.
Fixes the underlying issue in #1676.