### PR TITLE
Clean up overcoupling

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -338,7 +338,10 @@ pub fn install(
 
     let install_res: Result<utils::ExitCode> = (|| {
         install_bins()?;
+
+        #[cfg(unix)]
         do_write_env_files()?;
+
         if !opts.no_modify_path {
             do_add_to_path()?;
         }

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -144,11 +144,6 @@ pub fn do_add_to_path() -> Result<()> {
     _apply_new_path(new_path)
 }
 
-// Nothing to do for Windows for now
-pub fn do_write_env_files() -> Result<()> {
-    Ok(())
-}
-
 fn _apply_new_path(new_path: Option<String>) -> Result<()> {
     use std::ptr;
     use winapi::shared::minwindef::*;


### PR DESCRIPTION
In a previous PR which was rushed through in order to get 1.23.1 out I accidentally introduced extra coupling between the windows and unix interfaces of the self_update part of the CLI.  This was very much not ideal as pointed out in the PR's reviews post-merge.

This commit is intended to revert the coupling, instead using the `#[cfg(unix)]` approach as is used elsewhere in that code like I probably should have in the first place.

I'd like to do more to continue the decoupling as described in #2424 but I thought I'd push this draft up first for confirmation that I've gone in the right direction. Have I?