### PR TITLE
Dropped unnecessary curl option

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -25,7 +25,7 @@
 
 <div id="platform-instructions-unix" class="instructions display-none">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
-  <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+  <pre>curl --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Unix. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
@@ -36,7 +36,7 @@
     then follow the onscreen instructions.
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
-  <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+  <pre>curl --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Windows 32-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
@@ -47,7 +47,7 @@
     then follow the onscreen instructions.
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
-  <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+  <pre>curl --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   <p class="other-platforms-help">You appear to be running Windows 64-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
@@ -71,7 +71,7 @@
   <!-- duplicate the default cross-platform instructions -->
   <div>
     <p>If you are running Unix,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
-    <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+    <pre>curl --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   </div>
 
   <hr/>
@@ -100,7 +100,7 @@
   <div>
     <p>To install Rust, if you are running Unix,<br/>run the following
     in your terminal, then follow the onscreen instructions.</p>
-    <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+    <pre>curl --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
   </div>
 
   <hr/>


### PR DESCRIPTION
The curl *proto* option is not necessary (since target URL is https), hence it should be dropped.