### PR TITLE
build: Upgrade sccache to 0.2.11

### DIFF
--- a/ci/docker/scripts/sccache.bash
+++ b/ci/docker/scripts/sccache.bash
@@ -1,22 +1,15 @@
-#!/bin/sh
+#!/bin/bash
 set -xe
 
-VERSION=0.2.8
+VERSION=0.2.11
 TARGET=x86_64-unknown-linux-musl
 BIN_DIR=/usr/local/bin
 TEMP_DIR=$(mktemp -d)
 
+cd "${TEMP_DIR}"
 mkdir -p "${BIN_DIR}"
 
-curl \
-  -o "${TEMP_DIR}/sccache.tar.gz" \
-  -sSL \
-  "https://github.com/mozilla/sccache/releases/download/${VERSION}/sccache-${VERSION}-${TARGET}.tar.gz"
-
-tar \
-  -xzf "${TEMP_DIR}/sccache.tar.gz" \
-  -C "${BIN_DIR}" \
-  --strip-components 1 \
-  "sccache-${VERSION}-${TARGET}/sccache"
-
+curl -sSL "https://github.com/mozilla/sccache/releases/download/${VERSION}/sccache-${VERSION}-${TARGET}.tar.gz" | \
+tar -xzf - --strip-components 1
+cp sccache "${BIN_DIR}/sccache"
 chmod +x "${BIN_DIR}/sccache"


### PR DESCRIPTION
There are build errors in musl job: 
* https://travis-ci.com/rust-lang/rustup.rs/jobs/239713768#L902-L910
* https://travis-ci.com/rust-lang/rustup.rs/jobs/239716478
* https://travis-ci.com/rust-lang/rustup.rs/jobs/239712841

Let's see if upgrading sccache could help.