### PR TITLE
In process test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,8 +733,6 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "home"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -733,6 +733,7 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 [[package]]
 name = "home"
 version = "0.5.3"
+source = "git+https://github.com/rbtcollins/home?rev=81c8dfcd815765daf384319a04e237feb9d5e72d#81c8dfcd815765daf384319a04e237feb9d5e72d"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ error-chain = "0.12"
 effective-limits = "0.5"
 flate2 = "1"
 git-testament = "0.1.4"
-home = "0.5"
+home = { git = "https://github.com/rbtcollins/home", rev="81c8dfcd815765daf384319a04e237feb9d5e72d"  }
 lazy_static = "1"
 libc = "0.2"
 num_cpus = "1.13"
@@ -113,6 +113,3 @@ codegen-units = 1
 # Reduce build time by setting proc-macro crates non optimized.
 [profile.release.build-override]
 opt-level = 0
-
-[patch.crates-io]
-home = { path = "../rustup-home" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,3 +113,6 @@ codegen-units = 1
 # Reduce build time by setting proc-macro crates non optimized.
 [profile.release.build-override]
 opt-level = 0
+
+[patch.crates-io]
+home = { path = "../rustup-home" }

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -20,6 +20,7 @@ error_chain! {
     }
 
     foreign_links {
+        Clap(clap::Error);
         Temp(temp::Error);
         Io(io::Error);
         Term(term::Error);

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -55,7 +55,16 @@ where
 pub fn main() -> Result<utils::ExitCode> {
     self_update::cleanup_self_updater()?;
 
-    let matches = cli().get_matches_from(process().args_os());
+    let matches = match cli().get_matches_from_safe(process().args_os()) {
+        Ok(matches) => Ok(matches),
+        Err(e)
+            if e.kind == clap::ErrorKind::HelpDisplayed
+                || e.kind == clap::ErrorKind::VersionDisplayed =>
+        {
+            return Ok(utils::ExitCode(0))
+        }
+        Err(e) => Err(e),
+    }?;
     let verbose = matches.is_present("verbose");
     let quiet = matches.is_present("quiet");
     let cfg = &mut common::set_globals(verbose, quiet)?;

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -87,7 +87,16 @@ pub fn main() -> Result<utils::ExitCode> {
                 .help("Don't configure the PATH environment variable"),
         );
 
-    let matches = cli.get_matches_from(process().args_os());
+    let matches = match cli.get_matches_from_safe(process().args_os()) {
+        Ok(matches) => matches,
+        Err(e)
+            if e.kind == clap::ErrorKind::HelpDisplayed
+                || e.kind == clap::ErrorKind::VersionDisplayed =>
+        {
+            return Ok(utils::ExitCode(0))
+        }
+        Err(e) => Err(e)?,
+    };
     let no_prompt = matches.is_present("no-prompt");
     let verbose = matches.is_present("verbose");
     let quiet = matches.is_present("quiet");

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -1,7 +1,8 @@
-use crate::errors::*;
 use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+use super::errors::*;
 
 struct DocData<'a> {
     topic: &'a str,

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -14,6 +14,7 @@ use rand::{thread_rng, Rng};
 pub mod argsource;
 pub mod cwdsource;
 pub mod filesource;
+mod homethunk;
 pub mod varsource;
 
 use argsource::*;

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -194,6 +194,22 @@ impl TestProcess {
         let high_bits = rng.gen_range(0, u32::MAX) as u64;
         high_bits << 32 | low_bits
     }
+
+    /// Extracts the stdout from the process
+    pub fn get_stdout(&self) -> Vec<u8> {
+        self.stdout
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    /// Extracts the stderr from the process
+    pub fn get_stderr(&self) -> Vec<u8> {
+        self.stderr
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
 }
 
 impl ProcessSource for TestProcess {

--- a/src/currentprocess/homethunk.rs
+++ b/src/currentprocess/homethunk.rs
@@ -1,0 +1,21 @@
+/// Adapts currentprocess to the trait home::Env
+use std::ffi::OsString;
+use std::io;
+use std::ops::Deref;
+use std::path::PathBuf;
+
+use super::CurrentDirSource;
+use super::CurrentProcess;
+use super::VarSource;
+
+impl home::Env for Box<dyn CurrentProcess + 'static> {
+    fn home_dir(&self) -> Option<PathBuf> {
+        self.var("HOME").ok().map(|v| v.into())
+    }
+    fn current_dir(&self) -> Result<PathBuf, io::Error> {
+        CurrentDirSource::current_dir(self.deref())
+    }
+    fn var_os(&self, key: &str) -> Option<OsString> {
+        VarSource::var_os(self.deref(), key)
+    }
+}

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -466,11 +466,11 @@ pub fn to_absolute<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 }
 
 pub fn home_dir() -> Option<PathBuf> {
-    home::home_dir()
+    home::home_dir_from(&process())
 }
 
 pub fn cargo_home() -> Result<PathBuf> {
-    home::cargo_home().map_err(|e| Error::from_kind(ErrorKind::Io(e)))
+    home::cargo_home_from(&process()).map_err(|e| Error::from_kind(ErrorKind::Io(e)))
 }
 
 // Creates a ~/.rustup folder
@@ -496,7 +496,7 @@ pub fn rustup_home_in_user_dir() -> Result<PathBuf> {
 }
 
 pub fn rustup_home() -> Result<PathBuf> {
-    home::rustup_home().map_err(|e| Error::from_kind(ErrorKind::Io(e)))
+    home::rustup_home_from(&process()).map_err(|e| Error::from_kind(ErrorKind::Io(e)))
 }
 
 pub fn format_path_for_display(path: &str) -> String {

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -493,6 +493,8 @@ where
     //   collected for assertions to be made on it as our tests traverse layers.
     // - self update executions cannot run in-process because on windows the
     //    process replacement dance would replace the test process.
+    // - any command with --version in it is testing to see something was
+    //   installed properly, so we have to shell out to it to be sure
     if name != "rustup" {
         return false;
     }
@@ -500,6 +502,7 @@ where
     let mut no_self_update = false;
     let mut self_cmd = false;
     let mut run = false;
+    let mut version = false;
     for arg in args {
         if arg.as_ref() == "update" {
             is_update = true;
@@ -509,9 +512,11 @@ where
             self_cmd = true;
         } else if arg.as_ref() == "run" {
             run = true;
+        } else if arg.as_ref() == "--version" {
+            version = true;
         }
     }
-    !(run || self_cmd || (is_update && !no_self_update))
+    !(run || self_cmd || version || (is_update && !no_self_update))
 }
 
 pub fn run<I, A>(config: &Config, name: &str, args: I, env: &[(&str, &str)]) -> SanitizedOutput

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -92,6 +92,10 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     env::remove_var("RUSTUP_TOOLCHAIN");
     env::remove_var("SHELL");
     env::remove_var("ZDOTDIR");
+    // clap does it's own terminal colour probing, and that isn't
+    // trait-controllable, but it does honour the terminal. To avoid testing
+    // claps code, lie about whatever terminal this process was started under.
+    env::set_var("TERM", "dumb");
 
     match env::var("RUSTUP_BACKTRACE") {
         Ok(val) => env::set_var("RUST_BACKTRACE", val),


### PR DESCRIPTION
Run rustup tests in-process

Using the in-process test support feature, we can now change the test runner to run select CLI operations in-process.

More can be done, but this is the first major step: running rustup-mode in-process much of the time.