### PR TITLE
Fix typo in error messages.

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -425,7 +425,7 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
     if cs.len() == 1 {
         let _ = writeln!(
             buf,
-            "component {} is unavailable for download for channel '{}'",
+            "component {} is unavailable for download for channel '{}'. ",
             &cs[0].description(manifest),
             toolchain,
         );


### PR DESCRIPTION
**Problem:**
Currently when a component is unavailable, the error message shows:
```
error: component 'xxx' for target 'x' is unavailable for download for channel stableIf you don't need the component, you can remove it with:
```
A period is missing between stable and If.

**Changes:**
Add a period and a space here.