### PR TITLE
rust-toolchain: Support local toolchain names in the override file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -472,14 +472,18 @@ impl Cfg {
             if let Ok(s) = utils::read_file("toolchain file", &toolchain_file) {
                 if let Some(s) = s.lines().next() {
                     let toolchain_name = s.trim();
-                    dist::validate_channel_name(&toolchain_name).chain_err(|| {
-                        format!(
-                            "invalid channel name '{}' in '{}'",
-                            toolchain_name,
-                            toolchain_file.display()
-                        )
-                    })?;
-
+                    let all_toolchains = self.list_toolchains()?;
+                    if !all_toolchains.iter().any(|s| s == toolchain_name) {
+                        // The given name is not resolvable as a toolchain, so
+                        // instead check it's plausible for installation later
+                        dist::validate_channel_name(&toolchain_name).chain_err(|| {
+                            format!(
+                                "invalid channel name '{}' in '{}'",
+                                toolchain_name,
+                                toolchain_file.display()
+                            )
+                        })?;
+                    }
                     let reason = OverrideReason::ToolchainFile(toolchain_file);
                     return Ok(Some((toolchain_name.to_string(), reason)));
                 }

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1535,6 +1535,36 @@ fn bad_file_override() {
 }
 
 #[test]
+fn valid_override_settings() {
+    setup(&|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        raw::write_file(&toolchain_file, "nightly").unwrap();
+        expect_ok(config, &["rustc", "--version"]);
+        raw::write_file(&toolchain_file, for_host!("nightly-{}")).unwrap();
+        expect_ok(config, &["rustc", "--version"]);
+        let fullpath = config
+            .rustupdir
+            .clone()
+            .join("toolchains")
+            .join(for_host!("nightly-{}"));
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "link",
+                "system",
+                &format!("{}", fullpath.display()),
+            ],
+        );
+        raw::write_file(&toolchain_file, "system").unwrap();
+        expect_ok(config, &["rustc", "--version"]);
+    })
+}
+
+#[test]
 fn file_override_with_target_info() {
     setup(&|config| {
         let cwd = config.current_dir();


### PR DESCRIPTION
The `rust-toolchain` override file was limited to valid toolchain
names.  This commit weakens that slightly to permit *any* string so
long as it's a local toolchain name.  If it's not then it has to
be a valid channelish toolchain name instead.

This fixes #1745

It's worth noting that @mikhail-krainik won't be able to commit such a file to git and expect that others will have it work out of the box unless they also have the *exact* toolchain they list in the file, or the name is a valid channel/version/channel+date.