### PR TITLE
Fixed the copyright owner & year for the Apache License

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -186,7 +186,7 @@ APPENDIX: How to apply the Apache License to your work.
    same "printed page" as the copyright notice for easier
    identification within third-party archives.
 
-Copyright [yyyy] [name of copyright owner]
+Copyright 2016 The Rust Project Developers
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
##  Description of Change
The value for the year and owner was blank in the Apache License.
Mirrored the values of the year & owner from the MIT License (LICENSE-MIT).

## Testing
Checked the values in both `LICENSE-APACHE` and `LICENSE-MIT` to have the same values.