### PR TITLE
add illumos (amd64) support

### DIFF
--- a/ci/actions-templates/README.md
+++ b/ci/actions-templates/README.md
@@ -46,6 +46,7 @@ system.
 | arm-unknown-linux-gnueabihf   | Yes        | Two   | No     | No         |
 | x86_64-unknown-freebsd        | Yes        | Two   | No     | No         |
 | x86_64-unknown-netbsd         | Yes        | Two   | No     | No         |
+| x86_64-unknown-illumos        | Yes        | Two   | No     | No         |
 | powerpc-unknown-linux-gnu     | Yes        | Two   | No     | No         |
 | powerpc64le-unknown-linux-gnu | Yes        | Two   | No     | No         |
 | mips-unknown-linux-gnu        | Yes        | Two   | No     | No         |

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -36,6 +36,7 @@ jobs:
           - arm-unknown-linux-gnueabihf   # skip-pr skip-master
           - x86_64-unknown-freebsd        # skip-pr skip-master
           - x86_64-unknown-netbsd         # skip-pr skip-master
+          - x86_64-unknown-illumos        # skip-pr skip-master
           - powerpc-unknown-linux-gnu     # skip-pr skip-master
           - powerpc64le-unknown-linux-gnu # skip-pr skip-master
           - mips-unknown-linux-gnu        # skip-pr skip-master

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -53,6 +53,8 @@ rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
 rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe.sha256
 rustup/dist/x86_64-unknown-freebsd/rustup-init
 rustup/dist/x86_64-unknown-freebsd/rustup-init.sha256
+rustup/dist/x86_64-unknown-illumos/rustup-init
+rustup/dist/x86_64-unknown-illumos/rustup-init.sha256
 rustup/dist/x86_64-unknown-linux-gnu/rustup-init
 rustup/dist/x86_64-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/x86_64-unknown-linux-musl/rustup-init

--- a/ci/docker/x86_64-unknown-illumos/Dockerfile
+++ b/ci/docker/x86_64-unknown-illumos/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust-x86_64-unknown-illumos
+
+ENV \
+    AR_x86_64_unknown_illumos=x86_64-illumos-ar \
+    CC_x86_64_unknown_illumos=x86_64-illumos-gcc \
+    CXX_x86_64_unknown_illumos=x86_64-illumos-g++ \
+    CARGO_TARGET_X86_64_UNKNOWN_ILLUMOS_LINKER=x86_64-illumos-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -31,6 +31,7 @@ case "$TARGET" in
   powerpc64le-unknown-linux-gnu)   image=dist-powerpc64le-linux ;;
   s390x-unknown-linux-gnu)         image=dist-s390x-linux ;;
   x86_64-unknown-freebsd)          image=dist-x86_64-freebsd ;;
+  x86_64-unknown-illumos)          image=dist-x86_64-illumos ;;
   x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;
   x86_64-unknown-netbsd)           image=dist-x86_64-netbsd ;;
   riscv64gc-unknown-linux-gnu)     image=dist-riscv64-linux ;;

--- a/doc/src/installation/other.md
+++ b/doc/src/installation/other.md
@@ -58,6 +58,7 @@ choice:
 - [x86_64-pc-windows-gnu](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe)
 - [x86_64-pc-windows-msvc](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)[^msvc]
 - [x86_64-unknown-freebsd](https://static.rust-lang.org/rustup/dist/x86_64-unknown-freebsd/rustup-init)
+- [x86_64-unknown-illumos](https://static.rust-lang.org/rustup/dist/x86_64-unknown-illumos/rustup-init)
 - [x86_64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init)
 - [x86_64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init)
 - [x86_64-unknown-netbsd](https://static.rust-lang.org/rustup/dist/x86_64-unknown-netbsd/rustup-init)

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -103,6 +103,7 @@ static LIST_OSES: &[&str] = &[
     "linux",
     "rumprun-netbsd",
     "unknown-freebsd",
+    "unknown-illumos",
 ];
 static LIST_ENVS: &[&str] = &[
     "gnu",
@@ -259,6 +260,7 @@ impl TargetTriple {
                 (b"NetBSD", b"x86_64") => Some("x86_64-unknown-netbsd"),
                 (b"NetBSD", b"i686") => Some("i686-unknown-netbsd"),
                 (b"DragonFly", b"x86_64") => Some("x86_64-unknown-dragonfly"),
+                (b"SunOS", b"i86pc") => Some("x86_64-unknown-illumos"),
                 _ => None,
             };
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -101,6 +101,8 @@ pub fn this_host_triple() -> String {
         "unknown-linux"
     } else if cfg!(target_os = "macos") {
         "apple-darwin"
+    } else if cfg!(target_os = "illumos") {
+        "unknown-illumos"
     } else {
         unimplemented!()
     };

--- a/www/index.html
+++ b/www/index.html
@@ -84,7 +84,7 @@
   <!-- unrecognized platform: ask for help -->
   <p>I don't recognize your platform.</p>
   <p>
-    rustup runs on Windows, Linux, macOS, FreeBSD and NetBSD. If
+    rustup runs on Windows, Linux, macOS, FreeBSD, NetBSD, and illumos. If
     you are on one of these platforms and are seeing this then please
     <a href="https://github.com/rust-lang/rustup/issues/new">report an issue</a>,
     along with the following values:


### PR DESCRIPTION
With the integration of rust-lang/rust#71272, illumos is now (as I understand it!) a Tier 2 platform (see also rust-lang/compiler-team#279, rust-lang/rustup-components-history#19, etc).  We have target and host binaries being built through CI/CD, which you can see at: https://rust-lang.github.io/rustup-components-history/x86_64-unknown-illumos.html

This change adds support illumos systems to `rustup`, and to the installation wrapper script that folks use via the instructions on the site (i.e., `curl | bash`).  I believe it also rigs us up to cross build through the CI system, but I wasn't completely sure if I got this part right so any pointers definitely welcome.

### Testing Notes

* I tried `cargo test` on my OpenIndiana (an illumos distribution) build system.  It ran a lot of tests; they passed, except for a handful that were ignored.
* I ran the release build of `rustup-init` directly, and it was able to install the latest nightly toolchain.
* I ran `rustup-init.sh` directly, and it was able to correctly determine that there were no `rustup-init` binaries available yet -- but at a URL which seemed to make sense!