### PR TITLE
Update links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,15 +141,15 @@ This release was made to solve two problems spotted in `1.20.0`
 - Mitchell Hynes
 - Matt Kantor
 
-[pr#1673]: https://github.com/rust-lang/rustup.rs/pull/1673
-[pr#1980]: https://github.com/rust-lang/rustup.rs/pull/1980
-[pr#1988]: https://github.com/rust-lang/rustup.rs/pull/1988
-[pr#1995]: https://github.com/rust-lang/rustup.rs/pull/1995
-[pr#2002]: https://github.com/rust-lang/rustup.rs/pull/2002
-[pr#2014]: https://github.com/rust-lang/rustup.rs/pull/2014
-[pr#1945]: https://github.com/rust-lang/rustup.rs/pull/1945
-[pr#2026]: https://github.com/rust-lang/rustup.rs/pull/2026
-[pr#2030]: https://github.com/rust-lang/rustup.rs/pull/2030
+[pr#1673]: https://github.com/rust-lang/rustup/pull/1673
+[pr#1980]: https://github.com/rust-lang/rustup/pull/1980
+[pr#1988]: https://github.com/rust-lang/rustup/pull/1988
+[pr#1995]: https://github.com/rust-lang/rustup/pull/1995
+[pr#2002]: https://github.com/rust-lang/rustup/pull/2002
+[pr#2014]: https://github.com/rust-lang/rustup/pull/2014
+[pr#1945]: https://github.com/rust-lang/rustup/pull/1945
+[pr#2026]: https://github.com/rust-lang/rustup/pull/2026
+[pr#2030]: https://github.com/rust-lang/rustup/pull/2030
 
 ## [1.19.0] - 2019-09-09
 
@@ -193,19 +193,19 @@ This release was made to solve two problems spotted in `1.20.0`
 - Bjorn3
 - Iku Iwasa
 
-[pr#1873]: https://github.com/rust-lang/rustup.rs/pull/1873
-[pr#1885]: https://github.com/rust-lang/rustup.rs/pull/1885
-[pr#1882]: https://github.com/rust-lang/rustup.rs/pull/1882
-[pr#1895]: https://github.com/rust-lang/rustup.rs/pull/1895
-[pr#1876]: https://github.com/rust-lang/rustup.rs/pull/1876
-[pr#1901]: https://github.com/rust-lang/rustup.rs/pull/1901
-[pr#1925]: https://github.com/rust-lang/rustup.rs/pull/1925
-[pr#1914]: https://github.com/rust-lang/rustup.rs/pull/1914
-[pr#1931]: https://github.com/rust-lang/rustup.rs/pull/1931
-[pr#1961]: https://github.com/rust-lang/rustup.rs/pull/1961
-[pr#1868]: https://github.com/rust-lang/rustup.rs/pull/1868
-[pr#1933]: https://github.com/rust-lang/rustup.rs/pull/1933
-[pr#1978]: https://github.com/rust-lang/rustup.rs/pull/1978
+[pr#1873]: https://github.com/rust-lang/rustup/pull/1873
+[pr#1885]: https://github.com/rust-lang/rustup/pull/1885
+[pr#1882]: https://github.com/rust-lang/rustup/pull/1882
+[pr#1895]: https://github.com/rust-lang/rustup/pull/1895
+[pr#1876]: https://github.com/rust-lang/rustup/pull/1876
+[pr#1901]: https://github.com/rust-lang/rustup/pull/1901
+[pr#1925]: https://github.com/rust-lang/rustup/pull/1925
+[pr#1914]: https://github.com/rust-lang/rustup/pull/1914
+[pr#1931]: https://github.com/rust-lang/rustup/pull/1931
+[pr#1961]: https://github.com/rust-lang/rustup/pull/1961
+[pr#1868]: https://github.com/rust-lang/rustup/pull/1868
+[pr#1933]: https://github.com/rust-lang/rustup/pull/1933
+[pr#1978]: https://github.com/rust-lang/rustup/pull/1978
 
 ## [1.18.3] - 2019-05-22
 
@@ -237,16 +237,16 @@ This release was made to solve two problems spotted in `1.20.0`
 - Sunjay Varma
 - Lzu Tao (behind the scenes, lots of housekeeping and CI)
 
-[pr#1820]: https://github.com/rust-lang/rustup.rs/pull/1820
-[pr#1830]: https://github.com/rust-lang/rustup.rs/pull/1830
-[pr#1837]: https://github.com/rust-lang/rustup.rs/pull/1837
-[pr#1839]: https://github.com/rust-lang/rustup.rs/pull/1839
-[pr#1840]: https://github.com/rust-lang/rustup.rs/pull/1840
-[pr#1845]: https://github.com/rust-lang/rustup.rs/pull/1845
-[pr#1847]: https://github.com/rust-lang/rustup.rs/pull/1847
-[pr#1832]: https://github.com/rust-lang/rustup.rs/pull/1832
-[pr#1850]: https://github.com/rust-lang/rustup.rs/pull/1850
-[pr#1824]: https://github.com/rust-lang/rustup.rs/pull/1824
+[pr#1820]: https://github.com/rust-lang/rustup/pull/1820
+[pr#1830]: https://github.com/rust-lang/rustup/pull/1830
+[pr#1837]: https://github.com/rust-lang/rustup/pull/1837
+[pr#1839]: https://github.com/rust-lang/rustup/pull/1839
+[pr#1840]: https://github.com/rust-lang/rustup/pull/1840
+[pr#1845]: https://github.com/rust-lang/rustup/pull/1845
+[pr#1847]: https://github.com/rust-lang/rustup/pull/1847
+[pr#1832]: https://github.com/rust-lang/rustup/pull/1832
+[pr#1850]: https://github.com/rust-lang/rustup/pull/1850
+[pr#1824]: https://github.com/rust-lang/rustup/pull/1824
 
 ## [1.18.2] - 2019-05-02
 
@@ -276,13 +276,13 @@ This release was made, in part, thanks to:
 - Michael Maclean
 - Daniel Silverstone
 
-[pr#1809]: https://github.com/rust-lang/rustup.rs/pull/1809
-[pr#1801]: https://github.com/rust-lang/rustup.rs/pull/1801
-[pr#1819]: https://github.com/rust-lang/rustup.rs/pull/1819
-[pr#1822]: https://github.com/rust-lang/rustup.rs/pull/1822
-[pr#1808]: https://github.com/rust-lang/rustup.rs/pull/1808
-[pr#1810]: https://github.com/rust-lang/rustup.rs/pull/1810
-[pr#1813]: https://github.com/rust-lang/rustup.rs/pull/1813
+[pr#1809]: https://github.com/rust-lang/rustup/pull/1809
+[pr#1801]: https://github.com/rust-lang/rustup/pull/1801
+[pr#1819]: https://github.com/rust-lang/rustup/pull/1819
+[pr#1822]: https://github.com/rust-lang/rustup/pull/1822
+[pr#1808]: https://github.com/rust-lang/rustup/pull/1808
+[pr#1810]: https://github.com/rust-lang/rustup/pull/1810
+[pr#1813]: https://github.com/rust-lang/rustup/pull/1813
 
 ## [1.18.1] - 2019-04-25
 
@@ -293,10 +293,10 @@ This release was made, in part, thanks to:
 - [Detect s390x in rustup-init.sh][pr#1797]
 - [Fallback to less secure curl/wget invocation][pr#1803]
 
-[pr#1787]: https://github.com/rust-lang/rustup.rs/pull/1787
-[pr#1796]: https://github.com/rust-lang/rustup.rs/pull/1796
-[pr#1797]: https://github.com/rust-lang/rustup.rs/pull/1797
-[pr#1803]: https://github.com/rust-lang/rustup.rs/pull/1803
+[pr#1787]: https://github.com/rust-lang/rustup/pull/1787
+[pr#1796]: https://github.com/rust-lang/rustup/pull/1796
+[pr#1797]: https://github.com/rust-lang/rustup/pull/1797
+[pr#1803]: https://github.com/rust-lang/rustup/pull/1803
 
 ## [1.18.0] - 2019-04-22
 
@@ -337,31 +337,31 @@ This release was made, in part, thanks to:
 
 - [Remove old `multirust` & compatibility code][pr#1715]
 
-[pr#1646]: https://github.com/rust-lang/rustup.rs/pull/1646
-[pr#1762]: https://github.com/rust-lang/rustup.rs/pull/1762
-[pr#1524]: https://github.com/rust-lang/rustup.rs/pull/1524
-[pr#1655]: https://github.com/rust-lang/rustup.rs/pull/1655
-[pr#1716]: https://github.com/rust-lang/rustup.rs/pull/1716
-[pr#1701]: https://github.com/rust-lang/rustup.rs/pull/1701
-[pr#1744]: https://github.com/rust-lang/rustup.rs/pull/1744
-[pr#1769]: https://github.com/rust-lang/rustup.rs/pull/1769
-[pr#1770]: https://github.com/rust-lang/rustup.rs/pull/1770
-[pr#1773]: https://github.com/rust-lang/rustup.rs/pull/1773
-[pr#1752]: https://github.com/rust-lang/rustup.rs/pull/1752
-[pr#1683]: https://github.com/rust-lang/rustup.rs/pull/1683
-[pr#1699]: https://github.com/rust-lang/rustup.rs/pull/1699
-[pr#1725]: https://github.com/rust-lang/rustup.rs/pull/1725
-[pr#1746]: https://github.com/rust-lang/rustup.rs/pull/1746
-[pr#1747]: https://github.com/rust-lang/rustup.rs/pull/1747
-[pr#1767]: https://github.com/rust-lang/rustup.rs/pull/1767
-[pr#1765]: https://github.com/rust-lang/rustup.rs/pull/1765
-[pr#1763]: https://github.com/rust-lang/rustup.rs/pull/1763
-[pr#1715]: https://github.com/rust-lang/rustup.rs/pull/1715
-[pr#1776]: https://github.com/rust-lang/rustup.rs/pull/1776
-[pr#1778]: https://github.com/rust-lang/rustup.rs/pull/1778
-[pr#1780]: https://github.com/rust-lang/rustup.rs/pull/1780
-[pr#1781]: https://github.com/rust-lang/rustup.rs/pull/1781
-[pr#1788]: https://github.com/rust-lang/rustup.rs/pull/1788
+[pr#1646]: https://github.com/rust-lang/rustup/pull/1646
+[pr#1762]: https://github.com/rust-lang/rustup/pull/1762
+[pr#1524]: https://github.com/rust-lang/rustup/pull/1524
+[pr#1655]: https://github.com/rust-lang/rustup/pull/1655
+[pr#1716]: https://github.com/rust-lang/rustup/pull/1716
+[pr#1701]: https://github.com/rust-lang/rustup/pull/1701
+[pr#1744]: https://github.com/rust-lang/rustup/pull/1744
+[pr#1769]: https://github.com/rust-lang/rustup/pull/1769
+[pr#1770]: https://github.com/rust-lang/rustup/pull/1770
+[pr#1773]: https://github.com/rust-lang/rustup/pull/1773
+[pr#1752]: https://github.com/rust-lang/rustup/pull/1752
+[pr#1683]: https://github.com/rust-lang/rustup/pull/1683
+[pr#1699]: https://github.com/rust-lang/rustup/pull/1699
+[pr#1725]: https://github.com/rust-lang/rustup/pull/1725
+[pr#1746]: https://github.com/rust-lang/rustup/pull/1746
+[pr#1747]: https://github.com/rust-lang/rustup/pull/1747
+[pr#1767]: https://github.com/rust-lang/rustup/pull/1767
+[pr#1765]: https://github.com/rust-lang/rustup/pull/1765
+[pr#1763]: https://github.com/rust-lang/rustup/pull/1763
+[pr#1715]: https://github.com/rust-lang/rustup/pull/1715
+[pr#1776]: https://github.com/rust-lang/rustup/pull/1776
+[pr#1778]: https://github.com/rust-lang/rustup/pull/1778
+[pr#1780]: https://github.com/rust-lang/rustup/pull/1780
+[pr#1781]: https://github.com/rust-lang/rustup/pull/1781
+[pr#1788]: https://github.com/rust-lang/rustup/pull/1788
 
 ## [1.17.0] - 2019-03-05
 
@@ -396,42 +396,42 @@ This release was made, in part, thanks to:
 - [Add `clippy-driver` as a proxy][pr#1679]
 - [Remove the `rustup-win-installer` directory][pr#1666]
 
-[pr#1495]: https://github.com/rust-lang/rustup.rs/pull/1495
-[pr#1521]: https://github.com/rust-lang/rustup.rs/pull/1521
-[pr#1547]: https://github.com/rust-lang/rustup.rs/pull/1547
-[pr#1583]: https://github.com/rust-lang/rustup.rs/pull/1583
-[pr#1587]: https://github.com/rust-lang/rustup.rs/pull/1587
-[pr#1585]: https://github.com/rust-lang/rustup.rs/pull/1585
-[pr#1597]: https://github.com/rust-lang/rustup.rs/pull/1597
-[pr#1603]: https://github.com/rust-lang/rustup.rs/pull/1603
-[pr#1595]: https://github.com/rust-lang/rustup.rs/pull/1595
-[pr#1576]: https://github.com/rust-lang/rustup.rs/pull/1576
-[pr#1588]: https://github.com/rust-lang/rustup.rs/pull/1588
-[pr#1605]: https://github.com/rust-lang/rustup.rs/pull/1605
-[pr#1606]: https://github.com/rust-lang/rustup.rs/pull/1606
-[pr#1599]: https://github.com/rust-lang/rustup.rs/pull/1599
-[pr#1593]: https://github.com/rust-lang/rustup.rs/pull/1593
-[pr#1578]: https://github.com/rust-lang/rustup.rs/pull/1578
-[pr#1619]: https://github.com/rust-lang/rustup.rs/pull/1619
-[pr#1623]: https://github.com/rust-lang/rustup.rs/pull/1623
-[pr#1629]: https://github.com/rust-lang/rustup.rs/pull/1629
-[pr#1639]: https://github.com/rust-lang/rustup.rs/pull/1639
-[pr#1643]: https://github.com/rust-lang/rustup.rs/pull/1643
-[pr#1645]: https://github.com/rust-lang/rustup.rs/pull/1645
-[pr#1642]: https://github.com/rust-lang/rustup.rs/pull/1642
-[pr#1633]: https://github.com/rust-lang/rustup.rs/pull/1633
-[pr#1654]: https://github.com/rust-lang/rustup.rs/pull/1654
-[pr#1660]: https://github.com/rust-lang/rustup.rs/pull/1660
-[pr#1616]: https://github.com/rust-lang/rustup.rs/pull/1616
-[pr#1659]: https://github.com/rust-lang/rustup.rs/pull/1659
-[pr#1679]: https://github.com/rust-lang/rustup.rs/pull/1679
-[pr#1666]: https://github.com/rust-lang/rustup.rs/pull/1666
+[pr#1495]: https://github.com/rust-lang/rustup/pull/1495
+[pr#1521]: https://github.com/rust-lang/rustup/pull/1521
+[pr#1547]: https://github.com/rust-lang/rustup/pull/1547
+[pr#1583]: https://github.com/rust-lang/rustup/pull/1583
+[pr#1587]: https://github.com/rust-lang/rustup/pull/1587
+[pr#1585]: https://github.com/rust-lang/rustup/pull/1585
+[pr#1597]: https://github.com/rust-lang/rustup/pull/1597
+[pr#1603]: https://github.com/rust-lang/rustup/pull/1603
+[pr#1595]: https://github.com/rust-lang/rustup/pull/1595
+[pr#1576]: https://github.com/rust-lang/rustup/pull/1576
+[pr#1588]: https://github.com/rust-lang/rustup/pull/1588
+[pr#1605]: https://github.com/rust-lang/rustup/pull/1605
+[pr#1606]: https://github.com/rust-lang/rustup/pull/1606
+[pr#1599]: https://github.com/rust-lang/rustup/pull/1599
+[pr#1593]: https://github.com/rust-lang/rustup/pull/1593
+[pr#1578]: https://github.com/rust-lang/rustup/pull/1578
+[pr#1619]: https://github.com/rust-lang/rustup/pull/1619
+[pr#1623]: https://github.com/rust-lang/rustup/pull/1623
+[pr#1629]: https://github.com/rust-lang/rustup/pull/1629
+[pr#1639]: https://github.com/rust-lang/rustup/pull/1639
+[pr#1643]: https://github.com/rust-lang/rustup/pull/1643
+[pr#1645]: https://github.com/rust-lang/rustup/pull/1645
+[pr#1642]: https://github.com/rust-lang/rustup/pull/1642
+[pr#1633]: https://github.com/rust-lang/rustup/pull/1633
+[pr#1654]: https://github.com/rust-lang/rustup/pull/1654
+[pr#1660]: https://github.com/rust-lang/rustup/pull/1660
+[pr#1616]: https://github.com/rust-lang/rustup/pull/1616
+[pr#1659]: https://github.com/rust-lang/rustup/pull/1659
+[pr#1679]: https://github.com/rust-lang/rustup/pull/1679
+[pr#1666]: https://github.com/rust-lang/rustup/pull/1666
 
 ## [1.16.0] - 2018-12-06
 
 - [Fix rename_rls_remove test on Windows][pr#1561]
 
-[pr#1561]: https://github.com/rust-lang/rustup.rs/pull/1561
+[pr#1561]: https://github.com/rust-lang/rustup/pull/1561
 
 ## [1.15.0] - 2018-11-27
 
@@ -442,12 +442,12 @@ This release was made, in part, thanks to:
 - [Use `openssl-src` from crates.io to link to OpenSSL][pr#1536]
 - [Change handling of renames][pr#1549]
 
-[pr#1554]: https://github.com/rust-lang/rustup.rs/pull/1554
-[pr#1553]: https://github.com/rust-lang/rustup.rs/pull/1553
-[pr#1552]: https://github.com/rust-lang/rustup.rs/pull/1552
-[pr#1526]: https://github.com/rust-lang/rustup.rs/pull/1526
-[pr#1536]: https://github.com/rust-lang/rustup.rs/pull/1536
-[pr#1549]: https://github.com/rust-lang/rustup.rs/pull/1549
+[pr#1554]: https://github.com/rust-lang/rustup/pull/1554
+[pr#1553]: https://github.com/rust-lang/rustup/pull/1553
+[pr#1552]: https://github.com/rust-lang/rustup/pull/1552
+[pr#1526]: https://github.com/rust-lang/rustup/pull/1526
+[pr#1536]: https://github.com/rust-lang/rustup/pull/1536
+[pr#1549]: https://github.com/rust-lang/rustup/pull/1549
 
 ## [1.14.0] - 2018-10-04
 
@@ -457,17 +457,17 @@ This release was made, in part, thanks to:
 - [Fix removing toolchain fail when update-hash does not exist][pr#1472]
 - [Add note about installing the Windows SDK component][pr#1468]
 
-[pr#1511]: https://github.com/rust-lang/rustup.rs/pull/1511
-[pr#1504]: https://github.com/rust-lang/rustup.rs/pull/1504
-[pr#1478]: https://github.com/rust-lang/rustup.rs/pull/1478
-[pr#1472]: https://github.com/rust-lang/rustup.rs/pull/1472
-[pr#1468]: https://github.com/rust-lang/rustup.rs/pull/1468
+[pr#1511]: https://github.com/rust-lang/rustup/pull/1511
+[pr#1504]: https://github.com/rust-lang/rustup/pull/1504
+[pr#1478]: https://github.com/rust-lang/rustup/pull/1478
+[pr#1472]: https://github.com/rust-lang/rustup/pull/1472
+[pr#1468]: https://github.com/rust-lang/rustup/pull/1468
 
 ## [1.13.0] - 2018-07-16
 
 - [Add clippy to the tools list][pr1461]
 
-[pr1461]: https://github.com/rust-lang/rustup.rs/pull/1461
+[pr1461]: https://github.com/rust-lang/rustup/pull/1461
 
 Contributors: Jane Lusby
 
@@ -490,22 +490,22 @@ Contributors: Jane Lusby
 - [Use browser in BROWSER env if present for `doc` command][pr1289]
 - [Update shebang to reflect bashisms][pr1269]
 
-[pr1453]: https://github.com/rust-lang/rustup.rs/pull/1453
-[pr1449]: https://github.com/rust-lang/rustup.rs/pull/1449
-[pr1437]: https://github.com/rust-lang/rustup.rs/pull/1437
-[pr1435]: https://github.com/rust-lang/rustup.rs/pull/1435
-[pr1430]: https://github.com/rust-lang/rustup.rs/pull/1430
-[pr1428]: https://github.com/rust-lang/rustup.rs/pull/1428
-[pr1422]: https://github.com/rust-lang/rustup.rs/pull/1422
-[pr1419]: https://github.com/rust-lang/rustup.rs/pull/1419
-[pr1389]: https://github.com/rust-lang/rustup.rs/pull/1389
-[pr1379]: https://github.com/rust-lang/rustup.rs/pull/1379
-[pr1380]: https://github.com/rust-lang/rustup.rs/pull/1380
-[pr1373]: https://github.com/rust-lang/rustup.rs/pull/1373
-[pr1370]: https://github.com/rust-lang/rustup.rs/pull/1370
-[pr1290]: https://github.com/rust-lang/rustup.rs/pull/1290
-[pr1289]: https://github.com/rust-lang/rustup.rs/pull/1289
-[pr1269]: https://github.com/rust-lang/rustup.rs/pull/1269
+[pr1453]: https://github.com/rust-lang/rustup/pull/1453
+[pr1449]: https://github.com/rust-lang/rustup/pull/1449
+[pr1437]: https://github.com/rust-lang/rustup/pull/1437
+[pr1435]: https://github.com/rust-lang/rustup/pull/1435
+[pr1430]: https://github.com/rust-lang/rustup/pull/1430
+[pr1428]: https://github.com/rust-lang/rustup/pull/1428
+[pr1422]: https://github.com/rust-lang/rustup/pull/1422
+[pr1419]: https://github.com/rust-lang/rustup/pull/1419
+[pr1389]: https://github.com/rust-lang/rustup/pull/1389
+[pr1379]: https://github.com/rust-lang/rustup/pull/1379
+[pr1380]: https://github.com/rust-lang/rustup/pull/1380
+[pr1373]: https://github.com/rust-lang/rustup/pull/1373
+[pr1370]: https://github.com/rust-lang/rustup/pull/1370
+[pr1290]: https://github.com/rust-lang/rustup/pull/1290
+[pr1289]: https://github.com/rust-lang/rustup/pull/1289
+[pr1269]: https://github.com/rust-lang/rustup/pull/1269
 
 Contributors: Andrew Pennebaker, Who? Me?!, Matteo Bertini, mog422,
 Kasper Møller Andersen, Thibault Delor, Justin Worthe, TitanSnow,
@@ -518,7 +518,7 @@ Segev Finer, Dan Aloni, Joeri van Ruth
 
 - [windows: detect architecture on website, update to matching arch][pr1354]
 
-[pr1354]: https://github.com/rust-lang/rustup.rs/pull/1354
+[pr1354]: https://github.com/rust-lang/rustup/pull/1354
 
 Contributors: Steffen Butzer
 
@@ -526,7 +526,7 @@ Contributors: Steffen Butzer
 
 - [Warn when tools are missing and allow an override][pr1337]
 
-[pr1337]: https://github.com/rust-lang/rustup.rs/pull/1337
+[pr1337]: https://github.com/rust-lang/rustup/pull/1337
 
 Contributors: Nick Cameron, Steffen Butzer
 
@@ -534,7 +534,7 @@ Contributors: Nick Cameron, Steffen Butzer
 
 - [Fix self update errors filling in missing proxies][pr1326]
 
-[pr1326]: https://github.com/rust-lang/rustup.rs/pull/1326
+[pr1326]: https://github.com/rust-lang/rustup/pull/1326
 
 Contributors: Alex Crichton
 
@@ -544,9 +544,9 @@ Contributors: Alex Crichton
 - [Prevent `rustup update` to a toolchain without `rustc` or `cargo`][pr1298]
 - [Add support for `rustfmt` shims][pr1294]
 
-[pr1295]: https://github.com/rust-lang/rustup.rs/pull/1295
-[pr1298]: https://github.com/rust-lang/rustup.rs/pull/1298
-[pr1294]: https://github.com/rust-lang/rustup.rs/pull/1294
+[pr1295]: https://github.com/rust-lang/rustup/pull/1295
+[pr1298]: https://github.com/rust-lang/rustup/pull/1298
+[pr1294]: https://github.com/rust-lang/rustup/pull/1294
 
 Contributors: Alex Crichton, kennytm, Nick Cameron, Simon Sapin, Who? Me?!
 
@@ -556,9 +556,9 @@ Contributors: Alex Crichton, kennytm, Nick Cameron, Simon Sapin, Who? Me?!
 - [Support `--default-toolchain none`][pr1257]
 - [Automatically install override toolchain when missing][pr1250]
 
-[pr1255]: https://github.com/rust-lang/rustup.rs/pull/1255
-[pr1257]: https://github.com/rust-lang/rustup.rs/pull/1257
-[pr1250]: https://github.com/rust-lang/rustup.rs/pull/1250
+[pr1255]: https://github.com/rust-lang/rustup/pull/1255
+[pr1257]: https://github.com/rust-lang/rustup/pull/1257
+[pr1250]: https://github.com/rust-lang/rustup/pull/1250
 
 Contributors: Aidan Hobson Sayers, Alan Du, Alex Crichton, Christoph Wurst,
 Jason Mobarak, Leon Isenberg, Simon Sapin, Vadim Petrochenkov
@@ -572,12 +572,12 @@ Jason Mobarak, Leon Isenberg, Simon Sapin, Vadim Petrochenkov
 - [Consistently give a toolchain argument in the help text][pr1212]
 - [Use `exec` on Unix where possible to help manage Unix signals][pr1242]
 
-[pr1228]: https://github.com/rust-lang/rustup.rs/pull/1228
-[pr1189]: https://github.com/rust-lang/rustup.rs/pull/1189
-[pr1201]: https://github.com/rust-lang/rustup.rs/pull/1201
-[pr1222]: https://github.com/rust-lang/rustup.rs/pull/1222
-[pr1212]: https://github.com/rust-lang/rustup.rs/pull/1212
-[pr1242]: https://github.com/rust-lang/rustup.rs/pull/1242
+[pr1228]: https://github.com/rust-lang/rustup/pull/1228
+[pr1189]: https://github.com/rust-lang/rustup/pull/1189
+[pr1201]: https://github.com/rust-lang/rustup/pull/1201
+[pr1222]: https://github.com/rust-lang/rustup/pull/1222
+[pr1212]: https://github.com/rust-lang/rustup/pull/1212
+[pr1242]: https://github.com/rust-lang/rustup/pull/1242
 
 Contributors: Alex Crichton, Chen Rotem Levy, Krishna Sundarram, Martin Geisler,
 Matt Brubeck, Matt Ickstadt, Michael Benfield, Michael Fletcher, Nick Cameron,
@@ -585,46 +585,46 @@ Patrick Reisert, Ralf Jung, Sean McArthur, Steven Fackler
 
 ## [1.5.0] - 2017-06-24
 
-- [Rename references to multirust to rustup where applicable](https://github.com/rust-lang/rustup.rs/pull/1148)
-- [Update platform support in README](https://github.com/rust-lang/rustup.rs/pull/1159)
-- [Allow rustup to handle unavailable packages](https://github.com/rust-lang/rustup.rs/pull/1063)
-- [Update libz-sys and curl-sys](https://github.com/rust-lang/rustup.rs/pull/1176)
-- [Teach rustup to override the toolchain from a version file](https://github.com/rust-lang/rustup.rs/pull/1172)
-- [Update sha2 crate](https://github.com/rust-lang/rustup.rs/pull/1162)
-- [Check for unexpected cargo/rustc before install](https://github.com/rust-lang/rustup.rs/pull/705)
-- [Update PATH in .bash_profile](https://github.com/rust-lang/rustup.rs/pull/1179)
+- [Rename references to multirust to rustup where applicable](https://github.com/rust-lang/rustup/pull/1148)
+- [Update platform support in README](https://github.com/rust-lang/rustup/pull/1159)
+- [Allow rustup to handle unavailable packages](https://github.com/rust-lang/rustup/pull/1063)
+- [Update libz-sys and curl-sys](https://github.com/rust-lang/rustup/pull/1176)
+- [Teach rustup to override the toolchain from a version file](https://github.com/rust-lang/rustup/pull/1172)
+- [Update sha2 crate](https://github.com/rust-lang/rustup/pull/1162)
+- [Check for unexpected cargo/rustc before install](https://github.com/rust-lang/rustup/pull/705)
+- [Update PATH in .bash_profile](https://github.com/rust-lang/rustup/pull/1179)
 
 Contributors: Allen Welkie, bors, Brian Anderson, Diggory Blake, Erick
 Tryzelaar, Ricardo Martins, Артём Павлов [Artyom Pavlov]
 
 ## [1.4.0] - 2017-06-09
 
-- [set_file_perms: if the file is already executable, keep it executable](https://github.com/rust-lang/rustup.rs/pull/1141)
-- [Disable man support on Windows](https://github.com/rust-lang/rustup.rs/pull/1139)
-- [VS 2017 updates](https://github.com/rust-lang/rustup.rs/pull/1145)
-- [Show version of rust being installed](https://github.com/rust-lang/rustup.rs/pull/1025)
-- [Detect MSVC 2017](https://github.com/rust-lang/rustup.rs/pull/1136)
-- [Use same precision as rustc for commit sha](https://github.com/rust-lang/rustup.rs/pull/1134)
-- [Fix prompt asking for msvc even though -y is provided](https://github.com/rust-lang/rustup.rs/pull/1124)
-- [README: fix rust build dir](https://github.com/rust-lang/rustup.rs/pull/1135)
-- [Add support for XZ-compressed packages](https://github.com/rust-lang/rustup.rs/pull/1100)
-- [Add PATH in post-install message when not modifying PATH](https://github.com/rust-lang/rustup.rs/pull/1126)
-- [Cleanup download-related code in the rustup_dist crate](https://github.com/rust-lang/rustup.rs/pull/1131)
-- [Increase Rust detection timeout to 3 seconds](https://github.com/rust-lang/rustup.rs/pull/1130)
-- [Supress confusing NotADirectory error and show override missing](https://github.com/rust-lang/rustup.rs/pull/1128)
-- [Don't try to update archive toolchains](https://github.com/rust-lang/rustup.rs/pull/1121)
-- [Exit successfully on "update not yet available"](https://github.com/rust-lang/rustup.rs/pull/1120)
-- [Add a message when removing a component](https://github.com/rust-lang/rustup.rs/pull/1119)
-- [Use ShellExecute rather than start.exe to open docs on windows](https://github.com/rust-lang/rustup.rs/pull/1117)
-- [Clarify that rustup update updates rustup itself](https://github.com/rust-lang/rustup.rs/pull/1113)
-- [Ensure that intermediate directories exist when unpacking an entry](https://github.com/rust-lang/rustup.rs/pull/1098)
-- [Add the rust lib dir (containing std-<hash>.dll) to the path on windows](https://github.com/rust-lang/rustup.rs/pull/1093)
-- [Add x86_64-linux-android target](https://github.com/rust-lang/rustup.rs/pull/1086)
-- [Fix for help.rs suggestion](https://github.com/rust-lang/rustup.rs/pull/1107)
-- [Ignore remove_override_nonexistent on windows](https://github.com/rust-lang/rustup.rs/pull/1105)
-- [Update proxy setting docs](https://github.com/rust-lang/rustup.rs/pull/1088)
-- [Add sensible-browser to the browser list](https://github.com/rust-lang/rustup.rs/pull/1087)
-- [Added help for `rustup toolchain link`](https://github.com/rust-lang/rustup.rs/pull/1017)
+- [set_file_perms: if the file is already executable, keep it executable](https://github.com/rust-lang/rustup/pull/1141)
+- [Disable man support on Windows](https://github.com/rust-lang/rustup/pull/1139)
+- [VS 2017 updates](https://github.com/rust-lang/rustup/pull/1145)
+- [Show version of rust being installed](https://github.com/rust-lang/rustup/pull/1025)
+- [Detect MSVC 2017](https://github.com/rust-lang/rustup/pull/1136)
+- [Use same precision as rustc for commit sha](https://github.com/rust-lang/rustup/pull/1134)
+- [Fix prompt asking for msvc even though -y is provided](https://github.com/rust-lang/rustup/pull/1124)
+- [README: fix rust build dir](https://github.com/rust-lang/rustup/pull/1135)
+- [Add support for XZ-compressed packages](https://github.com/rust-lang/rustup/pull/1100)
+- [Add PATH in post-install message when not modifying PATH](https://github.com/rust-lang/rustup/pull/1126)
+- [Cleanup download-related code in the rustup_dist crate](https://github.com/rust-lang/rustup/pull/1131)
+- [Increase Rust detection timeout to 3 seconds](https://github.com/rust-lang/rustup/pull/1130)
+- [Supress confusing NotADirectory error and show override missing](https://github.com/rust-lang/rustup/pull/1128)
+- [Don't try to update archive toolchains](https://github.com/rust-lang/rustup/pull/1121)
+- [Exit successfully on "update not yet available"](https://github.com/rust-lang/rustup/pull/1120)
+- [Add a message when removing a component](https://github.com/rust-lang/rustup/pull/1119)
+- [Use ShellExecute rather than start.exe to open docs on windows](https://github.com/rust-lang/rustup/pull/1117)
+- [Clarify that rustup update updates rustup itself](https://github.com/rust-lang/rustup/pull/1113)
+- [Ensure that intermediate directories exist when unpacking an entry](https://github.com/rust-lang/rustup/pull/1098)
+- [Add the rust lib dir (containing std-<hash>.dll) to the path on windows](https://github.com/rust-lang/rustup/pull/1093)
+- [Add x86_64-linux-android target](https://github.com/rust-lang/rustup/pull/1086)
+- [Fix for help.rs suggestion](https://github.com/rust-lang/rustup/pull/1107)
+- [Ignore remove_override_nonexistent on windows](https://github.com/rust-lang/rustup/pull/1105)
+- [Update proxy setting docs](https://github.com/rust-lang/rustup/pull/1088)
+- [Add sensible-browser to the browser list](https://github.com/rust-lang/rustup/pull/1087)
+- [Added help for `rustup toolchain link`](https://github.com/rust-lang/rustup/pull/1017)
 
 Contributors: Andrea Canciani, bors, Brian Anderson, CrazyMerlyn, Diggory Blake,
 Fabio B, James Elford, Jim McGrath, johnthagen, Josh Lee, Kim Christensen, Marco
@@ -634,66 +634,66 @@ Xidorn Quan
 
 ## [1.3.0] - 2017-05-09
 
-- [Add armv8l support](https://github.com/rust-lang/rustup.rs/pull/1055)
-- [Update curl crate](https://github.com/rust-lang/rustup.rs/pull/1101)
-- [Fix inadvertent dependency on bash](https://github.com/rust-lang/rustup.rs/pull/1048)
-- [Update openssl-probe to 0.1.1](https://github.com/rust-lang/rustup.rs/pull/1061)
-- [zsh completions cleanup](https://github.com/rust-lang/rustup.rs/pull/1068)
-- [Alias 'rustup toolchain uninstall' to 'rustup uninstall'](https://github.com/rust-lang/rustup.rs/pull/1073)
-- [Fix a typo in PowerShell completion script help](https://github.com/rust-lang/rustup.rs/pull/1076)
-- [Enforce timeouts for reading rustc version](https://github.com/rust-lang/rustup.rs/pull/1071)
-- [Fix OpenSSL linkage by using the final install-directory in the build](https://github.com/rust-lang/rustup.rs/pull/1065)
+- [Add armv8l support](https://github.com/rust-lang/rustup/pull/1055)
+- [Update curl crate](https://github.com/rust-lang/rustup/pull/1101)
+- [Fix inadvertent dependency on bash](https://github.com/rust-lang/rustup/pull/1048)
+- [Update openssl-probe to 0.1.1](https://github.com/rust-lang/rustup/pull/1061)
+- [zsh completions cleanup](https://github.com/rust-lang/rustup/pull/1068)
+- [Alias 'rustup toolchain uninstall' to 'rustup uninstall'](https://github.com/rust-lang/rustup/pull/1073)
+- [Fix a typo in PowerShell completion script help](https://github.com/rust-lang/rustup/pull/1076)
+- [Enforce timeouts for reading rustc version](https://github.com/rust-lang/rustup/pull/1071)
+- [Fix OpenSSL linkage by using the final install-directory in the build](https://github.com/rust-lang/rustup/pull/1065)
 
 Contributors: bors, Brian Anderson, Diggory Blake, Greg Alexander, James Elford,
 Jordan Hiltunen, Justin Noah, Kang Seonghoon, Kevin K, Marco A L Barbosa
 
 ## [1.2.0] - 2017-04-08
 
-- [Check ZDOTDIR when adding path to .zprofile](https://github.com/rust-lang/rustup.rs/pull/1038)
-- [Update links and install page to include android support](https://github.com/rust-lang/rustup.rs/pull/1037)
-- [Add bash completion guidance for macOS users](https://github.com/rust-lang/rustup.rs/pull/1035)
-- [Support partial downloads](https://github.com/rust-lang/rustup.rs/pull/1020)
-- [Don't crash if modifying multiple profile files](https://github.com/rust-lang/rustup.rs/pull/1040)
+- [Check ZDOTDIR when adding path to .zprofile](https://github.com/rust-lang/rustup/pull/1038)
+- [Update links and install page to include android support](https://github.com/rust-lang/rustup/pull/1037)
+- [Add bash completion guidance for macOS users](https://github.com/rust-lang/rustup/pull/1035)
+- [Support partial downloads](https://github.com/rust-lang/rustup/pull/1020)
+- [Don't crash if modifying multiple profile files](https://github.com/rust-lang/rustup/pull/1040)
 
 Contributors: Brian Anderson, James Elford, Jason Dreyzehner, Marco A
 L Barbosa, Wim Looman
 
 ## [1.1.0] - 2017-04-06
 
-- [Fix browser detection for Linux ppc64 and NetBSD](https://github.com/rust-lang/rustup.rs/pull/875)
-- [Update windows info](https://github.com/rust-lang/rustup.rs/pull/879)
-- [Update to markdown 0.2](https://github.com/rust-lang/rustup.rs/pull/896)
-- [Make running program extension case insensitive](https://github.com/rust-lang/rustup.rs/pull/887)
-- [Add MIPS/s390x builders (with PPC64 compilation fixed)](https://github.com/rust-lang/rustup.rs/pull/890)
-- [Fix two missing quotes of download error message](https://github.com/rust-lang/rustup.rs/pull/867)
-- [www: MIPS support and cleanups](https://github.com/rust-lang/rustup.rs/pull/866)
-- [Update release instructions](https://github.com/rust-lang/rustup.rs/pull/863)
-- [Don't set low speed limits for curl](https://github.com/rust-lang/rustup.rs/pull/914)
-- [Attempt to fix msi build. Pin appveyor nightlies](https://github.com/rust-lang/rustup.rs/pull/910)
-- [Stop defaulting to \$PATH searches when the binary can't be found and causing infinite recursion](https://github.com/rust-lang/rustup.rs/pull/917)
-- [Upgrade openssl](https://github.com/rust-lang/rustup.rs/pull/934)
-- [Improve browser detection and install instructions](https://github.com/rust-lang/rustup.rs/pull/936)
-- [Add android support to rustup-init.sh](https://github.com/rust-lang/rustup.rs/pull/949)
-- [Add fallback to symlink if hardlink fails](https://github.com/rust-lang/rustup.rs/pull/951)
-- [readme: add tmp dir hint to Contributing section](https://github.com/rust-lang/rustup.rs/pull/985)
-- [Fixed link to the list of supported platforms](https://github.com/rust-lang/rustup.rs/pull/970)
-- [Update job object code to match Cargo's](https://github.com/rust-lang/rustup.rs/pull/984)
-- [Added argument-documentation to rustup-init.sh](https://github.com/rust-lang/rustup.rs/pull/962)
-- [Add/remove multiple toolchains](https://github.com/rust-lang/rustup.rs/pull/986)
-- [Remove curl usage from appveyor](https://github.com/rust-lang/rustup.rs/pull/1001)
-- [Store downloaded files in a persistent directory until installation](https://github.com/rust-lang/rustup.rs/pull/958)
-- [Add android build support](https://github.com/rust-lang/rustup.rs/pull/1000)
-- [Fix up a bunch of things indicated by clippy](https://github.com/rust-lang/rustup.rs/pull/1012)
-- [Ensure librssl compatibility](https://github.com/rust-lang/rustup.rs/pull/1011)
-- [RLS support](https://github.com/rust-lang/rustup.rs/pull/1005)
-- [Add 'docs' alias](https://github.com/rust-lang/rustup.rs/pull/1010)
-- [Use correct name for undefined linked toolchain invocation](https://github.com/rust-lang/rustup.rs/pull/1008)
-- [zsh install support](https://github.com/rust-lang/rustup.rs/pull/1013)
-- [Add/remove multiple components+targets](https://github.com/rust-lang/rustup.rs/pull/1016)
-- [Better error message when not running in a tty](https://github.com/rust-lang/rustup.rs/pull/1026)
-- [Indent help text](https://github.com/rust-lang/rustup.rs/pull/1019)
-- [Document installing to a custom location using CARGO_HOME and RUSTUP_HOME environment variables](https://github.com/rust-lang/rustup.rs/pull/1024)
-- [Aggressive remove_dir_all](https://github.com/rust-lang/rustup.rs/pull/1015)
+- [Fix browser detection for Linux ppc64 and NetBSD](https://github.com/rust-lang/rustup/pull/875)
+- [Update windows info](https://github.com/rust-lang/rustup/pull/879)
+- [Update to markdown 0.2](https://github.com/rust-lang/rustup/pull/896)
+- [Make running program extension case insensitive](https://github.com/rust-lang/rustup/pull/887)
+- [Add MIPS/s390x builders (with PPC64 compilation fixed)](https://github.com/rust-lang/rustup/pull/890)
+- [Fix two missing quotes of download error message](https://github.com/rust-lang/rustup/pull/867)
+- [www: MIPS support and cleanups](https://github.com/rust-lang/rustup/pull/866)
+- [Update release instructions](https://github.com/rust-lang/rustup/pull/863)
+- [Don't set low speed limits for curl](https://github.com/rust-lang/rustup/pull/914)
+- [Attempt to fix msi build. Pin appveyor nightlies](https://github.com/rust-lang/rustup/pull/910)
+- [Stop defaulting to \$PATH searches when the binary can't be found and causing infinite recursion](https://github.com/rust-lang/rustup/pull/917)
+- [Upgrade openssl](https://github.com/rust-lang/rustup/pull/934)
+- [Improve browser detection and install instructions](https://github.com/rust-lang/rustup/pull/936)
+- [Add android support to rustup-init.sh](https://github.com/rust-lang/rustup/pull/949)
+- [Add fallback to symlink if hardlink fails](https://github.com/rust-lang/rustup/pull/951)
+- [readme: add tmp dir hint to Contributing section](https://github.com/rust-lang/rustup/pull/985)
+- [Fixed link to the list of supported platforms](https://github.com/rust-lang/rustup/pull/970)
+- [Update job object code to match Cargo's](https://github.com/rust-lang/rustup/pull/984)
+- [Added argument-documentation to rustup-init.sh](https://github.com/rust-lang/rustup/pull/962)
+- [Add/remove multiple toolchains](https://github.com/rust-lang/rustup/pull/986)
+- [Remove curl usage from appveyor](https://github.com/rust-lang/rustup/pull/1001)
+- [Store downloaded files in a persistent directory until installation](https://github.com/rust-lang/rustup/pull/958)
+- [Add android build support](https://github.com/rust-lang/rustup/pull/1000)
+- [Fix up a bunch of things indicated by clippy](https://github.com/rust-lang/rustup/pull/1012)
+- [Ensure librssl compatibility](https://github.com/rust-lang/rustup/pull/1011)
+- [RLS support](https://github.com/rust-lang/rustup/pull/1005)
+- [Add 'docs' alias](https://github.com/rust-lang/rustup/pull/1010)
+- [Use correct name for undefined linked toolchain invocation](https://github.com/rust-lang/rustup/pull/1008)
+- [zsh install support](https://github.com/rust-lang/rustup/pull/1013)
+- [Add/remove multiple components+targets](https://github.com/rust-lang/rustup/pull/1016)
+- [Better error message when not running in a tty](https://github.com/rust-lang/rustup/pull/1026)
+- [Indent help text](https://github.com/rust-lang/rustup/pull/1019)
+- [Document installing to a custom location using CARGO_HOME and RUSTUP_HOME environment variables](https://github.com/rust-lang/rustup/pull/1024)
+- [Aggressive remove_dir_all](https://github.com/rust-lang/rustup/pull/1015)
 
 Contributors: Aarthi Janakiraman, Alex Burka, Alex Crichton, bors,
 Brian Anderson, Christian Muirhead, Christopher Armstrong, Daniel
@@ -704,8 +704,8 @@ Klabnik, Tomáš Hübelbauer, topecongiro, Wang Xuerui
 
 ## [1.0.0] - 2016-12-15
 
-- [Statically link MSVC CRT](https://github.com/rust-lang/rustup.rs/pull/843)
-- [Upgrade ~/.multirust correctly from rustup-init](https://github.com/rust-lang/rustup.rs/pull/858)
+- [Statically link MSVC CRT](https://github.com/rust-lang/rustup/pull/843)
+- [Upgrade ~/.multirust correctly from rustup-init](https://github.com/rust-lang/rustup/pull/858)
 
 Contributors: Alex Crichton, Andrew Koroluk, Arch, benaryorg, Benedikt Reinartz,
 Björn Steinbrink, bors, Boutin, Michael, Brian Anderson, Cam Swords, Chungmin
@@ -724,54 +724,54 @@ Wesley Moore, Yasushi Abe, Y. T. Chung
 
 ## [0.7.0] - 2016-12-11
 
-- [Correctly "detect" host endianness on MIPS](https://github.com/rust-lang/rustup.rs/pull/802)
-- [Add powershell completions](https://github.com/rust-lang/rustup.rs/pull/801)
-- [Update toolchain used to build rustup](https://github.com/rust-lang/rustup.rs/pull/741)
-- [Support probing MIPS64 n64 targets](https://github.com/rust-lang/rustup.rs/pull/815)
-- [Support MIPS architectures in rustup-init.sh](https://github.com/rust-lang/rustup.rs/pull/825)
-- [Automatically detect NetBSD during standard install](https://github.com/rust-lang/rustup.rs/pull/824)
-- [Fix symlink creation on windows](https://github.com/rust-lang/rustup.rs/pull/823)
-- [Search PATH for binaries run by `rustup run`](https://github.com/rust-lang/rustup.rs/pull/822)
-- [Recursive tool invocations should invoke the proxy, not the tool directly](https://github.com/rust-lang/rustup.rs/pull/812)
-- [Upgrade error-chain](https://github.com/rust-lang/rustup.rs/pull/841)
-- [Add FAQ entry for downloading Rust source](https://github.com/rust-lang/rustup.rs/pull/840)
-- [Rename ~/.multirust to ~/.rustup](https://github.com/rust-lang/rustup.rs/pull/830)
-- [Remove some codegen hacks](https://github.com/rust-lang/rustup.rs/pull/850)
-- [Update libc for MIPS64 host builds](https://github.com/rust-lang/rustup.rs/pull/847)
-- [Default to MSVC on Windows](https://github.com/rust-lang/rustup.rs/pull/842)
+- [Correctly "detect" host endianness on MIPS](https://github.com/rust-lang/rustup/pull/802)
+- [Add powershell completions](https://github.com/rust-lang/rustup/pull/801)
+- [Update toolchain used to build rustup](https://github.com/rust-lang/rustup/pull/741)
+- [Support probing MIPS64 n64 targets](https://github.com/rust-lang/rustup/pull/815)
+- [Support MIPS architectures in rustup-init.sh](https://github.com/rust-lang/rustup/pull/825)
+- [Automatically detect NetBSD during standard install](https://github.com/rust-lang/rustup/pull/824)
+- [Fix symlink creation on windows](https://github.com/rust-lang/rustup/pull/823)
+- [Search PATH for binaries run by `rustup run`](https://github.com/rust-lang/rustup/pull/822)
+- [Recursive tool invocations should invoke the proxy, not the tool directly](https://github.com/rust-lang/rustup/pull/812)
+- [Upgrade error-chain](https://github.com/rust-lang/rustup/pull/841)
+- [Add FAQ entry for downloading Rust source](https://github.com/rust-lang/rustup/pull/840)
+- [Rename ~/.multirust to ~/.rustup](https://github.com/rust-lang/rustup/pull/830)
+- [Remove some codegen hacks](https://github.com/rust-lang/rustup/pull/850)
+- [Update libc for MIPS64 host builds](https://github.com/rust-lang/rustup/pull/847)
+- [Default to MSVC on Windows](https://github.com/rust-lang/rustup/pull/842)
 
 Contributors: Alex Crichton, Arch, bors, Brian Anderson, Diggory Blake, Kai
 Roßwag, Kevin K, Oliver Schneider, Ryan Havar, Tobias Bucher, Wang Xuerui
 
 ## [0.6.5] - 2016-11-04
 
-- [Update bundled curl code](https://github.com/rust-lang/rustup.rs/pull/790)
-- [Remove old zsh completions](https://github.com/rust-lang/rustup.rs/pull/779)
-- [Fix two small typos in the error descriptions](https://github.com/rust-lang/rustup.rs/pull/788)
-- [Update README](https://github.com/rust-lang/rustup.rs/pull/782)
-- [Fix name of bash completion directory](https://github.com/rust-lang/rustup.rs/pull/780)
+- [Update bundled curl code](https://github.com/rust-lang/rustup/pull/790)
+- [Remove old zsh completions](https://github.com/rust-lang/rustup/pull/779)
+- [Fix two small typos in the error descriptions](https://github.com/rust-lang/rustup/pull/788)
+- [Update README](https://github.com/rust-lang/rustup/pull/782)
+- [Fix name of bash completion directory](https://github.com/rust-lang/rustup/pull/780)
 
 Contributors: Alex Crichton, Björn Steinbrink, Brian Anderson, Jian Zeng, Matt
 Brubeck
 
 ## [0.6.4] - 2016-10-24
 
-- [making rustup prepend cargo bin to path instead of append](https://github.com/rust-lang/rustup.rs/pull/707)
-- [Use released version of rustls dependency](https://github.com/rust-lang/rustup.rs/pull/711)
-- [Update OpenSSL](https://github.com/rust-lang/rustup.rs/pull/733)
-- [Made outputting of ANSI terminal escapes codes defensive](https://github.com/rust-lang/rustup.rs/pull/725)
-- [Adjusted rustup-init.sh need_cmd to add uname and remove printf](https://github.com/rust-lang/rustup.rs/pull/723)
-- [Update to error-chain 0.5.0 to allow optional backtrace](https://github.com/rust-lang/rustup.rs/pull/591)
-- [Fix variable naming in rustup-init.sh](https://github.com/rust-lang/rustup.rs/pull/737)
-- [Update clap to fix --help formatting](https://github.com/rust-lang/rustup.rs/pull/738)
-- [Add an FAQ entry about troubles with antivirus](https://github.com/rust-lang/rustup.rs/pull/739)
-- [Clarify how rustup toolchain installation works on Windows](https://github.com/rust-lang/rustup.rs/pull/744)
-- [Do not interpret commas when using "rustup run"](https://github.com/rust-lang/rustup.rs/pull/752)
-- [Fix local declarations for zsh completions](https://github.com/rust-lang/rustup.rs/pull/753)
-- [Fix checksum failures](https://github.com/rust-lang/rustup.rs/pull/759)
-- [Treat an empty `CARGO_HOME` the same as an unset `CARGO_HOME`](https://github.com/rust-lang/rustup.rs/pull/767)
-- [Check stdout is a tty before using terminal features](https://github.com/rust-lang/rustup.rs/pull/772)
-- [Add completion generation for zsh, bash and fish shells](https://github.com/rust-lang/rustup.rs/pull/773)
+- [making rustup prepend cargo bin to path instead of append](https://github.com/rust-lang/rustup/pull/707)
+- [Use released version of rustls dependency](https://github.com/rust-lang/rustup/pull/711)
+- [Update OpenSSL](https://github.com/rust-lang/rustup/pull/733)
+- [Made outputting of ANSI terminal escapes codes defensive](https://github.com/rust-lang/rustup/pull/725)
+- [Adjusted rustup-init.sh need_cmd to add uname and remove printf](https://github.com/rust-lang/rustup/pull/723)
+- [Update to error-chain 0.5.0 to allow optional backtrace](https://github.com/rust-lang/rustup/pull/591)
+- [Fix variable naming in rustup-init.sh](https://github.com/rust-lang/rustup/pull/737)
+- [Update clap to fix --help formatting](https://github.com/rust-lang/rustup/pull/738)
+- [Add an FAQ entry about troubles with antivirus](https://github.com/rust-lang/rustup/pull/739)
+- [Clarify how rustup toolchain installation works on Windows](https://github.com/rust-lang/rustup/pull/744)
+- [Do not interpret commas when using "rustup run"](https://github.com/rust-lang/rustup/pull/752)
+- [Fix local declarations for zsh completions](https://github.com/rust-lang/rustup/pull/753)
+- [Fix checksum failures](https://github.com/rust-lang/rustup/pull/759)
+- [Treat an empty `CARGO_HOME` the same as an unset `CARGO_HOME`](https://github.com/rust-lang/rustup/pull/767)
+- [Check stdout is a tty before using terminal features](https://github.com/rust-lang/rustup/pull/772)
+- [Add completion generation for zsh, bash and fish shells](https://github.com/rust-lang/rustup/pull/773)
 
 Contributors: Alex Crichton, Andrew Koroluk, Brian Anderson, Chungmin Park,
 Diggory Blake, Guillaume Fraux, Jake Goldsborough, jethrogb, Kamal Marhubi,
@@ -779,94 +779,94 @@ Kevin K, Kevin Rauwolf, Raphael Cohn, Ricardo Martins
 
 ## [0.6.3] - 2016-08-28
 
-- [Disable anti-sudo check](https://github.com/rust-lang/rustup.rs/pull/698)
-- [Fixed CI toolchain pinning](https://github.com/rust-lang/rustup.rs/pull/696)
+- [Disable anti-sudo check](https://github.com/rust-lang/rustup/pull/698)
+- [Fixed CI toolchain pinning](https://github.com/rust-lang/rustup/pull/696)
 
 Contributors: Brian Anderson
 
 ## [0.6.2] - 2016-08-27
 
-- [Add basic autocompletion for Zsh](https://github.com/rust-lang/rustup.rs/pull/689)
-- [Sort toolchains by semantic version](https://github.com/rust-lang/rustup.rs/pull/688)
+- [Add basic autocompletion for Zsh](https://github.com/rust-lang/rustup/pull/689)
+- [Sort toolchains by semantic version](https://github.com/rust-lang/rustup/pull/688)
 
 Contributors: Brian Anderson, Diggory Blake, Knight, Marco A L Barbosa
 
 ## [0.6.1] - 2016-08-24
 
-- [Fix mysterious crash on OS X 10.10+](https://github.com/rust-lang/rustup.rs/pull/684)
-- [Fix `component remove` command and add a test for it](https://github.com/rust-lang/rustup.rs/pull/683)
+- [Fix mysterious crash on OS X 10.10+](https://github.com/rust-lang/rustup/pull/684)
+- [Fix `component remove` command and add a test for it](https://github.com/rust-lang/rustup/pull/683)
 
 Contributors: Brian Anderson, Diggory Blake
 
 ## [0.6.0] - 2016-08-23
 
-- [Print rustup version after update](https://github.com/rust-lang/rustup.rs/pull/614)
-- [Don't spawn processes for copying](https://github.com/rust-lang/rustup.rs/pull/630)
-- [Upgrade error-chain to 0.3](https://github.com/rust-lang/rustup.rs/pull/636)
-- [Support telemetry with lots of output](https://github.com/rust-lang/rustup.rs/pull/645)
-- [Remove empty directories after component uninstall](https://github.com/rust-lang/rustup.rs/pull/634)
-- [Update rustup-init.sh for powerpc](https://github.com/rust-lang/rustup.rs/pull/647)
-- [Switch builds to current nightly toolchain](https://github.com/rust-lang/rustup.rs/pull/651)
-- [Add a WIP MSI installer](https://github.com/rust-lang/rustup.rs/pull/635)
-- [Add `--path` and `--nonexistent` options to `rustup override unset`](https://github.com/rust-lang/rustup.rs/pull/650)
-- [Add `component` subcommand](https://github.com/rust-lang/rustup.rs/pull/659)
+- [Print rustup version after update](https://github.com/rust-lang/rustup/pull/614)
+- [Don't spawn processes for copying](https://github.com/rust-lang/rustup/pull/630)
+- [Upgrade error-chain to 0.3](https://github.com/rust-lang/rustup/pull/636)
+- [Support telemetry with lots of output](https://github.com/rust-lang/rustup/pull/645)
+- [Remove empty directories after component uninstall](https://github.com/rust-lang/rustup/pull/634)
+- [Update rustup-init.sh for powerpc](https://github.com/rust-lang/rustup/pull/647)
+- [Switch builds to current nightly toolchain](https://github.com/rust-lang/rustup/pull/651)
+- [Add a WIP MSI installer](https://github.com/rust-lang/rustup/pull/635)
+- [Add `--path` and `--nonexistent` options to `rustup override unset`](https://github.com/rust-lang/rustup/pull/650)
+- [Add `component` subcommand](https://github.com/rust-lang/rustup/pull/659)
 
 Contributors: Alex Crichton, Brian Anderson, Diggory Blake, Ivan Nejgebauer Josh
 Machol, Julien Blanchard, Patrick Reisert, Ri, Tim Neumann
 
 ## [0.5.0] - 2016-07-30
 
-- [List custom toolchains in `rustup show`](https://github.com/rust-lang/rustup.rs/pull/620)
-- [Add a usage example for local builds](https://github.com/rust-lang/rustup.rs/pull/622)
-- [Read/Write impl rework for rustls](https://github.com/rust-lang/rustup.rs/pull/592)
-- [Introduce `+TOOLCHAIN` syntax for proxies](https://github.com/rust-lang/rustup.rs/pull/615)
-- [Add `rustup man`](https://github.com/rust-lang/rustup.rs/pull/616)
-- [Try detecting sudo when running `rustup-init`](https://github.com/rust-lang/rustup.rs/pull/617)
-- [Handle active custom toolchain in `rustup show`](https://github.com/rust-lang/rustup.rs/pull/621)
+- [List custom toolchains in `rustup show`](https://github.com/rust-lang/rustup/pull/620)
+- [Add a usage example for local builds](https://github.com/rust-lang/rustup/pull/622)
+- [Read/Write impl rework for rustls](https://github.com/rust-lang/rustup/pull/592)
+- [Introduce `+TOOLCHAIN` syntax for proxies](https://github.com/rust-lang/rustup/pull/615)
+- [Add `rustup man`](https://github.com/rust-lang/rustup/pull/616)
+- [Try detecting sudo when running `rustup-init`](https://github.com/rust-lang/rustup/pull/617)
+- [Handle active custom toolchain in `rustup show`](https://github.com/rust-lang/rustup/pull/621)
 
 Contributors: Brian Anderson, Cam Swords, Daniel Keep, Diggory Blake,
 Florian Gilcher, Ivan Nejgebauer, theindigamer
 
 ## [0.4.0] - 2016-07-22
 
-- [Improve rustls CA certificate loading](https://github.com/rust-lang/rustup.rs/pull/585)
-- [Detect ARMv7 CPUs without NEON extensions and treat as ARMv6](https://github.com/rust-lang/rustup.rs/pull/593)
-- [Allow any toolchain to be specified as the default during rustup installation](https://github.com/rust-lang/rustup.rs/pull/586)
-- [Add details about updating rustup to README](https://github.com/rust-lang/rustup.rs/pull/590)
-- [Update libbacktrace to generate less filesystem thrashing on Windows](https://github.com/rust-lang/rustup.rs/pull/604)
-- [Update gcc dep to fix building on MSVC](https://github.com/rust-lang/rustup.rs/pull/605)
-- [Remove the multirust binary](https://github.com/rust-lang/rustup.rs/pull/606)
-- [Use the env_proxy crate for proxy environment variable handling](https://github.com/rust-lang/rustup.rs/pull/598)
-- [Set system-specific dynamic loader env var for command execution](https://github.com/rust-lang/rustup.rs/pull/600)
-- [Hide telemetry command from top level help](https://github.com/rust-lang/rustup.rs/pull/601)
-- [Add the "no-self-update" feature](https://github.com/rust-lang/rustup.rs/pull/602)
-- [Update to error-chain 0.2.2](https://github.com/rust-lang/rustup.rs/pull/609)
-- [Add HTTP proxy documentation to README](https://github.com/rust-lang/rustup.rs/pull/610)
+- [Improve rustls CA certificate loading](https://github.com/rust-lang/rustup/pull/585)
+- [Detect ARMv7 CPUs without NEON extensions and treat as ARMv6](https://github.com/rust-lang/rustup/pull/593)
+- [Allow any toolchain to be specified as the default during rustup installation](https://github.com/rust-lang/rustup/pull/586)
+- [Add details about updating rustup to README](https://github.com/rust-lang/rustup/pull/590)
+- [Update libbacktrace to generate less filesystem thrashing on Windows](https://github.com/rust-lang/rustup/pull/604)
+- [Update gcc dep to fix building on MSVC](https://github.com/rust-lang/rustup/pull/605)
+- [Remove the multirust binary](https://github.com/rust-lang/rustup/pull/606)
+- [Use the env_proxy crate for proxy environment variable handling](https://github.com/rust-lang/rustup/pull/598)
+- [Set system-specific dynamic loader env var for command execution](https://github.com/rust-lang/rustup/pull/600)
+- [Hide telemetry command from top level help](https://github.com/rust-lang/rustup/pull/601)
+- [Add the "no-self-update" feature](https://github.com/rust-lang/rustup/pull/602)
+- [Update to error-chain 0.2.2](https://github.com/rust-lang/rustup/pull/609)
+- [Add HTTP proxy documentation to README](https://github.com/rust-lang/rustup/pull/610)
 
 Contributors: Alex Crichton, Brian Anderson, Ivan Nejgebauer, Jimmy
 Cuadra, Martin Pool, Wesley Moore
 
 ## [0.3.0] - 2016-07-14
 
-- [Teach rustup to download manifests from the `/staging/` directory](https://github.com/rust-lang/rustup.rs/pull/579).
-- [Treat all HTTP client errors the same](https://github.com/rust-lang/rustup.rs/pull/578).
-- [Remove winapi replacement](https://github.com/rust-lang/rustup.rs/pull/577).
-- [Remove toolchain directory if initial toolchain install fails](https://github.com/rust-lang/rustup.rs/pull/574).
-- [Fallback to old download methods if server returns 403](https://github.com/rust-lang/rustup.rs/pull/573).
-- [Add preliminary rustls support](https://github.com/rust-lang/rustup.rs/pull/572).
-- [Add a hack to remediate checksum failure issues](https://github.com/rust-lang/rustup.rs/pull/562).
-- [Move error-chain out of tree](https://github.com/rust-lang/rustup.rs/pull/564).
-- [Remove uses of subcommand synonyms in the examples](https://github.com/rust-lang/rustup.rs/pull/560).
-- [Add `--yes` as alias for `-y`](https://github.com/rust-lang/rustup.rs/pull/563).
-- [Remove unavailable toolchains from `target list`](https://github.com/rust-lang/rustup.rs/pull/553).
-- [Add powerpc builds](https://github.com/rust-lang/rustup.rs/pull/534).
-- [Fix help text for `rustup update`](https://github.com/rust-lang/rustup.rs/pull/552).
-- [Remove noisy "rustup is up to date" message](https://github.com/rust-lang/rustup.rs/pull/550).
-- [Fix references to non-existent `.rustup` directory](https://github.com/rust-lang/rustup.rs/pull/545).
-- [When listing toolchains only list directories](https://github.com/rust-lang/rustup.rs/pull/544).
-- [rustup-init: remove dependency on `file` command](https://github.com/rust-lang/rustup.rs/pull/543).
-- [Link to rustup-init.sh in README](https://github.com/rust-lang/rustup.rs/pull/541).
-- [Improve docs for `set default-host`](https://github.com/rust-lang/rustup.rs/pull/540).
+- [Teach rustup to download manifests from the `/staging/` directory](https://github.com/rust-lang/rustup/pull/579).
+- [Treat all HTTP client errors the same](https://github.com/rust-lang/rustup/pull/578).
+- [Remove winapi replacement](https://github.com/rust-lang/rustup/pull/577).
+- [Remove toolchain directory if initial toolchain install fails](https://github.com/rust-lang/rustup/pull/574).
+- [Fallback to old download methods if server returns 403](https://github.com/rust-lang/rustup/pull/573).
+- [Add preliminary rustls support](https://github.com/rust-lang/rustup/pull/572).
+- [Add a hack to remediate checksum failure issues](https://github.com/rust-lang/rustup/pull/562).
+- [Move error-chain out of tree](https://github.com/rust-lang/rustup/pull/564).
+- [Remove uses of subcommand synonyms in the examples](https://github.com/rust-lang/rustup/pull/560).
+- [Add `--yes` as alias for `-y`](https://github.com/rust-lang/rustup/pull/563).
+- [Remove unavailable toolchains from `target list`](https://github.com/rust-lang/rustup/pull/553).
+- [Add powerpc builds](https://github.com/rust-lang/rustup/pull/534).
+- [Fix help text for `rustup update`](https://github.com/rust-lang/rustup/pull/552).
+- [Remove noisy "rustup is up to date" message](https://github.com/rust-lang/rustup/pull/550).
+- [Fix references to non-existent `.rustup` directory](https://github.com/rust-lang/rustup/pull/545).
+- [When listing toolchains only list directories](https://github.com/rust-lang/rustup/pull/544).
+- [rustup-init: remove dependency on `file` command](https://github.com/rust-lang/rustup/pull/543).
+- [Link to rustup-init.sh in README](https://github.com/rust-lang/rustup/pull/541).
+- [Improve docs for `set default-host`](https://github.com/rust-lang/rustup/pull/540).
 
 Contributors: Alex Crichton, Brian Anderson, Drew Fisher, geemili,
 Ivan Petkov, James Lucas, jethrogb, Kevin Yap, leonardo.yvens, Michael
@@ -874,24 +874,24 @@ DeWitt, Nate Mara, Virgile Andreani
 
 ## [0.2.0] - 2016-06-21
 
-- [Indicate correct path to remove in multirust upgrade instructions](https://github.com/rust-lang/rustup.rs/pull/518).
-- [Bring back optional hyper with proxy support](https://github.com/rust-lang/rustup.rs/pull/532).
-- ['default' and 'update' heuristics for bare triples](https://github.com/rust-lang/rustup.rs/pull/516).
-- [Change upstream via \$RUSTUP_DIST_SERVER](https://github.com/rust-lang/rustup.rs/pull/521).
-- [Fail with a nicer error message if /tmp is mounted noexec](https://github.com/rust-lang/rustup.rs/pull/523).
-- [Remove printfs from ~/.cargo/env](https://github.com/rust-lang/rustup.rs/pull/527).
-- [Reduce margin in installer text to 79 columns](https://github.com/rust-lang/rustup.rs/pull/526).
-- [Fix typos](https://github.com/rust-lang/rustup.rs/pull/519).
-- [Fix missing curly braces in error-chain docs](https://github.com/rust-lang/rustup.rs/pull/522).
-- [Fix downloads of builds without v2 manifests](https://github.com/rust-lang/rustup.rs/pull/515).
-- [Explain toolchains in `help install`](https://github.com/rust-lang/rustup.rs/pull/496).
-- [Compile on stable Rust](https://github.com/rust-lang/rustup.rs/pull/476).
-- [Fix spelling mistakes](https://github.com/rust-lang/rustup.rs/pull/489).
-- [Fix the toolchain command synonyms](https://github.com/rust-lang/rustup.rs/pull/477).
-- [Configurable host triples](https://github.com/rust-lang/rustup.rs/pull/421).
-- [Use a .toml file to store settings](https://github.com/rust-lang/rustup.rs/pull/420).
-- [Point PATH to toolchain/bin on Windows](https://github.com/rust-lang/rustup.rs/pull/402).
-- [Remove extra '.' in docs](https://github.com/rust-lang/rustup.rs/pull/472).
+- [Indicate correct path to remove in multirust upgrade instructions](https://github.com/rust-lang/rustup/pull/518).
+- [Bring back optional hyper with proxy support](https://github.com/rust-lang/rustup/pull/532).
+- ['default' and 'update' heuristics for bare triples](https://github.com/rust-lang/rustup/pull/516).
+- [Change upstream via \$RUSTUP_DIST_SERVER](https://github.com/rust-lang/rustup/pull/521).
+- [Fail with a nicer error message if /tmp is mounted noexec](https://github.com/rust-lang/rustup/pull/523).
+- [Remove printfs from ~/.cargo/env](https://github.com/rust-lang/rustup/pull/527).
+- [Reduce margin in installer text to 79 columns](https://github.com/rust-lang/rustup/pull/526).
+- [Fix typos](https://github.com/rust-lang/rustup/pull/519).
+- [Fix missing curly braces in error-chain docs](https://github.com/rust-lang/rustup/pull/522).
+- [Fix downloads of builds without v2 manifests](https://github.com/rust-lang/rustup/pull/515).
+- [Explain toolchains in `help install`](https://github.com/rust-lang/rustup/pull/496).
+- [Compile on stable Rust](https://github.com/rust-lang/rustup/pull/476).
+- [Fix spelling mistakes](https://github.com/rust-lang/rustup/pull/489).
+- [Fix the toolchain command synonyms](https://github.com/rust-lang/rustup/pull/477).
+- [Configurable host triples](https://github.com/rust-lang/rustup/pull/421).
+- [Use a .toml file to store settings](https://github.com/rust-lang/rustup/pull/420).
+- [Point PATH to toolchain/bin on Windows](https://github.com/rust-lang/rustup/pull/402).
+- [Remove extra '.' in docs](https://github.com/rust-lang/rustup/pull/472).
 
 Contributors: Alex Crichton, benaryorg, Benedikt Reinartz, Boutin,
 Michael, Brian Anderson, Diggory Blake, Erick Tryzelaar, Ivan
@@ -900,47 +900,47 @@ Tad Hardesty
 
 ## [0.1.12] - 2016-05-12
 
-- [Don't install when multirust metadata exists](https://github.com/rust-lang/rustup.rs/pull/456).
+- [Don't install when multirust metadata exists](https://github.com/rust-lang/rustup/pull/456).
 
 ## [0.1.11] - 2016-05-12
 
-- [Actually dispatch the `rustup install` command](https://github.com/rust-lang/rustup.rs/pull/444).
-- [Migrate to libcurl instead of hyper](https://github.com/rust-lang/rustup.rs/pull/434).
-- [Add error for downloading bogus versions](https://github.com/rust-lang/rustup.rs/pull/428).
+- [Actually dispatch the `rustup install` command](https://github.com/rust-lang/rustup/pull/444).
+- [Migrate to libcurl instead of hyper](https://github.com/rust-lang/rustup/pull/434).
+- [Add error for downloading bogus versions](https://github.com/rust-lang/rustup/pull/428).
 
 ## [0.1.10] - 2016-05-09
 
-- [Multiple cli improvements](https://github.com/rust-lang/rustup.rs/pull/419).
-- [Support HTTP protocol again](https://github.com/rust-lang/rustup.rs/pull/431).
-- [Improvements to welcome screen](https://github.com/rust-lang/rustup.rs/pull/418).
-- [Don't try to update non-tracking channels](https://github.com/rust-lang/rustup.rs/pull/425).
-- [Don't panic when NativeSslStream lock is poisoned](https://github.com/rust-lang/rustup.rs/pull/429).
+- [Multiple cli improvements](https://github.com/rust-lang/rustup/pull/419).
+- [Support HTTP protocol again](https://github.com/rust-lang/rustup/pull/431).
+- [Improvements to welcome screen](https://github.com/rust-lang/rustup/pull/418).
+- [Don't try to update non-tracking channels](https://github.com/rust-lang/rustup/pull/425).
+- [Don't panic when NativeSslStream lock is poisoned](https://github.com/rust-lang/rustup/pull/429).
 - [Fix multiple issues in schannel bindings](https://github.com/sfackler/schannel-rs/pull/1)
 
 ## [0.1.9] - 2016-05-07
 
-- [Do TLS hostname verification](https://github.com/rust-lang/rustup.rs/pull/400).
-- [Expand `rustup show`](https://github.com/rust-lang/rustup.rs/pull/406).
-- [Add `rustup doc`](https://github.com/rust-lang/rustup.rs/pull/403).
-- [Refuse to install if it looks like other Rust installations are present](https://github.com/rust-lang/rustup.rs/pull/408).
-- [Update www platform detection for FreeBSD](https://github.com/rust-lang/rustup.rs/pull/399).
-- [Fix color display during telemetry capture](https://github.com/rust-lang/rustup.rs/pull/394).
-- [Make it less of an error for the self-update hash to be wrong](https://github.com/rust-lang/rustup.rs/pull/372).
+- [Do TLS hostname verification](https://github.com/rust-lang/rustup/pull/400).
+- [Expand `rustup show`](https://github.com/rust-lang/rustup/pull/406).
+- [Add `rustup doc`](https://github.com/rust-lang/rustup/pull/403).
+- [Refuse to install if it looks like other Rust installations are present](https://github.com/rust-lang/rustup/pull/408).
+- [Update www platform detection for FreeBSD](https://github.com/rust-lang/rustup/pull/399).
+- [Fix color display during telemetry capture](https://github.com/rust-lang/rustup/pull/394).
+- [Make it less of an error for the self-update hash to be wrong](https://github.com/rust-lang/rustup/pull/372).
 
 ## [0.1.8] - 2016-04-28
 
-- [Initial telemetry implementation (disabled)](https://github.com/rust-lang/rustup.rs/pull/289)
-- [Add hash to `--version`](https://github.com/rust-lang/rustup.rs/pull/347)
-- [Improve download progress](https://github.com/rust-lang/rustup.rs/pull/355)
-- [Completely overhaul error handling](https://github.com/rust-lang/rustup.rs/pull/358)
-- [Add armv7l support to www](https://github.com/rust-lang/rustup.rs/pull/359)
-- [Overhaul website](https://github.com/rust-lang/rustup.rs/pull/363)
+- [Initial telemetry implementation (disabled)](https://github.com/rust-lang/rustup/pull/289)
+- [Add hash to `--version`](https://github.com/rust-lang/rustup/pull/347)
+- [Improve download progress](https://github.com/rust-lang/rustup/pull/355)
+- [Completely overhaul error handling](https://github.com/rust-lang/rustup/pull/358)
+- [Add armv7l support to www](https://github.com/rust-lang/rustup/pull/359)
+- [Overhaul website](https://github.com/rust-lang/rustup/pull/363)
 
 ## [0.1.7] - 2016-04-17
 
-- [Fix overrides for Windows root directories](https://github.com/rust-lang/rustup.rs/pull/317).
-- [Remove 'multirust' binary and rename crates](https://github.com/rust-lang/rustup.rs/pull/312).
-- [Pass rustup-setup.sh arguments to rustup-setup](https://github.com/rust-lang/rustup.rs/pull/325).
-- [Don't open /dev/tty if passed -y](https://github.com/rust-lang/rustup.rs/pull/334).
-- [Add interactive install, `--default-toolchain` argument](https://github.com/rust-lang/rustup.rs/pull/293).
-- [Rename rustup-setup to rustu-init](https://github.com/rust-lang/rustup.rs/pull/303).
+- [Fix overrides for Windows root directories](https://github.com/rust-lang/rustup/pull/317).
+- [Remove 'multirust' binary and rename crates](https://github.com/rust-lang/rustup/pull/312).
+- [Pass rustup-setup.sh arguments to rustup-setup](https://github.com/rust-lang/rustup/pull/325).
+- [Don't open /dev/tty if passed -y](https://github.com/rust-lang/rustup/pull/334).
+- [Add interactive install, `--default-toolchain` argument](https://github.com/rust-lang/rustup/pull/293).
+- [Rename rustup-setup to rustu-init](https://github.com/rust-lang/rustup/pull/303).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "rustup"
 version = "1.21.1"
 authors = [ "Daniel Silverstone <dsilvers@digital-scurf.org>", "Diggory Blake <diggsey@googlemail.com>" ]
 build = "build.rs"
-documentation = "https://rust-lang.github.io/rustup.rs/rustup/index.html"
 edition = "2018"
 homepage = "https://github.com/rust-lang/rustup"
 keywords = ["rustup", "multirust", "install", "proxy"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ authors = [ "Daniel Silverstone <dsilvers@digital-scurf.org>", "Diggory Blake <d
 build = "build.rs"
 documentation = "https://rust-lang.github.io/rustup.rs/rustup/index.html"
 edition = "2018"
-homepage = "https://github.com/rust-lang/rustup.rs"
+homepage = "https://github.com/rust-lang/rustup"
 keywords = ["rustup", "multirust", "install", "proxy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/rust-lang/rustup.rs"
+repository = "https://github.com/rust-lang/rustup"
 description = "Manage multiple rust installations with ease"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -760,7 +760,7 @@ variable.
 work][s]. `rustup` performs all downloads over HTTPS, but does not
 yet validate signatures of downloads.
 
-[s]: https://github.com/rust-lang/rustup.rs/issues?q=is%3Aopen+is%3Aissue+label%3Asecurity
+[s]: https://github.com/rust-lang/rustup/issues?q=is%3Aopen+is%3Aissue+label%3Asecurity
 
 File modes on installation honor umask as of 1.18.4, use umask if
 very tight controls are desired.

--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ platforms The Rust Project publishes binary releases of the standard
 library, and for some the full compiler. `rustup` gives easy access
 to all of them.
 
-[p]: https://forge.rust-lang.org/platform-support.html
+[p]: https://forge.rust-lang.org/release/platform-support.html
 
 When you first install a toolchain, `rustup` installs only the
 standard library for your *host* platform - that is, the architecture

--- a/ci/build-run-docker.bash
+++ b/ci/build-run-docker.bash
@@ -54,7 +54,7 @@ docker run \
   -c 'PATH="${PATH}":/rustc-sysroot/bin bash ci/run.bash'
 
 # check that rustup-init was built with ssl support
-# see https://github.com/rust-lang/rustup.rs/issues/1051
+# see https://github.com/rust-lang/rustup/issues/1051
 if ! (nm target/"${TARGET}"/release/rustup-init | grep -q Curl_ssl_version); then
   echo "Missing ssl support!!!!" >&2
   exit 1

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -13,7 +13,7 @@ case "$(uname -s)" in
   * ) FEATURES=('--features' 'vendored-openssl') ;;
 esac
 
-# rustc only supports armv7: https://forge.rust-lang.org/platform-support.html
+# rustc only supports armv7: https://forge.rust-lang.org/release/platform-support.html
 if [ "$TARGET" = arm-linux-androideabi ]; then
   export CFLAGS='-march=armv7'
 fi

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -50,7 +50,7 @@ fn search_path(doc: &DocData, wpath: &Path, keywords: &[&str]) -> Result<PathBuf
 pub fn local_path(root: &Path, topic: &str) -> Result<PathBuf> {
     // The ORDER of keywords_top is used for the default search and should not
     // be changed.
-    // https://github.com/rust-lang/rustup.rs/issues/2076#issuecomment-546613036
+    // https://github.com/rust-lang/rustup/issues/2076#issuecomment-546613036
     let keywords_top = vec!["keyword", "primitive", "macro"];
     let keywords_mod = ["fn", "struct", "trait", "enum", "type", "constant"];
 

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -333,7 +333,7 @@ fn unpack_without_first_dir<'a, R: Read>(
         // - it is most likely an attack, as rusts cross-platform nature precludes
         // such artifacts
         let kind = entry.header().entry_type();
-        // https://github.com/rust-lang/rustup.rs/issues/1140 and before that
+        // https://github.com/rust-lang/rustup/issues/1140 and before that
         // https://github.com/rust-lang/rust/issues/25479
         // tl;dr: code got convoluted and we *may* have damaged tarballs out
         // there.

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -377,7 +377,7 @@ impl Package {
                     tpkgs
                         .get(t)
                         .ok_or_else(|| format!("target '{}' not found in channel.  \
-                        Perhaps check https://forge.rust-lang.org/platform-support.html for available targets", t).into())
+                        Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets", t).into())
                 } else {
                     Err("no target specified".into())
                 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -581,7 +581,7 @@ fn rename<'a, N>(
 where
     N: From<Notification<'a>>,
 {
-    // https://github.com/rust-lang/rustup.rs/issues/1870
+    // https://github.com/rust-lang/rustup/issues/1870
     // 21 fib steps from 1 sums to ~28 seconds, hopefully more than enough
     // for our previous poor performance that avoided the race condition with
     // McAfee and Norton.

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -427,7 +427,7 @@ fn update_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
+error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets
 ",
         );
     });
@@ -442,7 +442,7 @@ fn default_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/platform-support.html for available targets
+error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets
 ",
         );
     });

--- a/www/index.html
+++ b/www/index.html
@@ -57,7 +57,7 @@
   <p>
     rustup runs on Windows, Linux, macOS, FreeBSD and NetBSD. If
     you are on one of these platforms and are seeing this then please
-    <a href="https://github.com/rust-lang/rustup.rs/issues/new">report an issue</a>,
+    <a href="https://github.com/rust-lang/rustup/issues/new">report an issue</a>,
     along with the following values:
   </p>
 
@@ -133,11 +133,11 @@
   <img src="https://www.rust-lang.org/logos/rust-logo-blk.svg" alt="" />
   rustup is an official Rust project.
   <br/>
-  <a href="https://github.com/rust-lang/rustup.rs/#other-installation-methods">other installation options</a>
+  <a href="https://github.com/rust-lang/rustup/#other-installation-methods">other installation options</a>
   &nbsp;&middot;&nbsp;
   <a href="https://rust-lang.github.io/rustup-components-history/">component availability</a>
   &nbsp;&middot;&nbsp;
-  <a href="https://github.com/rust-lang/rustup.rs">about rustup</a>
+  <a href="https://github.com/rust-lang/rustup">about rustup</a>
 </p>
 
 <script src="rustup.js"></script>


### PR DESCRIPTION
- Replace https://forge.rust-lang.org/platform-support.html with https://forge.rust-lang.org/release/platform-support.html
- Replace https://github.com/rust-lang/rustup.rs with https://github.com/rust-lang/rustup

Also,

https://github.com/rust-lang/rustup/blob/7832b2ebee6468a9d88342181f8739c4c607d53f/Cargo.toml#L6

should be replaced but I'm not sure what the correct link is (https://rustup.rs?).