### PR TITLE
Make the CLI code a library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,10 +105,6 @@ name = "rustup"
 path = "src/lib.rs"
 test = false # no unit tests
 
-[[bin]]
-name = "rustup-init"
-path = "src/cli/main.rs"
-
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -14,29 +14,19 @@
 
 #![recursion_limit = "1024"]
 
-#[macro_use]
-mod log;
-mod common;
-mod download_tracker;
-mod errors;
-mod help;
-mod job;
-mod markdown;
-mod proxy_mode;
-mod rustup_mode;
-mod self_update;
-mod setup_mode;
-mod term2;
-mod topical_doc;
-
-use crate::errors::*;
-use rustup::env_var::RUST_RECURSION_COUNT_MAX;
-use rustup::utils::utils;
-
 use std::env;
 use std::path::PathBuf;
 
 use rs_tracing::*;
+
+use rustup::cli::common;
+use rustup::cli::errors::*;
+use rustup::cli::proxy_mode;
+use rustup::cli::rustup_mode;
+use rustup::cli::self_update;
+use rustup::cli::setup_mode;
+use rustup::env_var::RUST_RECURSION_COUNT_MAX;
+use rustup::utils::utils;
 
 fn main() {
     if let Err(ref e) = run_rustup() {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,15 @@
+/// The CLI specific code lives in the cli module and sub-modules.
+#[macro_use]
+pub mod log;
+pub mod common;
+mod download_tracker;
+pub mod errors;
+pub mod help;
+mod job;
+mod markdown;
+pub mod proxy_mode;
+pub mod rustup_mode;
+pub mod self_update;
+pub mod setup_mode;
+mod term2;
+mod topical_doc;

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -1,22 +1,24 @@
 //! Just a dumping ground for cli stuff
 
-use crate::errors::*;
-use crate::self_update;
-use crate::term2;
-use git_testament::{git_testament, render_testament};
-use lazy_static::lazy_static;
-use rustup::dist::notifications as dist_notifications;
-use rustup::toolchain::DistributableToolchain;
-use rustup::utils::notifications as util_notifications;
-use rustup::utils::notify::NotificationLevel;
-use rustup::utils::utils;
-use rustup::{Cfg, Notification, Toolchain, UpdateStatus};
 use std::fs;
 use std::io::{BufRead, ErrorKind, Write};
 use std::path::Path;
 use std::sync::Arc;
 use std::{cmp, env, iter};
+
+use git_testament::{git_testament, render_testament};
+use lazy_static::lazy_static;
 use term2::Terminal;
+
+use super::errors::*;
+use super::self_update;
+use super::term2;
+use crate::dist::notifications as dist_notifications;
+use crate::toolchain::DistributableToolchain;
+use crate::utils::notifications as util_notifications;
+use crate::utils::notify::NotificationLevel;
+use crate::utils::utils;
+use crate::{Cfg, Notification, Toolchain, UpdateStatus};
 
 pub const WARN_COMPLETE_PROFILE: &str = "downloading with complete profile isn't recommended unless you are a developer of the rust language";
 
@@ -148,8 +150,9 @@ impl NotifyOnConsole {
 }
 
 pub fn set_globals(verbose: bool, quiet: bool) -> Result<Cfg> {
-    use crate::download_tracker::DownloadTracker;
     use std::cell::RefCell;
+
+    use super::download_tracker::DownloadTracker;
 
     let download_tracker = RefCell::new(DownloadTracker::new().with_display_progress(!quiet));
     let console_notifier = RefCell::new(NotifyOnConsole {
@@ -168,14 +171,14 @@ pub fn set_globals(verbose: bool, quiet: bool) -> Result<Cfg> {
 pub fn show_channel_update(
     cfg: &Cfg,
     name: &str,
-    updated: rustup::Result<UpdateStatus>,
+    updated: crate::Result<UpdateStatus>,
 ) -> Result<()> {
     show_channel_updates(cfg, vec![(name.to_string(), updated)])
 }
 
 fn show_channel_updates(
     cfg: &Cfg,
-    toolchains: Vec<(String, rustup::Result<UpdateStatus>)>,
+    toolchains: Vec<(String, crate::Result<UpdateStatus>)>,
 ) -> Result<()> {
     let data = toolchains.into_iter().map(|(name, result)| {
         let toolchain = cfg.get_toolchain(&name, false).unwrap();
@@ -348,7 +351,7 @@ where
 pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new(&toolchain)
-        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        .chain_err(|| crate::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
     let components = distributable.list_components()?;
     for component in components {
         if component.component.short_name_in_manifest() == "rust-std" {
@@ -373,7 +376,7 @@ pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<()> {
 pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new(&toolchain)
-        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        .chain_err(|| crate::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
     let components = distributable.list_components()?;
     for component in components {
         if component.component.short_name_in_manifest() == "rust-std" {
@@ -393,7 +396,7 @@ pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<()> {
 pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new(&toolchain)
-        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        .chain_err(|| crate::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
     let components = distributable.list_components()?;
     for component in components {
         let name = component.name;
@@ -412,7 +415,7 @@ pub fn list_components(toolchain: &Toolchain<'_>) -> Result<()> {
 pub fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<()> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new(&toolchain)
-        .chain_err(|| rustup::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
+        .chain_err(|| crate::ErrorKind::ComponentsUnsupported(toolchain.name().to_string()))?;
     let components = distributable.list_components()?;
     for component in components {
         if component.installed {
@@ -586,7 +589,7 @@ pub fn report_error(e: &Error) {
     }
 }
 
-pub fn ignorable_error(error: crate::errors::Error, no_prompt: bool) -> Result<()> {
+pub fn ignorable_error(error: super::errors::Error, no_prompt: bool) -> Result<()> {
     report_error(&error);
     if no_prompt {
         warn!("continuing (because the -y flag is set and the error is ignorable)");

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -1,14 +1,16 @@
-use crate::term2;
-use rustup::dist::Notification as In;
-use rustup::utils::tty;
-use rustup::utils::units::{Size, Unit, UnitMode};
-use rustup::utils::Notification as Un;
-use rustup::Notification;
 use std::collections::VecDeque;
 use std::fmt;
 use std::io::Write;
 use std::time::{Duration, Instant};
+
 use term::Terminal;
+
+use super::term2;
+use crate::dist::Notification as In;
+use crate::utils::tty;
+use crate::utils::units::{Size, Unit, UnitMode};
+use crate::utils::Notification as Un;
+use crate::Notification;
 
 /// Keep track of this many past download amounts
 const DOWNLOAD_TRACK_COUNT: usize = 5;

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -2,8 +2,6 @@
 #![allow(dead_code)]
 #![allow(deprecated)] // because of `Error::description` deprecation in `error_chain`
 
-use crate::rustup_mode::CompletionCommand;
-
 use std::io;
 use std::path::PathBuf;
 
@@ -11,12 +9,14 @@ use clap::Shell;
 use error_chain::error_chain;
 use lazy_static::lazy_static;
 use regex::Regex;
-use rustup::dist::temp;
 use strsim::damerau_levenshtein;
+
+use super::rustup_mode::CompletionCommand;
+use crate::dist::temp;
 
 error_chain! {
     links {
-        Rustup(rustup::Error, rustup::ErrorKind);
+        Rustup(crate::Error, crate::ErrorKind);
     }
 
     foreign_links {

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -1,24 +1,25 @@
-use crate::term2;
 use std::fmt;
 use std::io::Write;
 use term2::Terminal;
 
+use super::term2;
+
 macro_rules! warn {
-    ( $ ( $ arg : tt ) * ) => ( $crate::log::warn_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+    ( $ ( $ arg : tt ) * ) => ( $crate::cli::log::warn_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 macro_rules! err {
-    ( $ ( $ arg : tt ) * ) => ( $crate::log::err_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+    ( $ ( $ arg : tt ) * ) => ( $crate::cli::log::err_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 macro_rules! info {
-    ( $ ( $ arg : tt ) * ) => ( $crate::log::info_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+    ( $ ( $ arg : tt ) * ) => ( $crate::cli::log::info_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
 macro_rules! verbose {
-    ( $ ( $ arg : tt ) * ) => ( $crate::log::verbose_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+    ( $ ( $ arg : tt ) * ) => ( $crate::cli::log::verbose_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
 macro_rules! debug {
-    ( $ ( $ arg : tt ) * ) => ( $crate::log::debug_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
+    ( $ ( $ arg : tt ) * ) => ( $crate::cli::log::debug_fmt ( format_args ! ( $ ( $ arg ) * ) ) )
 }
 
 pub fn warn_fmt(args: fmt::Arguments<'_>) {

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -1,9 +1,10 @@
 // Write Markdown to the terminal
 
-use crate::term2::{color, Attr, Terminal};
 use std::io;
 
 use pulldown_cmark::{Event, Tag};
+
+use super::term2::{color, Attr, Terminal};
 
 // Handles the wrapping of text written to the console
 struct LineWrapper<'a, T: Terminal> {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -1,16 +1,18 @@
-use crate::common::set_globals;
-use crate::errors::*;
-use crate::job;
-use rustup::command::run_command_for_dir;
-use rustup::utils::utils::{self, ExitCode};
-use rustup::Cfg;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::process;
 
+use super::common::set_globals;
+use super::errors::*;
+use super::job;
+use super::self_update;
+use crate::command::run_command_for_dir;
+use crate::utils::utils::{self, ExitCode};
+use crate::Cfg;
+
 pub fn main() -> Result<()> {
-    crate::self_update::cleanup_self_updater()?;
+    self_update::cleanup_self_updater()?;
 
     let ExitCode(c) = {
         let _setup = job::setup();

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -1,10 +1,12 @@
-use super::*;
-use path_update::PathUpdateMethod;
-use rustup::utils::utils;
-use rustup::utils::Notification;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
+
+use super::super::errors::*;
+use super::path_update::PathUpdateMethod;
+use super::{canonical_cargo_home, install_bins};
+use crate::utils::utils;
+use crate::utils::Notification;
 
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -1,16 +1,18 @@
-use super::*;
-use path_update::PathUpdateMethod;
-use rustup::dist::dist::TargetTriple;
-use rustup::utils::utils;
-use rustup::utils::Notification;
 use std::env;
 use std::env::consts::EXE_SUFFIX;
 use std::path::Path;
 use std::process::{self, Command};
 
+use super::super::errors::*;
+use super::path_update::PathUpdateMethod;
+use super::{install_bins, InstallOpts};
+use crate::dist::dist::TargetTriple;
+use crate::utils::utils;
+use crate::utils::Notification;
+
 // Provide guidance about setting up MSVC if it doesn't appear to be
 // installed
-pub fn do_msvc_check(opts: &InstallOpts) -> Result<bool> {
+pub fn do_msvc_check(opts: &InstallOpts<'_>) -> Result<bool> {
     // Test suite skips this since it's env dependent
     if env::var("RUSTUP_INIT_SKIP_MSVC_CHECK").is_ok() {
         return Ok(true);

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,9 +1,11 @@
-use crate::common;
-use crate::errors::*;
-use crate::self_update::{self, InstallOpts};
-use clap::{App, AppSettings, Arg};
-use rustup::dist::dist::Profile;
 use std::env;
+
+use clap::{App, AppSettings, Arg};
+
+use super::common;
+use super::errors::*;
+use super::self_update::{self, InstallOpts};
+use crate::dist::dist::Profile;
 
 pub fn main() -> Result<()> {
     let args: Vec<_> = env::args().collect();

--- a/src/cli/term2.rs
+++ b/src/cli/term2.rs
@@ -2,14 +2,15 @@
 //! that does not fail if `StdoutTerminal` etc can't be constructed, which happens
 //! if TERM isn't defined.
 
-use lazy_static::lazy_static;
-use rustup::utils::tty;
 use std::io;
 use std::sync::Mutex;
 
+use lazy_static::lazy_static;
 pub use term::color;
 pub use term::Attr;
 pub use term::Terminal;
+
+use crate::utils::tty;
 
 mod termhack {
     // Things we should submit to term as improvements: here temporarily.

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -13,7 +13,7 @@ fn no_document(topic: &str) -> Result<PathBuf> {
     Err(format!("No document for '{}'", topic).into())
 }
 
-fn index_html(doc: &DocData, wpath: &Path) -> Option<PathBuf> {
+fn index_html(doc: &DocData<'_>, wpath: &Path) -> Option<PathBuf> {
     let indexhtml = wpath.join("index.html");
     match &doc.root.join(&indexhtml).exists() {
         true => Some(indexhtml),
@@ -31,7 +31,7 @@ fn dir_into_vec(dir: &PathBuf) -> Result<Vec<OsString>> {
     Ok(v)
 }
 
-fn search_path(doc: &DocData, wpath: &Path, keywords: &[&str]) -> Result<PathBuf> {
+fn search_path(doc: &DocData<'_>, wpath: &Path, keywords: &[&str]) -> Result<PathBuf> {
     let dir = &doc.root.join(&wpath);
     if dir.is_dir() {
         let entries = dir_into_vec(dir)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
     }
 }
 
+pub mod cli;
 pub mod command;
 mod config;
 pub mod diskio;


### PR DESCRIPTION
In order to do in-process tests the CLI code must be (mostly) a library.

Thus:
 - rustup-init should moves to the usual place to make this visually
   distinct
 - cli.rs as a mod to define the import
 - 2018 edition changes to the cli code which had not been updated
 - export the needed parts of the cli code such that rustup-init can
   import them