### PR TITLE
Delete content of downloads dir of user home in update subcommand

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -812,6 +812,9 @@ fn update(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
         }
     } else {
         common::update_all_channels(cfg, self_update, m.is_present("force"))?;
+        info!("cleaning up downloads & tmp directories");
+        utils::delete_dir_contents(&cfg.download_dir);
+        cfg.temp_cfg.clean();
     }
 
     Ok(())

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -1,4 +1,5 @@
 use crate::utils::raw;
+use crate::utils::utils;
 use std::error;
 use std::fmt::{self, Display};
 use std::fs;
@@ -195,6 +196,10 @@ impl Cfg {
                 });
             }
         }
+    }
+
+    pub fn clean(&self) {
+        utils::delete_dir_contents(&self.root_directory);
     }
 }
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -587,6 +587,22 @@ where
     })
 }
 
+pub fn delete_dir_contents(dir_path: &Path) {
+    let dir_contents = fs::read_dir(dir_path);
+    if let Ok(contents) = dir_contents {
+        for entry in contents {
+            if let Ok(entry) = entry {
+                let path = entry.path();
+                if path.is_dir() {
+                    remove_dir_all::remove_dir_all(path).expect("Failed to remove a dir");
+                } else {
+                    fs::remove_file(path).expect("Failed to remove a file");
+                }
+            };
+        }
+    };
+}
+
 pub struct FileReaderWithProgress<'a> {
     fh: std::io::BufReader<std::fs::File>,
     notify_handler: &'a dyn Fn(Notification<'_>),

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -59,6 +59,7 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
+info: cleaning up downloads & tmp directories
 "
             ),
         );
@@ -98,6 +99,7 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
+info: cleaning up downloads & tmp directories
 "
             ),
         );
@@ -120,6 +122,7 @@ fn rustup_stable_no_change() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
+info: cleaning up downloads & tmp directories
 "
             ),
         );
@@ -188,6 +191,7 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
+info: cleaning up downloads & tmp directories
 "
             ),
         );
@@ -244,6 +248,7 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
+info: cleaning up downloads & tmp directories
 "
             ),
         );
@@ -260,6 +265,7 @@ fn rustup_no_channels() {
             &["rustup", "update", "--no-self-update"],
             r"",
             r"info: no updatable toolchains installed
+info: cleaning up downloads & tmp directories
 ",
         );
     })


### PR DESCRIPTION
Resolves #2038.

P.S.: can use some mentoring from review comments to:
- polish code pattern
- improve test to actually download a binary, run `update`and assert the deleted content of `downloads` folder of user home.

I'll keep thinking, and will push edit(s), if I could figure out a better test. But thought that I'd start the PR to collect some feedback.