### PR TITLE
Output the previous version of a toolchain when it is updated

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -840,7 +840,7 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<()> {
                 None
             };
 
-            if let Some(status) = status {
+            if let Some(status) = status.clone() {
                 println!();
                 common::show_channel_update(cfg, toolchain.name(), Ok(status))?;
             }
@@ -1002,11 +1002,11 @@ fn show(cfg: &Cfg) -> Result<()> {
             Ok(atc) => match atc {
                 Some((ref toolchain, Some(ref reason))) => {
                     writeln!(t, "{} ({})", toolchain.name(), reason)?;
-                    writeln!(t, "{}", common::rustc_version(toolchain))?;
+                    writeln!(t, "{}", toolchain.rustc_version())?;
                 }
                 Some((ref toolchain, None)) => {
                     writeln!(t, "{} (default)", toolchain.name())?;
-                    writeln!(t, "{}", common::rustc_version(toolchain))?;
+                    writeln!(t, "{}", toolchain.rustc_version())?;
                 }
                 None => {
                     writeln!(t, "no active toolchain")?;

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -40,7 +40,7 @@ fn rustup_stable() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-  stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+  stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
 
 "
             ),
@@ -80,7 +80,7 @@ fn rustup_stable_quiet() {
             &["rustup", "--quiet", "update", "--no-self-update"],
             for_host!(
                 r"
-  stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+  stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
 
 "
             ),
@@ -142,9 +142,9 @@ fn rustup_all_channels() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-   stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
-     beta-{0} updated - 1.2.0 (hash-beta-1.2.0)
-  nightly-{0} updated - 1.3.0 (hash-nightly-2)
+   stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
+     beta-{0} updated - 1.2.0 (hash-beta-1.2.0) (from 1.1.0 (hash-beta-1.1.0))
+  nightly-{0} updated - 1.3.0 (hash-nightly-2) (from 1.2.0 (hash-nightly-1))
 
 "
             ),
@@ -212,9 +212,9 @@ fn rustup_some_channels_up_to_date() {
             &["rustup", "update", "--no-self-update"],
             for_host!(
                 r"
-   stable-{0} updated - 1.1.0 (hash-stable-1.1.0)
+   stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
    beta-{0} unchanged - 1.2.0 (hash-beta-1.2.0)
-  nightly-{0} updated - 1.3.0 (hash-nightly-2)
+  nightly-{0} updated - 1.3.0 (hash-nightly-2) (from 1.2.0 (hash-nightly-1))
 
 "
             ),


### PR DESCRIPTION
This change modifies the cli output of `rustup update` to display the previous version of rustc for toolchains that are updated.

Before:

    $ rustup update

    info: syncing channel updates for 'stable-x86_64-apple-darwin'
    info: syncing channel updates for 'nightly-x86_64-apple-darwin'
    --snip--
      stable-x86_64-apple-darwin unchanged - rustc 1.39.0 (4560ea788 2019-11-04)
       nightly-x86_64-apple-darwin updated - rustc 1.41.0-nightly (7afe6d9d1 2019-12-03)

After:

    $ rustup update

    info: syncing channel updates for 'stable-x86_64-apple-darwin'
    info: syncing channel updates for 'nightly-x86_64-apple-darwin'
    --snip--
      stable-x86_64-apple-darwin unchanged - rustc 1.39.0 (4560ea788 2019-11-04)
       nightly-x86_64-apple-darwin updated - rustc 1.41.0-nightly (7afe6d9d1 2019-12-03) (from rustc 1.40.0-nightly (22bc9e1d9 2019-09-30))

Fixes #2110.