### PR TITLE
Improve handling/reporting of keys

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -115,21 +115,23 @@ pub fn set_globals(verbose: bool, quiet: bool) -> Result<Cfg> {
         if download_tracker.borrow_mut().handle_notification(&n) {
             return;
         }
-
-        match n.level() {
-            NotificationLevel::Verbose => {
-                if verbose {
-                    verbose!("{}", n);
+        let level = n.level();
+        for n in format!("{}", n).lines() {
+            match level {
+                NotificationLevel::Verbose => {
+                    if verbose {
+                        verbose!("{}", n);
+                    }
                 }
-            }
-            NotificationLevel::Info => {
-                info!("{}", n);
-            }
-            NotificationLevel::Warn => {
-                warn!("{}", n);
-            }
-            NotificationLevel::Error => {
-                err!("{}", n);
+                NotificationLevel::Info => {
+                    info!("{}", n);
+                }
+                NotificationLevel::Warn => {
+                    warn!("{}", n);
+                }
+                NotificationLevel::Error => {
+                    err!("{}", n);
+                }
             }
         }
     }))?)

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -65,7 +65,7 @@ pub fn debug_fmt(args: fmt::Arguments<'_>) {
         let mut t = term2::stderr();
         let _ = t.fg(term2::color::BLUE);
         let _ = t.attr(term2::Attr::Bold);
-        let _ = write!(t, "verbose: ");
+        let _ = write!(t, "debug: ");
         let _ = t.reset();
         let _ = t.write_fmt(args);
         let _ = writeln!(t);

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -51,6 +51,7 @@ pub fn main() -> Result<()> {
             ("active-toolchain", Some(_)) => handle_epipe(show_active_toolchain(cfg))?,
             ("home", Some(_)) => handle_epipe(show_rustup_home(cfg))?,
             ("profile", Some(_)) => handle_epipe(show_profile(cfg))?,
+            ("keys", Some(_)) => handle_epipe(show_keys(cfg))?,
             (_, _) => handle_epipe(show(cfg))?,
         },
         ("install", Some(m)) => update(cfg, m)?,
@@ -165,7 +166,8 @@ pub fn cli() -> App<'static, 'static> {
                     SubCommand::with_name("home")
                         .about("Display the computed value of RUSTUP_HOME"),
                 )
-                .subcommand(SubCommand::with_name("profile").about("Show the current profile")),
+                .subcommand(SubCommand::with_name("profile").about("Show the current profile"))
+                .subcommand(SubCommand::with_name("keys").about("Display the known PGP keys")),
         )
         .subcommand(
             SubCommand::with_name("install")
@@ -1335,6 +1337,15 @@ fn set_profile(cfg: &mut Cfg, m: &ArgMatches) -> Result<()> {
 
 fn show_profile(cfg: &Cfg) -> Result<()> {
     println!("{}", cfg.get_profile()?);
+    Ok(())
+}
+
+fn show_keys(cfg: &Cfg) -> Result<()> {
+    for key in cfg.get_pgp_keys() {
+        for l in key.show_key()? {
+            info!("{}", l);
+        }
+    }
     Ok(())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ impl Display for PgpPublicKey {
         match self {
             Self::Builtin => write!(f, "builtin Rust release key"),
             Self::FromEnvironment(p, _) => {
-                write!(f, "key specified in RUST_PGP_KEY ({})", p.display())
+                write!(f, "key specified in RUSTUP_PGP_KEY ({})", p.display())
             }
             Self::FromConfiguration(p, _) => {
                 write!(f, "key specified in configuration file ({})", p.display())

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,40 @@ impl PgpPublicKey {
             Self::FromConfiguration(_, k) => &k,
         }
     }
+
+    /// Display the key in detail for the user
+    pub fn show_key(&self) -> Result<Vec<String>> {
+        fn format_hex(bytes: &[u8], separator: &str, every: usize) -> Result<String> {
+            use std::fmt::Write;
+            let mut ret = String::new();
+            let mut wait = every;
+            for b in bytes.iter() {
+                if wait == 0 {
+                    ret.push_str(separator);
+                    wait = every;
+                }
+                wait -= 1;
+                write!(ret, "{:02X}", b).map_err(|e| format!("{:?}", e))?;
+            }
+            Ok(ret)
+        }
+        use pgp::types::KeyTrait;
+        let mut ret = Vec::new();
+        ret.push(format!("from {}", self));
+        let key = self.key();
+        let keyid = format_hex(&key.key_id().to_vec(), "-", 4)?;
+        let algo = key.algorithm();
+        let fpr = format_hex(&key.fingerprint(), " ", 2)?;
+        let uid0 = key
+            .details
+            .users
+            .get(0)
+            .map(|u| u.id.id())
+            .unwrap_or("<No User ID>");
+        ret.push(format!("  {:?}/{} - {}", algo, keyid, uid0));
+        ret.push(format!("  Fingerprint: {}", fpr));
+        Ok(ret)
+    }
 }
 
 impl Display for PgpPublicKey {

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -1,3 +1,4 @@
+use crate::config::PgpPublicKey;
 use crate::dist::dist::TargetTriple;
 use crate::dist::manifest::Component;
 use crate::dist::temp;
@@ -16,7 +17,7 @@ pub enum Notification<'a> {
     CantReadUpdateHash(&'a Path),
     NoUpdateHash(&'a Path),
     ChecksumValid(&'a str),
-    SignatureValid(&'a str),
+    SignatureValid(&'a str, &'a PgpPublicKey),
     FileAlreadyDownloaded,
     CachedFileChecksumFailed,
     RollingBack,
@@ -57,11 +58,11 @@ impl<'a> Notification<'a> {
             Temp(n) => n.level(),
             Utils(n) => n.level(),
             ChecksumValid(_)
+            | SignatureValid(_, _)
             | NoUpdateHash(_)
             | FileAlreadyDownloaded
             | DownloadingLegacyManifest => NotificationLevel::Verbose,
             Extracting(_, _)
-            | SignatureValid(_)
             | DownloadingComponent(_, _, _)
             | InstallingComponent(_, _, _)
             | RemovingComponent(_, _, _)
@@ -100,7 +101,13 @@ impl<'a> Display for Notification<'a> {
             ),
             NoUpdateHash(path) => write!(f, "no update hash at: '{}'", path.display()),
             ChecksumValid(_) => write!(f, "checksum passed"),
-            SignatureValid(_) => write!(f, "signature valid"),
+            SignatureValid(url, key) => (|| {
+                writeln!(f, "Good signature from on {} from:", url)?;
+                for l in key.show_key().map_err(|_| std::fmt::Error)?.iter() {
+                    writeln!(f, "{}", l)?;
+                }
+                Ok(())
+            })(),
             FileAlreadyDownloaded => write!(f, "reusing previously downloaded file"),
             CachedFileChecksumFailed => write!(f, "bad checksum for cached download"),
             RollingBack => write!(f, "rolling back changes"),

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1358,3 +1358,19 @@ fn warn_on_invalid_signature() {
         );
     });
 }
+
+#[test]
+fn check_pgp_keys() {
+    setup(&|config| {
+        expect_stderr_ok(
+            config,
+            &["rustup", "show", "keys"],
+            "Fingerprint: 108F 6620 5EAE B0AA A8DD 5E1C 85AB 96E6 FA1B E5FE",
+        );
+        expect_stderr_ok(
+            config,
+            &["rustup", "show", "keys"],
+            "Fingerprint: B695 EF92 BE5C D24E D391 24DD 1F62 3994 2A48 2D51",
+        );
+    })
+}


### PR DESCRIPTION
In order that we can see what keys we have access to and where
they came from, report the content of `cfg.get_pgp_keys()`.

@dignifiedquire is there an easier way to implement the key display code?  It'd be lovely if there were a clean way for `rpgp` to give me a nice render of the key algo+length+id among other things.  Or if fingerprints could be neatly formatted by the library.