### PR TITLE
compression: Refactor handling of compression formats

### DIFF
--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1051,7 +1051,7 @@ fn make_component_unavailable(config: &Config, name: &str, target: &str) {
         let std_pkg = manifest.packages.get_mut(name).unwrap();
         let target = TargetTriple::new(target);
         let target_pkg = std_pkg.targets.get_mut(&target).unwrap();
-        target_pkg.bins = None;
+        target_pkg.bins = Vec::new();
     }
     let manifest_str = manifest.stringify();
     rustup::utils::raw::write_file(&manifest_path, &manifest_str).unwrap();

--- a/tests/dist_manifest.rs
+++ b/tests/dist_manifest.rs
@@ -27,8 +27,8 @@ fn parse_smoke_test() {
         .get_target(Some(&x86_64_unknown_linux_gnu))
         .unwrap();
     assert_eq!(rust_target_pkg.available(), true);
-    assert_eq!(rust_target_pkg.bins.clone().unwrap().url, "example.com");
-    assert_eq!(rust_target_pkg.bins.clone().unwrap().hash, "...");
+    assert_eq!(rust_target_pkg.bins[0].1.url, "example.com");
+    assert_eq!(rust_target_pkg.bins[0].1.hash, "...");
 
     let component = &rust_target_pkg.components[0];
     assert_eq!(component.short_name_in_manifest(), "rustc");
@@ -42,7 +42,7 @@ fn parse_smoke_test() {
     let docs_target_pkg = docs_pkg
         .get_target(Some(&x86_64_unknown_linux_gnu))
         .unwrap();
-    assert_eq!(docs_target_pkg.bins.clone().unwrap().url, "example.com");
+    assert_eq!(docs_target_pkg.bins[0].1.url, "example.com");
 }
 
 #[test]


### PR DESCRIPTION
In preparation for adding zstd support to rustup, this rework
means that we treat compression formats we have available (and know)
generically without breaking if unexpected formats are present,
or if no format we know is present.

In theory this means that we won't error out if a component is labelled "available" but then has no compression format we understand.  Still things ought to behave well enough.