### PR TITLE
Fix double error label for certain error types

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -94,15 +94,22 @@ pub fn main() -> Result<utils::ExitCode> {
             }
             return Ok(utils::ExitCode(0));
         }
-        Err(clap::Error {
-            kind: MissingArgumentOrSubcommand,
-            message,
-            ..
-        }) => {
-            writeln!(process().stdout().lock(), "{}", message)?;
-            return Ok(utils::ExitCode(1));
-        }
-        Err(e) => Err(e),
+
+        Err(e) => match &e {
+            clap::Error { kind, message, .. } => {
+                if [
+                    InvalidSubcommand,
+                    UnknownArgument,
+                    MissingArgumentOrSubcommand,
+                ]
+                .contains(kind)
+                {
+                    writeln!(process().stdout().lock(), "{}", message)?;
+                    return Ok(utils::ExitCode(1));
+                }
+                Err(e)
+            }
+        },
     }?;
     let verbose = matches.is_present("verbose");
     let quiet = matches.is_present("quiet");


### PR DESCRIPTION
Fix for issue #2492 Second error message came from `src/bin/rustup-init.rs:37` in case if error was not matched in `src/cli/rustup_mode.rs:main`. I expanded match conditions for required error types here. 