### PR TITLE
Refactor self_update* to compile less OS-specific code

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -16,12 +16,14 @@
 
 use std::path::PathBuf;
 
+use cfg_if::cfg_if;
 use rs_tracing::*;
 
 use rustup::cli::common;
 use rustup::cli::errors::*;
 use rustup::cli::proxy_mode;
 use rustup::cli::rustup_mode;
+#[cfg(windows)]
 use rustup::cli::self_update;
 use rustup::cli::setup_mode;
 use rustup::currentprocess::{process, with, OSProcess};
@@ -83,7 +85,13 @@ fn run_rustup_inner() -> Result<utils::ExitCode> {
         Some(n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where
             // rustup deletes its own exe
-            self_update::complete_windows_uninstall()
+            cfg_if! {
+                if #[cfg(windows)] {
+                    self_update::complete_windows_uninstall()
+                } else {
+                    unreachable!("Attempted to use Windows-specific code on a non-Windows platform. Aborting.")
+                }
+            }
         }
         Some(_) => proxy_mode::main(),
         None => {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -124,7 +124,7 @@ these changes will be reverted.
     };
 }
 
-#[cfg(unix)]
+#[cfg(not(windows))]
 macro_rules! pre_install_msg_unix {
     () => {
         pre_install_msg_template!(
@@ -155,6 +155,7 @@ but will not be added automatically."
     };
 }
 
+#[cfg(not(windows))]
 macro_rules! post_install_msg_unix {
     () => {
         r"# Rust is installed now. Great!
@@ -168,6 +169,7 @@ To configure your current shell run `source {cargo_home}/env`
     };
 }
 
+#[cfg(windows)]
 macro_rules! post_install_msg_win {
     () => {
         r"# Rust is installed now. Great!
@@ -179,6 +181,7 @@ correct environment, but you may need to restart your current shell.
     };
 }
 
+#[cfg(not(windows))]
 macro_rules! post_install_msg_unix_no_modify_path {
     () => {
         r"# Rust is installed now. Great!
@@ -191,6 +194,7 @@ To configure your current shell run `source {cargo_home}/env`
     };
 }
 
+#[cfg(windows)]
 macro_rules! post_install_msg_win_no_modify_path {
     () => {
         r"# Rust is installed now. Great!
@@ -366,17 +370,23 @@ pub fn install(
     let cargo_home = canonical_cargo_home()?;
     #[cfg(windows)]
     let cargo_home = cargo_home.replace('\\', r"\\");
-    let msg = match (opts.no_modify_path, cfg!(unix)) {
-        (false, true) => format!(post_install_msg_unix!(), cargo_home = cargo_home),
-        (false, false) => format!(post_install_msg_win!(), cargo_home = cargo_home),
-        (true, true) => format!(
-            post_install_msg_unix_no_modify_path!(),
-            cargo_home = cargo_home
-        ),
-        (true, false) => format!(
+    #[cfg(windows)]
+    let msg = if opts.no_modify_path {
+        format!(
             post_install_msg_win_no_modify_path!(),
             cargo_home = cargo_home
-        ),
+        )
+    } else {
+        format!(post_install_msg_win!(), cargo_home = cargo_home)
+    };
+    #[cfg(not(windows))]
+    let msg = if opts.no_modify_path {
+        format!(
+            post_install_msg_unix_no_modify_path!(),
+            cargo_home = cargo_home
+        )
+    } else {
+        format!(post_install_msg_unix!(), cargo_home = cargo_home)
     };
     md(&mut term, msg);
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -986,19 +986,16 @@ pub fn prepare_update() -> Result<Option<PathBuf>> {
     }
 
     // Get build triple
-    let build_triple = dist::TargetTriple::from_build();
-    let triple = if cfg!(windows) {
-        // For windows x86 builds seem slow when used with windows defender.
-        // The website defaulted to i686-windows-gnu builds for a long time.
-        // This ensures that we update to a version thats appropriate for users
-        // and also works around if the website messed up the detection.
-        // If someone really wants to use another version, he still can enforce
-        // that using the environment variable RUSTUP_OVERRIDE_HOST_TRIPLE.
+    let triple = dist::TargetTriple::from_build();
 
-        dist::TargetTriple::from_host().unwrap_or(build_triple)
-    } else {
-        build_triple
-    };
+    // For windows x86 builds seem slow when used with windows defender.
+    // The website defaulted to i686-windows-gnu builds for a long time.
+    // This ensures that we update to a version thats appropriate for users
+    // and also works around if the website messed up the detection.
+    // If someone really wants to use another version, they still can enforce
+    // that using the environment variable RUSTUP_OVERRIDE_HOST_TRIPLE.
+    #[cfg(windows)]
+    let triple = dist::TargetTriple::from_host().unwrap_or(triple);
 
     let update_root = process()
         .var("RUSTUP_UPDATE_ROOT")

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -66,7 +66,9 @@ use crate::utils::Notification;
 use crate::{Cfg, UpdateStatus};
 use crate::{DUP_TOOLS, TOOLS};
 use os::*;
-pub use os::{complete_windows_uninstall, delete_rustup_and_cargo_home, run_update, self_replace};
+pub use os::{delete_rustup_and_cargo_home, run_update, self_replace};
+#[cfg(windows)]
+pub use windows::complete_windows_uninstall;
 
 pub struct InstallOpts<'a> {
     pub default_host_triple: Option<String>,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -51,6 +51,7 @@ use std::fs;
 use std::path::{Component, Path, PathBuf, MAIN_SEPARATOR};
 use std::process::Command;
 
+use cfg_if::cfg_if;
 use same_file::Handle;
 
 use super::common::{self, ignorable_error, Confirm};
@@ -250,10 +251,12 @@ fn canonical_cargo_home() -> Result<Cow<'static, str>> {
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".cargo");
     Ok(if default_cargo_home == path {
-        if cfg!(unix) {
-            "$HOME/.cargo".into()
-        } else {
-            r"%USERPROFILE%\.cargo".into()
+        cfg_if! {
+            if #[cfg(windows)] {
+                r"%USERPROFILE%\.cargo".into()
+            } else {
+                "$HOME/.cargo".into()
+            }
         }
     } else {
         path.to_string_lossy().into_owned().into()

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -352,10 +352,9 @@ pub fn install(
         // that may have opened just for this purpose, give
         // the user an opportunity to see the error before the
         // window closes.
-        if cfg!(windows) && !no_prompt {
-            writeln!(process().stdout(),)?;
-            writeln!(process().stdout(), "Press the Enter key to continue.")?;
-            common::read_line()?;
+        #[cfg(windows)]
+        if !no_prompt {
+            ensure_prompt()?;
         }
 
         return Ok(utils::ExitCode(1));
@@ -378,15 +377,12 @@ pub fn install(
     };
     md(&mut term, msg);
 
+    #[cfg(windows)]
     if !no_prompt {
         // On windows, where installation happens in a console
         // that may have opened just for this purpose, require
         // the user to press a key to continue.
-        if cfg!(windows) {
-            writeln!(process().stdout())?;
-            writeln!(process().stdout(), "Press the Enter key to continue.")?;
-            common::read_line()?;
-        }
+        ensure_prompt()?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -211,6 +211,7 @@ This will uninstall all Rust toolchains and data, and remove
     };
 }
 
+#[cfg(windows)]
 static MSVC_MESSAGE: &str = r#"# Rust Visual C++ prerequisites
 
 Rust requires the Microsoft C++ build tools for Visual Studio 2013 or
@@ -288,6 +289,8 @@ pub fn install(
     do_anti_sudo_check(no_prompt)?;
 
     let mut term = term2::stdout();
+
+    #[cfg(windows)]
     if !do_msvc_check(&opts)? {
         if no_prompt {
             warn!("installing msvc toolchain without its prerequisites");
@@ -501,11 +504,6 @@ fn do_pre_install_options_sanity_checks(opts: &InstallOpts<'_>) -> Result<()> {
         )
     })?;
     Ok(())
-}
-
-#[cfg(not(windows))]
-fn do_msvc_check(_opts: &InstallOpts<'_>) -> Result<bool> {
-    Ok(true)
 }
 
 fn pre_install_msg(no_modify_path: bool) -> Result<String> {

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -53,10 +53,6 @@ pub fn delete_rustup_and_cargo_home() -> Result<()> {
     Ok(())
 }
 
-pub fn complete_windows_uninstall() -> Result<utils::ExitCode> {
-    panic!("stop doing that")
-}
-
 pub fn do_remove_from_path() -> Result<()> {
     for sh in shell::get_available_shells() {
         let source_bytes = format!("{}\n", sh.source_string()?).into_bytes();

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -3,11 +3,19 @@ use std::path::Path;
 use std::process::Command;
 
 use super::super::errors::*;
+use super::common;
 use super::{install_bins, InstallOpts};
 use crate::dist::dist::TargetTriple;
 use crate::process;
 use crate::utils::utils;
 use crate::utils::Notification;
+
+pub fn ensure_prompt() -> Result<()> {
+    writeln!(process().stdout(),)?;
+    writeln!(process().stdout(), "Press the Enter key to continue.")?;
+    common::read_line()?;
+    Ok(())
+}
 
 // Provide guidance about setting up MSVC if it doesn't appear to be
 // installed


### PR DESCRIPTION
All of this, even removing the complete_windows_uninstall function from self_update/unix.rs is effectively just rearranging things (a function that does nothing but panic was replaced with an inlined cfg_if! panic). So there are no functional changes, it should remove object code from some compilations but not alter the logic of the program. As mentioned in #2424, the main purpose of this is to minimize events where changing OS-dependent code for one OS affects another OS.

This is a followup on but is not the end of #2453 currently because there is a lot of code that is still logically dependent on OS that has no particular reason to be in self_update.rs over self_update/{windows,unix}.rs. In a few cases it makes sense to have such code present, but in a lot of cases it doesn't. A total review of such code is beyond the scope of this PR.