### PR TITLE
Deploy docs on stable only.

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -3,7 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - master
+      - stable
 
 jobs:
   doc:


### PR DESCRIPTION
This changes it so that docs are only updated during a stable release. This ensures users don't see unreleased changes, which can be confusing.
