### PR TITLE
Make target="*" components detectable if ascribed a target.

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -593,4 +593,26 @@ impl Component {
             String::new()
         }
     }
+
+    pub fn contained_within(&self, components: &[Component]) -> bool {
+        if components.contains(self) {
+            // Yes, we're within the component set, move on
+            true
+        } else if self.target.is_none() {
+            // We weren't in the given component set, but we're a package
+            // which targets "*" and as such older rustups might have
+            // accidentally made us target specific due to a bug in profiles.
+            components
+                .iter()
+                // As such, if our target is None, it's sufficient to check pkg
+                .any(|other| other.pkg == self.pkg)
+        } else {
+            // As a last ditch effort, we're contained within the component
+            // set if the name matches and the other component's target
+            // is None
+            components
+                .iter()
+                .any(|other| other.pkg == self.pkg && other.target.is_none())
+        }
+    }
 }

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -584,7 +584,19 @@ impl Update {
                         if component_is_present {
                             self.final_component_list.push(existing_component.clone());
                         } else {
-                            self.missing_components.push(existing_component.clone());
+                            // Component not available, check if this is a case of
+                            // where rustup brokenly installed `rust-src` during
+                            // the 1.20.x series
+                            if existing_component.contained_within(&rust_target_package.components)
+                            {
+                                // It is the case, so we need to create a fresh wildcard
+                                // component using the package name and add it to the final
+                                // component list
+                                self.final_component_list
+                                    .push(existing_component.wildcard());
+                            } else {
+                                self.missing_components.push(existing_component.clone());
+                            }
                         }
                     }
                 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -548,7 +548,7 @@ impl<'a> Toolchain<'a> {
             for component in &targ_pkg.components {
                 let installed = config
                     .as_ref()
-                    .map(|c| c.components.contains(component))
+                    .map(|c| component.contained_within(&c.components))
                     .unwrap_or(false);
 
                 let component_target = TargetTriple::new(&component.target());


### PR DESCRIPTION
In order to mitigate an issue from Profile support where rust-src
would be ascribed a target during installation under the `complete`
profile, make the component-in-components check a little more robust.

In theory we can remove this when we're confident that future users
won't have broken installs left behind.

This ought to fix #2113