### PR TITLE
Adds Rust favicon

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -7,6 +7,9 @@
   <meta name="description" content="The Rust toolchain installer">
   <link rel="stylesheet" href="normalize.css">
   <link rel="stylesheet" href="rustup.css">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://www.rust-lang.org/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/svg+xml" href="https://www.rust-lang.org/static/images/favicon.svg">
+  <link rel="mask-icon" href="https://www.rust-lang.org/static/images/safari-pinned-tab.svg" color="#000">
 
 </head>
 


### PR DESCRIPTION
Adds favicons to minimally support Chrome, Firefox, and Safari browsers.