### PR TITLE
Add env variable to override the fallback settings file path

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -196,7 +196,14 @@ impl Cfg {
 
         // Centralised file for multi-user systems to provide admin/distributor set initial values.
         let fallback_settings = if cfg!(not(windows)) {
-            FallbackSettings::new(PathBuf::from(UNIX_FALLBACK_SETTINGS))?
+            // If present, use the RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS environment
+            // variable as settings path, or UNIX_FALLBACK_SETTINGS otherwise
+            FallbackSettings::new(
+                match process().var("RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS") {
+                    Ok(s) => PathBuf::from(s),
+                    Err(_) => PathBuf::from(UNIX_FALLBACK_SETTINGS),
+                },
+            )?
         } else {
             None
         };

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -446,6 +446,13 @@ pub fn env<E: rustup_test::Env>(config: &Config, cmd: &mut E) {
             .join("tests/mock/signing-key.pub.asc"),
     );
 
+    // The unix fallback settings file may be present in the test environment, so override
+    // the path to the settings file with a non-existing path to avoid intereference
+    cmd.env(
+        "RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS",
+        "/bogus-config-file.toml",
+    );
+
     if let Some(root) = config.rustup_update_root.as_ref() {
         cmd.env("RUSTUP_UPDATE_ROOT", root);
     }


### PR DESCRIPTION
This PR introduces the support for overriding the path of the fallback settings file (`/etc/rustup/settings.toml`) by specifying the `RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS` environment variable.

The fix can be verified by running the following commands
```
$ # Create an `/etc/rustup/settings.toml` file specifying a default toolchain
$ echo "default_toolchain = 'stable'" | sudo tee /etc/rustup/settings.toml
default_toolchain = 'stable'
$ cargo test update_once # Fails!
$ export RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS=/dev/null 
$ cargo test update_once # Does not fail
```

Fixes #2456 

Issue #2456  also mentions that the env variable should be "set up in the mock test support glue", but I'm not sure what it means..