### PR TITLE
Give a better error when std is missing for a target

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -351,11 +351,16 @@ error_chain! {
         }
         UnknownComponent(t: String, c: String, s: Option<String>) {
             description("toolchain does not contain component")
-            display("toolchain '{}' does not contain component {}{}", t, c, if let Some(suggestion) = s {
-                format!("; did you mean '{}'?", suggestion)
-            } else {
-                "".to_string()
-            })
+            display("toolchain '{}' does not contain component {}{}{}", t, c, if let Some(suggestion) = s {
+                    format!("; did you mean '{}'?", suggestion)
+                } else {
+                    "".to_string()
+                }, if c.contains("rust-std") {
+                    format!("\nnote: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html{}",
+                        if t.contains("nightly") { "\nhelp: consider using `cargo build -Z build-std` instead" } else { "" }
+                    )
+                } else { "".to_string() }
+            )
         }
         UnknownProfile(p: String) {
             description("unknown profile name")

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -784,7 +784,9 @@ fn add_target_bogus() {
         expect_err(
             config,
             &["rustup", "target", "add", "bogus"],
-            "does not contain component 'rust-std' for target 'bogus'",
+            "does not contain component 'rust-std' for target 'bogus'\n\
+                note: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html\n\
+                help: consider using `cargo build -Z build-std` instead",
         );
     });
 }


### PR DESCRIPTION
- Note that not all platforms have std pre-compiled
- Suggest `cargo build -Zbuild-std` on nightly

After https://github.com/rust-lang/rust/pull/84450, you can end up with a situation like this:
```
$ rustc +stage1 src/main.rs --target x86_64-unknown-uefi
error[E0463]: can't find crate for `core`
  |
  = note: the `x86_64-unknown-uefi` target may not be installed
  = help: consider downloading the target with `rustup target add x86_64-unknown-uefi`

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.

$ rustup target add x86_64-unknown-uefi

error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'x86_64-unknown-uefi'
```

That doesn't give you much info on how to proceed. After this PR, it will be more clear:

```
$ rustup target add x86_64-unknown-uefi

error: toolchain 'nightly-x86_64-unknown-linux-gnu' does not contain component 'rust-std' for target 'x86_64-unknown-uefi'
note: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html
help: consider using `cargo build -Z build-std` instead
```