### PR TITLE
rustup-init.sh: Check for /proc early

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -140,6 +140,14 @@ main() {
     return "$_retval"
 }
 
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
 get_bitness() {
     need_cmd head
     # Architecture detection without dependencies beyond coreutils.
@@ -237,6 +245,7 @@ get_architecture() {
             ;;
 
         Linux)
+            check_proc
             _ostype=unknown-linux-$_clibtype
             _bitness=$(get_bitness)
             ;;


### PR DESCRIPTION
Check for /proc being mounted as soon as we identify that we're
running the installer on Linux.  We need /proc for various reasons
and it'd be better to error out cleanly than to report spurious
messages and then error out later in a confusing way.

This fixes #2654

@joshtriplett Do you think this error is okay?  Testing this in CI is a tad tough sadly.