### PR TITLE
tests: Fix up lack of for_host!() usage

### DIFF
--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -911,7 +911,7 @@ fn override_by_toolchain_on_the_command_line() {
         expect_stdout_ok(
             config,
             &["rustup", "+stable", "which", "rustc"],
-            "\\toolchains\\stable-x86_64-",
+            for_host!("\\toolchains\\stable-{}"),
         );
         #[cfg(windows)]
         expect_stdout_ok(
@@ -923,7 +923,7 @@ fn override_by_toolchain_on_the_command_line() {
         expect_stdout_ok(
             config,
             &["rustup", "+stable", "which", "rustc"],
-            "/toolchains/stable-x86_64-",
+            for_host!("/toolchains/stable-{}"),
         );
         #[cfg(not(windows))]
         expect_stdout_ok(
@@ -936,7 +936,7 @@ fn override_by_toolchain_on_the_command_line() {
         expect_stdout_ok(
             config,
             &["rustup", "+nightly", "which", "rustc"],
-            "\\toolchains\\nightly-x86_64-",
+            for_host!("\\toolchains\\nightly-{}"),
         );
         #[cfg(windows)]
         expect_stdout_ok(
@@ -948,7 +948,7 @@ fn override_by_toolchain_on_the_command_line() {
         expect_stdout_ok(
             config,
             &["rustup", "+nightly", "which", "rustc"],
-            "/toolchains/nightly-x86_64-",
+            for_host!("/toolchains/nightly-{}"),
         );
         #[cfg(not(windows))]
         expect_stdout_ok(
@@ -976,7 +976,7 @@ fn override_by_toolchain_on_the_command_line() {
             &["rustup", "+stable", "set", "profile", "minimal"],
             "profile set to 'minimal'",
         );
-        expect_stdout_ok(config, &["rustup", "default"], "nightly-x86_64-");
+        expect_stdout_ok(config, &["rustup", "default"], for_host!("nightly-{}"));
     });
 }
 

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -108,13 +108,13 @@ fn list_toolchains() {
         expect_stdout_ok(
             config,
             &["rustup", "toolchain", "list", "-v"],
-            "\\toolchains\\nightly-x86",
+            for_host!("\\toolchains\\nightly-{}"),
         );
         #[cfg(not(windows))]
         expect_stdout_ok(
             config,
             &["rustup", "toolchain", "list", "-v"],
-            "/toolchains/nightly-x86",
+            for_host!("/toolchains/nightly-{}"),
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
         #[cfg(windows)]

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -152,13 +152,13 @@ fn list_toolchains() {
         expect_stdout_ok(
             config,
             &["rustup", "toolchain", "list", "-v"],
-            "\\toolchains\\nightly-x86",
+            for_host!("\\toolchains\\nightly-{}"),
         );
         #[cfg(not(windows))]
         expect_stdout_ok(
             config,
             &["rustup", "toolchain", "list", "-v"],
-            "/toolchains/nightly-x86",
+            for_host!("/toolchains/nightly-{}"),
         );
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
         #[cfg(windows)]


### PR DESCRIPTION
This should correct a bug I was seeing on i686 platforms.