### PR TITLE
dist: Support a bincoded manifest file for performance reasons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
+]
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1821,6 +1831,7 @@ name = "rustup"
 version = "1.23.1"
 dependencies = [
  "anyhow",
+ "bincode",
  "cc",
  "cfg-if 1.0.0",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ no-self-update = []
 # Sorted by alphabetic order
 [dependencies]
 anyhow = "1.0.31"
+bincode = "1.3.1"
 cfg-if = "1.0"
 chrono = "0.4"
 clap = "2"

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -7,6 +7,7 @@ use std::str::FromStr;
 use chrono::{Date, NaiveDate, TimeZone, Utc};
 use lazy_static::lazy_static;
 use regex::Regex;
+use serde::{Deserialize, Serialize};
 
 use crate::dist::download::DownloadCfg;
 use crate::dist::manifest::Manifest as ManifestV2;
@@ -64,7 +65,7 @@ pub struct ToolchainDesc {
     pub target: TargetTriple,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub struct TargetTriple(String);
 
 // Linux hosts don't indicate clib in uname, however binaries only
@@ -417,7 +418,7 @@ impl<'a> Manifest<'a> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub enum Profile {
     Minimal,
     Default,

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -20,10 +20,12 @@ use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
+use serde::{Deserialize, Serialize};
+
 pub const SUPPORTED_MANIFEST_VERSIONS: [&str; 1] = ["2"];
 pub const DEFAULT_MANIFEST_VERSION: &str = "2";
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Manifest {
     pub manifest_version: String,
     pub date: String,
@@ -33,25 +35,25 @@ pub struct Manifest {
     pub profiles: HashMap<Profile, Vec<String>>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Package {
     pub version: String,
     pub targets: PackageTargets,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PackageTargets {
     Wildcard(TargetedPackage),
     Targeted(HashMap<TargetTriple, TargetedPackage>),
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct TargetedPackage {
     pub bins: Option<PackageBins>,
     pub components: Vec<Component>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PackageBins {
     pub url: String,
     pub hash: String,
@@ -59,7 +61,7 @@ pub struct PackageBins {
     pub xz_hash: Option<String>,
 }
 
-#[derive(Clone, Debug, Eq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Eq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct Component {
     pkg: String,
     pub target: Option<TargetTriple>,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,7 @@ error_chain! {
         Io(io::Error);
         Open(opener::OpenError);
         Thread(std::sync::mpsc::RecvError);
+        Bincode(bincode::Error);
     }
 
     errors {

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -52,18 +52,22 @@ pub fn if_not_empty<S: PartialEq<str>>(s: S) -> Option<S> {
     }
 }
 
-pub fn write_file(path: &Path, contents: &str) -> io::Result<()> {
+pub fn write_file_bytes(path: &Path, contents: &[u8]) -> io::Result<()> {
     let mut file = fs::OpenOptions::new()
         .write(true)
         .truncate(true)
         .create(true)
         .open(path)?;
 
-    io::Write::write_all(&mut file, contents.as_bytes())?;
+    io::Write::write_all(&mut file, contents)?;
 
     file.sync_data()?;
 
     Ok(())
+}
+
+pub fn write_file(path: &Path, contents: &str) -> io::Result<()> {
+    write_file_bytes(path, contents.as_bytes())
 }
 
 pub fn filter_file<F: FnMut(&str) -> bool>(

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -61,6 +61,13 @@ pub fn read_file(name: &'static str, path: &Path) -> Result<String> {
     })
 }
 
+pub fn write_file_bytes(name: &'static str, path: &Path, contents: &[u8]) -> Result<()> {
+    raw::write_file_bytes(path, contents).chain_err(|| ErrorKind::WritingFile {
+        name,
+        path: PathBuf::from(path),
+    })
+}
+
 pub fn write_file(name: &'static str, path: &Path, contents: &str) -> Result<()> {
     raw::write_file(path, contents).chain_err(|| ErrorKind::WritingFile {
         name,


### PR DESCRIPTION
This goes some of the way to mitigating #2626 but isn't a "fix" per-se.

Not least, we need to be sure of whether this is valid.