### PR TITLE
Add path override to rust-toolchain.toml

### DIFF
--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -83,13 +83,16 @@ a directory, the latter is used for backwards compatibility. The files use the
 ``` toml
 [toolchain]
 channel = "nightly-2020-07-10"
+# or
+path = "/path/to/local/toolchain"
+
 components = [ "rustfmt", "rustc-dev" ]
 targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
 profile = "minimal"
 ```
 
 The `[toolchain]` section is mandatory, and at least one property must be
-specified.
+specified. `channel` and `path` are mutually exclusive.
 
 For backwards compatibility, `rust-toolchain` files also support a legacy
 format that only contains a toolchain name without any TOML encoding, e.g.
@@ -104,7 +107,9 @@ The toolchains named in these files have a more restricted form than `rustup`
 toolchains generally, and may only contain the names of the three release
 channels, 'stable', 'beta', 'nightly', Rust version numbers, like '1.0.0', and
 optionally an archive date, like 'nightly-2017-01-01'. They may not name
-custom toolchains, nor host-specific toolchains.
+custom toolchains, nor host-specific toolchains, except by giving the
+`path` to said toolchain directly. A relative `path` is resolved
+relative to the location of the `rust-toolchain.toml` file.
 
 ## Default toolchain
 

--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -83,9 +83,6 @@ a directory, the latter is used for backwards compatibility. The files use the
 ``` toml
 [toolchain]
 channel = "nightly-2020-07-10"
-# or
-path = "/path/to/local/toolchain"
-
 components = [ "rustfmt", "rustc-dev" ]
 targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
 profile = "minimal"
@@ -107,9 +104,19 @@ The toolchains named in these files have a more restricted form than `rustup`
 toolchains generally, and may only contain the names of the three release
 channels, 'stable', 'beta', 'nightly', Rust version numbers, like '1.0.0', and
 optionally an archive date, like 'nightly-2017-01-01'. They may not name
-custom toolchains, nor host-specific toolchains, except by giving the
-`path` to said toolchain directly. A relative `path` is resolved
-relative to the location of the `rust-toolchain.toml` file.
+custom toolchains, nor host-specific toolchains. To use a custom local
+toolchain, you can instead use a `path` toolchain:
+
+``` toml
+[toolchain]
+path = "/path/to/local/toolchain"
+```
+
+Since a `path` directive directly names a local toolchain, other options
+like `components`, `targets`, and `profile` have no effect. `channel`
+and `path` are mutually exclusive, since a `path` already points to a
+specific toolchain. A relative `path` is resolved relative to the
+location of the `rust-toolchain.toml` file.
 
 ## Default toolchain
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -54,14 +54,14 @@ impl<T: Into<String>> From<T> for OverrideFile {
         if Path::new(&override_).is_absolute() {
             Self {
                 toolchain: ToolchainSection {
-                    channel: Some(override_),
+                    path: Some(PathBuf::from(override_)),
                     ..Default::default()
                 },
             }
         } else {
             Self {
                 toolchain: ToolchainSection {
-                    path: Some(PathBuf::from(override_)),
+                    channel: Some(override_),
                     ..Default::default()
                 },
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,21 +47,11 @@ impl ToolchainSection {
 
 impl<T: Into<String>> From<T> for OverrideFile {
     fn from(channel: T) -> Self {
-        let channel = channel.into();
-        if channel.contains('/') || channel.contains('\\') {
-            Self {
-                toolchain: ToolchainSection {
-                    path: Some(channel),
-                    ..Default::default()
-                },
-            }
-        } else {
-            Self {
-                toolchain: ToolchainSection {
-                    channel: Some(channel),
-                    ..Default::default()
-                },
-            }
+        Self {
+            toolchain: ToolchainSection {
+                channel: Some(channel.into()),
+                ..Default::default()
+            },
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -609,6 +609,13 @@ impl Cfg {
                         dist::validate_channel_name(&toolchain_name)?;
                     }
                 }
+                if let Some(toolchain_path) = &override_file.toolchain.path {
+                    // Perform minimal validation; there should at least be a `bin/` that might
+                    // contain things for us to run.
+                    if !toolchain_path.join("bin").is_dir() {
+                        return Err(ErrorKind::InvalidToolchainPath(toolchain_path.into()).into());
+                    }
+                }
 
                 let reason = OverrideReason::ToolchainFile(toolchain_file);
                 return Ok(Some((override_file, reason)));

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,15 @@ impl<'a> OverrideCfg<'a> {
         Ok(Self {
             toolchain: match (file.toolchain.channel, file.toolchain.path) {
                 (Some(name), None) => Some(Toolchain::from(cfg, &name)?),
-                (None, Some(path)) => Some(Toolchain::from_path(cfg, cfg_path, &path)?),
+                (None, Some(path)) => {
+                    if file.toolchain.targets.is_some()
+                        || file.toolchain.components.is_some()
+                        || file.toolchain.profile.is_some()
+                    {
+                        return Err(ErrorKind::CannotSpecifyPathAndOptions(path.into()).into());
+                    }
+                    Some(Toolchain::from_path(cfg, cfg_path, &path)?)
+                }
                 (Some(channel), Some(path)) => {
                     return Err(ErrorKind::CannotSpecifyChannelAndPath(channel, path.into()).into())
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,11 +50,21 @@ impl ToolchainSection {
 
 impl<T: Into<String>> From<T> for OverrideFile {
     fn from(channel: T) -> Self {
-        Self {
-            toolchain: ToolchainSection {
-                channel: Some(channel.into()),
-                ..Default::default()
-            },
+        let override_ = channel.into();
+        if Path::new(&override_).is_absolute() {
+            Self {
+                toolchain: ToolchainSection {
+                    channel: Some(override_),
+                    ..Default::default()
+                },
+            }
+        } else {
+            Self {
+                toolchain: ToolchainSection {
+                    path: Some(PathBuf::from(override_)),
+                    ..Default::default()
+                },
+            }
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -552,11 +552,11 @@ impl Cfg {
                 }
                 OverrideReason::OverrideDB(ref path) => format!(
                     "the directory override for '{}' specifies an uninstalled toolchain",
-                    path.display()
+                    utils::canonicalize_path(path, self.notify_handler.as_ref()).display(),
                 ),
                 OverrideReason::ToolchainFile(ref path) => format!(
                     "the toolchain file at '{}' specifies an uninstalled toolchain",
-                    path.display()
+                    utils::canonicalize_path(path, self.notify_handler.as_ref()).display(),
                 ),
             };
 
@@ -593,8 +593,7 @@ impl Cfg {
         settings: &Settings,
     ) -> Result<Option<(OverrideFile, OverrideReason)>> {
         let notify = self.notify_handler.as_ref();
-        let dir = utils::canonicalize_path(dir, notify);
-        let mut dir = Some(&*dir);
+        let mut dir = Some(dir);
 
         while let Some(d) = dir {
             // First check the override database

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ impl OverrideFile {
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
 struct ToolchainSection {
     channel: Option<String>,
-    path: Option<String>,
+    path: Option<PathBuf>,
     components: Option<Vec<String>>,
     targets: Option<Vec<String>>,
     profile: Option<String>,
@@ -41,7 +41,10 @@ struct ToolchainSection {
 
 impl ToolchainSection {
     fn is_empty(&self) -> bool {
-        self.channel.is_none() && self.components.is_none() && self.targets.is_none()
+        self.channel.is_none()
+            && self.components.is_none()
+            && self.targets.is_none()
+            && self.path.is_none()
     }
 }
 
@@ -534,6 +537,7 @@ impl Cfg {
                     path.display()
                 ),
             };
+
             let override_cfg = OverrideCfg::from_file(self, file)?;
             if let Some(toolchain) = &override_cfg.toolchain {
                 // Overridden toolchains can be literally any string, but only
@@ -1015,6 +1019,27 @@ channel = "nightly-2020-07-10"
                 toolchain: ToolchainSection {
                     channel: Some("nightly-2020-07-10".into()),
                     path: None,
+                    components: None,
+                    targets: None,
+                    profile: None,
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn parse_toml_toolchain_file_only_path() {
+        let contents = r#"[toolchain]
+path = "foobar"
+"#;
+
+        let result = Cfg::parse_override_file(contents, ParseMode::Both);
+        assert_eq!(
+            result.unwrap(),
+            OverrideFile {
+                toolchain: ToolchainSection {
+                    channel: None,
+                    path: Some("foobar".into()),
                     components: None,
                     targets: None,
                     profile: None,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -192,6 +192,10 @@ error_chain! {
             description("invalid toolchain path"),
             display("invalid toolchain path: '{}'", p.display())
         }
+        CannotSpecifyPathAndOptions(path: PathBuf) {
+            description("toolchain options are ignored for path toolchains"),
+            display("toolchain options are ignored for path toolchain ({})", path.display())
+        }
         CannotSpecifyChannelAndPath(channel: String, path: PathBuf) {
             description("cannot specify channel and path simultaneously"),
             display("cannot specify both channel ({}) and path ({}) simultaneously", channel, path.display())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -188,6 +188,14 @@ error_chain! {
             description("invalid toolchain name")
             display("invalid toolchain name: '{}'", t)
         }
+        InvalidToolchainPath(p: PathBuf) {
+            description("invalid toolchain path"),
+            display("invalid toolchain path: '{}'", p.display())
+        }
+        CannotSpecifyChannelAndPath(channel: String, path: PathBuf) {
+            description("cannot specify channel and path simultaneously"),
+            display("cannot specify both channel ({}) and path ({}) simultaneously", channel, path.display())
+        }
         InvalidProfile(t: String) {
             description("invalid profile name")
             display("invalid profile name: '{}'; valid names are: {}", t, valid_profile_names())

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -190,7 +190,7 @@ error_chain! {
         }
         InvalidToolchainPath(p: PathBuf) {
             description("invalid toolchain path"),
-            display("invalid toolchain path: '{}'", p.display())
+            display("invalid toolchain path: '{}'", p.to_string_lossy())
         }
         CannotSpecifyPathAndOptions(path: PathBuf) {
             description("toolchain options are ignored for path toolchains"),

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -143,8 +143,14 @@ impl<'a> Display for Notification<'a> {
             } => write!(
                 f,
                 "both `{0}` and `{1}` exist. Using `{0}`",
-                rust_toolchain.display(),
-                rust_toolchain_toml.display()
+                rust_toolchain
+                    .canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(rust_toolchain))
+                    .display(),
+                rust_toolchain_toml
+                    .canonicalize()
+                    .unwrap_or_else(|_| PathBuf::from(rust_toolchain_toml))
+                    .display(),
             ),
         }
     }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -87,15 +87,13 @@ impl<'a> Toolchain<'a> {
 
         // Perform minimal validation; there should at least be a `bin/` that might
         // contain things for us to run.
-        if !path.join("bin").is_dir() {
+        if !dbg!(path.join("bin")).is_dir() {
             return Err(ErrorKind::InvalidToolchainPath(path.into()).into());
         }
 
         Ok(Toolchain {
             cfg,
-            name: path
-                .as_os_str()
-                .to_str()
+            name: dbg!(path.to_str())
                 .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.clone().into()))?
                 .to_owned(),
             path,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -63,12 +63,35 @@ pub enum UpdateStatus {
 
 impl<'a> Toolchain<'a> {
     pub fn from(cfg: &'a Cfg, name: &str) -> Result<Self> {
+        if name.contains('/') || name.contains('\\') {
+            return Self::from_path(cfg, name);
+        }
         let resolved_name = cfg.resolve_toolchain(name)?;
         let path = cfg.toolchains_dir.join(&resolved_name);
         Ok(Toolchain {
             cfg,
             name: resolved_name,
             path,
+            dist_handler: Box::new(move |n| (cfg.notify_handler)(n.into())),
+        })
+    }
+
+    pub fn from_path(cfg: &'a Cfg, path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let base = path
+            .components()
+            .last()
+            .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.into()))?
+            .as_os_str()
+            .to_string_lossy();
+        // Perform minimal validation - that there's a `bin/` which might contain things for us to run
+        if !path.join("bin").is_dir() {
+            return Err(ErrorKind::InvalidToolchainPath(path.into()).into());
+        }
+        Ok(Toolchain {
+            cfg,
+            name: base.into(),
+            path: path.to_path_buf(),
             dist_handler: Box::new(move |n| (cfg.notify_handler)(n.into())),
         })
     }
@@ -252,6 +275,15 @@ impl<'a> Toolchain<'a> {
         } else {
             String::from("(toolchain not installed)")
         }
+    }
+}
+
+impl<'a> std::fmt::Debug for Toolchain<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Toolchain")
+            .field("name", &self.name)
+            .field("path", &self.path)
+            .finish()
     }
 }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -87,13 +87,14 @@ impl<'a> Toolchain<'a> {
 
         // Perform minimal validation; there should at least be a `bin/` that might
         // contain things for us to run.
-        if !dbg!(path.join("bin")).is_dir() {
+        if !path.join("bin").is_dir() {
             return Err(ErrorKind::InvalidToolchainPath(path.into()).into());
         }
 
         Ok(Toolchain {
             cfg,
-            name: dbg!(path.to_str())
+            name: path
+                .to_str()
                 .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.clone().into()))?
                 .to_owned(),
             path,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -64,9 +64,6 @@ pub enum UpdateStatus {
 
 impl<'a> Toolchain<'a> {
     pub fn from(cfg: &'a Cfg, name: &str) -> Result<Self> {
-        if name.contains('/') || name.contains('\\') {
-            return Self::from_path(cfg, name);
-        }
         let resolved_name = cfg.resolve_toolchain(name)?;
         let path = cfg.toolchains_dir.join(&resolved_name);
         Ok(Toolchain {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -91,15 +91,13 @@ impl<'a> Toolchain<'a> {
             return Err(ErrorKind::InvalidToolchainPath(path.into()).into());
         }
 
-        let base = path
-            .components()
-            .last()
-            .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.clone()))?
-            .as_os_str()
-            .to_string_lossy();
         Ok(Toolchain {
             cfg,
-            name: base.into(),
+            name: path
+                .as_os_str()
+                .to_str()
+                .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.clone().into()))?
+                .to_owned(),
             path,
             dist_handler: Box::new(move |n| (cfg.notify_handler)(n.into())),
         })

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -82,10 +82,6 @@ impl<'a> Toolchain<'a> {
             .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.into()))?
             .as_os_str()
             .to_string_lossy();
-        // Perform minimal validation - that there's a `bin/` which might contain things for us to run
-        if !path.join("bin").is_dir() {
-            return Err(ErrorKind::InvalidToolchainPath(path.into()).into());
-        }
         Ok(Toolchain {
             cfg,
             name: base.into(),

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -93,7 +93,7 @@ impl<'a> Toolchain<'a> {
 
         Ok(Toolchain {
             cfg,
-            name: path
+            name: utils::canonicalize_path(&path, cfg.notify_handler.as_ref())
                 .to_str()
                 .ok_or_else(|| ErrorKind::InvalidToolchainPath(path.clone().into()))?
                 .to_owned(),

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1562,11 +1562,14 @@ fn file_override_path_relative() {
         for p in p1 {
             relative_path.push(p);
         }
-        assert!(relative_path.is_relative());
+        assert!(dbg!(&relative_path).is_relative());
 
         raw::write_file(
             &toolchain_file,
-            &format!("[toolchain]\npath='{}'", relative_path.to_str().unwrap()),
+            dbg!(&format!(
+                "[toolchain]\npath='{}'",
+                relative_path.to_str().unwrap()
+            )),
         )
         .unwrap();
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1516,10 +1516,6 @@ fn proxy_override_path() {
 }
 
 #[test]
-#[cfg_attr(
-    windows,
-    ignore = "FIXME: Windows uses UNC paths which do not work with relative paths"
-)]
 fn file_override_path_relative() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1470,7 +1470,10 @@ fn file_override_path() {
         let toolchain_file = config.current_dir().join("rust-toolchain.toml");
         raw::write_file(
             &toolchain_file,
-            &format!("[toolchain]\npath=\"{}\"", toolchain_path.to_str().unwrap()),
+            &dbg!(format!(
+                "[toolchain]\npath=\"{}\"",
+                toolchain_path.to_str().unwrap()
+            )),
         )
         .unwrap();
 
@@ -1545,7 +1548,7 @@ fn file_override_path_relative() {
         // Find shared prefix so we can determine a relative path
         let mut p1 = dbg!(&toolchain_path).components().peekable();
         let mut p2 = dbg!(&toolchain_file).components().peekable();
-        while let (Some(p1p), Some(p2p)) = (p1.peek(), p2.peek()) {
+        while let (Some(p1p), Some(p2p)) = (dbg!(p1.peek()), dbg!(p2.peek())) {
             if p1p == p2p {
                 let _ = p1.next();
                 let _ = p2.next();
@@ -1556,13 +1559,14 @@ fn file_override_path_relative() {
         }
         let mut relative_path = PathBuf::new();
         // NOTE: We skip 1 since we don't need to .. across the .toml file at the end of the path
-        for _ in p2.skip(1) {
+        for p in p2.skip(1) {
+            dbg!(p);
             relative_path.push("..");
         }
         for p in p1 {
-            relative_path.push(p);
+            relative_path.push(dbg!(p));
         }
-        assert!(relative_path.is_relative());
+        assert!(dbg!(&relative_path).is_relative());
 
         raw::write_file(
             &toolchain_file,

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1516,6 +1516,7 @@ fn proxy_override_path() {
 }
 
 #[test]
+#[ignore = "FIXME: Windows uses UNC paths which do not work with relative paths"]
 fn file_override_path_relative() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
@@ -1556,14 +1557,11 @@ fn file_override_path_relative() {
         for p in p1 {
             relative_path.push(p);
         }
-        assert!(dbg!(&relative_path).is_relative());
+        assert!(relative_path.is_relative());
 
         raw::write_file(
             &toolchain_file,
-            dbg!(&format!(
-                "[toolchain]\npath='{}'",
-                relative_path.to_str().unwrap()
-            )),
+            &format!("[toolchain]\npath='{}'", relative_path.to_str().unwrap()),
         )
         .unwrap();
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1516,7 +1516,10 @@ fn proxy_override_path() {
 }
 
 #[test]
-#[ignore = "FIXME: Windows uses UNC paths which do not work with relative paths"]
+#[cfg_attr(
+    windows,
+    ignore = "FIXME: Windows uses UNC paths which do not work with relative paths"
+)]
 fn file_override_path_relative() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1470,10 +1470,7 @@ fn file_override_path() {
         let toolchain_file = config.current_dir().join("rust-toolchain.toml");
         raw::write_file(
             &toolchain_file,
-            &dbg!(format!(
-                "[toolchain]\npath=\"{}\"",
-                toolchain_path.to_str().unwrap()
-            )),
+            &format!("[toolchain]\npath='{}'", toolchain_path.to_str().unwrap()),
         )
         .unwrap();
 
@@ -1510,7 +1507,7 @@ fn proxy_override_path() {
         let toolchain_file = config.current_dir().join("rust-toolchain.toml");
         raw::write_file(
             &toolchain_file,
-            &format!("[toolchain]\npath=\"{}\"", toolchain_path.to_str().unwrap()),
+            &format!("[toolchain]\npath='{}'", toolchain_path.to_str().unwrap()),
         )
         .unwrap();
 
@@ -1546,9 +1543,9 @@ fn file_override_path_relative() {
             .join("rust-toolchain.toml");
 
         // Find shared prefix so we can determine a relative path
-        let mut p1 = dbg!(&toolchain_path).components().peekable();
-        let mut p2 = dbg!(&toolchain_file).components().peekable();
-        while let (Some(p1p), Some(p2p)) = (dbg!(p1.peek()), dbg!(p2.peek())) {
+        let mut p1 = toolchain_path.components().peekable();
+        let mut p2 = toolchain_file.components().peekable();
+        while let (Some(p1p), Some(p2p)) = (p1.peek(), p2.peek()) {
             if p1p == p2p {
                 let _ = p1.next();
                 let _ = p2.next();
@@ -1559,18 +1556,17 @@ fn file_override_path_relative() {
         }
         let mut relative_path = PathBuf::new();
         // NOTE: We skip 1 since we don't need to .. across the .toml file at the end of the path
-        for p in p2.skip(1) {
-            dbg!(p);
+        for _ in p2.skip(1) {
             relative_path.push("..");
         }
         for p in p1 {
-            relative_path.push(dbg!(p));
+            relative_path.push(p);
         }
-        assert!(dbg!(&relative_path).is_relative());
+        assert!(relative_path.is_relative());
 
         raw::write_file(
             &toolchain_file,
-            &format!("[toolchain]\npath=\"{}\"", relative_path.to_str().unwrap()),
+            &format!("[toolchain]\npath='{}'", relative_path.to_str().unwrap()),
         )
         .unwrap();
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1479,6 +1479,54 @@ fn file_override_path_relative() {
 }
 
 #[test]
+fn file_override_path_no_options() {
+    setup(&|config| {
+        // Make a plausible-looking toolchain
+        let cwd = config.current_dir();
+        let toolchain_path = cwd.join("ephemeral");
+        let toolchain_bin = toolchain_path.join("bin");
+        fs::create_dir_all(&toolchain_bin).unwrap();
+
+        let toolchain_file = cwd.join("rust-toolchain.toml");
+        raw::write_file(
+            &toolchain_file,
+            "[toolchain]\npath=\"ephemeral\"\ntargets=[\"dummy\"]",
+        )
+        .unwrap();
+
+        expect_err(
+            config,
+            &["rustc", "--version"],
+            "toolchain options are ignored for path toolchain (ephemeral)",
+        );
+
+        raw::write_file(
+            &toolchain_file,
+            "[toolchain]\npath=\"ephemeral\"\ncomponents=[\"dummy\"]",
+        )
+        .unwrap();
+
+        expect_err(
+            config,
+            &["rustc", "--version"],
+            "toolchain options are ignored for path toolchain (ephemeral)",
+        );
+
+        raw::write_file(
+            &toolchain_file,
+            "[toolchain]\npath=\"ephemeral\"\nprofile=\"minimal\"",
+        )
+        .unwrap();
+
+        expect_err(
+            config,
+            &["rustc", "--version"],
+            "toolchain options are ignored for path toolchain (ephemeral)",
+        );
+    });
+}
+
+#[test]
 fn file_override_path_xor_channel() {
     setup(&|config| {
         // Make a plausible-looking toolchain

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1411,6 +1411,13 @@ fn file_override_path() {
         .unwrap();
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+
+        // Check that the toolchain has the right name
+        expect_stdout_ok(
+            config,
+            &["rustup", "show", "active-toolchain"],
+            &format!("nightly-{}", this_host_triple()),
+        );
     });
 }
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1533,14 +1533,8 @@ fn file_override_path_relative() {
         let toolchain_path = config
             .rustupdir
             .join("toolchains")
-            .join(format!("nightly-{}", this_host_triple()))
-            .canonicalize()
-            .unwrap();
-        let toolchain_file = config
-            .current_dir()
-            .canonicalize()
-            .unwrap()
-            .join("rust-toolchain.toml");
+            .join(format!("nightly-{}", this_host_triple()));
+        let toolchain_file = config.current_dir().join("rust-toolchain.toml");
 
         // Find shared prefix so we can determine a relative path
         let mut p1 = toolchain_path.components().peekable();


### PR DESCRIPTION
This PR implements path-based toolchain overrides from `rust-toolchain.toml`.

Specifically, it allows `rust-toolchain.toml` to specify:

```toml
[toolchain]
path = "./ephemeral/toolchain/"
```

Which will cause `rustc` to invoke `ephemeral/toolchain/bin/rustc`, and
similarly for all other parts of the toolchain. Relative paths are resolved
relative to the `.toml` file (as opposed to the current working directory).

Replaces #2471.
Fixes #2458.

## Unresolved questions

 - What should the name of a path toolchain be? This PR currently uses the last
   component of the path, but there's also a decent argument that it should
   instead be the whole path.