### PR TITLE
Cleanly report when rust-docs isn't installed

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1277,6 +1277,19 @@ const DOCS_DATA: &[(&str, &str, &str,)] = &[
 
 fn doc(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
+    for cstatus in &toolchain.list_components()? {
+        if cstatus.component.short_name_in_manifest() == "rust-docs" && !cstatus.installed {
+            info!(
+                "`rust-docs` not installed in toolchain `{}`",
+                toolchain.name()
+            );
+            info!(
+                "To install, try `rustup component add --toolchain {} rust-docs`",
+                toolchain.name()
+            );
+            return Err("unable to view documentation which is not installed".into());
+        }
+    }
     let topical_path: PathBuf;
 
     let doc_url = if let Some(topic) = m.value_of("topic") {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1616,6 +1616,19 @@ fn docs_topical_with_path() {
     });
 }
 
+#[test]
+fn docs_missing() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "set", "profile", "minimal"]);
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_err(
+            config,
+            &["rustup", "doc"],
+            "error: unable to view documentation which is not installed",
+        );
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn non_utf8_arg() {


### PR DESCRIPTION
When the user runs `rustup doc` on a toolchain which doesn't
have the `rust-docs` component installed, we now report more
nicely that the user ought to try and install the component.

Fixes #901
