### PR TITLE
Re-add rustls support (enabled by setting RUSTUP_USE_RUSTLS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.61"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
+checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
 
 [[package]]
 name = "cfb-mode"
@@ -691,6 +691,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +972,22 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37743cc83e8ee85eacfce90f2f4102030d9ff0a95244098d781e9bee4a90abb6"
+dependencies = [
+ "bytes 0.5.6",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -1332,9 +1358,9 @@ checksum = "37fd5004feb2ce328a52b0b3d01dbf4ffff72583493900ed15f22d4111c51693"
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
@@ -1720,6 +1746,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1730,15 +1757,18 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
  "serde",
  "serde_urlencoded",
  "tokio",
+ "tokio-rustls",
  "tokio-socks",
  "tokio-tls",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -1749,6 +1779,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddadf3a46af916aa0fe6b8283e676b6bb5cbdf835d986d98a49d7345072341e5"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1800,6 +1845,19 @@ name = "rustc-demangle"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2610b7f643d18c87dff3b489950269617e6601a51f1f05aa5daefee36f64f0b"
+
+[[package]]
+name = "rustls"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
 
 [[package]]
 name = "rustup"
@@ -1883,6 +1941,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
@@ -2252,6 +2320,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12831b255bcfa39dc0436b01e19fea231a37db570686c06ee72c423479f889a"
+dependencies = [
+ "futures-core",
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-socks"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,11 +2482,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
-name = "url"
-version = "2.1.1"
+name = "untrusted"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -2554,6 +2641,25 @@ checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
  "flate2",
  "futures-core",
  "memchr",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
 ]
 
 [[package]]
@@ -126,6 +126,12 @@ name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitfield"
@@ -329,6 +335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9cc5db465b294c3fa986d5bbb0f3017cd850bff6dd6c52f9ccff8b4d21b7b08"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d976903543e0c48546a91908f21588a680a8c8f984df9a5d69feccb2b2a211"
+dependencies = [
+ "cfg-if 0.1.10",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -561,12 +577,6 @@ dependencies = [
  "tokio",
  "url",
 ]
-
-[[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519"
@@ -1243,8 +1253,8 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
- "security-framework-sys",
+ "security-framework 0.4.4",
+ "security-framework-sys 0.4.3",
  "tempfile",
 ]
 
@@ -1432,7 +1442,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59698ea79df9bf77104aefd39cc3ec990cb9693fb59c3b0a70ddf2646fdffb4b"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "once_cell",
  "regex",
 ]
@@ -1493,7 +1503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501f8c2834bc16a23ae40932b9f924c6c5fc1d7cd1cc3536a532f37e81f603ed"
 dependencies = [
  "aes",
- "base64",
+ "base64 0.12.3",
  "bitfield",
  "block-modes",
  "block-padding 0.2.1",
@@ -1560,6 +1570,12 @@ name = "pin-project-lite"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
 
 [[package]]
 name = "pin-utils"
@@ -1733,12 +1749,12 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9eaa17ac5d7b838b7503d118fa16ad88f440498bf9ffe5424e621f93190d61e"
+checksum = "fb15d6255c792356a0f578d8a645c677904dc02e862bebe2ecc18e0c01b9a0ce"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.13.0",
  "bytes 0.5.6",
  "encoding_rs",
  "futures-core",
@@ -1756,8 +1772,9 @@ dependencies = [
  "mime_guess",
  "native-tls",
  "percent-encoding",
- "pin-project-lite",
+ "pin-project-lite 0.2.0",
  "rustls",
+ "rustls-native-certs",
  "serde",
  "serde_urlencoded",
  "tokio",
@@ -1767,8 +1784,8 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -1852,11 +1869,23 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d1126dcf58e93cee7d098dbda643b5f92ed724f1f6a63007c1116eed6700c81"
 dependencies = [
- "base64",
+ "base64 0.12.3",
  "log",
  "ring",
  "sct",
  "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d439a7672da82dd955498445e496ee2096fe2117b9f796558a43fdb9e59b8"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework 1.0.0",
 ]
 
 [[package]]
@@ -1937,6 +1966,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,7 +1997,20 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "security-framework-sys",
+ "security-framework-sys 0.4.3",
+]
+
+[[package]]
+name = "security-framework"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad502866817f0575705bd7be36e2b2535cc33262d493aa733a2ec862baa2bc2b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys 1.0.0",
 ]
 
 [[package]]
@@ -1970,6 +2018,16 @@ name = "security-framework-sys"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ceb04988b17b6d1dcd555390fa822ca5637b4a14e1f5099f13d351bed4d6c7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2027,14 +2085,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url",
 ]
 
 [[package]]
@@ -2315,7 +2373,7 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "slab",
 ]
 
@@ -2333,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-socks"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1997788a0e25e09300e44680ba1ef9d44d6f634a883641f80109e8b59c928daf"
+checksum = "d611fd5d241872372d52a0a3d309c52d0b95a6a67671a6c8f7ab2c4a37fb2539"
 dependencies = [
  "bytes 0.4.12",
  "either",
@@ -2364,7 +2422,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "tokio",
 ]
 
@@ -2391,7 +2449,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "tracing-core",
 ]
 
@@ -2634,6 +2692,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
 
 [[package]]
+name = "wasm-bindgen-test"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+dependencies = [
+ "console_error_panic_hook",
+ "js-sys",
+ "scoped-tls",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-test-macro"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2651,15 +2733,6 @@ checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
 dependencies = [
  "ring",
  "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,14 @@ version = "1.23.0"
 
 [features]
 curl-backend = ["download/curl-backend"]
-default = ["curl-backend", "reqwest-backend"]
+default = ["curl-backend", "reqwest-backend", "reqwest-default-tls", "reqwest-rustls-tls"]
+
 reqwest-backend = ["download/reqwest-backend"]
 vendored-openssl = ['openssl/vendored']
+
+reqwest-default-tls = ["download/reqwest-default-tls"]
+reqwest-rustls-tls = ["download/reqwest-rustls-tls"]
+
 # Include in the default set to disable self-update and uninstall.
 no-self-update = []
 
@@ -25,7 +30,7 @@ anyhow = "1.0.31"
 cfg-if = "1.0"
 chrono = "0.4"
 clap = "2"
-download = {path = "download"}
+download = { path = "download", default-features = false }
 effective-limits = "0.5.2"
 error-chain = "0.12"
 flate2 = "1"

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -9,10 +9,12 @@ license = "MIT/Apache-2.0"
 
 [features]
 
-default = ["reqwest-backend"]
+default = ["reqwest-backend", "reqwest-rustls-tls", "reqwest-default-tls"]
 
 curl-backend = ["curl"]
 reqwest-backend = ["reqwest", "env_proxy", "lazy_static"]
+reqwest-default-tls = ["reqwest/default-tls"]
+reqwest-rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 error-chain = "0.12"
@@ -20,7 +22,7 @@ url = "2.1"
 curl = { version = "0.4.11", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 lazy_static = { version = "1.0", optional = true }
-reqwest = { version = "0.10", features = ["blocking", "gzip", "socks"], optional = true }
+reqwest = { version = "0.10", default-features = false, features = ["blocking", "gzip", "socks"], optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -14,7 +14,7 @@ default = ["reqwest-backend", "reqwest-rustls-tls", "reqwest-default-tls"]
 curl-backend = ["curl"]
 reqwest-backend = ["reqwest", "env_proxy", "lazy_static"]
 reqwest-default-tls = ["reqwest/default-tls"]
-reqwest-rustls-tls = ["reqwest/rustls-tls"]
+reqwest-rustls-tls = ["reqwest/rustls-tls-native-roots"]
 
 [dependencies]
 error-chain = "0.12"
@@ -22,7 +22,7 @@ url = "2.1"
 curl = { version = "0.4.11", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 lazy_static = { version = "1.0", optional = true }
-reqwest = { version = "0.10", default-features = false, features = ["blocking", "gzip", "socks"], optional = true }
+reqwest = { version = "0.10.9", default-features = false, features = ["blocking", "gzip", "socks"], optional = true }
 
 [dev-dependencies]
 hyper = { version = "0.13", default-features = false, features = ["tcp"] }

--- a/download/tests/download-reqwest-resume.rs
+++ b/download/tests/download-reqwest-resume.rs
@@ -20,8 +20,14 @@ fn resume_partial_from_file_url() {
     write_file(&target_path, "123");
 
     let from_url = Url::from_file_path(&from_path).unwrap();
-    download_to_path_with_backend(Backend::Reqwest, &from_url, &target_path, true, None)
-        .expect("Test download failed");
+    download_to_path_with_backend(
+        Backend::Reqwest(TlsBackend::Default),
+        &from_url,
+        &target_path,
+        true,
+        None,
+    )
+    .expect("Test download failed");
 
     assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }
@@ -41,7 +47,7 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
     let received_in_callback = Mutex::new(Vec::new());
 
     download_to_path_with_backend(
-        Backend::Reqwest,
+        Backend::Reqwest(TlsBackend::Default),
         &from_url,
         &target_path,
         true,

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -243,20 +243,20 @@ fn download_file_(
 
     // Keep the curl env var around for a bit
     let use_curl_backend = process().var_os("RUSTUP_USE_CURL").is_some();
-    let avoid_rustls = process().var_os("RUSTUP_AVOID_RUSTLS").is_some();
+    let use_rustls = process().var_os("RUSTUP_USE_RUSTLS").is_some();
     let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)
     } else {
-        let tls_backend = if avoid_rustls {
-            TlsBackend::Default
+        let tls_backend = if use_rustls {
+            TlsBackend::Rustls
         } else {
-            #[cfg(feature = "reqwest-rustls-tls")]
-            {
-                TlsBackend::Rustls
-            }
-            #[cfg(not(feature = "reqwest-rustls-tls"))]
+            #[cfg(feature = "reqwest-default-tls")]
             {
                 TlsBackend::Default
+            }
+            #[cfg(not(feature = "reqwest-default-tls"))]
+            {
+                TlsBackend::Rustls
             }
         };
         (Backend::Reqwest(tls_backend), Notification::UsingReqwest)

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -207,7 +207,7 @@ fn download_file_(
     notify_handler: &dyn Fn(Notification<'_>),
 ) -> Result<()> {
     use download::download_to_path_with_backend;
-    use download::{Backend, Event};
+    use download::{Backend, Event, TlsBackend};
     use sha2::Digest;
     use std::cell::RefCell;
 
@@ -241,12 +241,25 @@ fn download_file_(
 
     // Download the file
 
-    // Keep the hyper env var around for a bit
+    // Keep the curl env var around for a bit
     let use_curl_backend = process().var_os("RUSTUP_USE_CURL").is_some();
+    let avoid_rustls = process().var_os("RUSTUP_AVOID_RUSTLS").is_some();
     let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)
     } else {
-        (Backend::Reqwest, Notification::UsingReqwest)
+        let tls_backend = if avoid_rustls {
+            TlsBackend::Default
+        } else {
+            #[cfg(feature = "reqwest-rustls-tls")]
+            {
+                TlsBackend::Rustls
+            }
+            #[cfg(not(feature = "reqwest-rustls-tls"))]
+            {
+                TlsBackend::Default
+            }
+        };
+        (Backend::Reqwest(tls_backend), Notification::UsingReqwest)
     };
     notify_handler(notification);
     let res =


### PR DESCRIPTION
rustls is seen as mature enough for curl to depend on it optionally,
and it recently has had an audit.

This commit adds back rustls support removed by 86bb1850b2c6c6fa7cf4bbfb2e2d50f0833f0127

You can opt into using rustls by setting the RUSTUP_USE_RUSTLS env variable.

Blockers:

- [x] [Ring not compiling on apple silicon](https://github.com/briansmith/ring/issues/1063)
- [x] Ring release with the apple silicon fix
- [x] [Reqwest support for native certificate store](https://github.com/seanmonstar/reqwest/pull/1058)
- [x] Reqwest release with the native cert store support

TODO:

- [x] Default should remain curl for now, but allow testing of rustls e.g. via `RUSTUP_USE_RUSTLS`

Fixes #568