### PR TITLE
Fix the macOS stable install rules to match Linux

### DIFF
--- a/.github/workflows/macos-builds-on-all.yaml
+++ b/.github/workflows/macos-builds-on-all.yaml
@@ -58,7 +58,15 @@ jobs:
           key: ${{ runner.os }}-cargo-build-trimmed-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -y
+          sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
+      - name: Ensure Stable is up to date
+        run: |
+          if rustc +stable -vV >/dev/null 2>/dev/null; then
+            rustup toolchain uninstall stable
+          fi
+          rustup toolchain install --profile=minimal stable
+      - name: Ensure we have our goal target installed
+        run: |
           rustup target install "$TARGET"
       - name: Run a full build and test
         run: bash ci/run.bash

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -58,7 +58,15 @@ jobs:
           key: ${{ runner.os }}-cargo-build-trimmed-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -y
+          sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
+      - name: Ensure Stable is up to date
+        run: |
+          if rustc +stable -vV >/dev/null 2>/dev/null; then
+            rustup toolchain uninstall stable
+          fi
+          rustup toolchain install --profile=minimal stable
+      - name: Ensure we have our goal target installed
+        run: |
           rustup target install "$TARGET"
       - name: Run a full build and test
         run: bash ci/run.bash


### PR DESCRIPTION
macOS was failing to update `stable` to 1.41 which was causing problems merging work done by @lzutao.  This PR ought to solve that.