### PR TITLE
Fallback to copy when rename causes cross-link error

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,14 @@ currently can define only `default_toolchain`.
 - `RUSTUP_NO_BACKTRACE`
   Disables backtraces on non-panic errors even when `RUST_BACKTRACE` is set.
 
+- `RUSTUP_PERMIT_COPY_RENAME`
+  *unstable* When set, allows rustup to fall-back to copying files if attempts to
+  `rename` result in an cross-device link errors. These errors occur on OverlayFS,
+  which is used by [Docker][dc]. This feature sacrifices some transactions protections
+  and may be removed at any point. Linux only.
+
+  [dc]: (https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories)
+
 ## Other installation methods
 
 The primary installation method, as described at https://rustup.rs, differs by platform:


### PR DESCRIPTION
This is the issue https://github.com/rust-lang/rustup/issues/1239.  There is further discussion [here](https://internals.rust-lang.org/t/contributing-to-rustup-help-with-code-structure-needed/7193). We came across it in our dockerized CI environment.

The fix for the bug is to fall back to copying when rename fails due to a cross-link error on Linux.
I'm not sure how a test could be created for this, but it can be reproduce in docker so long as dockerhub doesn't delete the images I used. 

```bash
# REPRODUCE ERROR
# Build yesterday with nightly toolchain. "rustup update nightly" should fail.
# From https://hub.docker.com/layers/rustlang/rust/nightly-stretch/images/sha256-6e27094d819a2eeaaddbda329cc8ddcc27666c701d51eb9a3d35d3d261ef321d?context=explore
docker run --net=host -t --rm \
    rustlang/rust:nightly-stretch@sha256:6e27094d819a2eeaaddbda329cc8ddcc27666c701d51eb9a3d35d3d261ef321d \
    rustup update nightly

# BUILD FIX
docker run --net=host -t --rm \
    -v ${PWD}:/rustup \
    -w /rustup \
    rust:stretch@sha256:cd0d96614c172237a7b782fc090733f3c12922fb29e3c064e8fe34453ac01b99 \
    bash -c 'cargo build && RUSTUP_HOME=home CARGO_HOME=home target/debug/rustup-init --no-modify-path -y'


# TEST FIX
docker run --net=host -t --rm \
    -v ${PWD}/home/bin/rustup:/usr/local/cargo/bin/rustup \
    rustlang/rust:nightly-stretch@sha256:6e27094d819a2eeaaddbda329cc8ddcc27666c701d51eb9a3d35d3d261ef321d \
    rustup update nightly
```
Please let me know what you think.