### PR TITLE
Give a better error message when a component isn't installed for a custom toolchain

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,10 @@
 #![allow(clippy::large_enum_variant)]
 #![allow(deprecated)] // because of `Error::description` deprecation in `error_chain`
 
-use crate::component_for_bin;
 use crate::dist::dist::Profile;
 use crate::dist::manifest::{Component, Manifest};
 use crate::dist::temp;
+use crate::{component_for_bin, Toolchain};
 use error_chain::error_chain;
 use std::ffi::OsString;
 use std::io::{self, Write};
@@ -444,6 +444,10 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
 }
 
 fn install_msg(bin: &str, toolchain: &str, is_default: bool) -> String {
+    if Toolchain::is_custom_name(toolchain) {
+        return "\nnote: this is a custom toolchain, which cannot use `rustup component add`\n\
+        help: if you built this toolchain from source, and used `rustup component link`, then you may be able to build the component with `x.py`".to_string();
+    }
     match component_for_bin(bin) {
         Some(c) => format!("\nTo install, run `rustup component add {}{}`", c, {
             if is_default {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -150,8 +150,13 @@ impl<'a> Toolchain<'a> {
 
     // Custom only
     pub fn is_custom(&self) -> bool {
-        ToolchainDesc::from_str(&self.name).is_err()
+        Toolchain::is_custom_name(&self.name)
     }
+
+    pub(crate) fn is_custom_name(name: &str) -> bool {
+        ToolchainDesc::from_str(name).is_err()
+    }
+
     // Distributable only
     pub fn is_tracking(&self) -> bool {
         ToolchainDesc::from_str(&self.name)

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -370,14 +370,10 @@ fn rustup_failed_path_search_toolchain() {
         expect_ok(config, &["rustup", "default", "custom-2"]);
 
         let broken = &["rustup", "run", "custom-1", "cargo-miri"];
-        expect_err(
-            config,
-            broken,
-            "rustup component add miri --toolchain custom-1",
-        );
+        expect_err(config, broken, "cannot use `rustup component add`");
 
         let broken = &["rustup", "run", "custom-2", "cargo-miri"];
-        expect_err(config, broken, "rustup component add miri");
+        expect_err(config, broken, "cannot use `rustup component add`");
 
         // Hardlink will be automatically cleaned up by test setup code
     });


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustup/issues/2470.

I did the thing you told me not to do which is mention x.py :P let me know if I should remove it.

I'm not sure how to run a custom rustup without installing it on top of my existing install ... `cargo run ` gives me
```
warning: it looks like you have an existing installation of Rust at:
warning: /home/joshua/.local/lib/cargo/bin
warning: rustup should not be installed alongside Rust. Please uninstall your existing Rust first.
warning: Otherwise you may have confusion unless you are careful with your PATH
warning: If you are sure that you want both rustup and your already installed Rust
warning: then please reply `y' or `yes' or set RUSTUP_INIT_SKIP_PATH_CHECK to yes
warning: or pass `-y' to ignore all ignorable checks.
error: cannot install while Rust is installed
```

Is there a way to test this by hand or do you only have unit tests? I want to see what the output looks like.