### PR TITLE
Do not completely remove ~/.rustup/tmp and download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,10 +1559,11 @@ dependencies = [
 
 [[package]]
 name = "remove_dir_all"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b19f5c2df95a07275e7224924cc62f76f04525f4fda801473f85e325e81977"
+checksum = "882f368737489ea543bc5c340e6f3d34a28c39980bd9a979e47322b26f60ac40"
 dependencies = [
+ "libc",
  "log",
  "num_cpus",
  "rayon",
@@ -1727,7 +1728,7 @@ dependencies = [
  "pulldown-cmark",
  "rand 0.8.3",
  "regex",
- "remove_dir_all 0.6.1",
+ "remove_dir_all 0.7.0",
  "retry",
  "rs_tracing",
  "same-file",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ pgp = {version = "0.7", default-features = false}
 pulldown-cmark = {version = "0.8", default-features = false}
 rand = "0.8"
 regex = "1"
-remove_dir_all = "0.6.0"
+remove_dir_all = "0.7.0"
 same-file = "1"
 scopeguard = "1"
 semver = "0.11"

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -637,7 +637,7 @@ where
 }
 
 pub fn delete_dir_contents(dir_path: &Path) {
-    match remove_dir_all::remove_dir_all(dir_path) {
+    match remove_dir_all::remove_dir_contents(dir_path) {
         Err(e) if e.kind() != io::ErrorKind::NotFound => {
             panic!("Unable to clean up {}: {:?}", dir_path.display(), e);
         }


### PR DESCRIPTION
As discussed in #2430, it is better to keep the top-level directory.  It might be a mountpoint, or a symlink which the user wants to keep, or have unusual permissions.

<strike>I wasn't able to find an implementation of "remove contents of this directory but not the directory itself", so I have implemeted one. Maybe this should be in some other crate somewhere but it's not that huge so I just put it here.</strike>  I use the new `remove_dir_contents` in the `remove_dir_all` crate

This change changes the behaviour of `delete_dir_contents` to actually just remove the contents, like the name suggests.  There are two call sites: one to delete tmp and one to delete download.  This is correct behaviour for both.

Fixes: #2430

I have done ad-hoc testing for this, and rerun the main test suite.  If you want a formal fails-before-passes-after test, I could provide one.