### PR TITLE
Fix path to rustup.exe and rustup-init.exe on self-update

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -34,7 +34,7 @@ use std::borrow::Cow;
 use std::env;
 use std::env::consts::EXE_SUFFIX;
 use std::fs;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path, PathBuf, MAIN_SEPARATOR};
 use std::process::Command;
 
 use same_file::Handle;
@@ -959,8 +959,8 @@ fn parse_new_rustup_version(version: String) -> String {
 
 pub fn prepare_update() -> Result<Option<PathBuf>> {
     let cargo_home = utils::cargo_home()?;
-    let rustup_path = cargo_home.join(&format!("bin/rustup{}", EXE_SUFFIX));
-    let setup_path = cargo_home.join(&format!("bin/rustup-init{}", EXE_SUFFIX));
+    let rustup_path = cargo_home.join(&format!("bin{}rustup{}", MAIN_SEPARATOR, EXE_SUFFIX));
+    let setup_path = cargo_home.join(&format!("bin{}rustup-init{}", MAIN_SEPARATOR, EXE_SUFFIX));
 
     if !rustup_path.exists() {
         return Err(ErrorKind::NotSelfInstalled(cargo_home).into());


### PR DESCRIPTION
While checking an error on GitHub Actions workflow in my project,

https://github.com/rhysd/wain/runs/865787365?check_suite_focus=true

I noticed the path to 'setup' file on Windows was not correct:

```
C:\Users\runneradmin\.cargo\bin/rustup-init.exe
```

I'm not sure this is the reason of the workflow failure, but this PR fixes the path as follows:

```
C:\Users\runneradmin\.cargo\bin\rustup-init.exe
```