### PR TITLE
Kinnison/retry downloads

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,13 @@ than 1, it is clamped to 1 at minimum.
 This is not meant for use by users, but can be suggested in diagnosing an issue
 should one arise with the backtrack limits.
 
+### `RUSTUP_MAX_RETRIES`
+
+When downloading a file, rustup will retry the download a number of times. The
+default is 3 times, but if this variable is set to a valid usize then it is the
+max retry count. A value of `0` means no retries, thus the default of `3` will
+mean a download is tried a total of four times before failing out.
+
 ### `RUSTUP_BACKTRACE`
 
 By default while running tests, we unset some environment variables that will

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -37,6 +37,7 @@ pub enum Notification<'a> {
     ComponentUnavailable(&'a str, Option<&'a TargetTriple>),
     StrayHash(&'a Path),
     SignatureInvalid(&'a str),
+    RetryingDownload(&'a str),
 }
 
 impl<'a> From<crate::utils::Notification<'a>> for Notification<'a> {
@@ -72,6 +73,7 @@ impl<'a> Notification<'a> {
             | RollingBack
             | DownloadingManifest(_)
             | SkippingNightlyMissingComponent(_)
+            | RetryingDownload(_)
             | DownloadedManifest(_, _) => NotificationLevel::Info,
             CantReadUpdateHash(_)
             | ExtensionNotInstalled(_)
@@ -181,6 +183,7 @@ impl<'a> Display for Notification<'a> {
                 write!(f, "Force-skipping unavailable component '{}'", component)
             }
             SignatureInvalid(url) => write!(f, "Signature verification failed for '{}'", url),
+            RetryingDownload(url) => write!(f, "Retrying download for '{}'", url),
         }
     }
 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -243,11 +243,12 @@ fn download_file_(
         (Backend::Reqwest, Notification::UsingReqwest)
     };
     notify_handler(notification);
-    download_to_path_with_backend(backend, url, path, resume_from_partial, Some(callback))?;
+    let res =
+        download_to_path_with_backend(backend, url, path, resume_from_partial, Some(callback));
 
     notify_handler(Notification::DownloadFinished);
 
-    Ok(())
+    res.map_err(|e| e.into())
 }
 
 pub fn parse_url(url: &str) -> Result<Url> {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -172,6 +172,9 @@ pub fn download_file_with_resume(
         Ok(_) => Ok(()),
         Err(e) => {
             let is_client_error = match e.kind() {
+                // Specifically treat the bad partial range error as not our
+                // fault in case it was something odd which happened.
+                ErrorKind::Download(DEK::HttpStatus(416)) => false,
                 ErrorKind::Download(DEK::HttpStatus(400..=499)) => true,
                 ErrorKind::Download(DEK::FileNotFound) => true,
                 _ => false,

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -2018,30 +2018,13 @@ fn handle_corrupt_partial_downloads() {
         )
         .unwrap();
 
-        let err = update_from_dist(
-            url,
-            toolchain,
-            prefix,
-            &[],
-            &[],
-            download_cfg,
-            temp_cfg,
-            false,
-        )
-        .unwrap_err();
-
-        match err.kind() {
-            ErrorKind::ComponentDownloadFailed(_) => (),
-            e => panic!("Unexpected error: {:?}", e),
-        }
-
         update_from_dist(
             url,
             toolchain,
             prefix,
             &[],
             &[],
-            &download_cfg,
+            download_cfg,
             temp_cfg,
             false,
         )


### PR DESCRIPTION
In an attempt to close #1722 as a way to fix #1667, fix #1243, and to fix #2071 more fully, add support for cleanly retrying downloads a fixed number of times.

Also this contains a small cleanup which means we finalise the download tracker properly on errors