### PR TITLE
shows (override) in toolchain list

### DIFF
--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -773,6 +773,39 @@ fn list_default_toolchain() {
 }
 
 #[test]
+fn list_override_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "override", "set", "nightly"]);
+        expect_ok_ex(
+            config,
+            &["rustup", "toolchain", "list"],
+            for_host!(
+                r"nightly-{0} (override)
+"
+            ),
+            r"",
+        );
+    });
+}
+
+#[test]
+fn list_default_and_override_toolchain() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "override", "set", "nightly"]);
+        expect_ok_ex(
+            config,
+            &["rustup", "toolchain", "list"],
+            for_host!(
+                r"nightly-{0} (default) (override)
+"
+            ),
+            r"",
+        );
+    });
+}
+
+#[test]
 #[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_override() {
     setup(&|config| {


### PR DESCRIPTION
This PR is for issue https://github.com/rust-lang/rustup/issues/2295
The command list now shows the override toolchain for this specific directory):

```bash
$ home/bin/rustup toolchain list
stable-x86_64-unknown-linux-gnu (default)
nightly-x86_64-unknown-linux-gnu

$ home/bin/rustup override set stable

$ home/bin/rustup toolchain list
stable-x86_64-unknown-linux-gnu (default) (override)
nightly-x86_64-unknown-linux-gnu

$ home/bin/rustup override set nightly

$ home/bin/rustup toolchain list
stable-x86_64-unknown-linux-gnu (default)
nightly-x86_64-unknown-linux-gnu (override)
```
