### PR TITLE
Backslashes must be escaped on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ Command                                                     | Description
 ## Environment variables
 
 
-- `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%/.rustup`)
+- `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%\.rustup`)
   Sets the root `rustup` folder, used for storing installed
   toolchains and configuration options.
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -224,6 +224,8 @@ fn canonical_cargo_home() -> Result<String> {
         if cfg!(unix) {
             path_str = String::from("$HOME/.cargo");
         } else {
+            // Since this string serves as documentation, backslashes must be
+            // escaped in order to be displayed correctly on Windows.
             path_str = String::from(r"%USERPROFILE%\\.cargo");
         }
     }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -224,7 +224,7 @@ fn canonical_cargo_home() -> Result<String> {
         if cfg!(unix) {
             path_str = String::from("$HOME/.cargo");
         } else {
-            path_str = String::from(r"%USERPROFILE%\.cargo");
+            path_str = String::from(r"%USERPROFILE%\\.cargo");
         }
     }
 


### PR DESCRIPTION
This was a small issue I noticed during the installation of Rust on Windows.