### PR TITLE
UX: Report non-installable toolchains

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -295,6 +295,10 @@ error_chain! {
             description("toolchain is not installed")
             display("toolchain '{}' is not installed", t)
         }
+        ToolchainNotInstallable(t: String) {
+            description("toolchain is not installable")
+            display("toolchain '{}' is not installable", t)
+        }
         ToolchainNotSelected {
             description("toolchain is not selected")
             display("no override and no default toolchain set")

--- a/src/install.rs
+++ b/src/install.rs
@@ -5,7 +5,7 @@ use crate::dist::dist;
 use crate::dist::download::DownloadCfg;
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::Notification;
-use crate::errors::Result;
+use crate::errors::{ErrorKind, Result};
 use crate::notifications::Notification as RootNotification;
 use crate::toolchain::{CustomToolchain, DistributableToolchain, Toolchain, UpdateStatus};
 use crate::utils::utils;
@@ -76,7 +76,12 @@ impl<'a> InstallMethod<'a> {
             (false, _) => UpdateStatus::Unchanged,
         };
 
-        Ok(status)
+        // Final check, to ensure we're installed
+        if !toolchain.exists() {
+            Err(ErrorKind::ToolchainNotInstallable(toolchain.name().to_string()).into())
+        } else {
+            Ok(status)
+        }
     }
 
     pub fn run(self, path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<bool> {

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -12,8 +12,8 @@ use rustup::test::with_saved_path;
 use rustup::utils::raw;
 
 use crate::mock::clitools::{
-    self, expect_ok, expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date, Config,
-    SanitizedOutput, Scenario,
+    self, expect_err, expect_ok, expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date,
+    Config, SanitizedOutput, Scenario,
 };
 
 fn run_input(config: &Config, args: &[&str], input: &str) -> SanitizedOutput {
@@ -604,4 +604,22 @@ fn with_no_prompt_install_succeeds_if_rustc_exists() {
         );
         assert!(out.ok);
     });
+}
+
+// Issue 2547
+#[test]
+fn install_non_installable_toolchain() {
+    clitools::setup(Scenario::Unavailable, &|config| {
+        expect_err(
+            config,
+            &[
+                "rustup-init",
+                "-y",
+                "--no-modify-path",
+                "--default-toolchain",
+                "nightly",
+            ],
+            "is not installable",
+        );
+    })
 }

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -685,6 +685,26 @@ fn update_unavailable_rustc() {
     });
 }
 
+// issue 2562
+#[test]
+fn install_unavailable_platform() {
+    clitools::setup(Scenario::Unavailable, &|config| {
+        set_current_dist_date(config, "2015-01-02");
+        // explicit attempt to install should fail
+        expect_err(
+            config,
+            &["rustup", "toolchain", "install", "nightly"],
+            "is not installable",
+        );
+        // implicit attempt to install should fail
+        expect_err(
+            config,
+            &["rustup", "default", "nightly"],
+            "is not installable",
+        );
+    });
+}
+
 #[test]
 fn update_nightly_even_with_incompat() {
     clitools::setup(Scenario::MissingComponent, &|config| {

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -310,7 +310,12 @@ fn bad_sha_on_manifest() {
         sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
         let sha_str = String::from_utf8(sha_bytes).unwrap();
         rustup::utils::raw::write_file(&sha_file, &sha_str).unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        // We fail because the sha is bad, but we should emit the special message to that effect.
+        expect_err(
+            config,
+            &["rustup", "default", "nightly"],
+            "update not yet available",
+        );
     });
 }
 


### PR DESCRIPTION
If you pick a default toolchain which is not installable, or if you
try to `rustup toolchain install` something non-installable then we
should report it as such and exit non-zero so scripting can fail.

This fixes #2547 

Starting this as draft because this needs tests but I'm feeling too tired to write some for now.