### PR TITLE
Simplify sudo check on unix

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -238,6 +238,7 @@ pub fn install(no_prompt: bool, verbose: bool, quiet: bool, mut opts: InstallOpt
     do_pre_install_sanity_checks()?;
     do_pre_install_options_sanity_checks(&opts)?;
     check_existence_of_rustc_or_cargo_in_path(no_prompt)?;
+    #[cfg(unix)]
     do_anti_sudo_check(no_prompt)?;
 
     let mut term = term2::stdout();
@@ -467,7 +468,7 @@ fn do_pre_install_options_sanity_checks(opts: &InstallOpts) -> Result<()> {
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because
 // sudo is configured not to change $HOME. Don't let that bogosity happen.
-#[allow(dead_code)]
+#[cfg(unix)]
 fn do_anti_sudo_check(no_prompt: bool) -> Result<()> {
     use std::ffi::OsString;
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -670,6 +670,39 @@ impl<'a> io::Read for FileReaderWithProgress<'a> {
     }
 }
 
+// search user database to get home dir of euid user
+#[cfg(unix)]
+pub fn home_dir_from_passwd() -> Option<PathBuf> {
+    use std::ffi::CStr;
+    use std::mem::MaybeUninit;
+    use std::os::unix::ffi::OsStringExt;
+    use std::ptr;
+    unsafe {
+        let init_size = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
+            -1 => 1024,
+            n => n as usize,
+        };
+        let mut buf = Vec::with_capacity(init_size);
+        let mut pwd: MaybeUninit<libc::passwd> = MaybeUninit::uninit();
+        let mut pwdp = ptr::null_mut();
+        match libc::getpwuid_r(
+            libc::geteuid(),
+            pwd.as_mut_ptr(),
+            buf.as_mut_ptr(),
+            buf.capacity(),
+            &mut pwdp,
+        ) {
+            0 if !pwdp.is_null() => {
+                let pwd = pwd.assume_init();
+                let bytes = CStr::from_ptr(pwd.pw_dir).to_bytes().to_vec();
+                let pw_dir = OsString::from_vec(bytes);
+                Some(PathBuf::from(pw_dir))
+            }
+            _ => None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR uses
* `cfg(unix)` attribute to limit sudo check on Unix platforms only.
* Move unsafe code interact with FFI to separate function: `home_dir_from_passwd`
  - Use `libc::sysconf` to get default entry size.