### PR TITLE
Improve preinstalled rust message

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -385,8 +385,10 @@ fn check_existence_of_rustc_or_cargo_in_path(no_prompt: bool) -> Result<()> {
     if let Err(path) = rustc_or_cargo_exists_in_path() {
         err!("it looks like you have an existing installation of Rust at:");
         err!("{}", path);
-        err!("rustup cannot be installed alongside Rust. Please uninstall first");
-        err!("if this is what you want, restart the installation with `-y'");
+        err!("rustup should not be installed alongside Rust. Please uninstall your existing Rust first.");
+        err!("Otherwise you may have confusion unless you are careful with your PATH");
+        err!("If you are sure that you want both rustup and your already installed Rust");
+        err!("then please restart the installation and pass `-y' to bypass this check.");
         Err("cannot install while Rust is installed".into())
     } else {
         Ok(())

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -622,7 +622,7 @@ fn install_stops_if_rustc_exists() {
             .contains("it looks like you have an existing installation of Rust at:"));
         assert!(out
             .stderr
-            .contains("if this is what you want, restart the installation with `-y'"));
+            .contains("restart the installation and pass `-y'"));
     });
 }
 
@@ -654,7 +654,7 @@ fn install_stops_if_cargo_exists() {
             .contains("it looks like you have an existing installation of Rust at:"));
         assert!(out
             .stderr
-            .contains("if this is what you want, restart the installation with `-y'"));
+            .contains("restart the installation and pass `-y'"));
     });
 }
 


### PR DESCRIPTION
Because some people install rustc/cargo from their distro and then
try and install rustup, they can get confused/worried by the error
message given.  This attempts to ameliorate the situation by being
a little clearer about what might go wrong.

This addresses some of #442 but does not close it.
