### PR TITLE
cli: exit gracefully when no subcommand

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -64,6 +64,10 @@ pub fn main() -> Result<utils::ExitCode> {
             writeln!(process().stdout().lock(), "{}", e.message)?;
             return Ok(utils::ExitCode(0));
         }
+        Err(e) if e.kind == clap::ErrorKind::MissingArgumentOrSubcommand => {
+            writeln!(process().stdout().lock(), "{}", e.message)?;
+            return Ok(utils::ExitCode(1));
+        }
         Err(e) => Err(e),
     }?;
     let verbose = matches.is_present("verbose");

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -4,6 +4,7 @@
 pub mod mock;
 
 use std::env::consts::EXE_SUFFIX;
+use std::str;
 
 use rustup::for_host;
 use rustup::test::this_host_triple;
@@ -129,8 +130,8 @@ fn show_works_with_dumb_term() {
     });
 }
 
-// Issue #140
-// Don't panic when `target`, `update` etc. are called without subcommands.
+// Issue #2425
+// Exit with error and help output when called without subcommand.
 #[test]
 fn subcommand_required_for_target() {
     setup(&|config| {
@@ -138,12 +139,13 @@ fn subcommand_required_for_target() {
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
-        assert_ne!(out.status.code().unwrap(), 101);
+        assert_eq!(out.status.code().unwrap(), 1);
+        assert!(str::from_utf8(&out.stdout).unwrap().contains(&"USAGE"));
     });
 }
 
-// Issue #140
-// Don't panic when `target`, `update` etc. are called without subcommands.
+// Issue #2425
+// Exit with error and help output when called without subcommand.
 #[test]
 fn subcommand_required_for_toolchain() {
     setup(&|config| {
@@ -151,12 +153,13 @@ fn subcommand_required_for_toolchain() {
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
-        assert_ne!(out.status.code().unwrap(), 101);
+        assert_eq!(out.status.code().unwrap(), 1);
+        assert!(str::from_utf8(&out.stdout).unwrap().contains(&"USAGE"));
     });
 }
 
-// Issue #140
-// Don't panic when `target`, `update` etc. are called without subcommands.
+// Issue #2425
+// Exit with error and help output when called without subcommand.
 #[test]
 fn subcommand_required_for_override() {
     setup(&|config| {
@@ -164,12 +167,13 @@ fn subcommand_required_for_override() {
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
-        assert_ne!(out.status.code().unwrap(), 101);
+        assert_eq!(out.status.code().unwrap(), 1);
+        assert!(str::from_utf8(&out.stdout).unwrap().contains(&"USAGE"));
     });
 }
 
-// Issue #140
-// Don't panic when `target`, `update` etc. are called without subcommands.
+// Issue #2425
+// Exit with error and help output when called without subcommand.
 #[test]
 fn subcommand_required_for_self() {
     setup(&|config| {
@@ -177,7 +181,8 @@ fn subcommand_required_for_self() {
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
-        assert_ne!(out.status.code().unwrap(), 101);
+        assert_eq!(out.status.code().unwrap(), 1);
+        assert!(str::from_utf8(&out.stdout).unwrap().contains(&"USAGE"));
     });
 }
 


### PR DESCRIPTION
### What
Exit from rustup CLI gracefully when no subcommand is provided.

### Why
That appears to be the intention because the `SubcommandRequiredElseHelp` app setting is configured on the CLI, however that is not the behavior because the `main` function treats the error indicating no subcommand was provided as an error.

https://github.com/rust-lang/rustup/blob/22dc71adbd7e19de0090f991b3609e5f14910dcb/src/cli/rustup_mode.rs#L152-L159

Instead of exiting gracefully the word `error:` is printed with no error message:
<img width="331" alt="Screen Shot 2020-07-17 at 12 22 44 AM" src="https://user-images.githubusercontent.com/351529/87759759-a6d8d600-c7c3-11ea-9863-37e078a22455.png">

Fixes #2425 

### Known Limitations
I have not added tests for this change. I'm rather new to rust and this codebase and I could not find tests for this code to modify or change.