### PR TITLE
Add socks5 support for reqwest-backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9021768bcce77296b64648cc7a7460e3df99979b97ed5c925c38d1cc83778d98"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "flate2",
  "futures-core",
  "memchr",
@@ -221,6 +221,16 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
 
 [[package]]
 name = "bytes"
@@ -684,12 +694,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -699,10 +725,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -725,12 +774,17 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project",
  "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
  "slab",
 ]
 
@@ -798,7 +852,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -849,7 +903,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -860,7 +914,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -876,7 +930,7 @@ version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e68a8dd9716185d9e64ea473ea6ef63529252e3e27623295a0378a19665d5eb"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -900,7 +954,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d979acc56dcb5b8dddba3917601745e877576475aa046df3226eabdecef78eed"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "hyper",
  "native-tls",
  "tokio",
@@ -1434,6 +1488,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,7 +1647,7 @@ checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
 dependencies = [
  "async-compression",
  "base64",
- "bytes",
+ "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1601,6 +1667,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "tokio",
+ "tokio-socks",
  "tokio-tls",
  "url",
  "wasm-bindgen",
@@ -2089,7 +2156,7 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
@@ -2099,6 +2166,19 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1997788a0e25e09300e44680ba1ef9d44d6f634a883641f80109e8b59c928daf"
+dependencies = [
+ "bytes 0.4.12",
+ "either",
+ "futures",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -2117,7 +2197,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -20,7 +20,7 @@ url = "2.1"
 curl = { version = "0.4.11", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 lazy_static = { version = "1.0", optional = true }
-reqwest = { version = "0.10", features = ["blocking", "gzip"], optional = true }
+reqwest = { version = "0.10", features = ["blocking", "gzip", "socks"], optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -1,8 +1,14 @@
 #![cfg(feature = "reqwest-backend")]
 
 use std::env::{remove_var, set_var};
+use std::error::Error;
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use std::time::Duration;
 
 use env_proxy::for_url;
+use reqwest::{blocking::Client, Proxy};
 use url::Url;
 
 fn scrub_env() {
@@ -27,4 +33,39 @@ fn read_basic_proxy_params() {
         for_url(&u).host_port(),
         Some(("proxy.example.com".to_string(), 8080))
     );
+}
+
+// Tests to verify if socks feature is available and being used
+#[test]
+fn socks_proxy_request() {
+    static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    scrub_env();
+    set_var("all_proxy", "socks5://127.0.0.1:1080");
+
+    thread::spawn(move || {
+        let listener = TcpListener::bind("127.0.0.1:1080").unwrap();
+        let incoming = listener.incoming();
+        for _ in incoming {
+            CALL_COUNT.fetch_add(1, Ordering::SeqCst);
+        }
+    });
+
+    let env_proxy = |url: &Url| for_url(&url).to_url();
+    let url = Url::parse("http://example.org").unwrap();
+
+    let client = Client::builder()
+        .proxy(Proxy::custom(env_proxy))
+        .timeout(Duration::from_secs(1))
+        .build()
+        .unwrap();
+    let res = client.get(url.as_str()).send();
+
+    if let Err(e) = res {
+        let s = e.source().unwrap();
+        assert_eq!(CALL_COUNT.load(Ordering::SeqCst), 1);
+        assert!(s.to_string().contains("socks connect error"));
+    } else {
+        panic!("Socks proxy was ignored")
+    }
 }

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -4,12 +4,18 @@ use std::env::{remove_var, set_var};
 use std::error::Error;
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
 use std::thread;
 use std::time::Duration;
 
 use env_proxy::for_url;
+use lazy_static::lazy_static;
 use reqwest::{blocking::Client, Proxy};
 use url::Url;
+
+lazy_static! {
+    static ref SERIALISE_TESTS: Mutex<()> = Mutex::new(());
+}
 
 fn scrub_env() {
     remove_var("http_proxy");
@@ -26,6 +32,9 @@ fn scrub_env() {
 // Tests for correctly retrieving the proxy (host, port) tuple from $https_proxy
 #[test]
 fn read_basic_proxy_params() {
+    let _guard = SERIALISE_TESTS
+        .lock()
+        .expect("Unable to lock the test guard");
     scrub_env();
     set_var("https_proxy", "http://proxy.example.com:8080");
     let u = Url::parse("https://www.example.org").ok().unwrap();
@@ -39,6 +48,9 @@ fn read_basic_proxy_params() {
 #[test]
 fn socks_proxy_request() {
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+    let _guard = SERIALISE_TESTS
+        .lock()
+        .expect("Unable to lock the test guard");
 
     scrub_env();
     set_var("all_proxy", "socks5://127.0.0.1:1080");


### PR DESCRIPTION
As discussed in #2409, rustup doesn't use socks5 proxy with reqwest backend. It turned out, that enabling socks feature in Cargo.toml is enough to make it work as intended.

There was no updates from the last person worked on this issue for almost a month, so I decided to pick it up.