### PR TITLE
Stop using bright colors

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -155,11 +155,11 @@ fn show_channel_updates(
         match result {
             Ok(UpdateStatus::Installed) => {
                 banner = "installed";
-                color = Some(term2::color::BRIGHT_GREEN);
+                color = Some(term2::color::GREEN);
             }
             Ok(UpdateStatus::Updated) => {
                 banner = "updated";
-                color = Some(term2::color::BRIGHT_GREEN);
+                color = Some(term2::color::GREEN);
             }
             Ok(UpdateStatus::Unchanged) => {
                 banner = "unchanged";
@@ -167,7 +167,7 @@ fn show_channel_updates(
             }
             Err(_) => {
                 banner = "update failed";
-                color = Some(term2::color::BRIGHT_RED);
+                color = Some(term2::color::RED);
             }
         }
 

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -23,7 +23,7 @@ macro_rules! debug {
 
 pub fn warn_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
-    let _ = t.fg(term2::color::BRIGHT_YELLOW);
+    let _ = t.fg(term2::color::YELLOW);
     let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "warning: ");
     let _ = t.reset();
@@ -33,7 +33,7 @@ pub fn warn_fmt(args: fmt::Arguments<'_>) {
 
 pub fn err_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
-    let _ = t.fg(term2::color::BRIGHT_RED);
+    let _ = t.fg(term2::color::RED);
     let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "error: ");
     let _ = t.reset();
@@ -52,7 +52,7 @@ pub fn info_fmt(args: fmt::Arguments<'_>) {
 
 pub fn verbose_fmt(args: fmt::Arguments<'_>) {
     let mut t = term2::stderr();
-    let _ = t.fg(term2::color::BRIGHT_MAGENTA);
+    let _ = t.fg(term2::color::MAGENTA);
     let _ = t.attr(term2::Attr::Bold);
     let _ = write!(t, "verbose: ");
     let _ = t.reset();
@@ -63,7 +63,7 @@ pub fn verbose_fmt(args: fmt::Arguments<'_>) {
 pub fn debug_fmt(args: fmt::Arguments<'_>) {
     if std::env::var("RUSTUP_DEBUG").is_ok() {
         let mut t = term2::stderr();
-        let _ = t.fg(term2::color::BRIGHT_BLUE);
+        let _ = t.fg(term2::color::BLUE);
         let _ = t.attr(term2::Attr::Bold);
         let _ = write!(t, "verbose: ");
         let _ = t.reset();

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -137,7 +137,7 @@ impl<'a, T: Terminal + io::Write + 'a> LineFormatter<'a, T> {
                 self.wrapper.write_line();
             }
             Tag::Emphasis => {
-                self.push_attr(Attr::ForegroundColor(color::BRIGHT_RED));
+                self.push_attr(Attr::ForegroundColor(color::RED));
             }
             Tag::Strong => {}
             Tag::Strikethrough => {}

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -766,23 +766,23 @@ fn check_updates(cfg: &Cfg) -> Result<()> {
                 write!(t, "{} - ", name)?;
                 match (current_version, dist_version) {
                     (None, None) => {
-                        let _ = t.fg(term2::color::BRIGHT_RED);
+                        let _ = t.fg(term2::color::RED);
                         writeln!(t, "Cannot identify installed or update versions")?;
                     }
                     (Some(cv), None) => {
-                        let _ = t.fg(term2::color::BRIGHT_GREEN);
+                        let _ = t.fg(term2::color::GREEN);
                         write!(t, "Up to date")?;
                         let _ = t.reset();
                         writeln!(t, " : {}", cv)?;
                     }
                     (Some(cv), Some(dv)) => {
-                        let _ = t.fg(term2::color::BRIGHT_YELLOW);
+                        let _ = t.fg(term2::color::YELLOW);
                         write!(t, "Update available")?;
                         let _ = t.reset();
                         writeln!(t, " : {} -> {}", cv, dv)?;
                     }
                     (None, Some(dv)) => {
-                        let _ = t.fg(term2::color::BRIGHT_YELLOW);
+                        let _ = t.fg(term2::color::YELLOW);
                         write!(t, "Update available")?;
                         let _ = t.reset();
                         writeln!(t, " : (Unknown version) -> {}", dv)?;

--- a/src/cli/term2.rs
+++ b/src/cli/term2.rs
@@ -162,16 +162,7 @@ where
         if !T::isatty() {
             return Ok(());
         }
-
-        if let Err(e) = self.0.attr(attr) {
-            // If `attr` is not supported, try to emulate it
-            match attr {
-                Attr::Bold => swallow_unsupported!(self.0.fg(color::BRIGHT_WHITE)),
-                _ => swallow_unsupported!(Err(e)),
-            }
-        } else {
-            Ok(())
-        }
+        swallow_unsupported!(self.0.attr(attr))
     }
 
     fn supports_attr(&self, attr: Attr) -> bool {
@@ -198,7 +189,6 @@ where
         if !T::isatty() {
             return Ok(());
         }
-
         swallow_unsupported!(self.0.cursor_up())
     }
 


### PR DESCRIPTION
Bright colors often display badly for those who are using colorschemes
that use unexpected bright colors such as solarized.

Additionally, many terminals automatically display bold text in bright
colors (unless this option is explicitly disabled) particularly if bold
text is not supported.

It should be left up to the user whether they want their bold text to be
displayed in bright colors.

This should also fix #433 (if it is still an issue).