### PR TITLE
Improve the reporting when CWD is invalid

### DIFF
--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -31,6 +31,7 @@ mod topical_doc;
 
 use crate::errors::*;
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
+use rustup::utils::utils;
 
 use std::env;
 use std::path::PathBuf;
@@ -59,6 +60,11 @@ fn run_rustup_inner() -> Result<()> {
     // Guard against infinite proxy recursion. This mostly happens due to
     // bugs in rustup.
     do_recursion_guard()?;
+
+    // Before we do anything else, ensure we know where we are and who we
+    // are because otherwise we cannot proceed usefully.
+    utils::current_dir()?;
+    utils::current_exe()?;
 
     // The name of arg0 determines how the program is going to behave
     let arg0 = match env::var("RUSTUP_FORCE_ARG0") {

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -32,7 +32,7 @@ error_chain! {
 
     errors {
         LocatingWorkingDir {
-            description("could not locate working directory")
+            description("Unable to proceed. Could not locate working directory.")
         }
         ReadingFile {
             name: &'static str,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -177,9 +177,6 @@ error_chain! {
             description("failed to set permissions")
             display("failed to set permissions for '{}'", path.display())
         }
-        GettingCwd {
-            description("couldn't get current working directory")
-        }
         CargoHome {
             description("couldn't find value of CARGO_HOME")
         }


### PR DESCRIPTION
We had accidentally regressed slightly, this forces us to ensure CWD is available before proceeding in rustup.

This should fix #1573
