### PR TITLE
Use "true" for force_update in relevant install_from_dist calls in config.rs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -317,7 +317,7 @@ impl Cfg {
                             ErrorKind::OverrideToolchainNotInstalled(name.to_string())
                         })
                     } else {
-                        toolchain.install_from_dist(false, &[], &[])?;
+                        toolchain.install_from_dist(true, &[], &[])?;
                         Ok(Some((toolchain, reason)))
                     }
                 }
@@ -478,7 +478,7 @@ impl Cfg {
     ) -> Result<Command> {
         let toolchain = self.get_toolchain(toolchain, false)?;
         if install_if_missing && !toolchain.exists() {
-            toolchain.install_from_dist(false, &[], &[])?;
+            toolchain.install_from_dist(true, &[], &[])?;
         }
 
         if let Some(cmd) = self.maybe_do_cargo_fallback(&toolchain, binary)? {


### PR DESCRIPTION
> ... there're three sites which call `install_from_dist()` in the `config.rs::Cfg code`, and the one in `update_all_channels()` should be left alone. As such there are two sites to amend a boolean ...

> The difficulty will be in devising a nice set of tests to verify that this works ...

This PR resolves #2068 by updating the `force_update` param from ~`false`~ to `true` in relevant `install_from_dist()` calls in config.rs, and provides two tests to mimic the users cases where these `install_from_dist` calls would occur. (Could update the tests better under review guidance. Thanks in advance.)  