### PR TITLE
Implement --allow-downgrade option for "component add" subcommand

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -446,7 +446,7 @@ pub fn cli() -> App<'static, 'static> {
                         .arg(Arg::with_name("target").long("target").takes_value(true))
                         .arg(
                             Arg::with_name("allow-downgrade")
-                                .help("Allow to downgrade the toolchain to satisfy your component choice")
+                                .help("Allow rustup to downgrade the toolchain to satisfy your component choice")
                                 .long("allow-downgrade")
                                 .takes_value(false),
                         ),


### PR DESCRIPTION
Implement `--allow-downgrade` option for `component add` sub-commend (e.g. `rustup component add rls --allow-downgrade`), to attempt to resolve #2146.

When `--allow-downgrade` is provide, it would run `toolchain.install_from_dist(...)`, to reuse the solution in #2126.
