### PR TITLE
Let docs pass through with custom toolchains

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1312,17 +1312,19 @@ const DOCS_DATA: &[(&str, &str, &str,)] = &[
 
 fn doc(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
-    for cstatus in &toolchain.list_components()? {
-        if cstatus.component.short_name_in_manifest() == "rust-docs" && !cstatus.installed {
-            info!(
-                "`rust-docs` not installed in toolchain `{}`",
-                toolchain.name()
-            );
-            info!(
-                "To install, try `rustup component add --toolchain {} rust-docs`",
-                toolchain.name()
-            );
-            return Err("unable to view documentation which is not installed".into());
+    if !toolchain.is_custom() {
+        for cstatus in &toolchain.list_components()? {
+            if cstatus.component.short_name_in_manifest() == "rust-docs" && !cstatus.installed {
+                info!(
+                    "`rust-docs` not installed in toolchain `{}`",
+                    toolchain.name()
+                );
+                info!(
+                    "To install, try `rustup component add --toolchain {} rust-docs`",
+                    toolchain.name()
+                );
+                return Err("unable to view documentation which is not installed".into());
+            }
         }
     }
     let topical_path: PathBuf;

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1654,6 +1654,17 @@ fn docs_missing() {
     });
 }
 
+#[test]
+fn docs_custom() {
+    setup(&|config| {
+        let path = config.customdir.join("custom-1");
+        let path = path.to_string_lossy();
+        expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
+        expect_ok(config, &["rustup", "default", "custom"]);
+        expect_stdout_ok(config, &["rustup", "doc", "--path"], "custom");
+    });
+}
+
 #[cfg(unix)]
 #[test]
 fn non_utf8_arg() {


### PR DESCRIPTION
Following #2116, custom toolchains started to fail `rustup doc`, since
they can't list components to check if `rust-docs` is installed.

    error: toolchain 'system' does not support components
    error: caused by: invalid toolchain name: 'system'

Now custom toolchains just skip that component check, and it's up to the
user to have installed the documentation in their own way.