### PR TITLE
for toolchains without cargo, set up environment to match rustc, not cargo

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -378,7 +378,7 @@ impl<'a> Toolchain<'a> {
             src_file
         };
         let mut cmd = Command::new(exe_path);
-        self.set_env(&mut cmd);
+        primary_toolchain.set_env(&mut cmd); // set up the environment to match rustc, not cargo
         cmd.env("RUSTUP_TOOLCHAIN", &primary_toolchain.name);
         Ok(cmd)
     }


### PR DESCRIPTION
This implements the suggestion by @ehuss for how to fix https://github.com/rust-lang/rustup.rs/issues/1575.