### PR TITLE
use indicatif progressbar for downloads

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ error-chain = "0.12"
 flate2 = "1"
 git-testament = "0.1.4"
 home = {git = "https://github.com/rbtcollins/home", rev = "a243ee2fbee6022c57d56f5aa79aefe194eabe53"}
+indicatif = "*"
 lazy_static = "1"
 libc = "0.2"
 num_cpus = "1.13"


### PR DESCRIPTION
start solving #1818 #1835 etc

@kinnison said

> It'll be quite a bit of work to rearrange **all the output** to go properly via that, but it would potentially allow some cleanup.

> I think that switching to indicatif or another similar library would be an interesting approach. It'd be a significant departure for the current UI if we also funnelled **all messaging** through such a beast, so we'd need to think carefully.

why refactor all the prints? i just want a download progressbar

code is not tested. github CI, what do you say?

edit: CI says no. also my cargo still says no:

```
$ cargo update
error: failed to parse manifest at `Cargo.toml`

Caused by:
  feature `profile-overrides` is required

this Cargo does not support nightly features, but if you
switch to nightly channel you can add
`cargo-features = ["profile-overrides"]` to enable this feature
```
