### PR TITLE
Fix a broken link and change links from http to https [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,8 +805,8 @@ contributors.
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or https://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -915,13 +915,13 @@ fn delete_rustup_and_cargo_home() -> Result<()> {
 //   last it will be deleted when the handle closes.
 //
 // This is the DELETE_ON_CLOSE method from
-// http://www.catch22.net/tuts/self-deleting-executables
+// https://www.catch22.net/tuts/win32/self-deleting-executables
 //
 // ... which doesn't actually work because Windows won't really
 // delete a FILE_FLAG_DELETE_ON_CLOSE process when it exits.
 //
 // .. augmented with this SO answer
-// http://stackoverflow.com/questions/10319526/understanding-a-self-deleting-program-in-c
+// https://stackoverflow.com/questions/10319526/understanding-a-self-deleting-program-in-c
 #[cfg(windows)]
 fn delete_rustup_and_cargo_home() -> Result<()> {
     use std::thread;


### PR DESCRIPTION
`http://www.catch22.net/tuts/self-deleting-executables` was a broken link. The other links I fixed can use https.