### PR TITLE
  Fix removing from PATH on windows when last item

### DIFF
--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -1093,42 +1093,6 @@ fn windows_handle_empty_path_registry_key() {
 
 #[test]
 #[cfg(windows)]
-fn windows_uninstall_removes_semicolon_from_path() {
-    use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
-    use winreg::RegKey;
-
-    setup(&|config| {
-        let root = RegKey::predef(HKEY_CURRENT_USER);
-        let environment = root
-            .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-            .unwrap();
-
-        // This time set the value of PATH and make sure it's restored exactly after uninstall,
-        // not leaving behind any semi-colons
-        environment.set_value("PATH", &"foo").unwrap();
-
-        expect_ok(config, &["rustup-init", "-y"]);
-
-        let root = RegKey::predef(HKEY_CURRENT_USER);
-        let environment = root
-            .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-            .unwrap();
-        let path = environment.get_raw_value("PATH").unwrap();
-        assert!(path.vtype == RegType::REG_EXPAND_SZ);
-
-        expect_ok(config, &["rustup", "self", "uninstall", "-y"]);
-
-        let root = RegKey::predef(HKEY_CURRENT_USER);
-        let environment = root
-            .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
-            .unwrap();
-        let path: String = environment.get_value("PATH").unwrap();
-        assert!(path == "foo");
-    });
-}
-
-#[test]
-#[cfg(windows)]
 fn install_doesnt_mess_with_a_non_unicode_path() {
     use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
     use winreg::{RegKey, RegValue};


### PR DESCRIPTION
When the cargo bin is the last item in the PATH on windows, a trailing ;
was left behind, which leave an empty segment in the PATH.

Also refactor into unit tests, for faster testing.

This has arguably the same coverage: we know that windows path setting
works in general due to the presence of at least one end to end test;
and it is implemented by calling this one code path; this pure function
in the code path can therefore be unit tested to examine it's corner
case behaviour rather than testing end to end every possible
interaction.

$ time ...

running 1 test
test cli::self_update::windows::tests::windows_uninstall_removes_semicolon_from_path ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out

real    0m0.041s
user    0m0.000s
sys     0m0.030s

$ time ...

running 1 test
test windows_uninstall_removes_semicolon_from_path ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 56 filtered out

real    0m13.450s
user    0m0.000s
sys     0m0.015s