### PR TITLE
Point to VS C++ Build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ $ rustup target add i686-pc-windows-gnu
 ```
 
 [ABIs]: https://en.wikipedia.org/wiki/Application_binary_interface
-[Visual Studio]: https://visualstudio.microsoft.com/downloads/
+[Visual Studio]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
 [GCC toolchain]: https://gcc.gnu.org/
 [MinGW/MSYS2 toolchain]: https://msys2.github.io/
 


### PR DESCRIPTION
https://visualstudio.microsoft.com/downloads/ - points to `vs_Community.exe`, when run will give us this screen:

![image](https://user-images.githubusercontent.com/28787/66828746-1a5a6800-ef52-11e9-961d-05ba94ef4f09.png)

What we want instead is https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019 - points to `vs_BuildTools.exe`, when run gives us this screen:

![image](https://user-images.githubusercontent.com/28787/66828661-e97a3300-ef51-11e9-8a89-f9c8eacc2e7b.png)


Similar as here https://github.com/rust-lang/rustup.rs/blob/1094d2e96ced2ad21e36ffff305236f908a19a5d/src/cli/self_update.rs#L194

Previously there were some problems:
- https://github.com/rust-lang/rustup.rs/issues/1772
- https://github.com/rust-lang/rust/issues/42744
