### PR TITLE
Allow rustup-init to install the default toolchain from a toolchain file

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -43,6 +43,7 @@ OPTIONS:
         --default-host <default-host>              Choose a default host triple
         --default-toolchain <default-toolchain>    Choose a default toolchain to install
         --default-toolchain none                   Do not install any toolchains
+        --from-file <rust-toolchain-file>          Use the default toolchain specified by the rust-toolchain file
         --profile [minimal|default|complete]       Choose a profile
     -c, --component <components>...                Component name to also install
     -t, --target <targets>...                      Target name to also install

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -914,3 +914,98 @@ fn install_minimal_profile() {
         expect_component_not_executable(config, "cargo");
     });
 }
+
+#[test]
+fn install_from_rust_toolchain_file_specific_version() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain.toml");
+
+        raw::write_file(
+            &toolchain_file,
+            r#"[toolchain]
+channel = "1.1.0""#,
+        )
+        .unwrap();
+
+        expect_ok(
+            config,
+            &["rustup-init", "-y", "--from-file", "rust-toolchain.toml"],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list"],
+            &format!("1.1.0-{} (default)", this_host_triple()),
+        );
+    })
+}
+
+#[test]
+fn install_from_rust_toolchain_file_latest_stable() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain.toml");
+
+        raw::write_file(
+            &toolchain_file,
+            r#"[toolchain]
+channel = "stable""#,
+        )
+        .unwrap();
+
+        expect_ok(
+            config,
+            &["rustup-init", "-y", "--from-file", "rust-toolchain.toml"],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list"],
+            &format!("stable-{} (default)", this_host_triple()),
+        );
+    })
+}
+
+#[test]
+fn install_from_rust_toolchain_file_toml_format_without_toml_extension() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain");
+
+        raw::write_file(
+            &toolchain_file,
+            r#"[toolchain]
+channel = "1.1.0""#,
+        )
+        .unwrap();
+
+        expect_ok(
+            config,
+            &["rustup-init", "-y", "--from-file", "rust-toolchain"],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list"],
+            &format!("1.1.0-{} (default)", this_host_triple()),
+        );
+    })
+}
+
+#[test]
+fn install_from_rust_toolchain_file_legacy_format() {
+    clitools::setup(Scenario::SimpleV2, &|config| {
+        let cwd = config.current_dir();
+        let toolchain_file = cwd.join("rust-toolchain");
+
+        raw::write_file(&toolchain_file, r#"nightly"#).unwrap();
+
+        expect_ok(
+            config,
+            &["rustup-init", "-y", "--from-file", "rust-toolchain"],
+        );
+        expect_stdout_ok(
+            config,
+            &["rustup", "toolchain", "list"],
+            &format!("nightly-{} (default)", this_host_triple()),
+        );
+    })
+}


### PR DESCRIPTION
This PR allows rustup-init to install a default toolchain from a specified toolchain file.

In the current draft PR:
1) The toolchain file is only checked for the [channel](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) field, which to the best of my knowledge corresponds to the `toolchain` field. I could also add overrides for the other fields which can be specified in the toolchain file: the `target` (in rust-toolchain.toml)/`host`(in rustup), the `components` and the `profile`.

2) I re-used the name suggested by @XAMPPRocky, `--from-file`.

3) The toolchain specified by the toolchain file is only used if the `--default-toolchain` option is not given.

3) The parse mode is determined based on the file extension, if it has a `toml` file extension, the `TomlOnly` mode is used, else, the legacy mode is available. When the toolchain file is used to override current toolchain, the toolchain file name is fixed. In the suggested option this is not necessarily the case, so I opted to take this middle ground for now.

4) I will add extra test cases in a bit (I'm a bit figuring out how the testing setup works :))

closes #2749 