### PR TITLE
Add support for aarch64-apple-darwin

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -209,6 +209,7 @@ impl TargetTriple {
                 (b"Linux", b"armv7l") => Some("armv7-unknown-linux-gnueabihf"),
                 (b"Linux", b"armv8l") => Some("armv7-unknown-linux-gnueabihf"),
                 (b"Linux", b"aarch64") => Some(TRIPLE_AARCH64_UNKNOWN_LINUX),
+                (b"Darwin", b"arm64") => Some("aarch64-apple-darwin"),
                 (b"Darwin", b"x86_64") => Some("x86_64-apple-darwin"),
                 (b"Darwin", b"i686") => Some("i686-apple-darwin"),
                 (b"FreeBSD", b"x86_64") => Some("x86_64-unknown-freebsd"),


### PR DESCRIPTION
Also, when rustup is installed, somewhere the default host is set to x86_64-apple-darwin even on aarch64-apple-darwin machine. I couldn't find that place, but it lead to some crazy behavior re: toolchains - see https://github.com/rust-lang/cargo/issues/8955
It probably needs to be fixed too, but I don't know where exactly.