### PR TITLE
Update deprecated GitHub Actions commands.

### DIFF
--- a/.github/workflows/centos-fmt-clippy-on-all.yaml
+++ b/.github/workflows/centos-fmt-clippy-on-all.yaml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -15,7 +15,7 @@ jobs:
         run: |
           mkdir mdbook
           curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.1/mdbook-v0.4.1-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo ::add-path::`pwd`/mdbook
+          echo "`pwd`/mdbook" >> $GITHUB_PATH
       - name: Build book
         run: cd doc && mdbook build
       - name: Deploy to GitHub

--- a/.github/workflows/linux-builds-on-master.yaml
+++ b/.github/workflows/linux-builds-on-master.yaml
@@ -49,11 +49,11 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
       - name: Skip tests
         run: |
-          echo "::set-env name=SKIP_TESTS::yes"
+          echo "SKIP_TESTS=yes" >> $GITHUB_ENV
         if: matrix.run_tests == ''
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
@@ -91,7 +91,7 @@ jobs:
             *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
             *)                DOCKER="$TARGET" ;;
           esac
-          echo "::set-env name=DOCKER::$DOCKER"
+          echo "DOCKER=$DOCKER" >> $GITHUB_ENV
       - name: Fetch the docker
         run: bash ci/fetch-rust-docker.bash "${TARGET}"
       - name: Maybe build a docker from there

--- a/.github/workflows/linux-builds-on-pr.yaml
+++ b/.github/workflows/linux-builds-on-pr.yaml
@@ -42,11 +42,11 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
       - name: Skip tests
         run: |
-          echo "::set-env name=SKIP_TESTS::yes"
+          echo "SKIP_TESTS=yes" >> $GITHUB_ENV
         if: matrix.run_tests == ''
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
@@ -84,7 +84,7 @@ jobs:
             *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
             *)                DOCKER="$TARGET" ;;
           esac
-          echo "::set-env name=DOCKER::$DOCKER"
+          echo "DOCKER=$DOCKER" >> $GITHUB_ENV
       - name: Fetch the docker
         run: bash ci/fetch-rust-docker.bash "${TARGET}"
       - name: Maybe build a docker from there

--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -71,11 +71,11 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
       - name: Skip tests
         run: |
-          echo "::set-env name=SKIP_TESTS::yes"
+          echo "SKIP_TESTS=yes" >> $GITHUB_ENV
         if: matrix.run_tests == ''
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
@@ -113,7 +113,7 @@ jobs:
             *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
             *)                DOCKER="$TARGET" ;;
           esac
-          echo "::set-env name=DOCKER::$DOCKER"
+          echo "DOCKER=$DOCKER" >> $GITHUB_ENV
       - name: Fetch the docker
         run: bash ci/fetch-rust-docker.bash "${TARGET}"
       - name: Maybe build a docker from there

--- a/.github/workflows/macos-builds-on-all.yaml
+++ b/.github/workflows/macos-builds-on-all.yaml
@@ -38,9 +38,9 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+          echo "SKIP_TESTS=" >> $GITHUB_ENV
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/macos-builds-on-all.yaml
+++ b/.github/workflows/macos-builds-on-all.yaml
@@ -57,8 +57,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ github.base_ref }}-${{ github.head_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.base_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ github.base_ref }}-${{ github.head_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}-3
+          restore-keys: ${{ github.base_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}-3
       - name: Install Rustup using ./rustup-init.sh
         run: |
           sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
@@ -92,3 +92,9 @@ jobs:
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache
+      - name: Flush cache
+        # This is a workaround for a bug with GitHub Actions Cache that causes
+        # corrupt cache entries (particularly in the target directory). See
+        # https://github.com/actions/cache/issues/403 and
+        # https://github.com/rust-lang/cargo/issues/8603.
+        run: sudo /usr/sbin/purge

--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -54,15 +54,15 @@ jobs:
           Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
           7z x -y mingw.7z -oC:\msys64 | Out-Null
           del mingw.7z
-          echo ::add-path::C:\msys64\usr\bin
-          echo ::add-path::C:\msys64\${{ matrix.mingwdir }}\bin
+          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         shell: powershell
         if: matrix.mingw != ''
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::%USERPROFILE%\.cargo\bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -51,15 +51,15 @@ jobs:
           Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
           7z x -y mingw.7z -oC:\msys64 | Out-Null
           del mingw.7z
-          echo ::add-path::C:\msys64\usr\bin
-          echo ::add-path::C:\msys64\${{ matrix.mingwdir }}\bin
+          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         shell: powershell
         if: matrix.mingw != ''
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::%USERPROFILE%\.cargo\bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -54,15 +54,15 @@ jobs:
           Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
           7z x -y mingw.7z -oC:\msys64 | Out-Null
           del mingw.7z
-          echo ::add-path::C:\msys64\usr\bin
-          echo ::add-path::C:\msys64\${{ matrix.mingwdir }}\bin
+          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         shell: powershell
         if: matrix.mingw != ''
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::%USERPROFILE%\.cargo\bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -79,11 +79,11 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
       - name: Skip tests
         run: |
-          echo "::set-env name=SKIP_TESTS::yes"
+          echo "SKIP_TESTS=yes" >> $GITHUB_ENV
         if: matrix.run_tests == ''
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
@@ -121,7 +121,7 @@ jobs:
             *-linux-android*) DOCKER=android   ;; # Android uses a local docker image
             *)                DOCKER="$TARGET" ;;
           esac
-          echo "::set-env name=DOCKER::$DOCKER"
+          echo "DOCKER=$DOCKER" >> $GITHUB_ENV
       - name: Fetch the docker
         run: bash ci/fetch-rust-docker.bash "${TARGET}"
       - name: Maybe build a docker from there

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -38,9 +38,9 @@ jobs:
           mkdir -p ~/.cargo/{registry,git}
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::$HOME/.cargo/bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+          echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
+          echo "SKIP_TESTS=" >> $GITHUB_ENV
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -57,8 +57,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: target
-          key: ${{ github.base_ref }}-${{ github.head_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ github.base_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ github.base_ref }}-${{ github.head_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}-3
+          restore-keys: ${{ github.base_ref }}-${{ matrix.target }}-cargo-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}-3
       - name: Install Rustup using ./rustup-init.sh
         run: |
           sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
@@ -92,3 +92,9 @@ jobs:
         run: |
           cargo install cargo-cache --no-default-features --features ci-autoclean
           cargo-cache
+      - name: Flush cache
+        # This is a workaround for a bug with GitHub Actions Cache that causes
+        # corrupt cache entries (particularly in the target directory). See
+        # https://github.com/actions/cache/issues/403 and
+        # https://github.com/rust-lang/cargo/issues/8603.
+        run: sudo /usr/sbin/purge

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -62,15 +62,15 @@ jobs:
           Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
           7z x -y mingw.7z -oC:\msys64 | Out-Null
           del mingw.7z
-          echo ::add-path::C:\msys64\usr\bin
-          echo ::add-path::C:\msys64\${{ matrix.mingwdir }}\bin
+          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
         shell: powershell
         if: matrix.mingw != ''
       - name: Set environment variables appropriately for the build
         run: |
-          echo "::add-path::%USERPROFILE%\.cargo\bin"
-          echo "::set-env name=TARGET::${{matrix.target}}"
-          echo "::set-env name=SKIP_TESTS::"
+          echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
The old method of using `::set-env` and `::add-path` have been deprecated, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

This includes a second commit to work around a GitHub Actions cache bug on macOS.