### PR TITLE
chore: Temporarily back out rust-analyzer proxy

### DIFF
--- a/ci/snapcraft.bash
+++ b/ci/snapcraft.bash
@@ -43,7 +43,7 @@ fi
 # as rustup.$PROXY.  If we have an alias which is not a supported proxy name
 # then rustup might get sad.
 
-PROXIES="cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rustc rustdoc rustfmt rust-analyzer"
+PROXIES="cargo cargo-clippy cargo-fmt cargo-miri clippy-driver rls rustc rustdoc rustfmt"
 
 # From now on, things should be automagic
 

--- a/doc/src/concepts/components.md
+++ b/doc/src/concepts/components.md
@@ -42,9 +42,6 @@ toolchains. The following is an overview of the different components:
   doc --help` for more options.
 * `rls` — [RLS] is a language server that provides support for editors and
   IDEs.
-* `rust-analyzer-preview` — [Rust anaylzer] is a new language server intended
-  to eventually replace [RLS]. This is a preview release as it is still in the
-  experimental phase.
 * `clippy` — [Clippy] is a lint tool that provides extra checks for common
   mistakes and stylistic choices.
 * `miri` — [Miri] is an experimental Rust interpreter, which can be used for
@@ -85,5 +82,4 @@ details.
 [rustfmt]: https://github.com/rust-lang/rustfmt
 [rustup components history]: https://rust-lang.github.io/rustup-components-history/
 [profiles]: profiles.md
-[rust anaylzer]: https://rust-analyzer.github.io/
 [nightly availability]: channels.md#nightly-availability

--- a/doc/src/concepts/profiles.md
+++ b/doc/src/concepts/profiles.md
@@ -16,7 +16,7 @@ available at this time are `minimal`, `default`, and `complete`:
   `rustup`. This should never be used, as it includes *every* component ever
   included in the metadata and thus will almost always fail. If you are
   looking for a way to install devtools such as `miri` or IDE integration
-  tools (`rls`, `rust-analyzer`), you should use the `default` profile and
+  tools (`rls`), you should use the `default` profile and
   install the needed additional components manually, either by using `rustup
   component add` or by using `-c` when installing the toolchain.
 

--- a/doc/src/concepts/proxies.md
+++ b/doc/src/concepts/proxies.md
@@ -16,7 +16,7 @@ The list of proxies is currently static in `rustup` and is as follows:
 
 - `rust-lldb` and `rust-gdb` are simple wrappers around the `lldb` and `gdb` debuggers respectively. The wrappers enable some pretty-printing of Rust values and add some convenience features to the debuggers by means of their scripting interfaces.
 
-- `rls` and `rust-analyzer` are two different generations of IDE integration tooling. They implement the language-server protocol to permit IDEs and editors such as Visual Studio Code, ViM, or Emacs, access to the semantics of the Rust code you are editing. They come from their respectively named components.
+- `rls` is part of the Rust IDE integration tooling. It implements the language-server protocol to permit IDEs and editors such as Visual Studio Code, ViM, or Emacs, access to the semantics of the Rust code you are editing. It comes from the `rls` component.
 
 - `cargo-clippy` and `clippy-driver` are related to the `clippy` linting tool which provides extra checks for common mistakes and stylistic choices and it comes from the `clippy` component.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ pub static TOOLS: &[&str] = &[
     "rust-lldb",
     "rust-gdb",
     "rls",
-    "rust-analyzer",
     "cargo-clippy",
     "clippy-driver",
     "cargo-miri",


### PR DESCRIPTION
For the 1.23.0 release we are temporarily backing out the rust-analyzer
proxy as r-a will only be on nightly at this point and so it's better if
we don't confuse people into expecting it on stable.  We'll reintroduce
it by reverting this commit when we're ready.

Signed-off-by: Daniel Silverstone (WSL2) <dsilvers@digital-scurf.org>