### PR TITLE
self_update: Ensure profile set on self-update

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1582,6 +1582,23 @@ pub fn run_update(setup_path: &Path) -> Result<()> {
     process::exit(0);
 }
 
+/// Ensure that the configuration is good after a self-update
+///
+/// Currently the only thing we do is ensure that a profile is set
+/// since that could mess things up otherwise, and we don't really
+/// want to do a full metadata update for that.  There are potentially
+/// legitimate reasons for a user to unset profile though so we only
+/// set it on updates rather than simply ensuring we always have a
+/// profile set in `Cfg::get_profile()`
+fn ensure_config_good() -> Result<()> {
+    let cfg = common::set_globals(false, true)?;
+    if cfg.get_profile()?.is_none() {
+        cfg.set_profile(Profile::default_name())?;
+    }
+
+    Ok(())
+}
+
 /// This function is as the final step of a self-upgrade. It replaces
 /// `CARGO_HOME`/bin/rustup with the running exe, and updates the the
 /// links to it. On windows this will run *after* the original
@@ -1589,6 +1606,7 @@ pub fn run_update(setup_path: &Path) -> Result<()> {
 #[cfg(unix)]
 pub fn self_replace() -> Result<()> {
     install_bins()?;
+    ensure_config_good()?;
 
     Ok(())
 }
@@ -1597,6 +1615,7 @@ pub fn self_replace() -> Result<()> {
 pub fn self_replace() -> Result<()> {
     wait_for_parent()?;
     install_bins()?;
+    ensure_config_good()?;
 
     Ok(())
 }


### PR DESCRIPTION
Fixes: #2045

This ought to resolve the issue by forcing a profile on self-update.  This is sub-optimal long-term but until I've satisfied myself that the potential use-cases for a config with no profile set are no longer relevant I refuse to force `Cfg::get_profile()` to always return a profile.