### PR TITLE
errors: Help the user to understand when nightly is in use.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -381,9 +381,14 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
     if cs.len() == 1 {
         let _ = write!(
             buf,
-            "component {} is unavailable for download for channel {}",
+            "component {} is unavailable for download for channel {}{}",
             &cs[0].description(manifest),
-            toolchain
+            toolchain,
+            if toolchain.starts_with("nightly") {
+                "\nSometimes not all components are available in any given nightly."
+            } else {
+                ""
+            }
         );
     } else {
         let same_target = cs


### PR DESCRIPTION
When adding a component to a `nightly` install, and that
component is missing, indicate to the user that this is expectable.

This ought to fix #1574 
