### PR TITLE
Support --toolchain option to rustup which

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -183,6 +183,19 @@ impl Cfg {
         Ok(self.update_hash_dir.join(toolchain))
     }
 
+    pub fn which_binary_by_toolchain(
+        &self,
+        toolchain: &str,
+        binary: &str,
+    ) -> Result<Option<PathBuf>> {
+        let toolchain = self.get_toolchain(toolchain, false)?;
+        if toolchain.exists() {
+            Ok(Some(toolchain.binary_file(binary)))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn which_binary(&self, path: &Path, binary: &str) -> Result<Option<PathBuf>> {
         if let Some((toolchain, _)) = self.find_override_toolchain_or_default(path)? {
             Ok(Some(toolchain.binary_file(binary)))

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -862,3 +862,46 @@ fn add_remove_component() {
         expect_component_executable(config, "rustc");
     });
 }
+
+#[test]
+fn which() {
+    setup(&|config| {
+        let path_1 = config.customdir.join("custom-1");
+        let path_1 = path_1.to_string_lossy();
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "link", "custom-1", &path_1],
+        );
+        expect_ok(config, &["rustup", "default", "custom-1"]);
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "which", "rustc"],
+            "\\toolchains\\custom-1\\bin\\rustc",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "which", "rustc"],
+            "/toolchains/custom-1/bin/rustc",
+        );
+        let path_2 = config.customdir.join("custom-2");
+        let path_2 = path_2.to_string_lossy();
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "link", "custom-2", &path_2],
+        );
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "which", "--toolchain=custom-2", "rustc"],
+            "\\toolchains\\custom-2\\bin\\rustc",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "which", "--toolchain=custom-2", "rustc"],
+            "/toolchains/custom-2/bin/rustc",
+        );
+    });
+}


### PR DESCRIPTION
Resolves #1489. Add `--toolchain` option to `rustup which` & test.

##### Local Test

```
→ rustup which --toolchain=stable rustc                    
/Users/bchen/.rustup/toolchains/stable-x86_64-apple-darwin/bin/rustc

→ rustup --toolchain=nightly-2019-09-25-x86_64-apple-darwin which cargo
/Users/bchen/.rustup/toolchains/nightly-x86_64-apple-darwin/bin/cargo
```