### PR TITLE
Simplify Notification::RemovingComponent invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,6 +103,7 @@ matrix:
       env: TARGET=x86_64-pc-windows-msvc NO_ADD=1 EXE_EXT=.exe
       services: nil
       language: bash
+      if: branch == disabled-for-now
 
 install:
   - sh rustup-init.sh --default-toolchain=stable -y

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,14 +7,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aho-corasick"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -665,26 +657,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "markdown"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "pipeline 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "memchr"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -704,7 +679,7 @@ name = "mime"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -713,7 +688,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -905,11 +880,6 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "pipeline"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +915,16 @@ dependencies = [
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1111,18 +1091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
-version = "0.1.80"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "regex"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1131,11 +1099,6 @@ dependencies = [
  "regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -1229,9 +1192,9 @@ dependencies = [
  "home 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "opener 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pulldown-cmark 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1498,23 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread-id"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "thread_local"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicase"
-version = "2.4.0"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1737,11 +1683,6 @@ dependencies = [
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "utf8-ranges"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uuid"
@@ -1871,7 +1812,6 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7e522997b529f05601e05166c07ed17789691f562762c7f3b987263d2dedee5c"
-"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b8d73f9beda665eaa98ab9e4f7442bd4e7de6652587de55b2525e52e29c1b0ba"
@@ -1944,9 +1884,7 @@ dependencies = [
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lzma-sys 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "53e48818fd597d46155132bbbb9505d6d1b3d360b4ee25cfa91c406f8a90fe91"
-"checksum markdown 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bdb7e864aa1dccbebb05751e899bc84c639df47490c0c24caf4b1a77770b6566"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
@@ -1971,12 +1909,12 @@ dependencies = [
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum pipeline 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
 "checksum pkg-config 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c1d2cfa5a714db3b5f24f0915e74fcdf91d09d496ba61329705dda7774d2af"
 "checksum ppv-lite86 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e3cbf9f658cdb5000fcf6f362b8ea2ba154b9f146a61c7a20d647034c6b6561b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
+"checksum pulldown-cmark 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85b0ad0d4c1702965ee6bb5b4ff5e71f83850b497d497e9444302987bf9e26a4"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -1995,9 +1933,7 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)" = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
-"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88c3d9193984285d544df4a30c23a4e62ead42edf70a4452ceb76dac1ce05c26"
-"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b143cceb2ca5e56d5671988ef8b15615733e7ee16cd348e064333b251b89343f"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.20 (registry+https://github.com/rust-lang/crates.io-index)" = "0f6d896143a583047512e59ac54a215cb203c29cc941917343edea3be8df9c78"
@@ -2034,8 +1970,6 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
-"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
@@ -2053,14 +1987,13 @@ dependencies = [
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
-"checksum unicase 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a84e5511b2a947f3ae965dcb29b13b7b1691b6e7332cf5dbc1744138d5acb7f6"
+"checksum unicase 2.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2e2e6bd1e59e56598518beb94fd6db628ded570326f0a98c679a304bd9f00150"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "141339a08b982d942be2ca06ff8b076563cbe223d1befd5450716790d44e2426"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
-"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,11 @@ git-testament = "0.1.4"
 home = "0.5"
 lazy_static = "1"
 libc = "0.2"
-markdown = "0.2"
 opener = "0.4.0"
 # Used by `curl` or `reqwest` backend although it isn't imported
 # by our rustup.
 openssl = { version = "0.10", optional = true }
+pulldown-cmark = { version = "0.6", default-features = false }
 rand = "0.7"
 regex = "1"
 remove_dir_all = "0.5.1"

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -1,9 +1,9 @@
 // Write Markdown to the terminal
 
 use crate::term2::{color, Attr, Terminal};
-use markdown::tokenize;
-use markdown::{Block, ListItem, Span};
 use std::io;
+
+use pulldown_cmark::{Event, Tag};
 
 // Handles the wrapping of text written to the console
 struct LineWrapper<'a, T: Terminal> {
@@ -85,6 +85,7 @@ impl<'a, T: Terminal + 'a> LineWrapper<'a, T> {
 
 // Handles the formatting of text
 struct LineFormatter<'a, T: Terminal + io::Write> {
+    is_code_block: bool,
     wrapper: LineWrapper<'a, T>,
     attrs: Vec<Attr>,
 }
@@ -92,6 +93,7 @@ struct LineFormatter<'a, T: Terminal + io::Write> {
 impl<'a, T: Terminal + io::Write + 'a> LineFormatter<'a, T> {
     fn new(w: &'a mut T, indent: u32, margin: u32) -> Self {
         LineFormatter {
+            is_code_block: false,
             wrapper: LineWrapper::new(w, indent, margin),
             attrs: Vec::new(),
         }
@@ -107,78 +109,114 @@ impl<'a, T: Terminal + io::Write + 'a> LineFormatter<'a, T> {
             let _ = self.wrapper.w.attr(*attr);
         }
     }
-    fn do_spans(&mut self, spans: Vec<Span>) {
-        for span in spans {
-            match span {
-                Span::Break => {}
-                Span::Text(text) => {
-                    self.wrapper.write_span(&text);
-                }
-                Span::Code(code) => {
-                    self.push_attr(Attr::Bold);
-                    self.wrapper.write_word(&code);
-                    self.pop_attr();
-                }
-                Span::Emphasis(spans) => {
-                    self.push_attr(Attr::ForegroundColor(color::BRIGHT_RED));
-                    self.do_spans(spans);
-                    self.pop_attr();
-                }
-                _ => {}
+
+    fn start_tag(&mut self, tag: Tag<'a>) {
+        match tag {
+            Tag::Paragraph => {
+                self.wrapper.write_line();
             }
-        }
-    }
-    fn do_block(&mut self, b: Block) {
-        match b {
-            Block::Header(spans, _) => {
+            Tag::Heading(_level) => {
                 self.push_attr(Attr::Bold);
                 self.wrapper.write_line();
-                self.do_spans(spans);
+            }
+            Tag::Table(_alignments) => {}
+            Tag::TableHead => {}
+            Tag::TableRow => {}
+            Tag::TableCell => {}
+            Tag::BlockQuote => {}
+            Tag::CodeBlock(_lang) => {
+                self.wrapper.write_line();
+                self.wrapper.indent += 2;
+                self.is_code_block = true;
+            }
+            Tag::List(_) => {
+                self.wrapper.write_line();
+                self.wrapper.indent += 2;
+            }
+            Tag::Item => {
+                self.wrapper.write_line();
+            }
+            Tag::Emphasis => {
+                self.push_attr(Attr::ForegroundColor(color::BRIGHT_RED));
+            }
+            Tag::Strong => {}
+            Tag::Strikethrough => {}
+            Tag::Link(_link_type, _dest, _title) => {}
+            Tag::Image(_link_type, _dest, _title) => {}
+            Tag::FootnoteDefinition(_name) => {}
+        }
+    }
+
+    fn end_tag(&mut self, tag: Tag<'a>) {
+        match tag {
+            Tag::Paragraph => {
+                self.wrapper.write_line();
+            }
+            Tag::Heading(_level) => {
                 self.wrapper.write_line();
                 self.pop_attr();
             }
-            Block::CodeBlock(code) => {
-                self.wrapper.write_line();
-                self.wrapper.indent += 2;
-                for line in code.lines() {
-                    // Don't word-wrap code lines
-                    self.wrapper.write_word(line);
-                    self.wrapper.write_line();
-                }
+            Tag::Table(_) => {}
+            Tag::TableHead => {}
+            Tag::TableRow => {}
+            Tag::TableCell => {}
+            Tag::BlockQuote => {}
+            Tag::CodeBlock(_) => {
+                self.is_code_block = false;
                 self.wrapper.indent -= 2;
             }
-            Block::Paragraph(spans) => {
-                self.wrapper.write_line();
-                self.do_spans(spans);
+            Tag::List(_) => {
+                self.wrapper.indent -= 2;
                 self.wrapper.write_line();
             }
-            Block::UnorderedList(items) => {
-                self.wrapper.write_line();
-                for item in items {
-                    self.wrapper.indent += 2;
-                    match item {
-                        ListItem::Simple(spans) => {
-                            self.do_spans(spans);
-                        }
-                        ListItem::Paragraph(blocks) => {
-                            for block in blocks {
-                                self.do_block(block);
-                            }
-                        }
-                    }
-                    self.wrapper.write_line();
-                    self.wrapper.indent -= 2;
+            Tag::Item => {}
+            Tag::Emphasis => {
+                self.pop_attr();
+            }
+            Tag::Strong => {}
+            Tag::Strikethrough => {}
+            Tag::Link(_, _, _) => {}
+            Tag::Image(_, _, _) => {} // shouldn't happen, handled in start
+            Tag::FootnoteDefinition(_) => {}
+        }
+    }
+
+    fn process_event(&mut self, event: Event<'a>) {
+        use self::Event::*;
+        match event {
+            Start(tag) => self.start_tag(tag),
+            End(tag) => self.end_tag(tag),
+            Text(text) => {
+                if self.is_code_block {
+                    self.wrapper.write_word(&text);
+                } else {
+                    self.wrapper.write_span(&text);
                 }
             }
-            _ => {}
+            Code(code) => {
+                self.push_attr(Attr::Bold);
+                self.wrapper.write_word(&code);
+                self.pop_attr();
+            }
+            Html(_html) => {}
+            SoftBreak => {
+                self.wrapper.write_line();
+            }
+            HardBreak => {
+                self.wrapper.write_line();
+            }
+            Rule => {}
+            FootnoteReference(_name) => {}
+            TaskListMarker(true) => {}
+            TaskListMarker(false) => {}
         }
     }
 }
 
 pub fn md<'a, S: AsRef<str>, T: Terminal + io::Write + 'a>(t: &'a mut T, content: S) {
     let mut f = LineFormatter::new(t, 0, 79);
-    let blocks = tokenize(content.as_ref());
-    for b in blocks {
-        f.do_block(b);
+    let parser = pulldown_cmark::Parser::new(content.as_ref());
+    for event in parser {
+        f.process_event(event);
     }
 }

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -120,23 +120,10 @@ impl<'a> Display for Notification<'a> {
                 }
             }
             RemovingComponent(c, h, t) => {
-                if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "removing component '{}'", c)
-                } else {
-                    write!(f, "removing component '{}' for '{}'", c, t.unwrap())
-                }
+                write!(f, "{}", parse_remove_component_notification(c, h, t))
             }
             RemovingOldComponent(c, h, t) => {
-                if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "removing previous version of component '{}'", c)
-                } else {
-                    write!(
-                        f,
-                        "removing previous version of component '{}' for '{}'",
-                        c,
-                        t.unwrap()
-                    )
-                }
+                write!(f, "{}", parse_remove_component_notification(c, h, t))
             }
             DownloadingManifest(t) => write!(f, "syncing channel updates for '{}'", t),
             DownloadedManifest(date, Some(version)) => {
@@ -168,4 +155,20 @@ impl<'a> Display for Notification<'a> {
             ),
         }
     }
+}
+
+fn parse_remove_component_notification(
+    c: &&str,
+    h: &&TargetTriple,
+    t: &Option<&TargetTriple>,
+) -> String {
+    return if Some(h) == t.as_ref() || t.is_none() {
+        format!("removing previous version of component '{}'", c)
+    } else {
+        format!(
+            "removing previous version of component '{}' for '{}'",
+            c,
+            t.unwrap()
+        )
+    };
 }


### PR DESCRIPTION
Fixes #1993.

After analyzing #1993 that led to #1283 & the source of #1639, the hypothesis is to simplify to just `Notification::RemovingComponent` invocation in "src/dist/manifestation.rs" and "src/dist/notification.rs", based on the understanding of the goal is to ultimately just display:

> info: removing previous version of component ***

By such simplification, also able to delete unneeded `RemovingOldComponent` code. Looking forward to review feedback & mentioning to update the PR, if my analysis or hypothesis is correctly.

P.S: I also tried to understand this comment from the 1st comment in #1993:

> Strangely enough, the relevant tests pass.

https://github.com/rust-lang/rustup.rs/blob/489fa585117dc0ac283f247f3c9a829fd32442af/src/dist/manifestation.rs#L133

I'm speculating that the `altered` variable checks for default dist server, and guessing that when tests run, the local env would somehow be considered truthy for the `altered` flag to call original `RemovingOldComponent` to land to the output code for "info: removing old component", and the tests would pass/

While running the "_prod dist_" build, the `altered` flag was considered falsy, and it would call the original `RemovingComponent` to land to the output code for "info: removing component".