### PR TITLE
#2572 - Add defaults to common::question_*

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -68,7 +68,7 @@ pub fn confirm_advanced() -> Result<Confirm> {
 }
 
 pub fn question_str(question: &str, default: &str) -> Result<String> {
-    writeln!(process().stdout(), "{}", question)?;
+    writeln!(process().stdout(), "{} [{}]", question, default)?;
     let _ = std::io::stdout().flush();
     let input = read_line()?;
 
@@ -82,7 +82,8 @@ pub fn question_str(question: &str, default: &str) -> Result<String> {
 }
 
 pub fn question_bool(question: &str, default: bool) -> Result<bool> {
-    writeln!(process().stdout(), "{}", question)?;
+    let default_text = if default { "(Y/n)" } else { "(y/N)" };
+    writeln!(process().stdout(), "{} {}", question, default_text)?;
 
     let _ = std::io::stdout().flush();
     let input = read_line()?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -612,8 +612,7 @@ fn customize_install(mut opts: InstallOpts<'_>) -> Result<InstallOpts<'_>> {
         &opts.profile,
     )?;
 
-    opts.no_modify_path =
-        !common::question_bool("Modify PATH variable? (y/n)", !opts.no_modify_path)?;
+    opts.no_modify_path = !common::question_bool("Modify PATH variable?", !opts.no_modify_path)?;
 
     Ok(opts)
 }

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -153,6 +153,123 @@ Rust is installed now. Great!
 }
 
 #[test]
+fn installer_shows_default_host_triple() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(config, &["rustup-init", "--no-modify-path"], "2\n");
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(for_host!(
+            r"
+Default host triple? [{0}]
+"
+        )));
+    });
+}
+
+#[test]
+fn installer_shows_default_toolchain_as_stable() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(config, &["rustup-init", "--no-modify-path"], "2\n\n");
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Default toolchain? (stable/beta/nightly/none) [stable]
+"
+        ));
+    });
+}
+
+#[test]
+fn installer_shows_default_toolchain_when_set_in_args() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(
+            config,
+            &[
+                "rustup-init",
+                "--no-modify-path",
+                "--default-toolchain=nightly",
+            ],
+            "2\n\n",
+        );
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Default toolchain? (stable/beta/nightly/none) [nightly]
+"
+        ));
+    });
+}
+
+#[test]
+fn installer_shows_default_profile() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(config, &["rustup-init", "--no-modify-path"], "2\n\n\n");
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Profile (which tools and data to install)? (minimal/default/complete) [default]
+"
+        ));
+    });
+}
+
+#[test]
+fn installer_shows_default_profile_when_set_in_args() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(
+            config,
+            &["rustup-init", "--no-modify-path", "--profile=minimal"],
+            "2\n\n\n",
+        );
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Profile (which tools and data to install)? (minimal/default/complete) [minimal]
+"
+        ));
+    });
+}
+
+#[test]
+fn installer_shows_default_for_modify_path() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(config, &["rustup-init"], "2\n\n\n\n");
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Modify PATH variable? (Y/n)
+"
+        ));
+    });
+}
+
+#[test]
+fn installer_shows_default_for_modify_path_when_set_with_args() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let out = run_input(config, &["rustup-init", "--no-modify-path"], "2\n\n\n\n");
+
+        println!("-- stdout --\n {}", out.stdout);
+        println!("-- stderr --\n {}", out.stderr);
+        assert!(out.stdout.contains(
+            r"
+Modify PATH variable? (y/N)
+"
+        ));
+    });
+}
+
+#[test]
 fn user_says_nope() {
     clitools::setup(Scenario::SimpleV2, &|config| {
         let out = run_input(config, &["rustup-init", "--no-modify-path"], "n\n\n");


### PR DESCRIPTION
Hopefully this is cleaner than specifying the default as a string in each use of the `common::question_{str|bool}` functions.