### PR TITLE
Reassert /bin/sh validity

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -1,8 +1,12 @@
-#!/bin/bash
+#!/bin/sh
+# shellcheck shell=dash
 
 # This is just a little script that can be downloaded from the internet to
 # install rustup. It just does platform detection, downloads the installer
 # and runs it.
+
+# It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
+# extension. Note: Most shells limit `local` to 1 var per line, contra bash.
 
 set -u
 


### PR DESCRIPTION
Reverts the shebang change in 6b4283f and adds a shellcheck directive
to suppress warnings about POSIX validity and prevent further drift.

The POSIX standard is not, despite its name, a reliable guide to what
features are actually standard, even for POSIX shells. rustup-init.sh
uses `local`, a non-POSIX extension supported by all POSIX shells known
in common use. Thus, it is fine to run it with #!/bin/sh instead.

The Debian Almquist shell is not the only POSIX shell but it is very
common, so is a useful proxy for whether the script actually runs for
non-bash shells.

It's worth noting this was already what was used in CI, via CLI command.