### PR TITLE
chore: Use new platform-support URL

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -13,7 +13,7 @@ case "$(uname -s)" in
   * ) FEATURES=('--features' 'vendored-openssl') ;;
 esac
 
-# rustc only supports armv7: https://forge.rust-lang.org/release/platform-support.html
+# rustc only supports armv7: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 if [ "$TARGET" = arm-linux-androideabi ]; then
   export CFLAGS='-march=armv7'
 fi

--- a/doc/src/cross-compilation.md
+++ b/doc/src/cross-compilation.md
@@ -4,7 +4,7 @@ Rust [supports a great number of platforms][p]. For many of these platforms
 The Rust Project publishes binary releases of the standard library, and for
 some the full compiler. `rustup` gives easy access to all of them.
 
-[p]: https://forge.rust-lang.org/release/platform-support.html
+[p]: https://doc.rust-lang.org/nightly/rustc/platform-support.html
 
 When you first install a toolchain, `rustup` installs only the standard
 library for your *host* platform - that is, the architecture and operating

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -379,7 +379,7 @@ impl Package {
                     tpkgs
                         .get(t)
                         .ok_or_else(|| format!("target '{}' not found in channel.  \
-                        Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets", t).into())
+                        Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets", t).into())
                 } else {
                     Err("no target specified".into())
                 }

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -425,7 +425,7 @@ fn update_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets
+error: target '2016-03-1' not found in channel.  Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets
 ",
         );
     });
@@ -440,7 +440,7 @@ fn default_invalid_toolchain() {
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-error: target '2016-03-1' not found in channel.  Perhaps check https://forge.rust-lang.org/release/platform-support.html for available targets
+error: target '2016-03-1' not found in channel.  Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets
 ",
         );
     });


### PR DESCRIPTION
This fixes #2588
