### PR TITLE
Treat Apple's `arm64` as `aarch64`

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -260,7 +260,7 @@ get_architecture() {
             fi
             ;;
 
-        aarch64)
+        aarch64 | arm64)
             _cputype=aarch64
             ;;
 


### PR DESCRIPTION
With this, I get the error

```
rustup: command failed: downloader
https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init
```

I believe that's where the binaries will be when they are published.