### PR TITLE
ci: riscv: Use new official riscv docker image

### DIFF
--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,11 +1,4 @@
 FROM rust-riscv64gc-unknown-linux-gnu
 
-
-# We install a stable toolchain using rustup anyway, this should stop us getting
-# confused and still having this toolchain in $PATH
-RUN /usr/local/lib/rustlib/uninstall.sh
-# Weirdly that doesn't remove these:
-RUN rm /usr/local/bin/cargo /usr/local/bin/rust*
-
 ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
     CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-unknown-linux-gnu-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -32,7 +32,7 @@ case "$TARGET" in
   x86_64-unknown-freebsd)          image=dist-x86_64-freebsd ;;
   x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;
   x86_64-unknown-netbsd)           image=dist-x86_64-netbsd ;;
-  riscv64gc-unknown-linux-gnu)     image=dist-various-1 ;;
+  riscv64gc-unknown-linux-gnu)     image=dist-riscv64-linux ;;
   *) exit ;;
 esac
 


### PR DESCRIPTION
New image was merged in rust-lang/rust#72973

~WIP until I've removed 02d29b2~