### PR TITLE
Allow installing `major.minor` channels

### DIFF
--- a/doc/src/concepts/toolchains.md
+++ b/doc/src/concepts/toolchains.md
@@ -15,15 +15,15 @@ Standard release channel toolchain names have the following form:
 ```
 <channel>[-<date>][-<host>]
 
-<channel>       = stable|beta|nightly|<version>
+<channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
 <date>          = YYYY-MM-DD
 <host>          = <target-triple>
 ```
 
-'channel' is either a named release channel or an explicit version number,
-such as `1.42.0`. Channel names can be optionally appended with an archive
-date, as in `nightly-2014-12-18`, in which case the toolchain is downloaded
-from the archive for that date.
+'channel' is a named release channel, a major and minor version number such as
+`1.42`, or a fully specified version number, such as `1.42.0`. Channel names
+can be optionally appended with an archive date, as in `nightly-2014-12-18`, in
+which case the toolchain is downloaded from the archive for that date.
 
 Finally, the host may be specified as a target triple. This is most useful for
 installing a 32-bit compiler on a 64-bit platform, or for installing the

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -55,14 +55,15 @@ pub static TOOLCHAIN_HELP: &str = r"DISCUSSION:
 
         <channel>[-<date>][-<host>]
 
-        <channel>       = stable|beta|nightly|<version>
+        <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
         <date>          = YYYY-MM-DD
         <host>          = <target-triple>
 
-    'channel' is either a named release channel or an explicit version
-    number, such as '1.42.0'. Channel names can be optionally appended
-    with an archive date, as in 'nightly-2017-05-09', in which case
-    the toolchain is downloaded from the archive for that date.
+    'channel' is a named release channel, a major and minor version
+    number such as `1.42`, or a fully specified version number, such
+    as `1.42.0`. Channel names can be optionally appended with an
+    archive date, as in `nightly-2014-12-18`, in which case the
+    toolchain is downloaded from the archive for that date.
 
     The host may be specified as a target triple. This is most useful
     for installing a 32-bit compiler on a 64-bit platform, or for

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -27,8 +27,8 @@ static TOOLCHAIN_CHANNELS: &[&str] = &[
     "nightly",
     "beta",
     "stable",
-    // Allow from 1.0.0 through to 9.999.99
-    r"\d{1}\.\d{1,3}\.\d{1,2}",
+    // Allow from 1.0.0 through to 9.999.99 with optional patch version
+    r"\d{1}\.\d{1,3}(?:\.\d{1,2})?",
 ];
 
 #[derive(Debug, PartialEq)]
@@ -951,6 +951,7 @@ mod tests {
             ("nightly", ("nightly", None, None)),
             ("beta", ("beta", None, None)),
             ("stable", ("stable", None, None)),
+            ("0.0", ("0.0", None, None)),
             ("0.0.0", ("0.0.0", None, None)),
             ("0.0.0--", ("0.0.0", None, Some("-"))), // possibly a bug?
             ("9.999.99", ("9.999.99", None, None)),
@@ -986,7 +987,7 @@ mod tests {
             assert_eq!(parsed.unwrap(), expected, "input: `{}`", input);
         }
 
-        let failure_cases = vec!["anything", "00.0000.000", "3", "3.4", "", "--", "0.0.0-"];
+        let failure_cases = vec!["anything", "00.0000.000", "3", "", "--", "0.0.0-"];
 
         for input in failure_cases {
             let parsed = input.parse::<ParsedToolchainDesc>();


### PR DESCRIPTION
This fixes #794!!! 🎉 🌮 

I would recommend not merging+releasing this until after 1.48 is released, because that's the first stable release that will [write out the new manifests](https://github.com/rust-lang/rust/pull/76107). We could even wait for a patch release to happen, to verify that the patch release overwrites the major.minor manifests correctly, but that's not predictable, so it's up to you.

I tested this out locally installing into a `home` subdir and [since the manifests have been backfilled for old versions](https://github.com/rust-lang/rust-central-station/pull/954), I was able to do the following:

```
$ home/bin/rustup install 1.47 # install a channel that hasn't had point releases
info: syncing channel updates for '1.47-x86_64-apple-darwin'
info: latest update on 2020-10-08, rust version 1.47.0 (18bf6b4f0 2020-10-07)
...snip...
  1.47-x86_64-apple-darwin installed - rustc 1.47.0 (18bf6b4f0 2020-10-07)

$ home/bin/rustup toolchain list # list all toolchains
stable-x86_64-apple-darwin (default)
nightly-2020-04-22-x86_64-apple-darwin
1.47-x86_64-apple-darwin

$ home/bin/rustup toolchain uninstall 1.47 # uninstall a toolchain of this style
info: uninstalling toolchain '1.47-x86_64-apple-darwin'
info: toolchain '1.47-x86_64-apple-darwin' uninstalled

$ home/bin/rustup install 1.45 # install a channel that has had point releases, I got the latest one
info: syncing channel updates for '1.45-x86_64-apple-darwin'
info: latest update on 2020-08-03, rust version 1.45.2 (d3fb005a3 2020-07-31)
...snip...
  1.45-x86_64-apple-darwin installed - rustc 1.45.2 (d3fb005a3 2020-07-31)

$ home/bin/rustup run 1.45 rustc --version
rustc 1.45.2 (d3fb005a3 2020-07-31)

$ home/bin/rustc +1.45 --version
rustc 1.45.2 (d3fb005a3 2020-07-31)
```

Please let me know if there's anything else I should test out manually!