### PR TITLE
Correct "toolchain list" command verbose option

### DIFF
--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -981,3 +981,19 @@ fn override_by_toolchain_on_the_command_line() {
         expect_stdout_ok(config, &["rustup", "default"], "nightly-x86_64-");
     });
 }
+
+#[test]
+fn toolchain_link_then_list_verbose() {
+    setup(&|config| {
+        let path_1 = config.customdir.join("custom-1");
+        let path_1 = path_1.to_string_lossy();
+        expect_ok(
+            config,
+            &["rustup", "toolchain", "link", "custom-1", &path_1],
+        );
+        #[cfg(windows)]
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "\\custom-1");
+        #[cfg(not(windows))]
+        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "/custom-1");
+    });
+}

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -104,14 +104,31 @@ fn list_toolchains() {
             &["rustup", "toolchain", "list", "-v"],
             "(default)\t",
         );
+        #[cfg(windows)]
         expect_stdout_ok(
             config,
-            &["rustup", "toolchain", "list", "--verbose"],
-            "(default)\t",
+            &["rustup", "toolchain", "list", "-v"],
+            "\\toolchains\\nightly-x86",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "/toolchains/nightly-x86",
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
-        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "\t");
-        expect_stdout_ok(config, &["rustup", "toolchain", "list", "--verbose"], "\t");
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "\\toolchains\\beta-2015-01-01",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "/toolchains/beta-2015-01-01",
+        );
     });
 }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -148,14 +148,31 @@ fn list_toolchains() {
             &["rustup", "toolchain", "list", "-v"],
             "(default)\t",
         );
+        #[cfg(windows)]
         expect_stdout_ok(
             config,
-            &["rustup", "toolchain", "list", "--verbose"],
-            "(default)\t",
+            &["rustup", "toolchain", "list", "-v"],
+            "\\toolchains\\nightly-x86",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "/toolchains/nightly-x86",
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
-        expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "\t");
-        expect_stdout_ok(config, &["rustup", "toolchain", "list", "--verbose"], "\t");
+        #[cfg(windows)]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "\\toolchains\\beta-2015-01-01",
+        );
+        #[cfg(not(windows))]
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list", "-v"],
+            "/toolchains/beta-2015-01-01",
+        );
     });
 }
 


### PR DESCRIPTION
Correct the `verbose` (or `v`) option of `toolchain list` to display full path of toolchains. Updated tests.

##### current observation - only displays user's rustup directory

```
→ rustup toolchain list -v                                                     
stable-x86_64-apple-darwin (default)	/Users/bchen/.rustup
nightly-2019-09-25-x86_64-apple-darwin	/Users/bchen/.rustup
nightly-x86_64-apple-darwin	/Users/bchen/.rustup
```

##### fixed version

```
→ rustup toolchain list -v                     
stable-x86_64-apple-darwin (default)	/Users/bchen/.rustup/toolchains/stable-x86_64-apple-darwin/
nightly-2019-09-25-x86_64-apple-darwin	/Users/bchen/.rustup/toolchains/nightly-2019-09-25-x86_64-apple-darwin/
nightly-x86_64-apple-darwin	/Users/bchen/.rustup/toolchains/nightly-x86_64-apple-darwin/
```