### PR TITLE
manifest: Do not wrongly ascribe target to rust-src and friends

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -256,13 +256,16 @@ impl Manifest {
         let rust_pkg = self.get_package("rust")?.get_target(Some(target))?;
         let result = profile
             .iter()
-            .filter(|s| {
-                rust_pkg
-                    .components
-                    .iter()
-                    .any(|c| &c.pkg == *s && c.target.as_ref().map(|t| t == target).unwrap_or(true))
+            .map(|s| {
+                (
+                    s,
+                    rust_pkg.components.iter().find(|c| {
+                        &c.pkg == s && c.target.as_ref().map(|t| t == target).unwrap_or(true)
+                    }),
+                )
             })
-            .map(|s| Component::new(s.to_owned(), Some(target.clone()), false))
+            .filter(|(_, c)| c.is_some())
+            .map(|(s, c)| Component::new(s.to_owned(), c.and_then(|c| c.target.clone()), false))
             .collect();
         Ok(result)
     }


### PR DESCRIPTION
Some components have no target (target="*") and as such when we
install them, we should not ascribe a target to them.  Before this,
installing `--profile complete` would incorrectly show `rust-src`
as not installed, despite being so.

After this fix, anyone updating such a broken toolchain install must
first `rustup component remove rust-src` and then reinstall it either
before or after upgrading.

Fixes: #2081