### PR TITLE
Fix/improve human-readable units

### DIFF
--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -6,6 +6,7 @@
 /// will cause minutes of wall clock time.
 use super::{perform, Executor, Item};
 use crate::utils::notifications::Notification;
+use crate::utils::units::Unit;
 
 use std::cell::Cell;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -118,7 +119,7 @@ impl<'a> Executor for Threaded<'a> {
         let mut prev_files = self.n_files.load(Ordering::Relaxed);
         if let Some(handler) = self.notify_handler {
             handler(Notification::DownloadFinished);
-            handler(Notification::DownloadPushUnits("iops"));
+            handler(Notification::DownloadPushUnit(Unit::IO));
             handler(Notification::DownloadContentLengthReceived(
                 prev_files as u64,
             ));
@@ -144,7 +145,7 @@ impl<'a> Executor for Threaded<'a> {
         self.pool.join();
         if let Some(handler) = self.notify_handler {
             handler(Notification::DownloadFinished);
-            handler(Notification::DownloadPopUnits);
+            handler(Notification::DownloadPopUnit);
         }
         // close the feedback channel so that blocking reads on it can
         // complete. send is atomic, and we know the threads completed from the

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ pub mod notifications;
 pub mod raw;
 pub mod toml_utils;
 pub mod tty;
+pub mod units;
 #[allow(clippy::module_inception)]
 pub mod utils;
 

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use url::Url;
 
 use crate::utils::notify::NotificationLevel;
+use crate::utils::units::Unit;
 
 #[derive(Debug)]
 pub enum Notification<'a> {
@@ -18,12 +19,12 @@ pub enum Notification<'a> {
     DownloadDataReceived(&'a [u8]),
     /// Download has finished.
     DownloadFinished,
-    /// This thins we're tracking is not counted in bytes.
+    /// The things we're tracking that are not counted in bytes.
     /// Must be paired with a pop-units; our other calls are not
     /// setup to guarantee this any better.
-    DownloadPushUnits(&'a str),
+    DownloadPushUnit(Unit),
     /// finish using an unusual unit.
-    DownloadPopUnits,
+    DownloadPopUnit,
     NoCanonicalPath(&'a Path),
     ResumingPartialDownload,
     UsingCurl,
@@ -47,8 +48,8 @@ impl<'a> Notification<'a> {
             | DownloadingFile(_, _)
             | DownloadContentLengthReceived(_)
             | DownloadDataReceived(_)
-            | DownloadPushUnits(_)
-            | DownloadPopUnits
+            | DownloadPushUnit(_)
+            | DownloadPopUnit
             | DownloadFinished
             | ResumingPartialDownload
             | UsingCurl
@@ -80,8 +81,8 @@ impl<'a> Display for Notification<'a> {
             DownloadingFile(url, _) => write!(f, "downloading file from: '{}'", url),
             DownloadContentLengthReceived(len) => write!(f, "download size is: '{}'", len),
             DownloadDataReceived(data) => write!(f, "received some data of size {}", data.len()),
-            DownloadPushUnits(_) => Ok(()),
-            DownloadPopUnits => Ok(()),
+            DownloadPushUnit(_) => Ok(()),
+            DownloadPopUnit => Ok(()),
             DownloadFinished => write!(f, "download finished"),
             NoCanonicalPath(path) => write!(f, "could not canonicalize path: '{}'", path.display()),
             ResumingPartialDownload => write!(f, "resuming partial download"),

--- a/src/utils/units.rs
+++ b/src/utils/units.rs
@@ -1,0 +1,156 @@
+use std::fmt::{self, Display};
+
+#[derive(Copy, Clone, Debug)]
+pub enum Unit {
+    B,
+    IO,
+}
+
+pub enum UnitMode {
+    Norm,
+    Rate,
+}
+
+/// Human readable size (some units)
+pub enum Size {
+    B(usize, UnitMode),
+    IO(usize, UnitMode),
+}
+
+impl Size {
+    pub fn new(size: usize, unit: Unit, unitmode: UnitMode) -> Self {
+        match unit {
+            Unit::B => Self::B(size, unitmode),
+            Unit::IO => Self::IO(size, unitmode),
+        }
+    }
+}
+
+impl Display for Size {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Size::B(size, unitmode) => {
+                const KI: f64 = 1024.0;
+                const MI: f64 = KI * KI;
+                const GI: f64 = KI * KI * KI;
+                let size = *size as f64;
+
+                let suffix: String = match unitmode {
+                    UnitMode::Norm => "".into(),
+                    UnitMode::Rate => "/s".into(),
+                };
+
+                if size >= GI {
+                    write!(f, "{:5.1} GiB{}", size / GI, suffix)
+                } else if size >= MI {
+                    write!(f, "{:5.1} MiB{}", size / MI, suffix)
+                } else if size >= KI {
+                    write!(f, "{:5.1} KiB{}", size / KI, suffix)
+                } else {
+                    write!(f, "{:3.0} B{}", size, suffix)
+                }
+            }
+            Size::IO(size, unitmode) => {
+                const K: f64 = 1000.0;
+                const M: f64 = K * K;
+                const G: f64 = K * K * K;
+                let size = *size as f64;
+
+                let suffix: String = match unitmode {
+                    UnitMode::Norm => "IO-ops".into(),
+                    UnitMode::Rate => "IOPS".into(),
+                };
+
+                if size >= G {
+                    write!(f, "{:5.1} giga-{}", size / G, suffix)
+                } else if size >= M {
+                    write!(f, "{:5.1} mega-{}", size / M, suffix)
+                } else if size >= K {
+                    write!(f, "{:5.1} kilo-{}", size / K, suffix)
+                } else {
+                    write!(f, "{:3.0} {}", size, suffix)
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn unit_formatter_test() {
+        use crate::utils::units::{Size, Unit, UnitMode};
+
+        // Test Bytes
+        assert_eq!(
+            format!("{}", Size::new(1 as usize, Unit::B, UnitMode::Norm)),
+            "  1 B"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024 as usize, Unit::B, UnitMode::Norm)),
+            "  1.0 KiB"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024usize.pow(2), Unit::B, UnitMode::Norm)),
+            "  1.0 MiB"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024usize.pow(3), Unit::B, UnitMode::Norm)),
+            "  1.0 GiB"
+        );
+
+        // Test Bytes at given rate
+        assert_eq!(
+            format!("{}", Size::new(1 as usize, Unit::B, UnitMode::Rate)),
+            "  1 B/s"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024 as usize, Unit::B, UnitMode::Rate)),
+            "  1.0 KiB/s"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024usize.pow(2), Unit::B, UnitMode::Rate)),
+            "  1.0 MiB/s"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1024usize.pow(3), Unit::B, UnitMode::Rate)),
+            "  1.0 GiB/s"
+        );
+
+        //Test I/O Operations
+        assert_eq!(
+            format!("{}", Size::new(1 as usize, Unit::IO, UnitMode::Norm)),
+            "  1 IO-ops"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000 as usize, Unit::IO, UnitMode::Norm)),
+            "  1.0 kilo-IO-ops"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000usize.pow(2), Unit::IO, UnitMode::Norm)),
+            "  1.0 mega-IO-ops"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000usize.pow(3), Unit::IO, UnitMode::Norm)),
+            "  1.0 giga-IO-ops"
+        );
+
+        //Test I/O Operations at given rate
+        assert_eq!(
+            format!("{}", Size::new(1 as usize, Unit::IO, UnitMode::Rate)),
+            "  1 IOPS"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000 as usize, Unit::IO, UnitMode::Rate)),
+            "  1.0 kilo-IOPS"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000usize.pow(2), Unit::IO, UnitMode::Rate)),
+            "  1.0 mega-IOPS"
+        );
+        assert_eq!(
+            format!("{}", Size::new(1000usize.pow(3), Unit::IO, UnitMode::Rate)),
+            "  1.0 giga-IOPS"
+        );
+    }
+}


### PR DESCRIPTION
Attempt to fix https://github.com/rust-lang/rustup.rs/issues/2041.

Differentiates between `B|B/s` and `IO-ops|IOPS` and formats them human-friendly.