### PR TITLE
Typo fix: "the a" -> "the"

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -4,7 +4,7 @@
 //! release of Rust. They are toml files, typically downloaded from
 //! e.g. static.rust-lang.org/dist/channel-rust-nightly.toml. They
 //! describe where to download, for all platforms, each component of
-//! the a release, and their relationships to each other.
+//! the release, and their relationships to each other.
 //!
 //! Installers use this info to customize Rust installations.
 //!


### PR DESCRIPTION
I think "the release" is preferable to "a release" in this context but I'm no grammarian. :)