### PR TITLE
Kinnison/forced install skipping fix

### DIFF
--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1176,5 +1176,12 @@ fn test_complete_profile_skips_missing_when_forced() {
             ],
             for_host!("warning: Force-skipping unavailable component 'rls-{}'"),
         );
+
+        // Ensure that the skipped component (rls) is not installed
+        expect_not_stdout_ok(
+            config,
+            &["rustup", "component", "list"],
+            for_host!("rls-{} (installed)"),
+        );
     })
 }


### PR DESCRIPTION
This ought to correct a regression hidden inside the force-skipping behaviour of `toolchain install --force`.

Fixes #2065 