### PR TITLE
Use dependent types to make programming errors harder

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -6,6 +6,7 @@ use crate::term2;
 use git_testament::{git_testament, render_testament};
 use lazy_static::lazy_static;
 use rustup::dist::notifications as dist_notifications;
+use rustup::toolchain::DistributableToolchain;
 use rustup::utils::notifications as util_notifications;
 use rustup::utils::notify::NotificationLevel;
 use rustup::utils::utils;
@@ -346,16 +347,9 @@ where
 
 pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
-    let components = match toolchain.list_components()? {
-        // XXX: long term move this error to cli ? the normal .into doesn't work
-        // because Result here is the wrong sort and expression type ascription
-        // isn't a feature yet.
-        None => Err(rustup::Error(
-            rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()),
-            error_chain::State::default(),
-        )),
-        Some(components) => Ok(components),
-    }?;
+    let distributable = DistributableToolchain::new(&toolchain)
+        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+    let components = distributable.list_components()?;
     for component in components {
         if component.component.short_name_in_manifest() == "rust-std" {
             let target = component
@@ -378,16 +372,9 @@ pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<()> {
 
 pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
-    let components = match toolchain.list_components()? {
-        // XXX: long term move this error to cli ? the normal .into doesn't work
-        // because Result here is the wrong sort and expression type ascription
-        // isn't a feature yet.
-        None => Err(rustup::Error(
-            rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()),
-            error_chain::State::default(),
-        )),
-        Some(components) => Ok(components),
-    }?;
+    let distributable = DistributableToolchain::new(&toolchain)
+        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+    let components = distributable.list_components()?;
     for component in components {
         if component.component.short_name_in_manifest() == "rust-std" {
             let target = component
@@ -405,16 +392,9 @@ pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<()> {
 
 pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
-    let components = match toolchain.list_components()? {
-        // XXX: long term move this error to cli ? the normal .into doesn't work
-        // because Result here is the wrong sort and expression type ascription
-        // isn't a feature yet.
-        None => Err(rustup::Error(
-            rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()),
-            error_chain::State::default(),
-        )),
-        Some(components) => Ok(components),
-    }?;
+    let distributable = DistributableToolchain::new(&toolchain)
+        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+    let components = distributable.list_components()?;
     for component in components {
         let name = component.name;
         if component.installed {
@@ -431,16 +411,9 @@ pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
 
 pub fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
-    let components = match toolchain.list_components()? {
-        // XXX: long term move this error to cli ? the normal .into doesn't work
-        // because Result here is the wrong sort and expression type ascription
-        // isn't a feature yet.
-        None => Err(rustup::Error(
-            rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()),
-            error_chain::State::default(),
-        )),
-        Some(components) => Ok(components),
-    }?;
+    let distributable = DistributableToolchain::new(&toolchain)
+        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+    let components = distributable.list_components()?;
     for component in components {
         if component.installed {
             writeln!(t, "{}", component.name)?;

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -26,6 +26,9 @@ error_chain! {
     }
 
     errors {
+        InvalidCustomToolchainName(t: String) {
+            display("invalid custom toolchain name: '{}'", t)
+        }
         PermissionDenied {
             description("permission denied")
         }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1130,7 +1130,8 @@ fn target_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
             Some(TargetTriple::new(target)),
             false,
         );
-        toolchain.add_component(new_component)?;
+        let distributable = DistributableToolchain::new(&toolchain)?;
+        distributable.add_component(new_component)?;
     }
 
     Ok(())
@@ -1176,8 +1177,8 @@ fn component_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     for component in m.values_of("component").unwrap() {
         let new_component = Component::new_with_target(component, false)
             .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
-
-        toolchain.add_component(new_component)?;
+        let distributable = DistributableToolchain::new(&toolchain)?;
+        distributable.add_component(new_component)?;
     }
 
     Ok(())

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -743,7 +743,8 @@ fn default_(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
         let toolchain = cfg.get_toolchain(toolchain, false)?;
 
         let status = if !toolchain.is_custom() {
-            Some(toolchain.install_from_dist_if_not_installed()?)
+            let distributable = DistributableToolchain::new(&toolchain)?;
+            Some(distributable.install_from_dist_if_not_installed()?)
         } else if !toolchain.exists() {
             return Err(ErrorKind::ToolchainNotInstalled(toolchain.name().to_string()).into());
         } else {
@@ -1251,7 +1252,8 @@ fn override_add(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
     let toolchain = cfg.get_toolchain(toolchain, false)?;
 
     let status = if !toolchain.is_custom() {
-        Some(toolchain.install_from_dist_if_not_installed()?)
+        let distributable = DistributableToolchain::new(&toolchain)?;
+        Some(distributable.install_from_dist_if_not_installed()?)
     } else if !toolchain.exists() {
         return Err(ErrorKind::ToolchainNotInstalled(toolchain.name().to_string()).into());
     } else {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -782,7 +782,8 @@ fn check_updates(cfg: &Cfg) -> Result<()> {
     for channel in channels {
         match channel {
             (ref name, Ok(ref toolchain)) => {
-                let current_version = toolchain.show_version()?;
+                let distributable = DistributableToolchain::new(&toolchain)?;
+                let current_version = distributable.show_version()?;
                 let dist_version = toolchain.show_dist_version()?;
                 let _ = t.attr(term2::Attr::Bold);
                 write!(t, "{} - ", name)?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -8,6 +8,7 @@ use crate::topical_doc;
 use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, Shell, SubCommand};
 use rustup::dist::dist::{PartialTargetTriple, PartialToolchainDesc, Profile, TargetTriple};
 use rustup::dist::manifest::Component;
+use rustup::toolchain::DistributableToolchain;
 use rustup::utils::utils::{self, ExitCode};
 use rustup::Notification;
 use rustup::{command, Cfg, ComponentStatus, Toolchain};
@@ -840,7 +841,8 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<()> {
                     .values_of("targets")
                     .map(|v| v.collect())
                     .unwrap_or_else(Vec::new);
-                Some(toolchain.install_from_dist(
+                let distributable = DistributableToolchain::new(&toolchain)?;
+                Some(distributable.install_from_dist(
                     m.is_present("force"),
                     m.is_present("allow-downgrade"),
                     &components,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1145,8 +1145,9 @@ fn target_remove(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
             Some(TargetTriple::new(target)),
             false,
         );
-
-        toolchain.remove_component(new_component)?;
+        let distributable = DistributableToolchain::new(&toolchain)
+            .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        distributable.remove_component(new_component)?;
     }
 
     Ok(())
@@ -1196,7 +1197,9 @@ fn component_remove(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<()> {
         let new_component = Component::new_with_target(component, false)
             .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
 
-        toolchain.remove_component(new_component)?;
+        let distributable = DistributableToolchain::new(&toolchain)
+            .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        distributable.remove_component(new_component)?;
     }
 
     Ok(())

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -784,7 +784,7 @@ fn check_updates(cfg: &Cfg) -> Result<()> {
             (ref name, Ok(ref toolchain)) => {
                 let distributable = DistributableToolchain::new(&toolchain)?;
                 let current_version = distributable.show_version()?;
-                let dist_version = toolchain.show_dist_version()?;
+                let dist_version = distributable.show_dist_version()?;
                 let _ = t.attr(term2::Attr::Bold);
                 write!(t, "{} - ", name)?;
                 match (current_version, dist_version) {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -35,6 +35,7 @@ use crate::errors::*;
 use crate::markdown::md;
 use crate::term2;
 use rustup::dist::dist::{self, Profile, TargetTriple};
+use rustup::toolchain::DistributableToolchain;
 use rustup::utils::utils;
 use rustup::utils::Notification;
 use rustup::{Cfg, UpdateStatus};
@@ -787,7 +788,8 @@ fn maybe_install_rust(
         if toolchain.exists() {
             warn!("Updating existing toolchain, profile choice will be ignored");
         }
-        let status = toolchain.install_from_dist(true, false, components, targets)?;
+        let distributable = DistributableToolchain::new(&toolchain)?;
+        let status = distributable.install_from_dist(true, false, components, targets)?;
         cfg.set_default(toolchain_str)?;
         println!();
         common::show_channel_update(&cfg, toolchain_str, Ok(status))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -658,7 +658,8 @@ impl Cfg {
         for fallback in &["nightly", "beta", "stable"] {
             let fallback = self.get_toolchain(fallback, false)?;
             if fallback.exists() {
-                let cmd = fallback.create_fallback_command("cargo", toolchain)?;
+                let distributable = DistributableToolchain::new(&fallback)?;
+                let cmd = distributable.create_fallback_command("cargo", toolchain)?;
                 return Ok(Some(cmd));
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -625,7 +625,10 @@ impl Cfg {
         if let Some(cmd) = self.maybe_do_cargo_fallback(toolchain, binary)? {
             Ok(cmd)
         } else {
-            toolchain.create_command(binary)
+            // NB this can only fail in race conditions since we used toolchain
+            // for dir.
+            let installed = toolchain.as_installed_common()?;
+            installed.create_command(binary)
         }
     }
 
@@ -644,7 +647,9 @@ impl Cfg {
         if let Some(cmd) = self.maybe_do_cargo_fallback(&toolchain, binary)? {
             Ok(cmd)
         } else {
-            toolchain.create_command(binary)
+            // NB note this really can't fail due to to having installed the toolchain if needed
+            let installed = toolchain.as_installed_common()?;
+            installed.create_command(binary)
         }
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -189,10 +189,6 @@ error_chain! {
             description("invalid toolchain name")
             display("invalid toolchain name: '{}'", t)
         }
-        InvalidCustomToolchainName(t: String) {
-            description("invalid custom toolchain name")
-            display("invalid custom toolchain name: '{}'", t)
-        }
         InvalidProfile(t: String) {
             description("invalid profile name")
             display("invalid profile name: '{}'; valid names are: {}", t, valid_profile_names())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,5 +62,5 @@ pub mod fallback_settings;
 mod install;
 mod notifications;
 pub mod settings;
-mod toolchain;
+pub mod toolchain;
 pub mod utils;

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -722,60 +722,6 @@ impl<'a> Toolchain<'a> {
             Err(ErrorKind::ComponentsUnsupported(self.name.to_string()).into())
         }
     }
-    // Distributable only. Installed only.
-    pub fn remove_component(&self, mut component: Component) -> Result<()> {
-        if !self.exists() {
-            return Err(ErrorKind::ToolchainNotInstalled(self.name.to_owned()).into());
-        }
-
-        let toolchain = &self.name;
-        let toolchain = ToolchainDesc::from_str(toolchain)
-            .chain_err(|| ErrorKind::ComponentsUnsupported(self.name.to_string()))?;
-
-        let prefix = InstallPrefix::from(self.path.to_owned());
-        let manifestation = Manifestation::open(prefix, toolchain.target.clone())?;
-
-        if let Some(manifest) = manifestation.load_manifest()? {
-            // Rename the component if necessary.
-            if let Some(c) = manifest.rename_component(&component) {
-                component = c;
-            }
-
-            let dist_config = manifestation.read_config()?.unwrap();
-            if !dist_config.components.contains(&component) {
-                let wildcard_component = component.wildcard();
-                if dist_config.components.contains(&wildcard_component) {
-                    component = wildcard_component;
-                } else {
-                    return Err(ErrorKind::UnknownComponent(
-                        self.name.to_string(),
-                        component.description(&manifest),
-                        self.get_component_suggestion(&component, &manifest, true),
-                    )
-                    .into());
-                }
-            }
-
-            let changes = Changes {
-                explicit_add_components: vec![],
-                remove_components: vec![component],
-            };
-
-            manifestation.update(
-                &manifest,
-                changes,
-                false,
-                &self.download_cfg(),
-                &self.download_cfg().notify_handler,
-                &toolchain.manifest_name(),
-                false,
-            )?;
-
-            Ok(())
-        } else {
-            Err(ErrorKind::ComponentsUnsupported(self.name.to_string()).into())
-        }
-    }
     // Distributable and Custom. Installed only.
     pub fn binary_file(&self, name: &str) -> PathBuf {
         let mut path = self.path.clone();
@@ -888,6 +834,62 @@ impl<'a> DistributableToolchain<'a> {
             components,
             targets,
         ))
+    }
+
+    // Installed only.
+    pub fn remove_component(&self, mut component: Component) -> Result<()> {
+        // Overlapping code with get_manifest :/.
+        if !self.0.exists() {
+            return Err(ErrorKind::ToolchainNotInstalled(self.0.name.to_owned()).into());
+        }
+
+        let toolchain = &self.0.name;
+        let toolchain = ToolchainDesc::from_str(toolchain)
+            .chain_err(|| ErrorKind::ComponentsUnsupported(self.0.name.to_string()))?;
+
+        let prefix = InstallPrefix::from(self.0.path.to_owned());
+        let manifestation = Manifestation::open(prefix, toolchain.target.clone())?;
+
+        if let Some(manifest) = manifestation.load_manifest()? {
+            // Rename the component if necessary.
+            if let Some(c) = manifest.rename_component(&component) {
+                component = c;
+            }
+
+            let dist_config = manifestation.read_config()?.unwrap();
+            if !dist_config.components.contains(&component) {
+                let wildcard_component = component.wildcard();
+                if dist_config.components.contains(&wildcard_component) {
+                    component = wildcard_component;
+                } else {
+                    return Err(ErrorKind::UnknownComponent(
+                        self.0.name.to_string(),
+                        component.description(&manifest),
+                        self.0.get_component_suggestion(&component, &manifest, true),
+                    )
+                    .into());
+                }
+            }
+
+            let changes = Changes {
+                explicit_add_components: vec![],
+                remove_components: vec![component],
+            };
+
+            manifestation.update(
+                &manifest,
+                changes,
+                false,
+                &self.0.download_cfg(),
+                &self.0.download_cfg().notify_handler,
+                &toolchain.manifest_name(),
+                false,
+            )?;
+
+            Ok(())
+        } else {
+            Err(ErrorKind::ComponentsUnsupported(self.0.name.to_string()).into())
+        }
     }
 
     // Installed only.

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -184,33 +184,6 @@ impl<'a> Toolchain<'a> {
         }
     }
 
-    // Distributable only. Not installed only?
-    pub fn install_from_dist(
-        &self,
-        force_update: bool,
-        allow_downgrade: bool,
-        components: &[&str],
-        targets: &[&str],
-    ) -> Result<UpdateStatus> {
-        let update_hash = self.update_hash()?;
-        let distributable = DistributableToolchain::new(&self)?;
-        let old_date = distributable
-            .get_manifest()
-            .ok()
-            .and_then(|m| m.map(|m| m.date));
-        self.install(InstallMethod::Dist(
-            &self.desc()?,
-            self.cfg.get_profile()?,
-            update_hash.as_ref().map(|p| &**p),
-            self.download_cfg(),
-            force_update,
-            allow_downgrade,
-            self.exists(),
-            old_date.as_ref().map(|s| &**s),
-            components,
-            targets,
-        ))
-    }
     // Distributable only. Installed or not installed.
     pub fn install_from_dist_if_not_installed(&self) -> Result<UpdateStatus> {
         let update_hash = self.update_hash()?;
@@ -899,5 +872,29 @@ impl<'a> DistributableToolchain<'a> {
         let manifestation = Manifestation::open(prefix, toolchain.target)?;
 
         manifestation.load_manifest()
+    }
+
+    // Not installed only?
+    pub fn install_from_dist(
+        &self,
+        force_update: bool,
+        allow_downgrade: bool,
+        components: &[&str],
+        targets: &[&str],
+    ) -> Result<UpdateStatus> {
+        let update_hash = self.0.update_hash()?;
+        let old_date = self.get_manifest().ok().and_then(|m| m.map(|m| m.date));
+        self.0.install(InstallMethod::Dist(
+            &self.0.desc()?,
+            self.0.cfg.get_profile()?,
+            update_hash.as_ref().map(|p| &**p),
+            self.0.download_cfg(),
+            force_update,
+            allow_downgrade,
+            self.0.exists(),
+            old_date.as_ref().map(|s| &**s),
+            components,
+            targets,
+        ))
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -184,22 +184,6 @@ impl<'a> Toolchain<'a> {
         }
     }
 
-    // Distributable only. Installed or not installed.
-    pub fn install_from_dist_if_not_installed(&self) -> Result<UpdateStatus> {
-        let update_hash = self.update_hash()?;
-        self.install_if_not_installed(InstallMethod::Dist(
-            &self.desc()?,
-            self.cfg.get_profile()?,
-            update_hash.as_ref().map(|p| &**p),
-            self.download_cfg(),
-            false,
-            false,
-            false,
-            None,
-            &[],
-            &[],
-        ))
-    }
     // Custom only
     pub fn is_custom(&self) -> bool {
         ToolchainDesc::from_str(&self.name).is_err()
@@ -754,6 +738,23 @@ impl<'a> DistributableToolchain<'a> {
             old_date.as_ref().map(|s| &**s),
             components,
             targets,
+        ))
+    }
+
+    // Installed or not installed.
+    pub fn install_from_dist_if_not_installed(&self) -> Result<UpdateStatus> {
+        let update_hash = self.0.update_hash()?;
+        self.0.install_if_not_installed(InstallMethod::Dist(
+            &self.0.desc()?,
+            self.0.cfg.get_profile()?,
+            update_hash.as_ref().map(|p| &**p),
+            self.0.download_cfg(),
+            false,
+            false,
+            false,
+            None,
+            &[],
+            &[],
         ))
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -496,14 +496,6 @@ impl<'a> Toolchain<'a> {
         })
     }
     // Distributable only. Installed only.
-    pub fn show_version(&self) -> Result<Option<String>> {
-        let distributable = DistributableToolchain::new(&self)?;
-        match distributable.get_manifest()? {
-            Some(manifest) => Ok(Some(manifest.get_rust_version()?.to_string())),
-            None => Ok(None),
-        }
-    }
-    // Distributable only. Installed only.
     pub fn show_dist_version(&self) -> Result<Option<String>> {
         let update_hash = self.update_hash()?;
 
@@ -860,7 +852,7 @@ impl<'a> DistributableToolchain<'a> {
     }
 
     // Installed only.
-    pub fn get_manifest(&self) -> Result<Option<Manifest>> {
+    fn get_manifest(&self) -> Result<Option<Manifest>> {
         if !self.0.exists() {
             return Err(ErrorKind::ToolchainNotInstalled(self.0.name().to_owned()).into());
         }
@@ -896,5 +888,13 @@ impl<'a> DistributableToolchain<'a> {
             components,
             targets,
         ))
+    }
+
+    // Installed only.
+    pub fn show_version(&self) -> Result<Option<String>> {
+        match self.get_manifest()? {
+            Some(manifest) => Ok(Some(manifest.get_rust_version()?.to_string())),
+            None => Ok(None),
+        }
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -496,19 +496,6 @@ impl<'a> Toolchain<'a> {
         })
     }
     // Distributable only. Installed only.
-    pub fn show_dist_version(&self) -> Result<Option<String>> {
-        let update_hash = self.update_hash()?;
-
-        match crate::dist::dist::dl_v2_manifest(
-            self.download_cfg(),
-            update_hash.as_ref().map(|p| &**p),
-            &self.desc()?,
-        )? {
-            Some((manifest, _)) => Ok(Some(manifest.get_rust_version()?.to_string())),
-            None => Ok(None),
-        }
-    }
-    // Distributable only. Installed only.
     pub fn list_components(&self) -> Result<Option<Vec<ComponentStatus>>> {
         if !self.exists() {
             return Err(ErrorKind::ToolchainNotInstalled(self.name.to_owned()).into());
@@ -891,6 +878,20 @@ impl<'a> DistributableToolchain<'a> {
             Ok(())
         } else {
             Err(ErrorKind::ComponentsUnsupported(self.0.name.to_string()).into())
+        }
+    }
+
+    // Installed only.
+    pub fn show_dist_version(&self) -> Result<Option<String>> {
+        let update_hash = self.0.update_hash()?;
+
+        match crate::dist::dist::dl_v2_manifest(
+            self.0.download_cfg(),
+            update_hash.as_ref().map(|p| &**p),
+            &self.0.desc()?,
+        )? {
+            Some((manifest, _)) => Ok(Some(manifest.get_rust_version()?.to_string())),
+            None => Ok(None),
         }
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -221,30 +221,6 @@ impl<'a> Toolchain<'a> {
         Ok(())
     }
 
-    // Custom only. Not installed only.
-    pub fn install_from_dir(&self, src: &Path, link: bool) -> Result<()> {
-        self.ensure_custom()?;
-        let custom = CustomToolchain::new(&self)?;
-
-        let mut pathbuf = PathBuf::from(src);
-
-        pathbuf.push("lib");
-        utils::assert_is_directory(&pathbuf)?;
-        pathbuf.pop();
-        pathbuf.push("bin");
-        utils::assert_is_directory(&pathbuf)?;
-        pathbuf.push(format!("rustc{}", EXE_SUFFIX));
-        utils::assert_is_file(&pathbuf)?;
-
-        if link {
-            InstallMethod::Link(&utils::to_absolute(src)?, &custom).install(&self)?;
-        } else {
-            InstallMethod::Copy(src, &custom).install(&self)?;
-        }
-
-        Ok(())
-    }
-
     // Both Distributable and Custom; Installed only.
     pub fn create_command<T: AsRef<OsStr>>(&self, binary: T) -> Result<Command> {
         if !self.exists() {
@@ -513,6 +489,27 @@ impl<'a> CustomToolchain<'a> {
         } else {
             Err(format!("{} is not a custom toolchain", toolchain.name()).into())
         }
+    }
+
+    // Not installed only.
+    pub fn install_from_dir(&self, src: &Path, link: bool) -> Result<()> {
+        let mut pathbuf = PathBuf::from(src);
+
+        pathbuf.push("lib");
+        utils::assert_is_directory(&pathbuf)?;
+        pathbuf.pop();
+        pathbuf.push("bin");
+        utils::assert_is_directory(&pathbuf)?;
+        pathbuf.push(format!("rustc{}", EXE_SUFFIX));
+        utils::assert_is_file(&pathbuf)?;
+
+        if link {
+            InstallMethod::Link(&utils::to_absolute(src)?, self).install(&self.0)?;
+        } else {
+            InstallMethod::Copy(src, self).install(&self.0)?;
+        }
+
+        Ok(())
     }
 }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -62,10 +62,6 @@ impl<'a> Toolchain<'a> {
     pub fn name(&self) -> &str {
         &self.name
     }
-    // Distributable only
-    pub fn desc(&self) -> Result<ToolchainDesc> {
-        Ok(ToolchainDesc::from_str(&self.name)?)
-    }
     pub fn path(&self) -> &Path {
         &self.path
     }
@@ -618,6 +614,11 @@ impl<'a> DistributableToolchain<'a> {
         }
     }
 
+    // Installed and not-installed?
+    pub fn desc(&self) -> Result<ToolchainDesc> {
+        Ok(ToolchainDesc::from_str(&self.0.name)?)
+    }
+
     // Installed only?
     fn get_component_suggestion(
         &self,
@@ -728,7 +729,7 @@ impl<'a> DistributableToolchain<'a> {
         let update_hash = self.0.update_hash()?;
         let old_date = self.get_manifest().ok().and_then(|m| m.map(|m| m.date));
         self.0.install(InstallMethod::Dist(
-            &self.0.desc()?,
+            &self.desc()?,
             self.0.cfg.get_profile()?,
             update_hash.as_ref().map(|p| &**p),
             self.0.download_cfg(),
@@ -745,7 +746,7 @@ impl<'a> DistributableToolchain<'a> {
     pub fn install_from_dist_if_not_installed(&self) -> Result<UpdateStatus> {
         let update_hash = self.0.update_hash()?;
         self.0.install_if_not_installed(InstallMethod::Dist(
-            &self.0.desc()?,
+            &self.desc()?,
             self.0.cfg.get_profile()?,
             update_hash.as_ref().map(|p| &**p),
             self.0.download_cfg(),
@@ -888,7 +889,7 @@ impl<'a> DistributableToolchain<'a> {
         match crate::dist::dist::dl_v2_manifest(
             self.0.download_cfg(),
             update_hash.as_ref().map(|p| &**p),
-            &self.0.desc()?,
+            &self.desc()?,
         )? {
             Some((manifest, _)) => Ok(Some(manifest.get_rust_version()?.to_string())),
             None => Ok(None),

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -713,19 +713,19 @@ impl<'a> DistributableToolchain<'a> {
     ) -> Result<UpdateStatus> {
         let update_hash = self.update_hash()?;
         let old_date = self.get_manifest().ok().and_then(|m| m.map(|m| m.date));
-        InstallMethod::Dist(
-            &self.desc()?,
-            self.0.cfg.get_profile()?,
-            Some(&update_hash),
-            self.0.download_cfg(),
+        InstallMethod::Dist {
+            desc: &self.desc()?,
+            profile: self.0.cfg.get_profile()?,
+            update_hash: Some(&update_hash),
+            dl_cfg: self.0.download_cfg(),
             force_update,
             allow_downgrade,
-            self.0.exists(),
-            old_date.as_ref().map(|s| &**s),
+            exists: self.0.exists(),
+            old_date: old_date.as_ref().map(|s| &**s),
             components,
             targets,
-            &self,
-        )
+            distributable: &self,
+        }
         .install(&self.0)
     }
 
@@ -734,19 +734,19 @@ impl<'a> DistributableToolchain<'a> {
         let update_hash = self.update_hash()?;
         (self.0.cfg.notify_handler)(Notification::LookingForToolchain(&self.0.name));
         if !self.0.exists() {
-            Ok(InstallMethod::Dist(
-                &self.desc()?,
-                self.0.cfg.get_profile()?,
-                Some(&update_hash),
-                self.0.download_cfg(),
-                false,
-                false,
-                false,
-                None,
-                &[],
-                &[],
-                &self,
-            )
+            Ok(InstallMethod::Dist {
+                desc: &self.desc()?,
+                profile: self.0.cfg.get_profile()?,
+                update_hash: Some(&update_hash),
+                dl_cfg: self.0.download_cfg(),
+                force_update: false,
+                allow_downgrade: false,
+                exists: false,
+                old_date: None,
+                components: &[],
+                targets: &[],
+                distributable: &self,
+            }
             .install(&self.0)?)
         } else {
             (self.0.cfg.notify_handler)(Notification::UsingExistingToolchain(&self.0.name));


### PR DESCRIPTION
This extends the minimal fix done the other week into a full blown set of types around the different sorts of distributions in use.