### PR TITLE
Allow selecting toolchains to uninstall with glob pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,6 +860,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "h2"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1821,7 @@ dependencies = [
  "error-chain",
  "flate2",
  "git-testament",
+ "glob",
  "home",
  "lazy_static",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ download = {path = "download"}
 error-chain = "0.12"
 flate2 = "1"
 git-testament = "0.1.4"
+glob = "0.3"
 home = {git = "https://github.com/rbtcollins/home", rev = "a243ee2fbee6022c57d56f5aa79aefe194eabe53"}
 lazy_static = "1"
 libc = "0.2"

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -24,6 +24,7 @@ error_chain! {
         Temp(temp::Error);
         Io(io::Error);
         Term(term::Error);
+        Glob(glob::PatternError);
     }
 
     errors {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -406,13 +406,6 @@ pub fn cli() -> App<'static, 'static> {
                         .about("Uninstall a toolchain")
                         .alias("remove")
                         .arg(
-                            Arg::with_name("pattern")
-                                .help("Treat arguments as glob patterns")
-                                .short("p")
-                                .long("pattern")
-                                .takes_value(false),
-                        )
-                        .arg(
                             Arg::with_name("toolchain")
                                 .help(TOOLCHAIN_ARG_HELP)
                                 .required(true)
@@ -1320,23 +1313,17 @@ fn toolchain_link(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
 }
 
 fn toolchain_remove(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
-    if m.is_present("pattern") {
-        for pattern_str in m.values_of("toolchain").unwrap() {
-            let pattern = Pattern::new(&pattern_str)?;
+    for pattern_str in m.values_of("toolchain").unwrap() {
+        let pattern = Pattern::new(&pattern_str)?;
 
-            let mut toolchains = cfg.get_toolchains_from_glob(pattern)?.peekable();
-            if toolchains.peek().is_none() {
-                info!("no toolchains matched pattern '{}'", pattern_str);
-                return Ok(utils::ExitCode(0));
-            }
+        let mut toolchains = cfg.get_toolchains_from_glob(pattern)?.peekable();
 
+        if toolchains.peek().is_some() {
             for toolchain in toolchains {
                 toolchain.remove()?;
             }
-        }
-    } else {
-        for toolchain in m.values_of("toolchain").unwrap() {
-            let toolchain = cfg.get_toolchain(toolchain, false)?;
+        } else {
+            let toolchain = cfg.get_toolchain(pattern_str, false)?;
             toolchain.remove()?;
         }
     }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1332,9 +1332,6 @@ fn toolchain_remove(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode
         }
     } else {
         for toolchain in m.values_of("toolchain").unwrap() {
-            if m.is_present("regex") {
-            } else {
-            }
             let toolchain = cfg.get_toolchain(toolchain, false)?;
             toolchain.remove()?;
         }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1319,10 +1319,12 @@ fn toolchain_remove(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode
         let mut toolchains = cfg.get_toolchains_from_glob(pattern)?.peekable();
 
         if toolchains.peek().is_some() {
+            // This pattern matched some toolchains, so remove each of the ones it matched.
             for toolchain in toolchains {
                 toolchain.remove()?;
             }
         } else {
+            // It didn't match any toolchains, so treat it as a partial toolchain specifier.
             let toolchain = cfg.get_toolchain(pattern_str, false)?;
             toolchain.remove()?;
         }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -7,6 +7,7 @@ use std::process::Command;
 use std::str::FromStr;
 
 use clap::{App, AppSettings, Arg, ArgGroup, ArgMatches, Shell, SubCommand};
+use regex::Regex;
 
 use super::common;
 use super::errors::*;
@@ -1324,7 +1325,7 @@ fn toolchain_remove(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode
             "exactly one regex filter must be supplied"
         );
 
-        let regex = regex::Regex::from_str(m.values_of("toolchain").unwrap().next().unwrap())
+        let regex = Regex::from_str(m.values_of("toolchain").unwrap().next().unwrap())
             .expect("invalid regex");
 
         for toolchain in cfg.get_toolchains_from_regex(regex)? {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1322,8 +1322,15 @@ fn toolchain_link(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
 fn toolchain_remove(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
     if m.is_present("pattern") {
         for pattern_str in m.values_of("toolchain").unwrap() {
-            let pattern = Pattern::new(pattern_str)?;
-            for toolchain in cfg.get_toolchains_from_glob(pattern)? {
+            let pattern = Pattern::new(&pattern_str)?;
+
+            let mut toolchains = cfg.get_toolchains_from_glob(pattern)?.peekable();
+            if toolchains.peek().is_none() {
+                info!("no toolchains matched pattern '{}'", pattern_str);
+                return Ok(utils::ExitCode(0));
+            }
+
+            for toolchain in toolchains {
                 toolchain.remove()?;
             }
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,8 @@ use std::process::Command;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use glob::Pattern;
 use pgp::{Deserializable, SignedPublicKey};
-use regex::Regex;
 use serde::Deserialize;
 
 use crate::dist::download::DownloadCfg;
@@ -364,13 +364,13 @@ impl Cfg {
         Toolchain::from(self, name)
     }
 
-    pub fn get_toolchains_from_regex(
+    pub fn get_toolchains_from_glob(
         &self,
-        regex: Regex,
+        pattern: Pattern,
     ) -> Result<impl Iterator<Item = Toolchain<'_>>> {
         Ok(self
             .list_toolchains_iter()?
-            .filter(move |toolchain| regex.is_match(toolchain))
+            .filter(move |toolchain| pattern.matches(toolchain))
             .map(move |toolchain| Toolchain::from(self, &toolchain).unwrap()))
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use pgp::{Deserializable, SignedPublicKey};
+use regex::Regex;
 use serde::Deserialize;
 
 use crate::dist::download::DownloadCfg;
@@ -363,7 +364,7 @@ impl Cfg {
         Toolchain::from(self, name)
     }
 
-    pub fn get_toolchains_from_regex(&self, regex: regex::Regex) -> Result<Vec<Toolchain<'_>>> {
+    pub fn get_toolchains_from_regex(&self, regex: Regex) -> Result<Vec<Toolchain<'_>>> {
         Ok(self
             .list_toolchains_iter()?
             .filter(|toolchain| regex.is_match(toolchain))

--- a/src/config.rs
+++ b/src/config.rs
@@ -364,12 +364,14 @@ impl Cfg {
         Toolchain::from(self, name)
     }
 
-    pub fn get_toolchains_from_regex(&self, regex: Regex) -> Result<Vec<Toolchain<'_>>> {
+    pub fn get_toolchains_from_regex(
+        &self,
+        regex: Regex,
+    ) -> Result<impl Iterator<Item = Toolchain<'_>>> {
         Ok(self
             .list_toolchains_iter()?
-            .filter(|toolchain| regex.is_match(toolchain))
-            .map(|toolchain| Toolchain::from(self, &toolchain).unwrap())
-            .collect())
+            .filter(move |toolchain| regex.is_match(toolchain))
+            .map(move |toolchain| Toolchain::from(self, &toolchain).unwrap()))
     }
 
     pub fn verify_toolchain(&self, name: &str) -> Result<Toolchain<'_>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::fmt::{self, Display};
 use std::io;
+use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
@@ -362,6 +363,14 @@ impl Cfg {
         Toolchain::from(self, name)
     }
 
+    pub fn get_toolchains_from_regex(&self, regex: regex::Regex) -> Result<Vec<Toolchain<'_>>> {
+        Ok(self
+            .list_toolchains_iter()?
+            .filter(|toolchain| regex.is_match(toolchain))
+            .map(|toolchain| Toolchain::from(self, &toolchain).unwrap())
+            .collect())
+    }
+
     pub fn verify_toolchain(&self, name: &str) -> Result<Toolchain<'_>> {
         let toolchain = self.get_toolchain(name, false)?;
         toolchain.verify()?;
@@ -694,18 +703,21 @@ impl Cfg {
     }
 
     pub fn list_toolchains(&self) -> Result<Vec<String>> {
+        let mut toolchains: Vec<_> = self.list_toolchains_iter()?.collect();
+        utils::toolchain_sort(&mut toolchains);
+        Ok(toolchains)
+    }
+
+    fn list_toolchains_iter(&self) -> Result<Box<dyn Iterator<Item = String>>> {
         if utils::is_directory(&self.toolchains_dir) {
-            let mut toolchains: Vec<_> = utils::read_dir("toolchains", &self.toolchains_dir)?
-                .filter_map(io::Result::ok)
-                .filter(|e| e.file_type().map(|f| !f.is_file()).unwrap_or(false))
-                .filter_map(|e| e.file_name().into_string().ok())
-                .collect();
-
-            utils::toolchain_sort(&mut toolchains);
-
-            Ok(toolchains)
+            Ok(Box::new(
+                utils::read_dir("toolchains", &self.toolchains_dir)?
+                    .filter_map(io::Result::ok)
+                    .filter(|e| e.file_type().map(|f| !f.is_file()).unwrap_or(false))
+                    .filter_map(|e| e.file_name().into_string().ok()),
+            ))
         } else {
-            Ok(Vec::new())
+            Ok(Box::new(iter::empty()))
         }
     }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1225,6 +1225,21 @@ fn toolchain_uninstall_is_like_uninstall() {
 }
 
 #[test]
+fn toolchain_uninstall_pattern() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "uninstall", "stable-*"]);
+        expect_ok(config, &["rustup", "uninstall", "nightly-*"]);
+        let mut cmd = clitools::cmd(config, "rustup", &["show"]);
+        clitools::env(config, &mut cmd);
+        let out = cmd.output().unwrap();
+        assert!(out.status.success());
+        let stdout = String::from_utf8(out.stdout).unwrap();
+        assert!(!stdout.contains(for_host!("'stable-{}'")));
+        assert!(!stdout.contains(for_host!("'nightly-2015-01-01-{}'")));
+    });
+}
+
+#[test]
 fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {
         expect_err(

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -99,9 +99,9 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     env::remove_var("RUSTUP_TOOLCHAIN");
     env::remove_var("SHELL");
     env::remove_var("ZDOTDIR");
-    // clap does it's own terminal colour probing, and that isn't
+    // clap does its own terminal colour probing, and that isn't
     // trait-controllable, but it does honour the terminal. To avoid testing
-    // claps code, lie about whatever terminal this process was started under.
+    // clap's code, lie about whatever terminal this process was started under.
     env::set_var("TERM", "dumb");
 
     match env::var("RUSTUP_BACKTRACE") {


### PR DESCRIPTION
Closes #2530.

## Examples

### Correct usage

```console
$ rustup toolchain list
stable-x86_64-apple-darwin (default)
nightly-2020-01-01-x86_64-apple-darwin
nightly-2020-06-01-x86_64-apple-darwin
nightly-x86_64-apple-darwin

$ rustup toolchain uninstall 'nightly-20*'
info: uninstalling toolchain 'nightly-2020-01-01-x86_64-apple-darwin'
info: toolchain 'nightly-2020-01-01-x86_64-apple-darwin' uninstalled
info: uninstalling toolchain 'nightly-2020-06-01-x86_64-apple-darwin'
info: toolchain 'nightly-2020-06-01-x86_64-apple-darwin' uninstalled

$ rustup toolchain list
stable-x86_64-apple-darwin (default)
nightly-x86_64-apple-darwin
```

### Invalid pattern

```console
$ rustup toolchain uninstall '***'
error: Pattern syntax error near position 2: wildcards are either regular `*` or recursive `**`
```

**Work-in-progress:**

- [x] Errors need improvement (instead of just panicking)
- [x] Needs test
- [ ] Needs CLI docs