### PR TITLE
cli: Allow specifying multiple component or target values in one argument

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -318,7 +318,8 @@ pub fn cli() -> App<'static, 'static> {
                                 .long("component")
                                 .short("c")
                                 .takes_value(true)
-                                .multiple(true),
+                                .multiple(true)
+                                .use_delimiter(true),
                         )
                         .arg(
                             Arg::with_name("targets")
@@ -326,7 +327,8 @@ pub fn cli() -> App<'static, 'static> {
                                 .long("target")
                                 .short("t")
                                 .takes_value(true)
-                                .multiple(true),
+                                .multiple(true)
+                                .use_delimiter(true),
                         )
                         .arg(
                             Arg::with_name("force")

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -67,7 +67,8 @@ pub fn main() -> Result<()> {
                 .long("component")
                 .short("c")
                 .takes_value(true)
-                .multiple(true),
+                .multiple(true)
+                .use_delimiter(true),
         )
         .arg(
             Arg::with_name("targets")
@@ -75,7 +76,8 @@ pub fn main() -> Result<()> {
                 .long("target")
                 .short("target")
                 .takes_value(true)
-                .multiple(true),
+                .multiple(true)
+                .use_delimiter(true),
         )
         .arg(
             Arg::with_name("no-modify-path")

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1236,6 +1236,71 @@ fn target_list_ignores_unavailable_targets() {
 }
 
 #[test]
+fn install_with_components() {
+    fn go(comp_args: &[&str]) {
+        let mut args = vec![
+            "rustup",
+            "toolchain",
+            "install",
+            "nightly",
+            "--no-self-update",
+        ];
+        args.extend_from_slice(comp_args);
+
+        setup(&|config| {
+            expect_ok(config, &args);
+            expect_stdout_ok(
+                config,
+                &["rustup", "component", "list"],
+                "rust-src (installed)",
+            );
+            expect_stdout_ok(
+                config,
+                &["rustup", "component", "list"],
+                &format!("rust-analysis-{} (installed)", this_host_triple()),
+            );
+        })
+    }
+
+    go(&["-c", "rust-src", "-c", "rust-analysis"]);
+    go(&["-c", "rust-src,rust-analysis"]);
+}
+
+#[test]
+fn install_with_targets() {
+    fn go(comp_args: &[&str]) {
+        let mut args = vec![
+            "rustup",
+            "toolchain",
+            "install",
+            "nightly",
+            "--no-self-update",
+        ];
+        args.extend_from_slice(comp_args);
+
+        setup(&|config| {
+            expect_ok(config, &args);
+            expect_stdout_ok(
+                config,
+                &["rustup", "target", "list"],
+                &format!("{} (installed)", clitools::CROSS_ARCH1),
+            );
+            expect_stdout_ok(
+                config,
+                &["rustup", "target", "list"],
+                &format!("{} (installed)", clitools::CROSS_ARCH2),
+            );
+        })
+    }
+
+    go(&["-t", clitools::CROSS_ARCH1, "-t", clitools::CROSS_ARCH2]);
+    go(&[
+        "-t",
+        &format!("{},{}", clitools::CROSS_ARCH1, clitools::CROSS_ARCH2),
+    ]);
+}
+
+#[test]
 fn install_with_component_and_target() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);


### PR DESCRIPTION
It has happened a few times to me now that I've tried to install a toolchain with `rustup toolchain install <toolchain> -c a,b,c`, only to get an error that the component "a,b,c" does not exist.

This PR changes the meaning of that command to the (IMO obvious) one of installing the toolchain `<toolchain>` with components `a`, `b` and `c`. Targets can also be specified in one `-t` argument when delimited with commas.