### PR TITLE
Verify behaviour if host triplet goes missing from the channel manifests

### DIFF
--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -186,13 +186,10 @@ fn subcommand_required_for_self() {
 
 #[test]
 fn multi_host_smoke_test() {
-    // FIXME: Unfortunately the list of supported hosts is hard-coded,
-    // so we have to use the triple of a host we actually test on. That means
-    // that when we're testing on that host we can't test 'multi-host'.
-    let trip = this_host_triple();
-    if trip == clitools::MULTI_ARCH1 {
-        return;
-    }
+    // We cannot run this test if the current host triple is equal to the
+    // multi-arch triple, but this should never be the case.  Check that just
+    // to be sure.
+    assert_ne!(this_host_triple(), clitools::MULTI_ARCH1);
 
     clitools::setup(Scenario::MultiHost, &|config| {
         let toolchain = format!("nightly-{}", clitools::MULTI_ARCH1);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1703,3 +1703,17 @@ fn non_utf8_toolchain() {
         assert!(out.stderr.contains("toolchain '��' is not installed"));
     });
 }
+
+#[test]
+fn check_host_goes_away() {
+    clitools::setup(Scenario::HostGoesMissing, &|config| {
+        set_current_dist_date(config, "2019-12-09");
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        set_current_dist_date(config, "2019-12-10");
+        expect_err(
+            config,
+            &["rustup", "update", "nightly", "--no-self-update"],
+            for_host!("target '{}' not found in channel"),
+        );
+    })
+}

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -650,11 +650,6 @@ nightly-{0} (default)
 
 #[test]
 fn show_multiple_targets() {
-    // Using the MULTI_ARCH1 target doesn't work on i686 linux
-    if cfg!(target_os = "linux") && cfg!(target_arch = "x86") {
-        return;
-    }
-
     clitools::setup(Scenario::MultiHost, &|config| {
         expect_ok(
             config,

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -54,6 +54,7 @@ pub enum Scenario {
     UnavailableRls,   // Two dates, v2 manifests, RLS unavailable in first date, restored on second.
     MissingComponent, // Three dates, v2 manifests, RLS available in first and last, not middle
     MissingNightly,   // Three dates, v2 manifests, RLS available in first, middle missing nightly
+    HostGoesMissing,  // Two dates, v2 manifests, host and MULTI_ARCH1 in first, host not in second
 }
 
 pub static CROSS_ARCH1: &str = "x86_64-unknown-linux-musl";
@@ -486,6 +487,12 @@ impl Release {
         self
     }
 
+    fn only_multi_arch(mut self) -> Self {
+        self.multi_arch = true;
+        self.available = false;
+        self
+    }
+
     fn new(channel: &str, version: &str, date: &str, suffix: &str) -> Self {
         Release {
             channel: channel.to_string(),
@@ -507,18 +514,24 @@ impl Release {
                 &self.hash,
                 self.rls,
                 self.multi_arch,
+                false,
             )
         } else {
             if self.multi_arch {
-                unimplemented!("no support for multi-arch unavailable channels");
+                // unavailable but multiarch means to build only with host==MULTI_ARCH1
+                // instead of true multiarch
+                build_mock_channel(
+                    &self.channel,
+                    &self.date,
+                    &self.version,
+                    &self.hash,
+                    self.rls,
+                    false,
+                    true,
+                )
+            } else {
+                build_mock_unavailable_channel(&self.channel, &self.date, &self.version, &self.hash)
             }
-            if self.rls != RlsStatus::Available {
-                unimplemented!(
-                    "no support for rls availability customization on unavailable channels"
-                );
-            }
-
-            build_mock_unavailable_channel(&self.channel, &self.date, &self.version, &self.hash)
         }
     }
 
@@ -620,6 +633,10 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
             Release::beta("1.2.0", "2015-01-02").multi_arch(),
             Release::stable("1.1.0", "2015-01-02").multi_arch(),
         ],
+        Scenario::HostGoesMissing => vec![
+            Release::new("nightly", "1.3.0", "2019-12-09", "1"),
+            Release::new("nightly", "1.3.0", "2019-12-10", "2").only_multi_arch(),
+        ],
     };
 
     let vs = match s {
@@ -631,6 +648,7 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
         | Scenario::Unavailable
         | Scenario::UnavailableRls
         | Scenario::MissingNightly
+        | Scenario::HostGoesMissing
         | Scenario::MissingComponent => vec![ManifestVersion::V2],
     };
 
@@ -652,9 +670,14 @@ fn build_mock_channel(
     version_hash: &str,
     rls: RlsStatus,
     multi_arch: bool,
+    swap_triples: bool,
 ) -> MockChannel {
     // Build the mock installers
-    let host_triple = this_host_triple();
+    let host_triple = if swap_triples {
+        MULTI_ARCH1.to_owned()
+    } else {
+        this_host_triple()
+    };
     let std = build_mock_std_installer(&host_triple);
     let rustc = build_mock_rustc_installer(&host_triple, version, version_hash);
     let cargo = build_mock_cargo_installer(version, version_hash);

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -60,10 +60,10 @@ pub static CROSS_ARCH1: &str = "x86_64-unknown-linux-musl";
 pub static CROSS_ARCH2: &str = "arm-linux-androideabi";
 
 // Architecture for testing 'multi-host' installation.
-// FIXME: Unfortunately the list of supported hosts is hard-coded,
-// so we have to use the triple of a host we actually test on. That means
-// that when we're testing on that host we can't test 'multi-host'.
+#[cfg(target_pointer_width = "64")]
 pub static MULTI_ARCH1: &str = "i686-unknown-linux-gnu";
+#[cfg(not(target_pointer_width = "64"))]
+pub static MULTI_ARCH1: &str = "x86_64-unknown-linux-gnu";
 
 /// Run this to create the test environment containing rustup, and
 /// a mock dist server.


### PR DESCRIPTION
Apple are removing support for i686 OSX.  As such, we need to be certain that rustup will behave gracefully should Rust remove tier 1 status from that target (or indeed any other in the future).

This PR tweaks the behaviour of the multi-arch tests and adds a scenario to model the above.

I'd appreciate @pietroalbini 's opinion on if it's sufficient for the use-case he mentioned to me.

I'd appreciate @jonhoo 's input on how to more nicely do the tweak to the channel generation which I'll admit is a bit of a hack in this PR currently.
