### PR TITLE
Don't access the Internet in the check_updates tests

### DIFF
--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -4,8 +4,8 @@
 pub mod mock;
 
 use crate::mock::clitools::{
-    self, expect_err_ex, expect_ok, expect_ok_ex, expect_stdout_ok, self_update_setup,
-    set_current_dist_date, Config, Scenario,
+    self, check_update_setup, expect_err_ex, expect_ok, expect_ok_ex, expect_stdout_ok,
+    self_update_setup, set_current_dist_date, Config, Scenario,
 };
 use rustup::for_host;
 use rustup::test::this_host_triple;
@@ -68,7 +68,7 @@ fn update_again() {
 
 #[test]
 fn check_updates_none() {
-    setup(&|config| {
+    check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
@@ -88,7 +88,7 @@ nightly-{0} - Up to date : 1.2.0 (hash-nightly-1)
 
 #[test]
 fn check_updates_some() {
-    setup(&|config| {
+    check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
@@ -151,7 +151,7 @@ fn check_updates_self_no_change() {
 
 #[test]
 fn check_updates_with_update() {
-    setup(&|config| {
+    check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
         expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
         expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -189,28 +189,31 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     assert!(!PathBuf::from("./bogus-cargo-home").exists());
 }
 
+fn create_local_update_server(self_dist: &Path, config: &mut Config, version: &str) {
+    let trip = this_host_triple();
+    let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
+    let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
+    let rustup_bin = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
+
+    fs::create_dir_all(dist_dir).unwrap();
+    output_release_file(&self_dist, "1", version);
+    fs::copy(&rustup_bin, &dist_exe).unwrap();
+
+    let root_url = format!("file://{}", self_dist.display());
+    config.rustup_update_root = Some(root_url);
+}
+
 pub fn check_update_setup(f: &dyn Fn(&mut Config)) {
     let version = env!("CARGO_PKG_VERSION");
 
     setup(Scenario::ArchivesV2, &|config| {
-        // Create a mock self-update server
         let self_dist_tmp = tempfile::Builder::new()
             .prefix("self_dist")
             .tempdir()
             .unwrap();
         let self_dist = self_dist_tmp.path();
 
-        let trip = this_host_triple();
-        let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
-        let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
-        let rustup_bin = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
-
-        fs::create_dir_all(dist_dir).unwrap();
-        output_release_file(self_dist, "1", version);
-        fs::copy(&rustup_bin, &dist_exe).unwrap();
-
-        let root_url = format!("file://{}", self_dist.display());
-        config.rustup_update_root = Some(root_url);
+        create_local_update_server(self_dist, config, version);
 
         f(config);
     });
@@ -225,21 +228,16 @@ pub fn self_update_setup(f: &dyn Fn(&Config, &Path), version: &str) {
             .unwrap();
         let self_dist = self_dist_tmp.path();
 
+        create_local_update_server(self_dist, config, version);
+
         let trip = this_host_triple();
         let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
         let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
-        let rustup_bin = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
 
-        fs::create_dir_all(dist_dir).unwrap();
-        output_release_file(self_dist, "1", version);
-        fs::copy(&rustup_bin, &dist_exe).unwrap();
         // Modify the exe so it hashes different
         raw::append_file(&dist_exe, "").unwrap();
 
-        let root_url = format!("file://{}", self_dist.display());
-        config.rustup_update_root = Some(root_url);
-
-        f(config, self_dist);
+        f(config, &self_dist);
     });
 }
 

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -189,6 +189,33 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     assert!(!PathBuf::from("./bogus-cargo-home").exists());
 }
 
+pub fn check_update_setup(f: &dyn Fn(&mut Config)) {
+    let version = env!("CARGO_PKG_VERSION");
+
+    setup(Scenario::ArchivesV2, &|config| {
+        // Create a mock self-update server
+        let self_dist_tmp = tempfile::Builder::new()
+            .prefix("self_dist")
+            .tempdir()
+            .unwrap();
+        let self_dist = self_dist_tmp.path();
+
+        let trip = this_host_triple();
+        let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
+        let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
+        let rustup_bin = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
+
+        fs::create_dir_all(dist_dir).unwrap();
+        output_release_file(self_dist, "1", version);
+        fs::copy(&rustup_bin, &dist_exe).unwrap();
+
+        let root_url = format!("file://{}", self_dist.display());
+        config.rustup_update_root = Some(root_url);
+
+        f(config);
+    });
+}
+
 pub fn self_update_setup(f: &dyn Fn(&Config, &Path), version: &str) {
     setup(Scenario::SimpleV2, &|config| {
         // Create a mock self-update server


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustup/issues/2663

---

Previously, three of the tests in `cli-exact.rs` would try to connect to the Internet, or fail if the Internet wasn't available:

*   `check_updates_with_update`
*   `check_updates_none`
*   `check_updates_some`

This is because all three tests would run `rustup check`, and because the tests weren't overriding the value of `RUSTUP_UPDATE_ROOT`, they'd go out to the Internet to try to download self-updates.

The new helper mimics the behaviour of the `self_update_setup()` helper in the same file.  It creates a mock self-update server in a local directory, and points rustup to the directory using a `file://` URL.  When it tries to get self-updates as part of `rustup check`, it only fetches from that directory.

---

I've tested this patch both with and without an Internet connection, and all the tests pass in both cases.

I've run the Clippy linter, but the only warnings are from code I haven't changed in this patch. Do I need to do anything about that?

<details>
<summary>Output of <code>cargo +nightly clippy --all --all-targets -- -D warnings</code></summary>

```
$ cargo +nightly clippy --all --all-targets -- -D warnings
    Checking rustup v1.23.1 (/Users/alexwlchan/repos/rustup)
error: name `OverrideDB` contains a capitalized acronym
  --> src/config.rs:62:5
   |
62 |     OverrideDB(PathBuf),
   |     ^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `OverrideDb`
   |
   = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `OSProcess` contains a capitalized acronym
   --> src/currentprocess.rs:182:12
    |
182 | pub struct OSProcess {}
    |            ^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `OsProcess`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `OverrideDB` contains a capitalized acronym
  --> src/config.rs:62:5
   |
62 |     OverrideDB(PathBuf),
   |     ^^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter: `OverrideDb`
   |
   = note: `-D clippy::upper-case-acronyms` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `OSProcess` contains a capitalized acronym
   --> src/currentprocess.rs:182:12
    |
182 | pub struct OSProcess {}
    |            ^^^^^^^^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `OsProcess`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `IO` contains a capitalized acronym
 --> src/utils/units.rs:6:5
  |
6 |     IO,
  |     ^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `Io`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `IO` contains a capitalized acronym
  --> src/utils/units.rs:17:5
   |
17 |     IO(usize, UnitMode),
   |     ^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `Io`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `IO` contains a capitalized acronym
 --> src/utils/units.rs:6:5
  |
6 |     IO,
  |     ^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `Io`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: name `IO` contains a capitalized acronym
  --> src/utils/units.rs:17:5
   |
17 |     IO(usize, UnitMode),
   |     ^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `Io`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

error: aborting due to 4 previous errors

error: could not compile `rustup`

To learn more, run the command again with --verbose.
warning: build failed, waiting for other jobs to finish...
error: aborting due to 4 previous errors

error: build failed
```
</details>

h/t @Manishearth for [his tweet linking to Rustup issues](https://twitter.com/ManishEarth/status/1361785243070459904), and @brson for a comment written five years ago (https://github.com/rust-lang/rustup/commit/922babebb3287039ed85aad24153c08e630cca9c / `cli-self-update.rs` / _"Modify the exe so it hashes different"_) that helped me understand some confusing behaviour while I was debugging my changes.