### PR TITLE
download: Fix some error paths for anyhow

### DIFF
--- a/download/src/errors.rs
+++ b/download/src/errors.rs
@@ -15,6 +15,7 @@ pub enum DownloadError {
     #[cfg(feature = "reqwest-backend")]
     #[error(transparent)]
     Reqwest(#[from] ::reqwest::Error),
+    #[cfg(feature = "curl-backend")]
     #[error(transparent)]
     CurlError(#[from] curl::Error),
 }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -354,13 +354,13 @@ pub mod reqwest_be {
             TlsBackend::Rustls => &CLIENT_RUSTLS_TLS,
             #[cfg(not(feature = "reqwest-rustls-tls"))]
             TlsBackend::Rustls => {
-                return Err(ErrorKind::BackendUnavailable("reqwest rustls").into());
+                return Err(DownloadError::BackendUnavailable("reqwest rustls"));
             }
             #[cfg(feature = "reqwest-default-tls")]
             TlsBackend::Default => &CLIENT_DEFAULT_TLS,
             #[cfg(not(feature = "reqwest-default-tls"))]
             TlsBackend::Default => {
-                return Err(ErrorKind::BackendUnavailable("reqwest default TLS").into());
+                return Err(DownloadError::BackendUnavailable("reqwest default TLS"));
             }
         };
         let mut req = client.get(url.as_str());
@@ -414,6 +414,8 @@ pub mod reqwest_be {
 #[cfg(not(feature = "curl-backend"))]
 pub mod curl {
 
+    use anyhow::{anyhow, Result};
+
     use super::Event;
     use crate::errors::*;
     use url::Url;
@@ -421,14 +423,16 @@ pub mod curl {
     pub fn download(
         _url: &Url,
         _resume_from: u64,
-        _callback: &dyn Fn(Event<'_>) -> Result<(), DownloadError>,
-    ) -> Result<(), DownloadError> {
-        Err(ErrorKind::BackendUnavailable("curl").into())
+        _callback: &dyn Fn(Event<'_>) -> Result<()>,
+    ) -> Result<()> {
+        Err(anyhow!(DownloadError::BackendUnavailable("curl")))
     }
 }
 
 #[cfg(not(feature = "reqwest-backend"))]
 pub mod reqwest_be {
+
+    use anyhow::{anyhow, Result};
 
     use super::Event;
     use super::TlsBackend;
@@ -438,9 +442,9 @@ pub mod reqwest_be {
     pub fn download(
         _url: &Url,
         _resume_from: u64,
-        _callback: &dyn Fn(Event<'_>) -> Result<(), DownloadError>,
+        _callback: &dyn Fn(Event<'_>) -> Result<()>,
         _tls: TlsBackend,
-    ) -> Result<(), DownloadError> {
-        Err(ErrorKind::BackendUnavailable("reqwest").into())
+    ) -> Result<()> {
+        Err(anyhow!(DownloadError::BackendUnavailable("reqwest")))
     }
 }


### PR DESCRIPTION
There were a few error paths missed since they're only used in
rare cases or unusual platforms (e.g. ones which do not support `ring`)

