### PR TITLE
Re-add unreleased documentation.

### DIFF
--- a/doc/src/environment-variables.md
+++ b/doc/src/environment-variables.md
@@ -34,5 +34,12 @@
 - `RUSTUP_NO_BACKTRACE` Disables backtraces on non-panic errors even when
   `RUST_BACKTRACE` is set.
 
+- `RUSTUP_PERMIT_COPY_RENAME` *unstable* When set, allows rustup to fall-back
+  to copying files if attempts to `rename` result in an cross-device link
+  errors. These errors occur on OverlayFS, which is used by [Docker][dc]. This
+  feature sacrifices some transactions protections and may be removed at any
+  point. Linux only.
+
+[dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md
 [tracing viewer]: https://github.com/catapult-project/catapult/blob/master/tracing/README.md

--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -74,10 +74,22 @@ case for nightly-only software that pins to a revision from the release
 archives.
 
 In these cases the toolchain can be named in the project's directory in a file
-called `rust-toolchain`, the content of which is the name of a single `rustup`
-toolchain, and which is suitable to check in to source control. This file has
-to be encoded in US-ASCII (if you are on Windows, check the encoding and that
-it does not starts with a BOM).
+called `rust-toolchain`, the content of which is either the name of a single
+`rustup` toolchain, or a TOML file with the following layout:
+
+``` toml
+[toolchain]
+channel = "nightly-2020-07-10"
+components = [ "rustfmt", "rustc-dev" ]
+targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
+```
+
+If the TOML format is used, the `[toolchain]` section is mandatory, and at
+least one property must be specified.
+
+The `rust-toolchain` file is suitable to check in to source control. This file
+has to be encoded in US-ASCII (if you are on Windows, check the encoding and
+that it does not starts with a BOM).
 
 The toolchains named in this file have a more restricted form than `rustup`
 toolchains generally, and may only contain the names of the three release


### PR DESCRIPTION
Reverts #2477 now that #2478 has been merged.
