### PR TITLE
Force strong TLS cipher suite in rustup-init.sh for curl and wget if support is detected

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -376,6 +376,7 @@ ignore() {
 # use wget instead.
 downloader() {
     local _dld
+    local _ciphersuites
     if check_cmd curl; then
         _dld=curl
     elif check_cmd wget; then
@@ -387,18 +388,32 @@ downloader() {
     if [ "$1" = --check ]; then
         need_cmd "$_dld"
     elif [ "$_dld" = curl ]; then
-        if ! check_help_for "$3" curl --proto --tlsv1.2; then
-            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
-            curl --silent --show-error --fail --location "$1" --output "$2"
+        get_ciphersuites_for_curl
+        _ciphersuites="$RETVAL"
+        if [ -n "$_ciphersuites" ]; then
+            curl --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2"
         else
-            curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
+            echo "Warning: Not forcing strong cipher suites for TLS, this is potentially less secure"
+            if ! check_help_for "$3" curl --proto --tlsv1.2; then
+                echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
+                curl --silent --show-error --fail --location "$1" --output "$2"
+            else
+                curl --proto '=https' --tlsv1.2 --silent --show-error --fail --location "$1" --output "$2"
+            fi
         fi
     elif [ "$_dld" = wget ]; then
-        if ! check_help_for "$3" wget --https-only --secure-protocol; then
-            echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
-            wget "$1" -O "$2"
+        get_ciphersuites_for_wget
+        _ciphersuites="$RETVAL"
+        if [ -n "$_ciphersuites" ]; then
+            wget --https-only --secure-protocol=TLSv1_2 --ciphers "$_ciphersuites" "$1" -O "$2"
         else
-            wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
+            echo "Warning: Not forcing strong cipher suites for TLS, this is potentially less secure"
+            if ! check_help_for "$3" wget --https-only --secure-protocol; then
+                echo "Warning: Not forcing TLS v1.2, this is potentially less secure"
+                wget "$1" -O "$2"
+            else
+                wget --https-only --secure-protocol=TLSv1_2 "$1" -O "$2"
+            fi
         fi
     else
         err "Unknown downloader"   # should not reach here
@@ -439,6 +454,93 @@ check_help_for() {
     done
 
     test "$_ok" = "y"
+}
+
+# Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
+# if support by local tools is detected. Detection currently supports these curl backends: 
+# GnuTLS and OpenSSL (possibly also LibreSSL and BoringSSL). Return value can be empty.
+get_ciphersuites_for_curl() {
+    if [ -n "${RUSTUP_TLS_CIPHERSUITES-}" ]; then
+        # user specified custom cipher suites, assume they know what they're doing
+        RETVAL="$RUSTUP_TLS_CIPHERSUITES"
+        return
+    fi
+
+    local _openssl_syntax="no"
+    local _gnutls_syntax="no"
+    local _backend_supported="yes"
+    if curl -V | grep -q ' OpenSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' LibreSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' BoringSSL/'; then
+        _openssl_syntax="yes"
+    elif curl -V | grep -iq ' GnuTLS/'; then
+        _gnutls_syntax="yes"
+    else
+        _backend_supported="no"
+    fi
+
+    local _args_supported="no"
+    if [ "$_backend_supported" = "yes" ]; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "curl" "--tlsv1.2" "--ciphers" "--proto"; then
+            _args_supported="yes"
+        fi
+    fi
+
+    local _cs=""
+    if [ "$_args_supported" = "yes" ]; then
+        if [ "$_openssl_syntax" = "yes" ]; then
+            _cs=$(get_strong_ciphersuites_for "openssl")
+        elif [ "$_gnutls_syntax" = "yes" ]; then
+            _cs=$(get_strong_ciphersuites_for "gnutls")
+        fi
+    fi
+
+    RETVAL="$_cs"
+}
+
+# Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites
+# if support by local tools is detected. Detection currently supports these wget backends: 
+# GnuTLS and OpenSSL (possibly also LibreSSL and BoringSSL). Return value can be empty.
+get_ciphersuites_for_wget() {
+    if [ -n "${RUSTUP_TLS_CIPHERSUITES-}" ]; then
+        # user specified custom cipher suites, assume they know what they're doing
+        RETVAL="$RUSTUP_TLS_CIPHERSUITES"
+        return
+    fi
+
+    local _cs=""
+    if wget -V | grep -q '\-DHAVE_LIBSSL'; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "wget" "TLSv1_2" "--ciphers" "--https-only" "--secure-protocol"; then
+            _cs=$(get_strong_ciphersuites_for "openssl")
+        fi
+    elif wget -V | grep -q '\-DHAVE_LIBGNUTLS'; then
+        # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
+        if check_help_for "notspecified" "wget" "TLSv1_2" "--ciphers" "--https-only" "--secure-protocol"; then
+            _cs=$(get_strong_ciphersuites_for "gnutls")
+        fi
+    fi
+
+    RETVAL="$_cs"
+}
+
+# Return strong TLS 1.2-1.3 cipher suites in OpenSSL or GnuTLS syntax. TLS 1.2 
+# excludes non-ECDHE and non-AEAD cipher suites. DHE is excluded due to bad 
+# DH params often found on servers (see RFC 7919). Sequence matches or is
+# similar to Firefox 68 ESR with weak cipher suites disabled via about:config.  
+# $1 must be openssl or gnutls.
+get_strong_ciphersuites_for() {
+    if [ "$1" = "openssl" ]; then
+        # OpenSSL is forgiving of unknown values, no problems with TLS 1.3 values on versions that don't support it yet.
+        echo "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384"
+    elif [ "$1" = "gnutls" ]; then
+        # GnuTLS isn't forgiving of unknown values, so this may require a GnuTLS version that supports TLS 1.3 even if wget doesn't.
+        # Begin with SECURE128 (and higher) then remove/add to build cipher suites. Produces same 9 cipher suites as OpenSSL but in slightly different order.
+        echo "SECURE128:-VERS-SSL3.0:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-DTLS-ALL:-CIPHER-ALL:-MAC-ALL:-KX-ALL:+AEAD:+ECDHE-ECDSA:+ECDHE-RSA:+AES-128-GCM:+CHACHA20-POLY1305:+AES-256-GCM"
+    fi 
 }
 
 main "$@" || exit 1


### PR DESCRIPTION
Force curl and wget to use strong TLS cipher suites if supported by local tools.  If RUSTUP_TLS_CIPHERSUITES variable is set by user then use it. Closes #2284.

curl and wget TLS backends supported for strong TLS cipher suites: GnuTLS, OpenSSL, LibreSSL and BoringSSL.  Other backends (NSS, WolfSSL, etc.) fall back to prior behavior but can also handle user-specified cipher suites in any syntax required (syntax is not checked by script).

curl and wget (if support is detected) will use the same strong TLS 1.2-1.3 cipher suite as Firefox 68 ESR with all weak cipher suites disabled using `about:config`.  Sequence of all 9 cipher suites is identical for OpenSSL (to Firefox) and slightly different for GnuTLS.

<details>
  <summary>(click to expand) :camera: SSL Client Test for Firefox with Strong TLS 1.2-1.3 Cipher Suites</summary><p>

![image](https://user-images.githubusercontent.com/57072051/79347577-769a4680-7ef9-11ea-84c4-94fd7fda2e89.png)

</details>

#### Status

- [x] test dl from server with only strong cipher suites
- [x] test dl from server with only weak cipher suites
- [x] test dl from server preferring weak cipher suites before strong cipher suites
- [x] commit tested changes to rustup-init.sh
- [x] make it automatic based on local tools rather than based on flag per [feedback](https://github.com/rust-lang/rustup/issues/2284#issuecomment-615348823) from @kinnison  
  - [x] detect if curl TLS backend is OpenSSL-compatible version and supports TLS 1.2
    - [x] OpenSSL (Fedora, OpenSUSE)
    - [x] GnuTLS (implemented but not tested with curl)
    - [x] LibreSSL (macOS 10.14)
    - [x] BoringSSL (implemented but not tested with curl)
  - [x] detect if wget TLS backend is OpenSSL version that supports TLS 1.2
    - [x] OpenSSL (OpenSUSE)
    - [x] GnuTLS (Fedora)
    - [x] LibreSSL (implemented but not tested with wget)
    - [x] BoringSSL (implemented but not tested with wget)
  - [x] undo -s, --strong-tls flag to make it automatic if local tools support it
- [x] allow user to specify RUSTUP_TLS_CIPHERSUITES (empty by default), force strong TLS if empty and supported by local tools.  This replaces RUSTUP_STRONG_TLS_CS variable.
- [x] limited testing on Fedora and OpenSUSE client to nginx server
- [x] fix unbound var error on Centos 6, then retest on Fedora and OpenSUSE
- [x] wget+GnuTLS compatibility with old systems appear good enough (tested on Fedora 30 and doesn't break CI tests on other platforms)

Detection of local tools other than OpenSSL or GnuTLS is out of scope due to time required for all possible combinations (NSS, Schannel, WolfSSL, etc.).

Special thanks to @kinnison for his excellent feedback and suggestions.

#### Details

Tests used nginx server configured for TLS 1.2.

If local tools support it, make curl and wget require TLS 1.3 + TLS 1.2 with strong cipher suites specified in RUSTUP_STRONG_TLS_CS.

RUSTUP_STRONG_TLS_CS can be overridden by the user if they need to specify syntax other than OpenSSL/LibreSSL/BoringSSL such as NSS, Schannel, WolfSSL, etc.  

<details>
  <summary>(click to expand) More details</summary><p>

Strong cipher suite list defaults to:

  TLS_AES_128_GCM_SHA256:
  TLS_CHACHA20_POLY1305_SHA256:
  TLS_AES_256_GCM_SHA384:
  ECDHE-ECDSA-AES128-GCM-SHA256:
  ECDHE-RSA-AES128-GCM-SHA256:
  ECDHE-ECDSA-CHACHA20-POLY1305:
  ECDHE-RSA-CHACHA20-POLY1305:
  ECDHE-ECDSA-AES256-GCM-SHA384:
  ECDHE-RSA-AES256-GCM-SHA384

The first 3 cipher suites are TLS 1.3.  The remaining are TLS 1.2
cipher suites limited to ECDHE key exchange + AEAD cipher.

DHE is disabled for TLS 1.2 due to frequent misconfiguration on
servers such as not specifying 2048-bit or stronger DH group with
safe primes (see RFC 7919).

The OpenSSL syntax was chosen for cipher suites because:
* most Linux distros and *BSD use OpenSSL, LibreSSL, or BoringSSL.
* official curl binary for Windows uses OpenSSL 1.1.1f static linked.
* homebrew and macports provide curl+OpenSSL for Mac.

RUSTUP_TLS_CIPHERSUITES can be specified by user with any syntax.

</details>