### PR TITLE
Quick addition to `--version` to mention rustc

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -75,12 +75,10 @@ pub fn main() -> Result<utils::ExitCode> {
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
 
             fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
-                let cmd = Command::new("rustc").arg("--version").output()?;
-                if cmd.status.success() {
-                    Ok(String::from_utf8_lossy(&cmd.stdout).trim().into())
-                } else {
-                    Err(String::from_utf8_lossy(&cmd.stderr).into())
-                }
+                let cfg = &mut common::set_globals(false, true)?;
+                let cwd = std::env::current_dir()?;
+                let toolchain = cfg.find_or_install_override_toolchain_or_default(&cwd)?.0;
+                Ok(toolchain.rustc_version())
             }
 
             match rustc_version() {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -55,17 +55,46 @@ where
 pub fn main() -> Result<utils::ExitCode> {
     self_update::cleanup_self_updater()?;
 
+    use clap::ErrorKind::*;
     let matches = match cli().get_matches_from_safe(process().args_os()) {
         Ok(matches) => Ok(matches),
-        Err(e)
-            if e.kind == clap::ErrorKind::HelpDisplayed
-                || e.kind == clap::ErrorKind::VersionDisplayed =>
-        {
-            writeln!(process().stdout().lock(), "{}", e.message)?;
+        Err(clap::Error {
+            kind: HelpDisplayed,
+            message,
+            ..
+        }) => {
+            writeln!(process().stdout().lock(), "{}", message)?;
             return Ok(utils::ExitCode(0));
         }
-        Err(e) if e.kind == clap::ErrorKind::MissingArgumentOrSubcommand => {
-            writeln!(process().stdout().lock(), "{}", e.message)?;
+        Err(clap::Error {
+            kind: VersionDisplayed,
+            message,
+            ..
+        }) => {
+            writeln!(process().stdout().lock(), "{}", message)?;
+            info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
+
+            fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
+                let cmd = Command::new("rustc").arg("--version").output()?;
+                if cmd.status.success() {
+                    Ok(String::from_utf8_lossy(&cmd.stdout).trim().into())
+                } else {
+                    Err(String::from_utf8_lossy(&cmd.stderr).into())
+                }
+            }
+
+            match rustc_version() {
+                Ok(version) => info!("The currently active `rustc` version is `{}`", version),
+                Err(err) => debug!("Wanted to tell you the current rustc version, too, but ran into this error: {}", err),
+            }
+            return Ok(utils::ExitCode(0));
+        }
+        Err(clap::Error {
+            kind: MissingArgumentOrSubcommand,
+            message,
+            ..
+        }) => {
+            writeln!(process().stdout().lock(), "{}", message)?;
             return Ok(utils::ExitCode(1));
         }
         Err(e) => Err(e),

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -77,7 +77,14 @@ pub fn main() -> Result<utils::ExitCode> {
             fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
                 let cfg = &mut common::set_globals(false, true)?;
                 let cwd = std::env::current_dir()?;
+
+                if let Some(t) = process().args().find(|x| x.starts_with('+')) {
+                    debug!("Fetching rustc version from toolchain `{}`", t);
+                    cfg.set_toolchain_override(&t[1..]);
+                }
+
                 let toolchain = cfg.find_or_install_override_toolchain_or_default(&cwd)?.0;
+
                 Ok(toolchain.rustc_version())
             }
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -28,6 +28,23 @@ fn smoke_test() {
 }
 
 #[test]
+fn version_mentions_rustc_version_confusion() {
+    setup(&|config| {
+        let out = run(config, "rustup", &vec!["--version"], &[]);
+        assert!(out.ok);
+        assert!(out
+            .stderr
+            .contains("This is the version for the rustup toolchain manager"));
+
+        let out = run(config, "rustup", &vec!["+nightly", "--version"], &[]);
+        assert!(out.ok);
+        assert!(out
+            .stderr
+            .contains("The currently active `rustc` version is `1.3.0"));
+    });
+}
+
+#[test]
 fn no_colors_in_piped_error_output() {
     setup(&|config| {
         let args: Vec<&str> = vec![];


### PR DESCRIPTION
As discussed in #2447, rustup versions are getting closer to rustc
versions (because the rustup maintainers are working too much I'm sure).
This leads to confusion when running `rustup --version` while intending
to run `rustc --version`.

The change introduced here will print two additional (stderr) lines
after rustup's default `--version` output. The first mentions this
issue, and the second will print the output of `rustc --version` as a
hint (by trivially calling out to `rustc`, whatever binary that may be).