### PR TITLE
config: get_default_host_triple() should use from_host_or_build()

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -666,7 +666,7 @@ impl Cfg {
                     .as_ref()
                     .map(|s| dist::TargetTriple::new(&s)))
             })?
-            .unwrap_or_else(dist::TargetTriple::from_build))
+            .unwrap_or_else(dist::TargetTriple::from_host_or_build))
     }
 
     pub fn resolve_toolchain(&self, name: &str) -> Result<String> {


### PR DESCRIPTION
In order to resolve an issue where installing on x86_64 with the
i686 installer would claim to want to install x86_64 and then
install i686 instead, ensure that we match the obvious behaviour
(install matching the host) by making the default for the config
match that.

Fixes: #2179

At the time of writing the initial change, I'm not certain how we'd test this in CI, but I'll give that some thought.