### PR TITLE
Docs: indicate the default settings.toml location

### DIFF
--- a/doc/src/configuration.md
+++ b/doc/src/configuration.md
@@ -1,9 +1,9 @@
 # Configuration
 
-Rustup has a settings file in [TOML](https://github.com/toml-lang/toml) format
-at `${RUSTUP_HOME}/settings.toml`. The schema for this file is not part of the
-public interface for rustup - the rustup CLI should be used to query and set
-settings.
+Rustup has a [TOML](https://github.com/toml-lang/toml) settings file at
+`${RUSTUP_HOME}/settings.toml` (which defaults to `~/.rustup` or
+`%USERPROFILE%/.rustup`). The schema for this file is not part of the public
+interface for rustup - the rustup CLI should be used to query and set settings.
 
 On Unix operating systems a fallback settings file is consulted for some
 settings. This fallback file is located at `/etc/rustup/settings.toml` and


### PR DESCRIPTION
After having trouble finding the `settings.toml` file in my system, I thought this could be useful as there is no obvious indication that the `${RUSTUP_HOME}` is by default `~/.rustup`, maybe that should've been pointed out too?

I'm a non-native english speaker, so any corrections would be appreciated.