### PR TITLE
Kinnison/fixups 1.20.1

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -279,6 +279,12 @@ pub fn cli() -> App<'static, 'static> {
                                 .short("t")
                                 .takes_value(true)
                                 .multiple(true)
+                        )
+                        .arg(
+                            Arg::with_name("force")
+                                .help("Force an update, even if some components are missing")
+                                .long("force")
+                                .takes_value(false),
                         ),
                 )
                 .subcommand(

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1304,10 +1304,7 @@ fn set_profile(cfg: &Cfg, m: &ArgMatches) -> Result<()> {
 }
 
 fn show_profile(cfg: &Cfg) -> Result<()> {
-    match cfg.get_profile()? {
-        Some(p) => println!("{}", p),
-        None => println!("No profile set"),
-    }
+    println!("{}", cfg.get_profile()?);
     Ok(())
 }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1582,23 +1582,6 @@ pub fn run_update(setup_path: &Path) -> Result<()> {
     process::exit(0);
 }
 
-/// Ensure that the configuration is good after a self-update
-///
-/// Currently the only thing we do is ensure that a profile is set
-/// since that could mess things up otherwise, and we don't really
-/// want to do a full metadata update for that.  There are potentially
-/// legitimate reasons for a user to unset profile though so we only
-/// set it on updates rather than simply ensuring we always have a
-/// profile set in `Cfg::get_profile()`
-fn ensure_config_good() -> Result<()> {
-    let cfg = common::set_globals(false, true)?;
-    if cfg.get_profile()?.is_none() {
-        cfg.set_profile(Profile::default_name())?;
-    }
-
-    Ok(())
-}
-
 /// This function is as the final step of a self-upgrade. It replaces
 /// `CARGO_HOME`/bin/rustup with the running exe, and updates the the
 /// links to it. On windows this will run *after* the original
@@ -1606,7 +1589,6 @@ fn ensure_config_good() -> Result<()> {
 #[cfg(unix)]
 pub fn self_replace() -> Result<()> {
     install_bins()?;
-    ensure_config_good()?;
 
     Ok(())
 }
@@ -1615,7 +1597,6 @@ pub fn self_replace() -> Result<()> {
 pub fn self_replace() -> Result<()> {
     wait_for_parent()?;
     install_bins()?;
-    ensure_config_good()?;
 
     Ok(())
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -760,7 +760,7 @@ fn maybe_install_rust(
         // Set host triple first as it will affect resolution of toolchain_str
         cfg.set_default_host_triple(default_host_triple)?;
         let toolchain = cfg.get_toolchain(toolchain_str, false)?;
-        let status = toolchain.install_from_dist(false, components, targets)?;
+        let status = toolchain.install_from_dist(true, components, targets)?;
         cfg.set_default(toolchain_str)?;
         println!();
         common::show_channel_update(&cfg, toolchain_str, Ok(status))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -140,18 +140,18 @@ impl Cfg {
     // Returns a profile, if one exists in the settings file.
     //
     // Returns `Err` if the settings file could not be read or the profile is
-    // invalid. Returns `Ok(Some(...))` if there is a valid profile, and `Ok(None)`
+    // invalid. Returns `Ok(...)` if there is a valid profile, and `Ok(Profile::default())`
     // if there is no profile in the settings file. The last variant happens when
     // a user upgrades from a version of Rustup without profiles to a version of
     // Rustup with profiles.
-    pub fn get_profile(&self) -> Result<Option<dist::Profile>> {
+    pub fn get_profile(&self) -> Result<dist::Profile> {
         self.settings_file.with(|s| {
             let p = match &s.profile {
                 Some(p) => p,
-                None => return Ok(None),
+                None => dist::Profile::default_name(),
             };
             let p = dist::Profile::from_str(p)?;
-            Ok(Some(p))
+            Ok(p)
         })
     }
 

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -31,6 +31,7 @@ pub enum Notification<'a> {
     DownloadedManifest(&'a str, Option<&'a str>),
     DownloadingLegacyManifest,
     SkippingNightlyMissingComponent(&'a [Component]),
+    ForcingUnavailableComponent(&'a str),
     ManifestChecksumFailedHack,
     ComponentUnavailable(&'a str, Option<&'a TargetTriple>),
     StrayHash(&'a Path),
@@ -75,6 +76,7 @@ impl<'a> Notification<'a> {
             | MissingInstalledComponent(_)
             | CachedFileChecksumFailed
             | ComponentUnavailable(_, _)
+            | ForcingUnavailableComponent(_)
             | StrayHash(_) => NotificationLevel::Warn,
             NonFatalError(_) => NotificationLevel::Error,
         }
@@ -166,6 +168,9 @@ impl<'a> Display for Notification<'a> {
                 "skipping nightly which is missing installed component '{}'",
                 components[0].short_name_in_manifest()
             ),
+            ForcingUnavailableComponent(component) => {
+                write!(f, "Force-skipping unavailable component '{}'", component)
+            }
         }
     }
 }

--- a/src/install.rs
+++ b/src/install.rs
@@ -19,7 +19,7 @@ pub enum InstallMethod<'a> {
     // bool is whether to force an update
     Dist(
         &'a dist::ToolchainDesc,
-        Option<dist::Profile>,
+        dist::Profile,
         Option<&'a Path>,
         DownloadCfg<'a>,
         // --force
@@ -76,7 +76,7 @@ impl<'a> InstallMethod<'a> {
                     dl_cfg,
                     update_hash,
                     toolchain,
-                    if exists { None } else { profile },
+                    if exists { None } else { Some(profile) },
                     prefix,
                     force_update,
                     old_date,

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -669,6 +669,14 @@ fn build_mock_channel(
     } else if rls == RlsStatus::Available {
         let rls = build_mock_rls_installer(version, version_hash, false);
         all.push(("rls", vec![(rls, host_triple.clone())]));
+    } else {
+        all.push((
+            "rls",
+            vec![(
+                MockInstallerBuilder { components: vec![] },
+                host_triple.clone(),
+            )],
+        ))
     }
 
     let more = vec![
@@ -726,7 +734,7 @@ fn build_mock_channel(
             .into_iter()
             .map(|(installer, triple)| MockTargetedPackage {
                 target: triple,
-                available: true,
+                available: !installer.components.is_empty(),
                 components: vec![],
                 installer,
             });
@@ -776,6 +784,12 @@ fn build_mock_channel(
                     target: target.to_string(),
                     is_extension: true,
                 });
+            } else {
+                target_pkg.components.push(MockComponent {
+                    name: "rls".to_string(),
+                    target: target.to_string(),
+                    is_extension: true,
+                })
             }
             target_pkg.components.push(MockComponent {
                 name: "rust-std".to_string(),

--- a/tests/mock/dist.rs
+++ b/tests/mock/dist.rs
@@ -391,7 +391,10 @@ impl MockDistServer {
         let profiles = &[
             ("minimal", vec!["rustc"]),
             ("default", vec!["rustc", "cargo", "rust-std", "rust-docs"]),
-            ("complete", vec!["rustc", "cargo", "rust-std"]),
+            (
+                "complete",
+                vec!["rustc", "cargo", "rust-std", "rust-docs", "rls"],
+            ),
         ];
         for (profile, values) in profiles {
             let array = values


### PR DESCRIPTION
This branch covers two major things to improve matters arising from 1.20

1. We now assume the default profile if there's nothing in the config -- this means that distro-provided `rustup` won't fail to install new toolchains entirely and strangely.
2. We now force the toolchain installation during `rustup-init` so that platforms missing components will at least still install to some extent.

Minor fixes:

1. `rustup toolchain install` now has `--force` where somehow we missed it off before.
2. Report when we skip a missing component because we're `--force`d
