### PR TITLE
rustup-init.sh: Support detecting 32bit userland on aarch64

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -309,6 +309,14 @@ get_architecture() {
             powerpc64)
                 _cputype=powerpc
                 ;;
+            aarch64)
+                _cputype=armv7
+                if [ "$_ostype" = "linux-android" ]; then
+                    _ostype=linux-androideabi
+                else
+                    _ostype="${_ostype}eabihf"
+                fi
+                ;;
         esac
     fi
 


### PR DESCRIPTION
We duplicate the 'eabihf' suffix code here to ensure that if we
select armv7 as a result, we append the ABI suffix if necessary.

This should fix #2111

cc @NoraCodes