### PR TITLE
Convert unicode uninstall test to unit test

### DIFF
--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -160,7 +160,7 @@ impl ProcessSource for OSProcess {
 
 // ------------ test process ----------------
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct TestProcess {
     cwd: PathBuf,
     args: Vec<String>,

--- a/tests/mock/mod.rs
+++ b/tests/mock/mod.rs
@@ -180,6 +180,10 @@ pub fn get_path() -> Option<String> {
         .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
         .unwrap();
 
+    // XXX: Suspect code: This uses ok to allow signalling None for 'delete', but this
+    // can fail e.g. with !(winerror::ERROR_BAD_FILE_TYPE) or other
+    // failures; which would lead to attempting to delete the users path
+    // rather than aborting the test suite.
     environment.get_value("PATH").ok()
 }
 


### PR DESCRIPTION
Added a mutex for registry editing unit tests as they will need to
mutually exclude as the functional test suite does. For now I've copied
the support functions; it is small and I've left a pointer.