### PR TITLE
Update notification for removing component

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -731,6 +731,7 @@ fn try_update_from_dist_<'a>(
                 &download,
                 &download.notify_handler,
                 &toolchain.manifest_name(),
+                true,
             )? {
                 UpdateStatus::Unchanged => Ok(None),
                 UpdateStatus::Changed => Ok(Some(hash)),

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -108,6 +108,7 @@ impl Manifestation {
         download_cfg: &DownloadCfg<'_>,
         notify_handler: &dyn Fn(Notification<'_>),
         toolchain_str: &str,
+        implicit_modify: bool,
     ) -> Result<UpdateStatus> {
         // Some vars we're going to need a few times
         let temp_cfg = download_cfg.temp_cfg;
@@ -168,7 +169,7 @@ impl Manifestation {
 
         // Uninstall components
         for component in &update.components_to_uninstall {
-            let notification = if altered {
+            let notification = if implicit_modify {
                 Notification::RemovingOldComponent
             } else {
                 Notification::RemovingComponent

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -710,6 +710,7 @@ impl<'a> Toolchain<'a> {
                 &self.download_cfg(),
                 &self.download_cfg().notify_handler,
                 &toolchain.manifest_name(),
+                false,
             )?;
 
             Ok(())
@@ -763,6 +764,7 @@ impl<'a> Toolchain<'a> {
                 &self.download_cfg(),
                 &self.download_cfg().notify_handler,
                 &toolchain.manifest_name(),
+                false,
             )?;
 
             Ok(())

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -460,6 +460,7 @@ fn update_from_dist(
         download_cfg,
         download_cfg.notify_handler,
         &toolchain.manifest_name(),
+        true,
     )
 }
 


### PR DESCRIPTION
Fixes #1993. (Previously reviewed in #2012 and corrected based on comment in this new PR)

###### Local Test

```sh
→ rustup update               
info: syncing channel updates for 'stable-x86_64-apple-darwin'
info: syncing channel updates for 'nightly-x86_64-apple-darwin'
info: latest update on 2019-09-25, rust version 1.39.0-nightly (6ef275e6c 2019-09-24)
info: downloading component 'clippy'
info: downloading component 'rustfmt'
info: downloading component 'rustc'
 60.1 MiB /  60.1 MiB (100 %)   7.6 MiB/s in  7s ETA:  0s
info: downloading component 'rust-std'
172.7 MiB / 172.7 MiB (100 %)   7.9 MiB/s in 22s ETA:  0s
info: downloading component 'cargo'
info: downloading component 'rust-docs'
 11.8 MiB /  11.8 MiB (100 %)   7.6 MiB/s in  1s ETA:  0s
info: downloading component 'rust-src'
info: removing previous version of component 'clippy'
info: removing previous version of component 'rustfmt'
info: removing previous version of component 'rustc'
info: removing previous version of component 'rust-std'
info: removing previous version of component 'cargo'
info: removing previous version of component 'rust-docs'
info: removing previous version of component 'rust-src'
info: installing component 'clippy'
info: installing component 'rustfmt'
info: installing component 'rustc'
 60.1 MiB /  60.1 MiB (100 %)   7.6 MiB/s in  8s ETA:  0s
info: installing component 'rust-std'
172.7 MiB / 172.7 MiB (100 %)  15.2 MiB/s in 10s ETA:  0s
info: installing component 'cargo'
info: installing component 'rust-docs'
 11.8 MiB /  11.8 MiB (100 %)   2.3 MiB/s in  4s ETA:  0s
info: installing component 'rust-src'
info: checking for self-updates

  stable-x86_64-apple-darwin unchanged - rustc 1.37.0 (eae3437df 2019-08-13)
   nightly-x86_64-apple-darwin updated - rustc 1.39.0-nightly (6ef275e6c 2019-09-24)
```