### PR TITLE
Fix missing space in error message

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -431,7 +431,7 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
             if toolchain.starts_with("nightly") {
                 "\nSometimes not all components are available in any given nightly. "
             } else {
-                ""
+                " "
             }
         );
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1071,7 +1071,7 @@ fn update_unavailable_std() {
             config,
             &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
-                "component 'rust-std' for target '{0}' is unavailable for download for channel nightly"
+                "component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'"
             ),
         );
     });
@@ -1098,7 +1098,7 @@ fn update_unavailable_force() {
             config,
             &["rustup", "update", "nightly", "--no-self-update"],
             for_host!(
-                "component 'rls' for target '{0}' is unavailable for download for channel nightly"
+                "component 'rls' for target '{0}' is unavailable for download for channel 'nightly'"
             ),
         );
         expect_ok(
@@ -1359,7 +1359,7 @@ fn test_complete_profile_skips_missing_when_forced() {
                 "nightly",
                 "--no-self-update",
             ],
-            for_host!("error: component 'rls' for target '{}' is unavailable for download for channel nightly")
+            for_host!("error: component 'rls' for target '{}' is unavailable for download for channel 'nightly'")
         );
         // Now try and force
         expect_stderr_ok(
@@ -1493,7 +1493,7 @@ fn install_allow_downgrade() {
                 "rls",
             ],
             &format!(
-                "component 'rls' for target '{}' is unavailable for download for channel nightly",
+                "component 'rls' for target '{}' is unavailable for download for channel 'nightly'",
                 trip,
             ),
         );


### PR DESCRIPTION
This PR is 2 commits. The first simply fixes and issue that wasn't totally resolved by 5414c42 (the other branch of the "if" statement wasn't covered). The second goes further and does some cleanup that I thought would be worthwhile (removing duplicated code, making the channel quoted as in ```unavailable for download for channel 'beta'```, making the use of newline more consistent, etc.).

new behavior: left
![Screenshot from 2020-12-25 00-07-45](https://user-images.githubusercontent.com/2751996/103121288-8e5dc900-4649-11eb-88d8-23cecea07da1.png)
