### PR TITLE
notifications: list all missing components when skipping nightlies

### DIFF
--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -176,8 +176,13 @@ impl<'a> Display for Notification<'a> {
             ),
             SkippingNightlyMissingComponent(components) => write!(
                 f,
-                "skipping nightly which is missing installed component '{}'",
-                components[0].short_name_in_manifest()
+                "skipping nightly which is missing installed component{} '{}'",
+                if components.len() > 1 { "s" } else { "" },
+                components
+                    .iter()
+                    .map(|component| component.short_name_in_manifest().to_owned())
+                    .collect::<Vec<_>>()
+                    .join("', '")
             ),
             ForcingUnavailableComponent(component) => {
                 write!(f, "Force-skipping unavailable component '{}'", component)


### PR DESCRIPTION
Currently when updating and skipping nightlies due to missing required components only one such missing component is shown. Users might consider removing the requirement for the component and updating to the specific nightly that was missing it, only to find out that there is another, newly discovered missing component.

With this change all required and missing components are shown when a nightly is skipped, so users might be able to quickly identify which nightly version, if any, has an acceptable set of missing components.