### PR TITLE
Add gnux32 to `LIST_ENVS`

### DIFF
--- a/src/dist/triple.rs
+++ b/src/dist/triple.rs
@@ -36,6 +36,7 @@ static LIST_OSES: &[&str] = &[
 ];
 static LIST_ENVS: &[&str] = &[
     "gnu",
+    "gnux32",
     "msvc",
     "gnueabi",
     "gnueabihf",


### PR DESCRIPTION
This got rustup to accept set default-host and the installer to not choke on it, though not much further