### PR TITLE
cli: Support prefixes of toolchains in + argument

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -82,7 +82,7 @@ pub fn main() -> Result<utils::ExitCode> {
 
                 if let Some(t) = process().args().find(|x| x.starts_with('+')) {
                     debug!("Fetching rustc version from toolchain `{}`", t);
-                    cfg.set_toolchain_override(&t[1..]);
+                    cfg.set_toolchain_override(&t[1..])?;
                 }
 
                 let toolchain = cfg.find_or_install_override_toolchain_or_default(&cwd)?.0;
@@ -118,7 +118,7 @@ pub fn main() -> Result<utils::ExitCode> {
     let cfg = &mut common::set_globals(verbose, quiet)?;
 
     if let Some(t) = matches.value_of("+toolchain") {
-        cfg.set_toolchain_override(&t[1..]);
+        cfg.set_toolchain_override(&t[1..])?;
     }
 
     if maybe_upgrade_data(cfg, &matches)? {


### PR DESCRIPTION
Where +n is unique, expand it to +nightly (or whatever).
This means if you have nightly, beta, and stable, then
`cargo +n run` will use nightly.  If the prefix you provide
is not unique then we won't expand it and you'll get the
same error you would have before.

This will fix #1491

Currently a draft because it needs tests.  Seeking opinions from @rbtcollins and @joshtriplett who originally requested the feature.

```console
dsilvers@listless:~$ rustup toolchain list
stable-x86_64-unknown-linux-gnu (default)
beta-x86_64-unknown-linux-gnu
nightly-2020-11-24-x86_64-unknown-linux-gnu
nightly-x86_64-unknown-linux-gnu
dsilvers@listless:~$ rustup show active-toolchain
stable-x86_64-unknown-linux-gnu (default)
dsilvers@listless:~$ rustup +beta show active-toolchain
beta-x86_64-unknown-linux-gnu (overridden by +toolchain on the command line)
dsilvers@listless:~$ rustup +nightly show active-toolchain
nightly-x86_64-unknown-linux-gnu (overridden by +toolchain on the command line)
dsilvers@listless:~$ rustup +n show active-toolchain
error: override toolchain 'n' is not installed
error: caused by: the +toolchain on the command line specifies an uninstalled toolchain
dsilvers@listless:~$ rustup +b show active-toolchain
beta-x86_64-unknown-linux-gnu (overridden by +toolchain on the command line)
dsilvers@listless:~$ 
```