### PR TITLE
rustup-init.sh: Support Big Sur major version

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -493,15 +493,27 @@ check_help_for() {
 
     case "$_arch" in
 
-        # If we're running on OS-X, older than 10.13, then we always
-        # fail to find these options to force fallback
         *darwin*)
         if check_cmd sw_vers; then
-            if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
-                # Older than 10.13
-                echo "Warning: Detected OS X platform older than 10.13"
-                return 1
-            fi
+            case $(sw_vers -productVersion) in
+                10.*)
+                    # If we're running on macOS, older than 10.13, then we always
+                    # fail to find these options to force fallback
+                    if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+                        # Older than 10.13
+                        echo "Warning: Detected macOS platform older than 10.13"
+                        return 1
+                    fi
+                    ;;
+                11.*)
+                    # We assume Big Sur will be OK for now
+                    ;;
+                *)
+                    # Unknown product version, warn and continue
+                    echo "Warning: Detected unknown macOS major version: $(sw_vers -productVersion)"
+                    echo "Warning TLS capabilities detection may fail"
+                    ;;
+            esac
         fi
         ;;
 


### PR DESCRIPTION
In theory this fixes #2606 by detecting major os x version 11 in rustup-init.sh

I would appreciate it if @arafangion would check this, and also @shepmaster 