### PR TITLE
Add link to channel layout docs.

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -9,6 +9,8 @@
 //! Installers use this info to customize Rust installations.
 //!
 //! See tests/channel-rust-nightly-example.toml for an example.
+//!
+//! Docs: https://forge.rust-lang.org/infra/channel-layout.html
 
 use crate::errors::*;
 use crate::utils::toml_utils::*;


### PR DESCRIPTION
There's a significant amount of information about the channel manifests in the documentation but the source doesn't currently link to it.

The additional documentation would have been useful while I was working out how to manually add a target to a standalone Rust install. (See also: https://github.com/rust-lang/rust/issues/77503.)

_Note: This two line documentation patch is **not** related to the Hacktober event._ 