### PR TITLE
download: Use an IP address when testing socks support

### DIFF
--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -64,7 +64,7 @@ fn socks_proxy_request() {
     });
 
     let env_proxy = |url: &Url| for_url(&url).to_url();
-    let url = Url::parse("http://example.org").unwrap();
+    let url = Url::parse("http://192.168.0.1/").unwrap();
 
     let client = Client::builder()
         .proxy(Proxy::custom(env_proxy))


### PR DESCRIPTION
In order that we can test socks, we have to attempt an HTTP request
in toto.  Unfortunately if the test environment has broken (or
intermittently failing) DNS then this test can fail incorrectly.

By changing the request to an IP address we can check that the
SOCKS proxy is used without needing to rely on the DNS.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>