### PR TITLE
riscv64gc-unknown-linux-gnu support

### DIFF
--- a/ci/actions-templates/README.md
+++ b/ci/actions-templates/README.md
@@ -56,6 +56,7 @@ system.
 | armv7-linux-androideabi       | Yes        | Two   | No     | No         |
 | i686-linux-android            | Yes        | Two   | No     | No         |
 | x86_64-linux-android          | Yes        | Two   | No     | No         |
+| riscv64gc-unknown-linux-gnu   | Yes        | ---   | No     | No         |
 | ----------------------------- | ---------- | ----- | ------ | ---------- |
 | x86_64-apple-darwin           | No         | One   | Yes    | Yes        |
 | ----------------------------- | ---------- | ----- | ------ | ---------- |

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -46,6 +46,7 @@ jobs:
           - armv7-linux-androideabi       # skip-pr skip-master
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
+          - riscv64gc-unknown-linux-gnu   # skip-pr skip-master skip-stable
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,11 @@
+FROM rust-riscv64gc-unknown-linux-gnu
+
+
+# We install a stable toolchain using rustup anyway, this should stop us getting
+# confused and still having this toolchain in $PATH
+RUN /usr/local/lib/rustlib/uninstall.sh
+# Weirdly that doesn't remove these:
+RUN rm /usr/local/bin/cargo /usr/local/bin/rust*
+
+ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
+    CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-unknown-linux-gnu-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -32,6 +32,7 @@ case "$TARGET" in
   x86_64-unknown-freebsd)          image=dist-x86_64-freebsd ;;
   x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;
   x86_64-unknown-netbsd)           image=dist-x86_64-netbsd ;;
+  riscv64gc-unknown-linux-gnu)     image=dist-various-1 ;;
   *) exit ;;
 esac
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -295,7 +295,9 @@ get_architecture() {
         s390x)
             _cputype=s390x
             ;;
-
+        riscv64)
+            _cputype=riscv64gc
+            ;;
         *)
             err "unknown CPU type: $_cputype"
 
@@ -320,6 +322,9 @@ get_architecture() {
                 else
                     _ostype="${_ostype}eabihf"
                 fi
+                ;;
+            riscv64gc)
+                err "riscv64 with 32-bit userland unsupported"
                 ;;
         esac
     fi

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -90,6 +90,7 @@ static LIST_ARCHS: &[&str] = &[
     "powerpc",
     "powerpc64",
     "powerpc64le",
+    "riscv64gc",
     "s390x",
 ];
 static LIST_OSES: &[&str] = &[

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -980,6 +980,8 @@ pub fn this_host_triple() -> String {
             "i686"
         } else if cfg!(target_arch = "x86_64") {
             "x86_64"
+        } else if cfg!(target_arch = "riscv64") {
+            "riscv64gc"
         } else {
             unimplemented!()
         };


### PR DESCRIPTION
## Current status
`rustup` builds on riscv, tests pass*, and rustup can install toolchains for supported host architectures.

Tested on Debian using Qemu full system emulation.

## To resolve WIP status
- [ ]  rust-lang/rust needs to publish official `riscv64gc-unknown-linux-gnu` host toolchains for `rustup` on riscv to be useful.
- [x] rust-lang/rust needs to publish a docker image to allow CI for `riscv64gc-unknown-linux-gnu` to run
- [x] https://github.com/rust-lang/libc/pull/1745 needs merging so that ca3cec0 can go away