### PR TITLE
Tidy up the mock dist server

### DIFF
--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -26,13 +26,13 @@ fn update() {
             &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
-  nightly-{0} installed - 1.3.0 (hash-n-2)
+  nightly-{0} installed - 1.3.0 (hash-nightly-2)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -57,7 +57,7 @@ fn update_again() {
             &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
-  nightly-{0} unchanged - 1.3.0 (hash-n-2)
+  nightly-{0} unchanged - 1.3.0 (hash-nightly-2)
 
 "
             ),
@@ -80,9 +80,9 @@ fn check_updates_none() {
             config,
             &["rustup", "check"],
             for_host!(
-                r"stable-{0} - Up to date : 1.0.0 (hash-s-1)
-beta-{0} - Up to date : 1.1.0 (hash-b-1)
-nightly-{0} - Up to date : 1.2.0 (hash-n-1)
+                r"stable-{0} - Up to date : 1.0.0 (hash-stable-1.0.0)
+beta-{0} - Up to date : 1.1.0 (hash-beta-1.1.0)
+nightly-{0} - Up to date : 1.2.0 (hash-nightly-1)
 "
             ),
         );
@@ -101,9 +101,9 @@ fn check_updates_some() {
             config,
             &["rustup", "check"],
             for_host!(
-                r"stable-{0} - Update available : 1.0.0 (hash-s-1) -> 1.1.0 (hash-s-2)
-beta-{0} - Update available : 1.1.0 (hash-b-1) -> 1.2.0 (hash-b-2)
-nightly-{0} - Update available : 1.2.0 (hash-n-1) -> 1.3.0 (hash-n-2)
+                r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-{0} - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
+nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
 "
             ),
         );
@@ -121,9 +121,9 @@ fn check_updates_with_update() {
             config,
             &["rustup", "check"],
             for_host!(
-                r"stable-{0} - Up to date : 1.0.0 (hash-s-1)
-beta-{0} - Up to date : 1.1.0 (hash-b-1)
-nightly-{0} - Up to date : 1.2.0 (hash-n-1)
+                r"stable-{0} - Up to date : 1.0.0 (hash-stable-1.0.0)
+beta-{0} - Up to date : 1.1.0 (hash-beta-1.1.0)
+nightly-{0} - Up to date : 1.2.0 (hash-nightly-1)
 "
             ),
         );
@@ -132,9 +132,9 @@ nightly-{0} - Up to date : 1.2.0 (hash-n-1)
             config,
             &["rustup", "check"],
             for_host!(
-                r"stable-{0} - Update available : 1.0.0 (hash-s-1) -> 1.1.0 (hash-s-2)
-beta-{0} - Update available : 1.1.0 (hash-b-1) -> 1.2.0 (hash-b-2)
-nightly-{0} - Update available : 1.2.0 (hash-n-1) -> 1.3.0 (hash-n-2)
+                r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-{0} - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
+nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
 "
             ),
         );
@@ -143,9 +143,9 @@ nightly-{0} - Update available : 1.2.0 (hash-n-1) -> 1.3.0 (hash-n-2)
             config,
             &["rustup", "check"],
             for_host!(
-                r"stable-{0} - Update available : 1.0.0 (hash-s-1) -> 1.1.0 (hash-s-2)
-beta-{0} - Up to date : 1.2.0 (hash-b-2)
-nightly-{0} - Update available : 1.2.0 (hash-n-1) -> 1.3.0 (hash-n-2)
+                r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-{0} - Up to date : 1.2.0 (hash-beta-1.2.0)
+nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
 "
             ),
         );
@@ -160,13 +160,13 @@ fn default() {
             &["rustup", "default", "nightly"],
             for_host!(
                 r"
-  nightly-{0} installed - 1.3.0 (hash-n-2)
+  nightly-{0} installed - 1.3.0 (hash-nightly-2)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -192,7 +192,7 @@ fn override_again() {
             &["rustup", "override", "add", "nightly"],
             for_host!(
                 r"
-  nightly-{} unchanged - 1.3.0 (hash-n-2)
+  nightly-{} unchanged - 1.3.0 (hash-nightly-2)
 
 "
             ),
@@ -426,7 +426,7 @@ fn update_invalid_toolchain() {
             &["rustup", "update", "nightly-2016-03-1"],
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
 ",
         );
@@ -441,7 +441,7 @@ fn default_invalid_toolchain() {
             &["rustup", "default", "nightly-2016-03-1"],
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
 ",
         );

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -84,7 +84,7 @@ fn blank_lines_around_stderr_log_output_install() {
 3) Cancel installation
 >
 
-  stable installed - 1.1.0 (hash-s-2)
+  stable installed - 1.1.0 (hash-stable-1.1.0)
 
 
 Rust is installed now. Great!

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -100,7 +100,7 @@ fn update_all_no_update_whitespace() {
             &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
                 r"
-  nightly-{} installed - 1.3.0 (hash-n-2)
+  nightly-{} installed - 1.3.0 (hash-nightly-2)
 
 "
             ),
@@ -197,7 +197,7 @@ fn multi_host_smoke_test() {
     clitools::setup(Scenario::MultiHost, &|config| {
         let toolchain = format!("nightly-{}", clitools::MULTI_ARCH1);
         expect_ok(config, &["rustup", "default", &toolchain]);
-        expect_stdout_ok(config, &["rustc", "--version"], "xxxx-n-2"); // cross-host mocks have their own versions
+        expect_stdout_ok(config, &["rustc", "--version"], "xxxx-nightly-2"); // cross-host mocks have their own versions
     });
 }
 
@@ -219,13 +219,13 @@ fn custom_toolchain_cargo_fallback_proxy() {
         expect_ok(config, &["rustup", "default", "mytoolchain"]);
 
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
-        expect_stdout_ok(config, &["cargo", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["cargo", "--version"], "hash-stable-1.1.0");
 
         expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
-        expect_stdout_ok(config, &["cargo", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["cargo", "--version"], "hash-beta-1.2.0");
 
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["cargo", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["cargo", "--version"], "hash-nightly-2");
     });
 }
 
@@ -250,21 +250,21 @@ fn custom_toolchain_cargo_fallback_run() {
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-s-2",
+            "hash-stable-1.1.0",
         );
 
         expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-b-2",
+            "hash-beta-1.2.0",
         );
 
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-n-2",
+            "hash-nightly-2",
         );
     });
 }
@@ -738,13 +738,13 @@ fn update_unavailable_rustc() {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
 
         // latest nightly is unavailable
         set_current_dist_date(config, "2015-01-02");
         // update should do nothing
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
     });
 }
 
@@ -754,7 +754,7 @@ fn update_nightly_even_with_incompat() {
         set_current_dist_date(config, "2019-09-12");
         expect_ok(config, &["rustup", "default", "nightly"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_component_executable(config, "rls");
 
@@ -764,7 +764,7 @@ fn update_nightly_even_with_incompat() {
         expect_component_executable(config, "rls");
         // update should bring us to latest nightly that does
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_component_executable(config, "rls");
     });
 }
@@ -775,14 +775,14 @@ fn nightly_backtrack_skips_missing() {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
 
         // nightly is missing on latest
         set_current_dist_date(config, "2015-01-02");
 
         // update should not change nightly, and should not error
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
     });
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -40,13 +40,13 @@ fn rustup_stable() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-  stable-{0} updated - 1.1.0 (hash-s-2)
+  stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -75,7 +75,7 @@ fn rustup_stable_no_change() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-  stable-{0} unchanged - 1.0.0 (hash-s-1)
+  stable-{0} unchanged - 1.0.0 (hash-stable-1.0.0)
 
 "
             ),
@@ -100,15 +100,15 @@ fn rustup_all_channels() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-   stable-{0} updated - 1.1.0 (hash-s-2)
-     beta-{0} updated - 1.2.0 (hash-b-2)
-  nightly-{0} updated - 1.3.0 (hash-n-2)
+   stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+     beta-{0} updated - 1.2.0 (hash-beta-1.2.0)
+  nightly-{0} updated - 1.3.0 (hash-nightly-2)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -122,7 +122,7 @@ info: installing component 'cargo'
 info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'beta-{0}'
-info: latest update on 2015-01-02, rust version 1.2.0 (hash-b-2)
+info: latest update on 2015-01-02, rust version 1.2.0 (hash-beta-1.2.0)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -136,7 +136,7 @@ info: installing component 'cargo'
 info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -169,15 +169,15 @@ fn rustup_some_channels_up_to_date() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-   stable-{0} updated - 1.1.0 (hash-s-2)
-   beta-{0} unchanged - 1.2.0 (hash-b-2)
-  nightly-{0} updated - 1.3.0 (hash-n-2)
+   stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+   beta-{0} unchanged - 1.2.0 (hash-beta-1.2.0)
+  nightly-{0} updated - 1.3.0 (hash-nightly-2)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -192,7 +192,7 @@ info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: syncing channel updates for 'beta-{0}'
 info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -234,13 +234,13 @@ fn default() {
             &["rustup", "default", "nightly"],
             for_host!(
                 r"
-  nightly-{0} installed - 1.3.0 (hash-n-2)
+  nightly-{0} installed - 1.3.0 (hash-nightly-2)
 
 "
             ),
             for_host!(
                 r"info: syncing channel updates for 'nightly-{0}'
-info: latest update on 2015-01-02, rust version 1.3.0 (hash-n-2)
+info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -503,7 +503,7 @@ fn fallback_cargo_calls_correct_rustc() {
         expect_ok(config, &["rustup", "default", "custom"]);
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
-        expect_stdout_ok(config, &["cargo", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["cargo", "--version"], "hash-nightly-2");
 
         assert!(rustc_path.exists());
 
@@ -563,7 +563,7 @@ fn show_toolchain_default() {
 rustup home:  {1}
 
 nightly-{0} (default)
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 "
             ),
             r"",
@@ -594,7 +594,7 @@ active toolchain
 ----------------
 
 nightly-{0} (default)
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 
 "
             ),
@@ -637,7 +637,7 @@ active toolchain
 ----------------
 
 nightly-{0} (default)
-1.3.0 (xxxx-n-2)
+1.3.0 (xxxx-nightly-2)
 
 ",
                 clitools::MULTI_ARCH1,
@@ -698,7 +698,7 @@ active toolchain
 ----------------
 
 nightly-{0} (default)
-1.3.0 (xxxx-n-2)
+1.3.0 (xxxx-nightly-2)
 
 ",
                 clitools::MULTI_ARCH1,
@@ -741,7 +741,7 @@ fn show_toolchain_override() {
 rustup home:  {1}
 
 nightly-{0} (directory override for '{2}')
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 ",
                 this_host_triple(),
                 config.rustupdir.display(),
@@ -781,7 +781,7 @@ active toolchain
 ----------------
 
 nightly-{0} (overridden by '{2}')
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 
 ",
                 this_host_triple(),
@@ -825,7 +825,7 @@ active toolchain
 ----------------
 
 nightly-{0} (overridden by '{1}')
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 
 ",
                     this_host_triple(),
@@ -932,7 +932,7 @@ fn show_toolchain_env() {
 rustup home:  {1}
 
 nightly-{0} (environment override by RUSTUP_TOOLCHAIN)
-1.3.0 (hash-n-2)
+1.3.0 (hash-nightly-2)
 "
             )
         );
@@ -1076,7 +1076,7 @@ fn toolchain_install_is_like_update() {
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
-            "hash-n-2",
+            "hash-nightly-2",
         );
     });
 }
@@ -1108,7 +1108,7 @@ fn toolchain_update_is_like_update() {
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
-            "hash-n-2",
+            "hash-nightly-2",
         );
     });
 }
@@ -1151,9 +1151,17 @@ fn proxy_toolchain_shorthand() {
                 "--no-self-update",
             ],
         );
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
-        expect_stdout_ok(config, &["rustc", "+stable", "--version"], "hash-s-2");
-        expect_stdout_ok(config, &["rustc", "+nightly", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        expect_stdout_ok(
+            config,
+            &["rustc", "+stable", "--version"],
+            "hash-stable-1.1.0",
+        );
+        expect_stdout_ok(
+            config,
+            &["rustc", "+nightly", "--version"],
+            "hash-nightly-2",
+        );
     });
 }
 
@@ -1232,13 +1240,13 @@ fn file_override() {
             ],
         );
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -1257,7 +1265,7 @@ fn file_override_subdir() {
             ],
         );
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1266,7 +1274,7 @@ fn file_override_subdir() {
         let subdir = cwd.join("subdir");
         fs::create_dir_all(&subdir).unwrap();
         config.change_dir(&subdir, &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -1286,13 +1294,13 @@ fn file_override_with_archive() {
             ],
         );
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly-2015-01-01").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
     });
 }
 
@@ -1316,13 +1324,13 @@ fn directory_override_beats_file_override() {
         );
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
     });
 }
 
@@ -1346,7 +1354,7 @@ fn close_file_override_beats_far_directory_override() {
         );
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
 
@@ -1357,7 +1365,7 @@ fn close_file_override_beats_far_directory_override() {
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
         config.change_dir(&subdir, &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -1373,13 +1381,13 @@ fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
         // not installing nightly
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
     });
 }
 
@@ -1411,7 +1419,9 @@ fn env_override_beats_file_override() {
         cmd.env("RUSTUP_TOOLCHAIN", "beta");
 
         let out = cmd.output().unwrap();
-        assert!(String::from_utf8(out.stdout).unwrap().contains("hash-b-2"));
+        assert!(String::from_utf8(out.stdout)
+            .unwrap()
+            .contains("hash-beta-1.2.0"));
     });
 }
 
@@ -1438,7 +1448,7 @@ fn plus_override_beats_file_override() {
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "+beta", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "+beta", "--version"], "hash-beta-1.2.0");
     });
 }
 

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -762,7 +762,7 @@ fn rustup_self_update_exact() {
             &["rustup", "update"],
             for_host!(
                 r"
-  stable-{0} unchanged - 1.1.0 (hash-s-2)
+  stable-{0} unchanged - 1.1.0 (hash-stable-1.1.0)
 
 "
             ),
@@ -831,9 +831,9 @@ fn rustup_still_works_after_update() {
         expect_ok(config, &["rustup-init", "-y"]);
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "self", "update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
     });
 }
 
@@ -864,12 +864,12 @@ fn first_install_exact() {
             config,
             &["rustup-init", "-y"],
             r"
-  stable installed - 1.1.0 (hash-s-2)
+  stable installed - 1.1.0 (hash-stable-1.1.0)
 
 ",
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0 (hash-s-2)
+info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
 info: downloading component 'rustc'
 info: downloading component 'cargo'
 info: downloading component 'rust-std'
@@ -923,7 +923,7 @@ fn doesnt_produce_env_file_on_windows() {}
 fn install_sets_up_stable() {
     setup(&|config| {
         expect_ok(config, &["rustup-init", "-y"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -934,7 +934,7 @@ fn install_sets_up_stable_unless_a_different_default_is_requested() {
             config,
             &["rustup-init", "-y", "--default-toolchain", "nightly"],
         );
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -945,7 +945,7 @@ fn install_sets_up_stable_unless_there_is_already_a_default() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
         expect_ok(config, &["rustup-init", "-y"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_err(
             config,
             &["rustup", "run", "stable", "rustc", "--version"],

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -38,11 +38,11 @@ fn expected_bins_exist() {
 fn install_toolchain_from_channel() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -50,11 +50,11 @@ fn install_toolchain_from_channel() {
 fn install_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["rustup", "default", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         expect_ok(config, &["rustup", "default", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
         expect_ok(config, &["rustup", "default", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
@@ -62,7 +62,7 @@ fn install_toolchain_from_archive() {
 fn install_toolchain_from_version() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -83,10 +83,10 @@ fn update_channel() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -203,11 +203,11 @@ fn bad_sha_on_installer() {
 fn install_override_toolchain_from_channel() {
     setup(&|config| {
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_ok(config, &["rustup", "override", "add", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         expect_ok(config, &["rustup", "override", "add", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -215,11 +215,11 @@ fn install_override_toolchain_from_channel() {
 fn install_override_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         expect_ok(config, &["rustup", "override", "add", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         expect_ok(config, &["rustup", "override", "add", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
         expect_ok(config, &["rustup", "override", "add", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
@@ -227,7 +227,7 @@ fn install_override_toolchain_from_archive() {
 fn install_override_toolchain_from_version() {
     setup(&|config| {
         expect_ok(config, &["rustup", "override", "add", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -238,7 +238,7 @@ fn override_overrides_default() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -257,13 +257,13 @@ fn multiple_overrides() {
             expect_ok(config, &["rustup", "override", "add", "stable"]);
         });
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
 
         config.change_dir(tempdir1.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -275,7 +275,7 @@ fn change_override() {
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -300,7 +300,7 @@ fn remove_override_with_default() {
             expect_ok(config, &["rustup", "default", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -317,13 +317,13 @@ fn remove_override_with_multiple_overrides() {
         config.change_dir(tempdir2.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "stable"]);
         });
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         config.change_dir(tempdir1.path(), &|| {
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -345,10 +345,10 @@ fn update_on_channel_when_date_has_changed() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -360,7 +360,7 @@ fn run_command() {
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
-            "hash-n-2",
+            "hash-nightly-2",
         );
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -41,11 +41,11 @@ fn expected_bins_exist() {
 fn install_toolchain_from_channel() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -53,11 +53,11 @@ fn install_toolchain_from_channel() {
 fn install_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         expect_ok(config, &["rustup", "default", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         expect_ok(config, &["rustup", "default", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
         expect_ok(config, &["rustup", "default", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
@@ -65,7 +65,7 @@ fn install_toolchain_from_archive() {
 fn install_toolchain_from_version() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -86,10 +86,10 @@ fn update_channel() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -276,11 +276,11 @@ fn bad_sha_on_installer() {
 fn install_override_toolchain_from_channel() {
     setup(&|config| {
         expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_ok(config, &["rustup", "override", "add", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         expect_ok(config, &["rustup", "override", "add", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -288,11 +288,11 @@ fn install_override_toolchain_from_channel() {
 fn install_override_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         expect_ok(config, &["rustup", "override", "add", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         expect_ok(config, &["rustup", "override", "add", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-b-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
         expect_ok(config, &["rustup", "override", "add", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
@@ -300,7 +300,7 @@ fn install_override_toolchain_from_archive() {
 fn install_override_toolchain_from_version() {
     setup(&|config| {
         expect_ok(config, &["rustup", "override", "add", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -311,7 +311,7 @@ fn override_overrides_default() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -330,13 +330,13 @@ fn multiple_overrides() {
             expect_ok(config, &["rustup", "override", "add", "stable"]);
         });
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
 
         config.change_dir(tempdir1.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -362,9 +362,9 @@ fn override_windows_root() {
         config.change_dir(&PathBuf::from(&prefix), &|| {
             expect_ok(config, &["rustup", "default", "stable"]);
             expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -376,7 +376,7 @@ fn change_override() {
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-b-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -401,7 +401,7 @@ fn remove_override_with_default() {
             expect_ok(config, &["rustup", "default", "nightly"]);
             expect_ok(config, &["rustup", "override", "add", "beta"]);
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -418,13 +418,13 @@ fn remove_override_with_multiple_overrides() {
         config.change_dir(tempdir2.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "stable"]);
         });
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         config.change_dir(tempdir1.path(), &|| {
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-s-2");
+            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -446,10 +446,10 @@ fn update_on_channel_when_date_has_changed() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -461,7 +461,7 @@ fn run_command() {
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
-            "hash-n-2",
+            "hash-nightly-2",
         );
     });
 }
@@ -484,10 +484,10 @@ fn upgrade_v1_to_v2() {
         // Delete the v2 manifest so the first day we install from the v1s
         fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-1");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-n-2");
+        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
 


### PR DESCRIPTION
This is follow-on clean-up work from #1997 which tidies up `tests::mock::clitools::create_mock_dist_server` so that it is much clearer which versions are available with each "`Scenario`". I will mark this as ready to review and rebase once #1997 lands.