### PR TITLE
config: Try and heal default toolchains missing manifests

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -631,7 +631,7 @@ impl Cfg {
                 manifest
             } else {
                 // If we can't read the manifest we'd best try and install
-                return Ok(true);
+                return Ok(false);
             };
             match (distributable.list_components(), components_requested) {
                 // If the toolchain does not support components but there were components requested, bubble up the error


### PR DESCRIPTION
This fixes an oversight in #2573 which @rbtcollins spotted.

Ideally we'd also add some tests for this behaviour, but I can file an issue for that.