### PR TITLE
Fix some warnings

### DIFF
--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -42,10 +42,8 @@ fn search_path(doc: &DocData<'_>, wpath: &Path, keywords: &[&str]) -> Result<Pat
                 return Ok(dir.join(filename));
             }
         }
-        no_document(doc.topic)
-    } else {
-        no_document(doc.topic)
     }
+    no_document(doc.topic)
 }
 
 pub fn local_path(root: &Path, topic: &str) -> Result<PathBuf> {

--- a/src/diskio/immediate.rs
+++ b/src/diskio/immediate.rs
@@ -154,8 +154,8 @@ impl IncrementalFileWriter {
             opts.write(true).create(true).truncate(true).open(path)?
         });
         Ok(IncrementalFileWriter {
-            file,
             state,
+            file,
             path_display,
         })
     }

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -14,7 +14,7 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
         vars,
         ..Default::default()
     });
-    currentprocess::with(tp.clone(), || -> Result<()> {
+    currentprocess::with(tp, || -> Result<()> {
         let mut written = 0;
         let mut file_finished = false;
         let mut io_executor: Box<dyn Executor> = get_executor(None)?;
@@ -31,7 +31,7 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
         chunk.extend(b"0123456789");
         // We should be able to submit more than one chunk
         sender(chunk.clone());
-        sender(chunk.clone());
+        sender(chunk);
         loop {
             for work in io_executor.completed().collect::<Vec<_>>() {
                 match work {
@@ -54,7 +54,7 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
                     }
                 }
             }
-            if file_finished == true {
+            if file_finished {
                 break;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 #![allow(
     clippy::too_many_arguments,
     clippy::type_complexity,
-    clippy::upper_case_acronyms // see https://github.com/rust-lang/rust-clippy/issues/6974
+    clippy::upper_case_acronyms, // see https://github.com/rust-lang/rust-clippy/issues/6974
+    clippy::vec_init_then_push, // uses two different styles of initialization
 )]
 #![recursion_limit = "1024"]
 

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -106,7 +106,8 @@ Rust is installed now. Great!
 
 "
             )),
-            format!("pattern not found in \"\"\"{}\"\"\"", out.stdout)
+            "pattern not found in \"\"\"{}\"\"\"",
+            out.stdout
         );
         if cfg!(unix) {
             assert!(!config.homedir.join(".profile").exists());

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -501,17 +501,16 @@ enum Compressions {
     GZOnly,
     AddXZ,
     AddZStd,
-    AddXZAndZStd,
 }
 use Compressions::*;
 
 impl Compressions {
     fn enable_xz(self) -> bool {
-        matches!(self, AddXZ | AddXZAndZStd)
+        matches!(self, AddXZ)
     }
 
     fn enable_zst(self) -> bool {
-        matches!(self, AddZStd | AddXZAndZStd)
+        matches!(self, AddZStd)
     }
 }
 


### PR DESCRIPTION
- Remove unnecessary format
- Remove unnecessary clones
- Remove unused enum variants
- Reorder fields to make clippy happy
- Remove duplicate code in if/else block
- Silence unhelpful lint