### PR TITLE
sync-dist.py: Also ensure static.rlo/rustup.sh is updated

### DIFF
--- a/ci/sync-dist.py
+++ b/ci/sync-dist.py
@@ -145,6 +145,7 @@ if command == "dev-to-local":
 if command == "local-to-prod":
     run_s3cmd("aws s3 cp ./local-rustup/rustup-init.sh s3://{}/rustup/rustup-init.sh"
               .format(s3_bucket))
+    run_s3cmd("aws s3 cp ./local-rustup/rustup-init.sh s3://{}/rustup.sh")
     run_s3cmd("aws s3 cp --recursive ./local-rustup/www/ s3://{}/rustup/www/"
               .format(s3_bucket))
     if live_run:


### PR DESCRIPTION
This PR should ensure `https://static.rust-lang.org/rustup.sh` is updated with `rustup-init.sh` content on releases.

Hopefully this can be considered to fix #1507 

cc @pietroalbini 