### PR TITLE
CI: Check riscv64gc-unknown-linux-gnu for stable releases

### DIFF
--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -38,6 +38,7 @@ jobs:
           - armv7-linux-androideabi       # skip-pr skip-master
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
+          - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -46,7 +46,7 @@ jobs:
           - armv7-linux-androideabi       # skip-pr skip-master
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
-          - riscv64gc-unknown-linux-gnu   # skip-pr skip-master skip-stable
+          - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES


### PR DESCRIPTION
`riscv64gc-unknown-linux-gnu` is now tier 2
    https://github.com/ehuss/rust-forge/commit/c1ae62fbb3d91af8fc6a55ebb175309d79b091f2

~TODO: b66bc057ac18b0f0e641dc02f604fc742610c249 is only here to verify the CI passes~