### PR TITLE
Cleaned up error messages

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -517,37 +517,35 @@ pub fn dump_testament() {
     }
 }
 
+fn show_backtrace() -> bool {
+    if let Ok(true) = env::var("RUSTUP_NO_BACKTRACE").map(|s| s == "1") {
+        return false;
+    }
+
+    if let Ok(true) = env::var("RUST_BACKTRACE").map(|s| s == "1") {
+        return true;
+    }
+
+    for arg in env::args() {
+        if arg == "-v" || arg == "--verbose" {
+            return true;
+        }
+    }
+
+    false
+}
+
 pub fn report_error(e: &Error) {
     err!("{}", e);
 
     for e in e.iter().skip(1) {
-        info!("caused by: {}", e);
+        err!("caused by: {}", e);
     }
 
     if show_backtrace() {
         if let Some(backtrace) = e.backtrace() {
-            info!("backtrace:");
-            println!();
-            println!("{:?}", backtrace);
+            err!("backtrace:");
+            err!("{:?}", backtrace);
         }
-    } else {
-    }
-
-    fn show_backtrace() -> bool {
-        if let Ok(true) = env::var("RUSTUP_NO_BACKTRACE").map(|s| s == "1") {
-            return false;
-        }
-
-        if let Ok(true) = env::var("RUST_BACKTRACE").map(|s| s == "1") {
-            return true;
-        }
-
-        for arg in env::args() {
-            if arg == "-v" || arg == "--verbose" {
-                return true;
-            }
-        }
-
-        false
     }
 }


### PR DESCRIPTION
This diff is a bit hard to follow, but I changed the error messages from this:
```
$ rustup update stable
info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'
info: downloading component 'rustc'
info: downloading component 'rust-std'
info: downloading component 'cargo'
info: downloading component 'rust-std' for 'armv7-apple-ios'
info: downloading component 'rust-std' for 'i686-apple-darwin'
error: component download failed for rust-std-i686-apple-darwin
info: caused by: could not download file from 'https://static.rust-lang.org/dist/2017-03-11/rust-std-1.16.0-i686-apple-darwin.tar.gz' to 'C:\Users\brian\.rustup\tmp\4y0bss25meytiiyq_file
info: caused by: error during download
info: caused by: [18] Transferred a partial file (transfer closed with 3544136 bytes remaining to read)
```

To this:

```
$ rustup update stable
info: syncing channel updates for 'stable-x86_64-pc-windows-msvc'
info: downloading component 'rustc'
info: downloading component 'rust-std'
info: downloading component 'cargo'
info: downloading component 'rust-std' for 'armv7-apple-ios'
info: downloading component 'rust-std' for 'i686-apple-darwin'
error: component download failed for rust-std-i686-apple-darwin
error: caused by: could not download file from 'https://static.rust-lang.org/dist/2017-03-11/rust-std-1.16.0-i686-apple-darwin.tar.gz' to 'C:\Users\brian\.rustup\tmp\4y0bss25meytiiyq_file
error: caused by: error during download
error: caused by: [18] Transferred a partial file (transfer closed with 3544136 bytes remaining to read)
```

As described in #991