### PR TITLE
Support toolchain keyword (e.g. "+nightly") to set override at root command

### DIFF
--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -905,3 +905,79 @@ fn which() {
         );
     });
 }
+
+#[test]
+fn override_by_toolchain_on_the_command_line() {
+    setup(&|config| {
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+stable", "which", "rustc"],
+            "\\toolchains\\stable-x86_64-",
+        );
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+stable", "which", "rustc"],
+            "\\bin\\rustc",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+stable", "which", "rustc"],
+            "/toolchains/stable-x86_64-",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+stable", "which", "rustc"],
+            "/bin/rustc",
+        );
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+nightly", "which", "rustc"],
+            "\\toolchains\\nightly-x86_64-",
+        );
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+nightly", "which", "rustc"],
+            "\\bin\\rustc",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+nightly", "which", "rustc"],
+            "/toolchains/nightly-x86_64-",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "+nightly", "which", "rustc"],
+            "/bin/rustc",
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "+nightly", "show"],
+            "(overridden by +toolchain on the command line)",
+        );
+        expect_err(
+            config,
+            &["rustup", "+foo", "which", "rustc"],
+            "toolchain 'foo' is not installed",
+        );
+        expect_err(
+            config,
+            &["rustup", "@stable", "which", "rustc"],
+            "Invalid value for '<+toolchain>': Toolchain overrides must begin with '+'",
+        );
+        expect_stderr_ok(
+            config,
+            &["rustup", "+stable", "set", "profile", "minimal"],
+            "profile set to 'minimal'",
+        );
+        expect_stdout_ok(config, &["rustup", "default"], "nightly-x86_64-");
+    });
+}


### PR DESCRIPTION
Support the toolchain keyword (e.g "+nightly") to set override of the current working directory for toolchain, at the root command.

This PR should resolve #1498, as the local test is using similar test case to the reported command from the issue:

##### Test w. `rustup +nightly target add wasm32-unknown-unknown`
```
→ rustup +nightly target add wasm32-unknown-unknown
info: using existing install for 'nightly-x86_64-apple-darwin'
info: override toolchain for '/Users/bchen/github/rustup.rs' set to 'nightly-x86_64-apple-darwin'

  nightly-x86_64-apple-darwin unchanged - rustc 1.40.0-nightly (702b45e40 2019-10-01)

info: downloading component 'rust-std' for 'wasm32-unknown-unknown'
 10.9 MiB /  10.9 MiB (100 %)   7.7 MiB/s in  3s ETA:  0s
info: installing component 'rust-std' for 'wasm32-unknown-unknown'
 10.9 MiB /  10.9 MiB (100 %)  10.0 MiB/s in  1s ETA:  0s
```

##### Confirm that the target is added in my rustup toolchain nightly folder

```
→ ls -la ~/.rustup/toolchains/nightly-x86_64-apple-darwin/lib/rustlib/wasm32-unknown-unknown/
total 0
drwxr-xr-x   3 bchen  CORP\Domain Users   96 Oct  6 21:54 .
drwxr-xr-x  19 bchen  CORP\Domain Users  608 Oct  6 21:54 ..
drwxr-xr-x  24 bchen  CORP\Domain Users  768 Oct  6 21:54 lib

```