### PR TITLE
rustup-init: Support updating the installed toolchain

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -758,6 +758,20 @@ fn maybe_install_rust(
     // install, so we leave their setup alone.
     if toolchain == Some("none") {
         info!("skipping toolchain installation");
+        if !components.is_empty() {
+            warn!(
+                "ignoring requested component{}: {}",
+                if components.len() == 1 { "" } else { "s" },
+                components.join(", ")
+            );
+        }
+        if !targets.is_empty() {
+            warn!(
+                "ignoring requested target{}: {}",
+                if targets.len() == 1 { "" } else { "s" },
+                targets.join(", ")
+            );
+        }
         println!();
     } else if user_specified_something || cfg.find_default()?.is_none() {
         let toolchain_str = toolchain.unwrap_or("stable");

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -88,7 +88,7 @@ pub fn main() -> Result<()> {
     let verbose = matches.is_present("verbose");
     let quiet = matches.is_present("quiet");
     let default_host = matches.value_of("default-host").map(ToOwned::to_owned);
-    let default_toolchain = matches.value_of("default-toolchain").unwrap_or("stable");
+    let default_toolchain = matches.value_of("default-toolchain").map(ToOwned::to_owned);
     let profile = matches
         .value_of("profile")
         .expect("Unreachable: Clap should supply a default");

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -892,8 +892,43 @@ fn reinstall_exact() {
         expect_stderr_ok(
             config,
             &["rustup-init", "-y"],
-            r"info: updating existing rustup installation
-",
+            r"info: updating existing rustup installation - leaving toolchains alone",
+        );
+    });
+}
+
+#[test]
+fn reinstall_specifying_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup-init", "-y"]);
+        expect_stdout_ok(
+            config,
+            &["rustup-init", "-y", "--default-toolchain=stable"],
+            r"stable unchanged - 1.1.0",
+        );
+    });
+}
+
+#[test]
+fn reinstall_specifying_component() {
+    setup(&|config| {
+        expect_ok(config, &["rustup-init", "-y", "--component=rls"]);
+        expect_stdout_ok(
+            config,
+            &["rustup-init", "-y", "--default-toolchain=stable"],
+            r"stable unchanged - 1.1.0",
+        );
+    });
+}
+
+#[test]
+fn reinstall_specifying_different_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup-init", "-y"]);
+        expect_stderr_ok(
+            config,
+            &["rustup-init", "-y", "--default-toolchain=nightly"],
+            r"info: default toolchain set to 'nightly'",
         );
     });
 }


### PR DESCRIPTION
If the user specifies any of --default-toolchain (not none)
or --target or --component when invoking `rustup-init` then
we will update the existing installation toolchains, rather
than the previous behaviour which was to skip toolchain
installation.  This is nominally a breaking change but likely
ends up adhering closer to the principle of least surprise.

At this point, the profile will not be applied, so a change
of profile from minimal to default will not cause additional
components to end up being installed.

In theory this fixes #2194 but will need checking with @flaviojs
Also @lzutao filed another bug, this closes #2215 too.