### PR TITLE
Update rustup-init to detect tls1.2 for curl 7.73+ (Fixes #2603)

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -491,6 +491,13 @@ check_help_for() {
     _cmd="$1"
     shift
 
+    local _category
+    if "$_cmd" --help | grep -q 'For all options use the manual or "--help all".'; then
+      _category="all"
+    else
+      _category=""
+    fi
+
     case "$_arch" in
 
         # If we're running on OS-X, older than 10.13, then we always
@@ -508,7 +515,7 @@ check_help_for() {
     esac
 
     for _arg in "$@"; do
-        if ! "$_cmd" --help | grep -q -- "$_arg"; then
+        if ! "$_cmd" --help $_category | grep -q -- "$_arg"; then
             return 1
         fi
     done


### PR DESCRIPTION
This fixes #2603.  In curl 7.73.0, the help format was changed so as to only show a summary when calling `curl --help`, while the old menu can be accessed as `curl --help all`.  This change updates the `check_help_for` function to detect if the command being checked contains the curl 7.73.0+ language indicating the use of `--help all`.

If this language is present, `check_help_for` will insert the `all` category after the `--help` flag, allowing the query to work.  If the language is not present, then it will insert an empty string following the `--help` flag, maintaining the same behavior with pre-7.73 versions of curl.

Side Note: This is my first contribution to the rustup repository and I've tried to follow the contribution guidelines to the best of my ability; however, it seems that much of that document is relevant mainly for actual code changes to rustup itself, not to the init script.  I still ran the test suite just in case one of those tests covered the init script somehow.  Please let me know if there's anything else I need to do for this contribution.