### PR TITLE
docs, comments: Editing and style cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rustup: the Rust toolchain installer
+# Rustup: the Rust toolchain installer
 
 | Master CI    | Build Status                                             |
 |--------------|----------------------------------------------------------|
@@ -6,7 +6,7 @@
 | macOS        | ![maOS builds][actions-macos-master]                     |
 | Linux Etc    | ![Linux (etc) builds][actions-linux-master]              |
 
-*rustup* installs [The Rust Programming Language][rustlang] from the official
+*Rustup* installs [The Rust Programming Language][rustlang] from the official
 release channels, enabling you to easily switch between stable, beta,
 and nightly compilers and keep them updated. It makes cross-compiling
 simpler with binary builds of the standard library for common platforms.
@@ -16,16 +16,16 @@ And it runs on all platforms Rust supports, including Windows.
 
 ## Documentation
 
-See [**The rustup book**](https://rust-lang.github.io/rustup/) for
-documentation on installing and using rustup.
+See [**The Rustup book**](https://rust-lang.github.io/rustup/) for
+documentation on installing and using Rustup.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for information on contributing to rustup.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for information on contributing to Rustup.
 
 ## License
 
-Copyright Diggory Blake, the Mozilla Corporation, and rustup
+Copyright Diggory Blake, the Mozilla Corporation, and Rustup
 contributors.
 
 Licensed under either of

--- a/doc/src/installation/other.md
+++ b/doc/src/installation/other.md
@@ -3,19 +3,19 @@
 The primary installation method, as described at <https://rustup.rs>, differs
 by platform:
 
-* On Windows, download and run the [rustup-init.exe built for
-  `i686-pc-windows-gnu` target][setup]. In general, this is the build of
-  `rustup` one should install on Windows. Despite being built against the GNU
-  toolchain, _the Windows build of `rustup` will install Rust for the MSVC
-  toolchain if it detects that MSVC is installed_. If you prefer to install
-  GNU toolchains or x86_64 toolchains by default this can be modified at
-  install time, either interactively or with the `--default-host` flag, or
-  after installation via `rustup set default-host`.
+* On Windows, download and run the [`rustup-init.exe` built for the
+  `x86_64-pc-windows-msvc` target][setup]. In general, this is the build of
+  `rustup` one should install on Windows. This will require the Visual C++
+  Build Tools 2019 or equivalent (Visual Studio 2019, etc.) to already be
+  installed. If you would prefer to install GNU toolchains or the i686
+  toolchains by default this can be modified at install time, either
+  interactively, with the `--default-host` flag, or after installation
+  via `rustup set default-host`.
 * On Unix, run `curl https://sh.rustup.rs -sSf | sh` in your shell. This
   downloads and runs [`rustup-init.sh`], which in turn downloads and runs the
   correct version of the `rustup-init` executable for your platform.
 
-[setup]: https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe
+[setup]: https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
 [`rustup-init.sh`]: https://static.rust-lang.org/rustup/rustup-init.sh
 
 `rustup-init` accepts arguments, which can be passed through the shell script.

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -1,15 +1,14 @@
-//! The main rustup commandline application
+//! The main Rustup command-line interface
 //!
 //! The rustup binary is a chimera, changing its behavior based on the
 //! name of the binary. This is used most prominently to enable
-//! rustup's tool 'proxies' - that is, rustup itself and the rustup
-//! proxies are the same binary; when the binary is called 'rustup' or
-//! 'rustup.exe' rustup behaves like the rustup commandline
-//! application; when it is called 'rustc' it behaves as a proxy to
-//! 'rustc'.
+//! Rustup's tool 'proxies' - that is, rustup itself and the rustup
+//! proxies are the same binary: when the binary is called 'rustup' or
+//! 'rustup.exe' it offers the Rustup command-line interface, and
+//! when it is called 'rustc' it behaves as a proxy to 'rustc'.
 //!
-//! This scheme is further used to distinguish the rustup installer,
-//! called 'rustup-init' which is again just the rustup binary under a
+//! This scheme is further used to distinguish the Rustup installer,
+//! called 'rustup-init', which is again just the rustup binary under a
 //! different name.
 
 #![recursion_limit = "1024"]

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,5 +1,5 @@
 pub static RUSTUP_HELP: &str = r"DISCUSSION:
-    rustup installs The Rust Programming Language from the official
+    Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes
     cross-compiling simpler with binary builds of the standard library
@@ -105,7 +105,7 @@ pub static TOOLCHAIN_LINK_HELP: &str = r"DISCUSSION:
     toolchain 'latest-stage1' will be used.";
 
 pub static OVERRIDE_HELP: &str = r"DISCUSSION:
-    Overrides configure rustup to use a specific toolchain when
+    Overrides configure Rustup to use a specific toolchain when
     running in a specific directory.
 
     Directories can be assigned their own Rust toolchain with `rustup

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -1,6 +1,6 @@
 // FIXME: stolen from cargo. Should be extracted into a common crate.
 
-//! Job management (mostly for windows)
+//! Job management (mostly for Windows)
 //!
 //! Most of the time when you're running cargo you expect Ctrl-C to actually
 //! terminate the entire tree of processes in play, not just the one at the top

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -21,7 +21,7 @@
 //!
 //! Rustup addresses this by:
 //! 1) using a shell script that updates PATH if the path is not in PATH
-//! 2) sourcing this script in any known and appropriate rc file
+//! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
 
 use std::path::PathBuf;
 
@@ -82,7 +82,7 @@ pub trait UnixShell {
     // heuristic should be used, assuming shells exist if any traces do.
     fn does_exist(&self) -> bool;
 
-    // Gives all rcfiles of a given shell that rustup is concerned with.
+    // Gives all rcfiles of a given shell that Rustup is concerned with.
     // Used primarily in checking rcfiles for cleanup.
     fn rcfiles(&self) -> Vec<PathBuf>;
 

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -129,13 +129,7 @@ pub fn do_remove_from_programs() -> Result<()> {
 }
 
 /// Tell the upgrader to replace the rustup bins, then delete
-/// itself. Like with uninstallation, on Windows we're going to
-/// have to jump through hoops to make everything work right.
-///
-/// On windows we're not going to wait for it to finish before exiting
-/// successfully, so it should not do much, and it should try
-/// really hard to succeed, because at this point the upgrade is
-/// considered successful.
+/// itself.
 pub fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
     let status = Command::new(setup_path)
         .arg("--self-replace")
@@ -151,8 +145,7 @@ pub fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
 
 /// This function is as the final step of a self-upgrade. It replaces
 /// `CARGO_HOME`/bin/rustup with the running exe, and updates the the
-/// links to it. On windows this will run *after* the original
-/// rustup process exits.
+/// links to it.
 pub fn self_replace() -> Result<utils::ExitCode> {
     install_bins()?;
 
@@ -181,7 +174,7 @@ fn remove_legacy_source_command(source_cmd: String) -> Result<()> {
 
 fn remove_legacy_paths() -> Result<()> {
     // Before the work to support more kinds of shells, which was released in
-    // version 1.23.0 of rustup, we always inserted this line instead, which is
+    // version 1.23.0 of Rustup, we always inserted this line instead, which is
     // now considered legacy
     remove_legacy_source_command(format!(
         "export PATH=\"{}/bin:$PATH\"\n",

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -383,7 +383,7 @@ pub fn self_replace() -> Result<utils::ExitCode> {
 // like when they are running.
 //
 // Here's what we're going to do:
-// - Copy rustup to a temporary file in
+// - Copy rustup.exe to a temporary file in
 //   CARGO_HOME/../rustup-gc-$random.exe.
 // - Open the gc exe with the FILE_FLAG_DELETE_ON_CLOSE and
 //   FILE_SHARE_DELETE flags. This is going to be the last

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -391,7 +391,7 @@ pub fn self_replace() -> Result<utils::ExitCode> {
 //   This file is opened as inheritable so that subsequent
 //   processes created with the option to inherit handles
 //   will also keep them open.
-// - Run the gc exe, which waits for the original rustup
+// - Run the gc exe, which waits for the original rustup.exe
 //   process to close, then deletes CARGO_HOME. This process
 //   has inherited a FILE_FLAG_DELETE_ON_CLOSE handle to itself.
 // - Finally, spawn yet another system binary with the inherit handles

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,4 @@
-///!  Utility functions for rustup
+///!  Utility functions for Rustup
 pub mod notifications;
 pub mod raw;
 pub mod toml_utils;


### PR DESCRIPTION
Closes #2693.
Stylistic choices for the "Rustup" name based on remarks in #2670. I have followed, where possible, the intuition that the binary itself is named `rustup` (or `rustup.exe`) and that the _notional_ software is named Rustup.