### PR TITLE
Mark `rustup {un,}install` deprecated and report that

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -27,6 +27,15 @@ fn handle_epipe(res: Result<()>) -> Result<()> {
     }
 }
 
+fn deprecated<F, A, B>(instead: &str, cfg: A, matches: B, callee: F) -> Result<()>
+where
+    F: FnOnce(A, B) -> Result<()>,
+{
+    warn!("Use of deprecated command line interface.");
+    warn!("  Please use `rustup {}` instead", instead);
+    callee(cfg, matches)
+}
+
 pub fn main() -> Result<()> {
     crate::self_update::cleanup_self_updater()?;
 
@@ -53,10 +62,10 @@ pub fn main() -> Result<()> {
             ("profile", Some(_)) => handle_epipe(show_profile(cfg))?,
             (_, _) => handle_epipe(show(cfg))?,
         },
-        ("install", Some(m)) => update(cfg, m)?,
+        ("install", Some(m)) => deprecated("toolchain install", cfg, m, update)?,
         ("update", Some(m)) => update(cfg, m)?,
         ("check", Some(_)) => check_updates(cfg)?,
-        ("uninstall", Some(m)) => toolchain_remove(cfg, m)?,
+        ("uninstall", Some(m)) => deprecated("toolchain uninstall", &*cfg, m, toolchain_remove)?,
         ("default", Some(m)) => default_(cfg, m)?,
         ("toolchain", Some(c)) => match c.subcommand() {
             ("install", Some(m)) => update(cfg, m)?,

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -5,8 +5,8 @@ pub mod mock;
 
 use crate::mock::clitools::{
     self, expect_component_executable, expect_component_not_executable, expect_err, expect_ok,
-    expect_ok_eq, expect_ok_ex, expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date,
-    this_host_triple, Config, Scenario,
+    expect_ok_contains, expect_ok_eq, expect_ok_ex, expect_stderr_ok, expect_stdout_ok, run,
+    set_current_dist_date, this_host_triple, Config, Scenario,
 };
 use rustup::utils::{raw, utils};
 
@@ -996,4 +996,22 @@ fn toolchain_link_then_list_verbose() {
         #[cfg(not(windows))]
         expect_stdout_ok(config, &["rustup", "toolchain", "list", "-v"], "/custom-1");
     });
+}
+
+#[test]
+fn deprecated_interfaces() {
+    setup(&|config| {
+        expect_ok_contains(
+            config,
+            &["rustup", "install", "nightly", "--no-self-update"],
+            "",
+            "Please use `rustup toolchain install` instead",
+        );
+        expect_ok_contains(
+            config,
+            &["rustup", "uninstall", "nightly"],
+            "",
+            "Please use `rustup toolchain uninstall` instead",
+        );
+    })
 }


### PR DESCRIPTION
I've long wanted to get rid of `rustup install` and `rustup uninstall` because they are a pain to keep in sync with `rustup toolchain install` and `rustup toolchain uninstall` respectively.

This PR causes them to emit deprecation warnings when used.  Hopefully that for a release or two will encourage people to change over to the proper names, and then we can drop these **HIDDEN** aliases.