### PR TITLE
rustup_mode: add toolchain install --allow-downgrade option

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -319,6 +319,12 @@ pub fn cli() -> App<'static, 'static> {
                                 .help("Force an update, even if some components are missing")
                                 .long("force")
                                 .takes_value(false),
+                        )
+                        .arg(
+                            Arg::with_name("allow-downgrade")
+                                .help("Allow rustup to downgrade the toolchain to satisfy your component choice")
+                                .long("allow-downgrade")
+                                .takes_value(false),
                         ),
                 )
                 .subcommand(
@@ -822,7 +828,12 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<()> {
                     .values_of("targets")
                     .map(|v| v.collect())
                     .unwrap_or_else(Vec::new);
-                Some(toolchain.install_from_dist(m.is_present("force"), &components, &targets)?)
+                Some(toolchain.install_from_dist(
+                    m.is_present("force"),
+                    m.is_present("allow-downgrade"),
+                    &components,
+                    &targets,
+                )?)
             } else if !toolchain.exists() {
                 return Err(ErrorKind::InvalidToolchainName(toolchain.name().to_string()).into());
             } else {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -782,7 +782,7 @@ fn maybe_install_rust(
         println!();
     } else if cfg.find_default()?.is_none() {
         let toolchain = cfg.get_toolchain(toolchain_str, false)?;
-        let status = toolchain.install_from_dist(true, components, targets)?;
+        let status = toolchain.install_from_dist(true, false, components, targets)?;
         cfg.set_default(toolchain_str)?;
         println!();
         common::show_channel_update(&cfg, toolchain_str, Ok(status))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -438,7 +438,7 @@ impl Cfg {
                             ErrorKind::OverrideToolchainNotInstalled(name.to_string())
                         })
                     } else {
-                        toolchain.install_from_dist(true, &[], &[])?;
+                        toolchain.install_from_dist(true, false, &[], &[])?;
                         Ok(Some((toolchain, reason)))
                     }
                 }
@@ -547,7 +547,7 @@ impl Cfg {
         // Update toolchains and collect the results
         let channels = channels.map(|(n, t)| {
             let t = t.and_then(|t| {
-                let t = t.install_from_dist(force_update, &[], &[]);
+                let t = t.install_from_dist(force_update, false, &[], &[]);
                 if let Err(ref e) = t {
                     (self.notify_handler)(Notification::NonFatalError(e));
                 }
@@ -599,7 +599,7 @@ impl Cfg {
     ) -> Result<Command> {
         let toolchain = self.get_toolchain(toolchain, false)?;
         if install_if_missing && !toolchain.exists() {
-            toolchain.install_from_dist(true, &[], &[])?;
+            toolchain.install_from_dist(true, false, &[], &[])?;
         }
 
         if let Some(cmd) = self.maybe_do_cargo_fallback(&toolchain, binary)? {

--- a/src/install.rs
+++ b/src/install.rs
@@ -24,6 +24,8 @@ pub enum InstallMethod<'a> {
         DownloadCfg<'a>,
         // --force
         bool,
+        // --allow-downgrade
+        bool,
         // toolchain already exists
         bool,
         // currently installed date
@@ -66,6 +68,7 @@ impl<'a> InstallMethod<'a> {
                 update_hash,
                 dl_cfg,
                 force_update,
+                allow_downgrade,
                 exists,
                 old_date,
                 components,
@@ -79,6 +82,7 @@ impl<'a> InstallMethod<'a> {
                     if exists { None } else { Some(profile) },
                     prefix,
                     force_update,
+                    allow_downgrade,
                     old_date,
                     components,
                     targets,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -166,6 +166,7 @@ impl<'a> Toolchain<'a> {
     pub fn install_from_dist(
         &self,
         force_update: bool,
+        allow_downgrade: bool,
         components: &[&str],
         targets: &[&str],
     ) -> Result<UpdateStatus> {
@@ -177,6 +178,7 @@ impl<'a> Toolchain<'a> {
             update_hash.as_ref().map(|p| &**p),
             self.download_cfg(),
             force_update,
+            allow_downgrade,
             self.exists(),
             old_date.as_ref().map(|s| &**s),
             components,
@@ -191,6 +193,7 @@ impl<'a> Toolchain<'a> {
             self.cfg.get_profile()?,
             update_hash.as_ref().map(|p| &**p),
             self.download_cfg(),
+            false,
             false,
             false,
             None,


### PR DESCRIPTION
In case you have an already installed nightly toolchain
and you want to install a nightly toolchain with a component
which is not available in the installed toolchain,
rustup is searching for the most recent nightly supporting
all requested components and which is not older than the currently
installed nightly.

With this option set it will also search for toolchains older
than the currently installed one.

- [x] add a test for downgrading

Should fix #2067