### PR TITLE
Replace & add tags for product names

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -20,9 +20,9 @@
 </a>
 
 <p id="pitch">
-  <em>rustup</em> is an installer for<br/>
+  <i>rustup</i> is an installer for<br/>
   the systems programming language
-  <a href="https://www.rust-lang.org">Rust</a>
+  <a href="https://www.rust-lang.org"><i>Rust</i></a>
 </p>
 
 <div id="platform-instructions-unix" class="instructions display-none">
@@ -43,11 +43,11 @@
 
 <div id="platform-instructions-win32" class="instructions display-none">
   <p>
-    To install Rust, download and run
+    To install <i>Rust</i>, download and run
     <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install <i>Rust</i>.</p>
   <div class="copy-container">
     <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
     <button id="copy-button-win32" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
@@ -64,11 +64,11 @@
 
 <div id="platform-instructions-win64" class="instructions display-none">
   <p>
-    To install Rust, download and run
+    To install <i>Rust</i>, download and run
     <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install <i>Rust</i>.</p>
   <div class="copy-container">
     <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
     <button id="copy-button-win64" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
@@ -140,7 +140,7 @@
 
 <div id="platform-instructions-default" class="instructions">
   <div>
-    <p>To install Rust, if you are running Unix,<br/>run the following
+    <p>To install <i>Rust</i>, if you are running Unix,<br/>run the following
     in your terminal, then follow the onscreen instructions.</p>
     <div class="copy-container">
       <pre>curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
@@ -177,19 +177,19 @@
 </div>
 
 <p>
-  Need help?<br>Ask on <a href="https://discord.gg/rust-lang">#beginners in the Rust Discord</a><br>
-  or in the <a href="https://users.rust-lang.org">Rust Users Forum</a>.
+  Need help?<br>Ask on <a href="https://discord.gg/rust-lang">#beginners in the <i>Rust Discord</i></a><br>
+  or in the <a href="https://users.rust-lang.org"><i>Rust</i> Users Forum</a>.
 </p>
 
 <p id="about">
   <img src="https://www.rust-lang.org/logos/rust-logo-blk.svg" alt="" />
-  rustup is an official Rust project.
+  <i>rustup</i> is an official <i>Rust</i> project.
   <br/>
   <a href="https://rust-lang.github.io/rustup/installation/other.html">other installation options</a>
   &nbsp;&middot;&nbsp;
   <a href="https://rust-lang.github.io/rustup-components-history/">component availability</a>
   &nbsp;&middot;&nbsp;
-  <a href="https://rust-lang.github.io/rustup/">about rustup</a>
+  <a href="https://rust-lang.github.io/rustup/">about <i>rustup</i></a>
 </p>
 
 <script src="rustup.js"></script>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -70,9 +70,13 @@ body#idx > #pitch {
     width: 35rem;
 }
 
-#pitch em {
+#pitch i {
     font-style: normal;
     font-weight: 400;
+}
+
+#about i ,i, #platform-instructions-default i, #platform-instructions-win64 i, #platform-instructions-win32 i{
+    font-style: normal;
 }
 
 body#idx p {


### PR DESCRIPTION
This pull request only contains changes about `rustup website`.
Using `<em></em>` for product names is not capable, according to [MDN Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em#usage_notes). This may cause some translator (like Microsoft Translator) to translate product names.
BTW, Before I commit, I found that even if I change tags, MS Translator still translate names lol, so this pr is only for make this webpage much more correct.