### PR TITLE
Warn if complete profile is used

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -18,6 +18,8 @@ use std::{cmp, env, iter};
 use term2::Terminal;
 use wait_timeout::ChildExt;
 
+pub const WARN_COMPLETE_PROFILE: &str = "downloading with complete profile isn't recommended unless you are a developer of the rust language";
+
 pub fn confirm(question: &str, default: bool) -> Result<bool> {
     print!("{} ", question);
     let _ = std::io::stdout().flush();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -805,6 +805,9 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<()> {
         cfg.set_profile_override(p);
     }
     let cfg = &cfg;
+    if cfg.get_profile()? == Profile::Complete {
+        warn!("{}", common::WARN_COMPLETE_PROFILE);
+    }
     if let Some(names) = m.values_of("toolchain") {
         for name in names {
             update_bare_triple_check(cfg, name)?;

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -115,6 +115,10 @@ pub fn main() -> Result<()> {
         targets: &targets,
     };
 
+    if profile == "complete" {
+        warn!("{}", common::WARN_COMPLETE_PROFILE);
+    }
+
     self_update::install(no_prompt, verbose, quiet, opts)?;
 
     Ok(())

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -3,7 +3,8 @@
 pub mod mock;
 
 use crate::mock::clitools::{
-    self, expect_stdout_ok, set_current_dist_date, Config, SanitizedOutput, Scenario,
+    self, expect_stderr_ok, expect_stdout_ok, set_current_dist_date, Config, SanitizedOutput,
+    Scenario,
 };
 use crate::mock::{get_path, restore_path};
 use lazy_static::lazy_static;
@@ -252,5 +253,16 @@ fn install_forces_and_skips_rls() {
         assert!(out
             .stderr
             .contains("warning: Force-skipping unavailable component"));
+    });
+}
+
+#[test]
+fn test_warn_if_complete_profile_is_used() {
+    setup(&|config| {
+        expect_stderr_ok(
+            config,
+            &["rustup-init", "-y", "--profile", "complete"],
+            "warning: downloading with complete profile",
+        );
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1259,6 +1259,24 @@ fn install_with_component_and_target() {
 }
 
 #[test]
+fn test_warn_if_complete_profile_is_used() {
+    setup(&|config| {
+        expect_err(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "--profile",
+                "complete",
+                "stable",
+            ],
+            "warning: downloading with complete profile",
+        );
+    });
+}
+
+#[test]
 fn test_complete_profile_skips_missing_when_forced() {
     setup_complex(&|config| {
         set_current_dist_date(config, "2015-01-01");


### PR DESCRIPTION
This change was requested in #2136.
Whenever a user downloads a toolchain with the complete profile, 
a warn message will be printed.