### PR TITLE
component: Support installation/removal of `component-target`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1127,7 +1127,8 @@ fn component_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     });
 
     for component in m.values_of("component").expect("") {
-        let new_component = Component::new(component.to_string(), target.clone(), true);
+        let new_component = Component::new_with_target(component, false)
+            .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
 
         toolchain.add_component(new_component)?;
     }
@@ -1146,7 +1147,8 @@ fn component_remove(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     });
 
     for component in m.values_of("component").expect("") {
-        let new_component = Component::new(component.to_string(), target.clone(), true);
+        let new_component = Component::new_with_target(component, false)
+            .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
 
         toolchain.remove_component(new_component)?;
     }

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -218,6 +218,22 @@ impl TargetTriple {
     }
 }
 
+impl std::convert::TryFrom<PartialTargetTriple> for TargetTriple {
+    type Error = &'static str;
+    fn try_from(value: PartialTargetTriple) -> std::result::Result<Self, Self::Error> {
+        if value.arch.is_some() && value.os.is_some() && value.env.is_some() {
+            Ok(Self(format!(
+                "{}-{}-{}",
+                value.arch.unwrap(),
+                value.os.unwrap(),
+                value.env.unwrap()
+            )))
+        } else {
+            Err("Incomplete / bad target triple")
+        }
+    }
+}
+
 impl PartialTargetTriple {
     pub fn new(name: &str) -> Option<Self> {
         if name.is_empty() {

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -13,7 +13,7 @@
 use crate::errors::*;
 use crate::utils::toml_utils::*;
 
-use crate::dist::dist::{Profile, TargetTriple};
+use crate::dist::dist::{PartialTargetTriple, Profile, TargetTriple};
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
@@ -496,6 +496,25 @@ impl Component {
             is_extension,
         }
     }
+
+    pub fn new_with_target(pkg_with_target: &str, is_extension: bool) -> Option<Self> {
+        use std::convert::TryFrom;
+        for (pos, _) in pkg_with_target.match_indices('-') {
+            let pkg = &pkg_with_target[0..pos];
+            let target = &pkg_with_target[pos + 1..];
+            if let Some(partial) = PartialTargetTriple::new(target) {
+                if let Ok(triple) = TargetTriple::try_from(partial) {
+                    return Some(Self {
+                        pkg: pkg.to_string(),
+                        target: Some(triple),
+                        is_extension,
+                    });
+                }
+            }
+        }
+        None
+    }
+
     pub fn wildcard(&self) -> Self {
         Self {
             pkg: self.pkg.clone(),

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -679,6 +679,59 @@ fn add_all_targets_fail() {
 }
 
 #[test]
+fn add_target_by_component_add() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_not_stdout_ok(
+            config,
+            &["rustup", "target", "list"],
+            &format!("{} (installed)", clitools::CROSS_ARCH1),
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "component",
+                "add",
+                &format!("rust-std-{}", clitools::CROSS_ARCH1),
+            ],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "target", "list"],
+            &format!("{} (installed)", clitools::CROSS_ARCH1),
+        );
+    })
+}
+
+#[test]
+fn remove_target_by_component_remove() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        expect_stdout_ok(
+            config,
+            &["rustup", "target", "list"],
+            &format!("{} (installed)", clitools::CROSS_ARCH1),
+        );
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "component",
+                "remove",
+                &format!("rust-std-{}", clitools::CROSS_ARCH1),
+            ],
+        );
+        expect_not_stdout_ok(
+            config,
+            &["rustup", "target", "list"],
+            &format!("{} (installed)", clitools::CROSS_ARCH1),
+        );
+    })
+}
+
+#[test]
 fn add_target_no_toolchain() {
     setup(&|config| {
         expect_err(


### PR DESCRIPTION
In order to reduce the surprise available when someone expects to be able to
take output of `rustup component list` and use it as input to `rustup component
add` or `rustup component remove` we now support creation of `Component`
objects by attempting to split it on '-' and see if we get a component name and
valid full target triple.

Fixes: #2057