### PR TITLE
Auto-install toolchains more consistently

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -300,6 +300,10 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        ToolchainNotSelected {
+            description("toolchain is not selected")
+            display("no override and no default toolchain set")
+        }
         OverrideToolchainNotInstalled(t: String) {
             description("override toolchain is not installed")
             display("override toolchain '{}' is not installed", t)

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -22,7 +22,11 @@ pub fn setup(f: &dyn Fn(&mut Config)) {
 #[test]
 fn rustc_no_default_toolchain() {
     setup(&|config| {
-        expect_err(config, &["rustc"], "no default toolchain configured");
+        expect_err(
+            config,
+            &["rustc"],
+            "no override and no default toolchain set",
+        );
     });
 }
 
@@ -158,14 +162,14 @@ fn remove_toolchain() {
 }
 
 #[test]
-fn remove_default_toolchain_err_handling() {
+fn remove_default_toolchain_autoinstalls() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_err(
+        expect_stderr_ok(
             config,
-            &["rustc"],
-            for_host!("toolchain 'nightly-{0}' is not installed"),
+            &["rustc", "--version"],
+            "info: installing component",
         );
     });
 }
@@ -304,7 +308,11 @@ fn remove_override_no_default() {
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "nightly"]);
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_err(config, &["rustc"], "no default toolchain configured");
+            expect_err(
+                config,
+                &["rustc"],
+                "no override and no default toolchain set",
+            );
         });
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -30,7 +30,11 @@ pub fn setup_complex(f: &dyn Fn(&mut Config)) {
 #[test]
 fn rustc_no_default_toolchain() {
     setup(&|config| {
-        expect_err(config, &["rustc"], "no default toolchain configured");
+        expect_err(
+            config,
+            &["rustc"],
+            "no override and no default toolchain set",
+        );
     });
 }
 
@@ -245,14 +249,14 @@ fn add_remove_multiple_toolchains() {
 }
 
 #[test]
-fn remove_default_toolchain_err_handling() {
+fn remove_default_toolchain_autoinstalls() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_err(
+        expect_stderr_ok(
             config,
-            &["rustc"],
-            for_host!("toolchain 'nightly-{0}' is not installed"),
+            &["rustc", "--version"],
+            "info: installing component",
         );
     });
 }
@@ -446,7 +450,11 @@ fn remove_override_no_default() {
         config.change_dir(tempdir.path(), &|| {
             expect_ok(config, &["rustup", "override", "add", "nightly"]);
             expect_ok(config, &["rustup", "override", "remove"]);
-            expect_err(config, &["rustc"], "no default toolchain configured");
+            expect_err(
+                config,
+                &["rustc"],
+                "no override and no default toolchain set",
+            );
         });
     });
 }


### PR DESCRIPTION
This combines all auto-installation logic to the root of the codepaths
leading to running a binary, which should lead to auto-installation
happening for all cases, as long as a toolchain has been selected.

Config.find_default no longer verifies the toolchain in order to permit
this auto-installation to take place in one location; the callers of
find_default do not generally need verified toolchains, so this should
be fine.