### PR TITLE
install: add --profile flag to override profile

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -746,7 +746,7 @@ fn maybe_install_rust(
     verbose: bool,
     quiet: bool,
 ) -> Result<()> {
-    let cfg = common::set_globals(verbose, quiet)?;
+    let mut cfg = common::set_globals(verbose, quiet)?;
     cfg.set_profile(profile_str)?;
 
     // If there is already an install, then `toolchain_str` may not be


### PR DESCRIPTION
Previously, the profile to use when installing a new toolchain had to be
set globally through `rustup set profile`, or at rustup-init time.
However, sometimes this is inconvenient, because you only want to use a
particular profile for a specific toolchain. This patch allows users to
pass `--profile` to `rustup install` to override the profile used for
that one install.

Fixes #2004.