### PR TITLE
Update the sanity limit from 200M to 220M per file. 

### DIFF
--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -296,7 +296,7 @@ fn unpack_without_first_dir<'a, R: Read>(
     let entries = archive
         .entries()
         .chain_err(|| ErrorKind::ExtractingPackage)?;
-    const MAX_FILE_SIZE: u64 = 200_000_000;
+    const MAX_FILE_SIZE: u64 = 220_000_000;
     let effective_max_ram = match effective_limits::memory_limit() {
         Ok(ram) => Some(ram as usize),
         Err(e) => {


### PR DESCRIPTION
This is needed because the librustc_driver-*.so filesize on some targets
now exceed 200M. i.e. nightly-mips64el-unknown-linux-gnuabi64

This will close #2362.

The commit e23a7be3d39cf9d3b0f99626f20ce699b611ff15 , in which we lift the limit
from 100M to 200M, was commited 9 monthes ago. Thus we can estimate that the
driver size will grow 10M per month on nightly-mips64el target. With extra 20M
limit, we will be able to perform a better solution in about 2 monthes.

Signed-off-by: LIU An <liuan@sgcc.com.cn>