### PR TITLE
do_msvc_check: set default choice to no

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -307,7 +307,7 @@ pub fn install(
             warn!("installing msvc toolchain without its prerequisites");
         } else {
             md(&mut term, MSVC_MESSAGE);
-            if !common::confirm("\nContinue? (Y/n)", true)? {
+            if !common::confirm("\nContinue? (y/N)", false)? {
                 info!("aborting installation");
                 return Ok(utils::ExitCode(0));
             }


### PR DESCRIPTION
Before that the behavior on Windows when running rustup-init
without having build tools installed was to continue.

Now the user need to explicitly choose to continue installation,
and thus we are making sure they are carefully reading the warning
message.

Closes: #2514