### PR TITLE
Lower-case unpack ram log message

### DIFF
--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -87,7 +87,7 @@ impl<'a> Display for Notification<'a> {
             ),
             SetDefaultBufferSize(size) => write!(
                 f,
-                "Defaulting to {} unpack ram",
+                "defaulting to {} unpack ram",
                 units::Size::new(*size, units::Unit::B, units::UnitMode::Norm)
             ),
             DownloadingFile(url, _) => write!(f, "downloading file from: '{}'", url),

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -34,7 +34,7 @@ info: downloading component 'rust-docs'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -169,7 +169,7 @@ info: downloading component 'rust-docs'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -502,7 +502,7 @@ fn cross_install_indicates_target() {
             &format!(
                 r"info: downloading component 'rust-std' for '{0}'
 info: installing component 'rust-std' for '{0}'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 ",
                 clitools::CROSS_ARCH1
             ),

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -54,7 +54,7 @@ info: removing previous version of component 'rust-docs'
 info: removing previous version of component 'rust-std'
 info: removing previous version of component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -95,7 +95,7 @@ info: removing previous version of component 'rust-docs'
 info: removing previous version of component 'rust-std'
 info: removing previous version of component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -160,7 +160,7 @@ info: removing previous version of component 'rust-docs'
 info: removing previous version of component 'rust-std'
 info: removing previous version of component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -231,7 +231,7 @@ info: removing previous version of component 'rust-docs'
 info: removing previous version of component 'rust-std'
 info: removing previous version of component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
@@ -293,7 +293,7 @@ info: downloading component 'rust-docs'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -112,7 +112,7 @@ info: downloading component 'rust-docs'
 info: downloading component 'rust-std'
 info: downloading component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1409,7 +1409,7 @@ info: downloading component 'cargo'
 info: downloading component 'rust-docs'
 info: downloading component 'rustc'
 info: installing component 'cargo'
-info: Defaulting to 500.0 MiB unpack ram
+info: defaulting to 500.0 MiB unpack ram
 info: installing component 'rust-docs'
 info: installing component 'rustc'
 "


### PR DESCRIPTION
All other log messages start with a lower-case word, so adapt the unpac ram message accordingly,