### PR TITLE
Add aarch64-unknown-linux-musl support

### DIFF
--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -20,6 +20,7 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
+          - aarch64-unknown-linux-musl    # skip-pr skip-master
           - powerpc64-unknown-linux-gnu   # skip-pr
           - x86_64-unknown-linux-musl     # skip-pr
           - i686-unknown-linux-gnu        # skip-pr skip-master

--- a/ci/actions-templates/README.md
+++ b/ci/actions-templates/README.md
@@ -38,6 +38,7 @@ system.
 | armv7-unknown-linux-gnueabihf | Yes        | Two   | Yes    | Yes        |
 | aarch64-linux-android         | Yes        | Two   | Yes    | Yes        |
 | aarch64-unknown-linux-gnu     | Yes        | Two   | No     | Yes        |
+| aarch64-unknown-linux-musl    | Yes        | Two   | No     | Yes        |
 | powerpc64-unknown-linux-gnu   | Yes        | Two   | No     | Yes        |
 | x86_64-unknown-linux-musl     | Yes        | Two   | No     | Yes        |
 | i686-unknown-linux-gnu        | Yes        | One   | No     | No         |

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -28,6 +28,7 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
+          - aarch64-unknown-linux-musl
           - powerpc64-unknown-linux-gnu   # skip-pr
           - x86_64-unknown-linux-musl     # skip-pr
           - i686-unknown-linux-gnu        # skip-pr skip-master

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -28,7 +28,7 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
-          - aarch64-unknown-linux-musl
+          - aarch64-unknown-linux-musl    # skip-pr skip-master
           - powerpc64-unknown-linux-gnu   # skip-pr
           - x86_64-unknown-linux-musl     # skip-pr
           - i686-unknown-linux-gnu        # skip-pr skip-master

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -5,6 +5,8 @@ rustup/dist/aarch64-linux-android/rustup-init
 rustup/dist/aarch64-linux-android/rustup-init.sha256
 rustup/dist/aarch64-unknown-linux-gnu/rustup-init
 rustup/dist/aarch64-unknown-linux-gnu/rustup-init.sha256
+rustup/dist/aarch64-unknown-linux-musl/rustup-init
+rustup/dist/aarch64-unknown-linux-musl/rustup-init.sha256
 rustup/dist/arm-linux-androideabi/rustup-init
 rustup/dist/arm-linux-androideabi/rustup-init.sha256
 rustup/dist/arm-unknown-linux-gnueabi/rustup-init

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,0 +1,5 @@
+FROM rust-aarch64-unknown-linux-musl
+
+ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
+    RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-lgcc"

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -16,6 +16,7 @@ LOCAL_DOCKER_TAG="rust-$TARGET"
 # Use images from rustc master
 case "$TARGET" in
   aarch64-unknown-linux-gnu)       image=dist-aarch64-linux ;;
+  aarch64-unknown-linux-musl)      image=dist-arm-linux ;;
   arm-unknown-linux-gnueabi)       image=dist-arm-linux ;;
   arm-unknown-linux-gnueabihf)     image=dist-armhf-linux ;;
   armv7-unknown-linux-gnueabihf)   image=dist-armv7-linux ;;

--- a/doc/src/installation/other.md
+++ b/doc/src/installation/other.md
@@ -34,6 +34,7 @@ choice:
 
 - [aarch64-linux-android](https://static.rust-lang.org/rustup/dist/aarch64-linux-android/rustup-init)
 - [aarch64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init)
+- [aarch64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-musl/rustup-init)
 - [arm-linux-androideabi](https://static.rust-lang.org/rustup/dist/arm-linux-androideabi/rustup-init)
 - [arm-unknown-linux-gnueabi](https://static.rust-lang.org/rustup/dist/arm-unknown-linux-gnueabi/rustup-init)
 - [arm-unknown-linux-gnueabihf](https://static.rust-lang.org/rustup/dist/arm-unknown-linux-gnueabihf/rustup-init)

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -121,6 +121,10 @@ static LIST_ENVS: &[&str] = &[
 const TRIPLE_X86_64_UNKNOWN_LINUX: &str = "x86_64-unknown-linux-gnu";
 #[cfg(all(not(windows), target_env = "musl"))]
 const TRIPLE_X86_64_UNKNOWN_LINUX: &str = "x86_64-unknown-linux-musl";
+#[cfg(all(not(windows), not(target_env = "musl")))]
+const TRIPLE_AARCH64_UNKNOWN_LINUX: &str = "aarch64-unknown-linux-gnu";
+#[cfg(all(not(windows), target_env = "musl"))]
+const TRIPLE_AARCH64_UNKNOWN_LINUX: &str = "aarch64-unknown-linux-musl";
 
 // MIPS platforms don't indicate endianness in uname, however binaries only
 // run on boxes with the same endianness, as expected.
@@ -245,7 +249,7 @@ impl TargetTriple {
                 (b"Linux", b"arm") => Some("arm-unknown-linux-gnueabi"),
                 (b"Linux", b"armv7l") => Some("armv7-unknown-linux-gnueabihf"),
                 (b"Linux", b"armv8l") => Some("armv7-unknown-linux-gnueabihf"),
-                (b"Linux", b"aarch64") => Some("aarch64-unknown-linux-gnu"),
+                (b"Linux", b"aarch64") => Some(TRIPLE_AARCH64_UNKNOWN_LINUX),
                 (b"Darwin", b"x86_64") => Some("x86_64-apple-darwin"),
                 (b"Darwin", b"i686") => Some("i686-apple-darwin"),
                 (b"FreeBSD", b"x86_64") => Some("x86_64-unknown-freebsd"),
@@ -373,10 +377,10 @@ impl PartialToolchainDesc {
         let env = if self.target.os.is_some() {
             self.target.env
         } else {
-            self.target.env.or_else(|| host_env)
+            self.target.env.or(host_env)
         };
-        let arch = self.target.arch.unwrap_or_else(|| host_arch);
-        let os = self.target.os.unwrap_or_else(|| host_os);
+        let arch = self.target.arch.unwrap_or(host_arch);
+        let os = self.target.os.unwrap_or(host_os);
 
         let trip = if let Some(env) = env {
             format!("{}-{}-{}", arch, os, env)


### PR DESCRIPTION
See #2003 

I have no clue what to do with the .github/workflows files as they state not to edit them. Same applies to tests/channel-rust-nightly-example2.toml which seems autogenerated.

This is mainly the result of a grep for `aarch64-unknown-linux-gnu` and appropiate changes