### PR TITLE
build: Use uname to determine OS

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -8,9 +8,10 @@ rustc -vV
 cargo -vV
 
 FEATURES=()
-if [ "$TRAVIS_OS_NAME" != "windows" ]; then
-  FEATURES=('--features' 'vendored-openssl')
-fi
+case "$(uname -s)" in
+  *NT* ) ;; # Windows NT
+  * ) FEATURES=('--features' 'vendored-openssl') ;;
+esac
 
 # rustc only supports armv7: https://forge.rust-lang.org/platform-support.html
 if [ "$TARGET" = arm-linux-androideabi ]; then


### PR DESCRIPTION
`ci/run.bash` could run in docker environments, so there are no
TRAVIS_OS_NAME env.