### PR TITLE
Few improvement for Windows string manipulation

### DIFF
--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -506,8 +506,9 @@ pub fn format_path_for_display(path: &str) -> String {
 /// Encodes a utf-8 string as a null-terminated UCS-2 string in bytes
 #[cfg(windows)]
 pub fn string_to_winreg_bytes(s: &str) -> Vec<u8> {
+    use std::ffi::OsStr;
     use std::os::windows::ffi::OsStrExt;
-    let v: Vec<_> = OsString::from(format!("{}\x00", s)).encode_wide().collect();
+    let v: Vec<u16> = OsStr::new(s).encode_wide().chain(Some(0)).collect();
     unsafe { std::slice::from_raw_parts(v.as_ptr().cast::<u8>(), v.len() * 2).to_vec() }
 }
 

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -4,6 +4,8 @@ pub mod clitools;
 pub mod dist;
 pub mod topical_doc_data;
 
+#[cfg(windows)]
+use rustup::utils::utils;
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::Path;
@@ -184,24 +186,12 @@ pub fn restore_path(p: Option<String>) {
 
     if let Some(p) = p.as_ref() {
         let reg_value = RegValue {
-            bytes: string_to_winreg_bytes(&p),
+            bytes: utils::string_to_winreg_bytes(&p),
             vtype: RegType::REG_EXPAND_SZ,
         };
         environment.set_raw_value("PATH", &reg_value).unwrap();
     } else {
         let _ = environment.delete_value("PATH");
-    }
-
-    fn string_to_winreg_bytes(s: &str) -> Vec<u8> {
-        use std::ffi::OsStr;
-        use std::os::windows::ffi::OsStrExt;
-        let v: Vec<u16> = OsStr::new(s)
-            .encode_wide()
-            .chain(std::iter::once(0))
-            .collect();
-        let ptr = v.as_ptr().cast::<u8>();
-        let len = v.len() * 2;
-        unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec()
     }
 }
 


### PR DESCRIPTION
* De-duplicate `string_to_winreg_bytes` function
* Use `encode_wide().chain` when possible