### PR TITLE
Disable threading when on single core hardware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,6 +1475,7 @@ dependencies = [
  "home",
  "lazy_static",
  "libc",
+ "num_cpus",
  "opener",
  "openssl",
  "pgp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ git-testament = "0.1.4"
 home = "0.5"
 lazy_static = "1"
 libc = "0.2"
+num_cpus = "1.13"
 opener = "0.4.0"
 # Used by `curl` or `reqwest` backend although it isn't imported
 # by our rustup.

--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ currently can define only `default_toolchain`.
   Sets the root URL for downloading self-updates.
 
 - `RUSTUP_IO_THREADS` *unstable* (defaults to reported cpu count). Sets the
-  number of threads to perform close IO in. Set to `disabled` to force
+  number of threads to perform close IO in. Set to `1` to force
   single-threaded IO for troubleshooting, or an arbitrary number to
   override automatic detection.
 

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -34,29 +34,7 @@ pub struct Threaded<'a> {
 }
 
 impl<'a> Threaded<'a> {
-    pub fn new(notify_handler: Option<&'a dyn Fn(Notification<'_>)>) -> Self {
-        // Defaults to hardware thread count threads; this is suitable for
-        // our needs as IO bound operations tend to show up as write latencies
-        // rather than close latencies, so we don't need to look at
-        // more threads to get more IO dispatched at this stage in the process.
-        let pool = threadpool::Builder::new()
-            .thread_name("CloseHandle".into())
-            .thread_stack_size(1_048_576)
-            .build();
-        let (tx, rx) = channel();
-        Self {
-            n_files: Arc::new(AtomicUsize::new(0)),
-            pool,
-            notify_handler,
-            rx,
-            tx,
-        }
-    }
-
-    pub fn new_with_threads(
-        notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
-        thread_count: usize,
-    ) -> Self {
+    pub fn new(notify_handler: Option<&'a dyn Fn(Notification<'_>)>, thread_count: usize) -> Self {
         // Defaults to hardware thread count threads; this is suitable for
         // our needs as IO bound operations tend to show up as write latencies
         // rather than close latencies, so we don't need to look at

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -293,7 +293,7 @@ fn unpack_without_first_dir<'a, R: Read>(
     path: &Path,
     notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
 ) -> Result<()> {
-    let mut io_executor: Box<dyn Executor> = get_executor(notify_handler);
+    let mut io_executor: Box<dyn Executor> = get_executor(notify_handler)?;
     let entries = archive
         .entries()
         .chain_err(|| ErrorKind::ExtractingPackage)?;


### PR DESCRIPTION
An improvement that will (at least temporarily) fix #2365.

No need to run a thread pool if the number of available CPUs/cores is one anyway. So it can fall back to the special single threaded mode in that case. The single threaded mode uses less memory so it's really useful on low end machines, such as the Raspberry Pi zero and similar.

Since setting the `RUSTUP_IO_THREADS` environment variable to zero on one now produces the same result as `"disabled"` did previously the `"disabled"` value does not need to exist any longer, and the code can be simpler if it just needs to be an integer directly. Since the variable was regarded as unstable in the docs I thought it was fine to change how it behaved.

This new code also prints a warning on stderr if `RUSTUP_IO_THREADS` is set to an invalid value, instead of just silently falling back to automatically detecting the number of cores.

I'm still working on trying to get this tested locally. But the Rpi zero is *incredibly* slow at compiling such a big project 😅 At least it builds. So I figured I could submit the PR and get some feedback.