### PR TITLE
Fix 2601

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -617,8 +617,10 @@ impl Update {
                                 // It is the case, so we need to create a fresh wildcard
                                 // component using the package name and add it to the final
                                 // component list
-                                self.final_component_list
-                                    .push(existing_component.wildcard());
+                                let wildcarded = existing_component.wildcard();
+                                if !self.final_component_list.contains(&wildcarded) {
+                                    self.final_component_list.push(wildcarded);
+                                }
                             } else {
                                 self.missing_components.push(existing_component.clone());
                             }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1517,3 +1517,32 @@ fn install_allow_downgrade() {
         expect_component_executable(config, "rls");
     });
 }
+
+#[test]
+fn regression_2601() {
+    // We're checking that we don't regress per #2601
+    setup(&|config| {
+        expect_ok(
+            config,
+            &[
+                "rustup",
+                "toolchain",
+                "install",
+                "--profile",
+                "minimal",
+                "nightly",
+                "--component",
+                "rust-src",
+                "--no-self-update",
+            ],
+        );
+        // The bug exposed in #2601 was that the above would end up installing
+        // rust-src-$ARCH which would then have to be healed on the following
+        // command, resulting in a reinstallation.
+        expect_stderr_ok(
+            config,
+            &["rustup", "component", "add", "rust-src"],
+            "info: component 'rust-src' is up to date",
+        );
+    });
+}


### PR DESCRIPTION
Previously we attempted to resolve a situation where a toolchain which had a wildcarded component installed as target-specific due to profiles would break things.  Sadly it seems we missed one other mechanism by which such a component installation might occur - namely if someone requests a wildcarded component as an *additional* component during toolchain installation.

This PR resolves this by detecting such components during the building of the dist changeset.  As such, it fixes #2601 

@eddyb When this has built, assuming a green CI, if you're logged into Github then you should be able to download an artifact from the relevant CI run and try it out.  Would you mind checking if this fixes your problem?