### PR TITLE
Update Microsoft C++ Build Tools url

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ $ rustup target add i686-pc-windows-gnu
 ```
 
 [ABIs]: https://en.wikipedia.org/wiki/Application_binary_interface
-[Visual Studio]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
+[Visual Studio]: https://visualstudio.microsoft.com/visual-cpp-build-tools/
 [GCC toolchain]: https://gcc.gnu.org/
 [MinGW/MSYS2 toolchain]: https://msys2.github.io/
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -198,7 +198,7 @@ The easiest way to acquire the build tools is by installing Microsoft
 Visual C++ Build Tools 2019 which provides just the Visual C++ build
 tools:
 
-    https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2019
+    https://visualstudio.microsoft.com/visual-cpp-build-tools/
 
 Please ensure the Windows 10 SDK and the English language pack components
 are included when installing the Visual C++ Build Tools.


### PR DESCRIPTION
Microsoft now have a dedicated page for the C++ Build Tools (which even mentions Rust). It is simpler to direct users to that rather than the full list of Visual Studio 2019 downloads.