### PR TITLE
Fix the shebang for rustup-init.sh

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This is just a little script that can be downloaded from the internet to
 # install rustup. It just does platform detection, downloads the installer


### PR DESCRIPTION
The [normal installation guidance](https://rustup.rs/) is to pipe the contents of this file into `sh`, which is not `bash` (it may be `dash` or `bash` in POSIX-mode in certain systems, neither of which support most Bash-isms). Given that this script is intended to be run by `sh` the shebang should reflect that.