### PR TITLE
Removes need for `local`, making script POSIX compliant.

### DIFF
--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -79,7 +79,7 @@ jobs:
             sh ./ci/raw_init.sh
       - name: Run shell checks
         run: |
-          shellcheck -s dash -- rustup-init.sh
+          shellcheck rustup-init.sh
           git ls-files -- '*.sh' | xargs shellcheck -s dash -e SC1090
           git ls-files -- '*.bash' | xargs shellcheck -s bash -e SC1090
       - name: Run formatting checks


### PR DESCRIPTION
Removes need for using the `local` keyword that is supported by
a number of shells. Instead, we can create a new sub shell when
calling a given function, which creates a new process without
any shared memory with the rest of the shell script, in the same way
calling any other command does. For example,

```
#!/bin/sh
set -eu
a=1
b=1

mutate_yes() {
	a=2
}

mutate_no() {
	(
		b=2
	)
}

mutate_yes
mutate_no

printf "%s\n" "$a" # prints 2
printf "%s\n" "$b" # prints 1
```
See
https://unix.stackexchange.com/questions/138463/do-parentheses-really-put-the-command-in-a-subshell
for more information.