### PR TITLE
Add missing space in error message

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -429,7 +429,7 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
             &cs[0].description(manifest),
             toolchain,
             if toolchain.starts_with("nightly") {
-                "\nSometimes not all components are available in any given nightly."
+                "\nSometimes not all components are available in any given nightly. "
             } else {
                 ""
             }


### PR DESCRIPTION
Before the error looked like:

> Sometimes not all components are available in any given nightly.If you
> don't need the component, you can remove it with:

Note how it's missing a space after the period after the first sentence.