### PR TITLE
Update env_proxy to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "env_proxy"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8731da06ff3731a69115a2910345ae5ee8d1fe09c846a9eca101b444a30ad454"
+checksum = "3a5019be18538406a43b5419a5501461f0c8b49ea7dfda0cfc32f4e51fc44be1"
 dependencies = [
  "log",
  "url",

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -18,7 +18,7 @@ reqwest-backend = ["reqwest", "env_proxy", "lazy_static"]
 error-chain = "0.12"
 url = "2.1"
 curl = { version = "0.4.11", optional = true }
-env_proxy = { version = "0.4", optional = true }
+env_proxy = { version = "0.4.1", optional = true }
 lazy_static = { version = "1.0", optional = true }
 reqwest = { version = "0.10", features = ["blocking", "gzip"], optional = true }
 


### PR DESCRIPTION
This version works around breakage introduced by `url` >= 2.1.1. See inejge/env_proxy#8 and inejge/env_proxy@5591cc7. Without the fix, `env_proxy` couldn't return the values read from the environment, so `rustup` would fail when invoked behind a proxy.