### PR TITLE
Support set auto-self-update mode

### DIFF
--- a/doc/src/basics.md
+++ b/doc/src/basics.md
@@ -30,9 +30,22 @@ info: downloading self-updates
 
 ## Keeping `rustup` up to date
 
-Running `rustup update` also checks for updates to `rustup` itself and automatically
-installs the latest version. To manually update `rustup` only,
-without updating installed toolchains, type `rustup self update`:
+If your `rustup` was built with the `no-self-update` feature, it can not update
+itself. This is not the default, and only versions of `rustup` built with
+`--no-default-features`, or obtained from a third-party distributor who has
+disabled it (such as the Ubuntu snap store).
+
+Otherwise Rustup can update itself. It is possible to control Rustup's automatic
+self update mechanism with the `auto-self-update` configuration variable. This
+setting supports three values: `enable` and `disable` and `check-only`.
+
+* `disable` will ensure that no automatic self updating actions are taken.
+* `enable` will mean that `rustup update` and similar commands will also check for, and install, any update to Rustup.
+* `check-only` will cause any automatic self update to check and report on any updates, but not to automatically install them.
+
+Whether `auto-self-update` is `enable` or not, you can request that Rustup
+update itself to the latest version of `rustup` by running `rustup self update`.
+This will not download new toolchains:
 
 ```console
 $ rustup self update
@@ -40,10 +53,10 @@ info: checking for self-updates
 info: downloading self-updates
 ```
 
-> #### Disable automatic self-updates
-> `rustup` will automatically update itself at the end of any toolchain installation.
-> You can prevent this automatic behaviour by passing the `--no-self-update` argument
-> when running `rustup update` or `rustup toolchain install`.
+### Disabling self updates on a per-invocation basis
+> Self updates can also be suppressed on individual invocations of `rustup` by
+> passing the argurment `--no-self-update`  when running `rustup update` or
+> `rustup toolchain install`.
 
 ## Help system
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -13,6 +13,7 @@ pub enum Notification<'a> {
     SetDefaultToolchain(&'a str),
     SetOverrideToolchain(&'a Path, &'a str),
     SetProfile(&'a str),
+    SetSelfUpdate(&'a str),
     LookingForToolchain(&'a str),
     ToolchainDirectory(&'a Path, &'a str),
     UpdatingToolchain(&'a str),
@@ -73,6 +74,7 @@ impl<'a> Notification<'a> {
             SetDefaultToolchain(_)
             | SetOverrideToolchain(_, _)
             | SetProfile(_)
+            | SetSelfUpdate(_)
             | UsingExistingToolchain(_)
             | UninstallingToolchain(_)
             | UninstalledToolchain(_)
@@ -102,6 +104,7 @@ impl<'a> Display for Notification<'a> {
                 name
             ),
             SetProfile(name) => write!(f, "profile set to '{}'", name),
+            SetSelfUpdate(mode) => write!(f, "auto-self-update mode set to '{}'", mode),
             LookingForToolchain(name) => write!(f, "looking for installed toolchain '{}'", name),
             ToolchainDirectory(path, _) => write!(f, "toolchain directory: '{}'", path.display()),
             UpdatingToolchain(name) => write!(f, "updating existing install for '{}'", name),

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -112,7 +112,7 @@ fn update_all_no_update_whitespace() {
     setup(&|config| {
         expect_stdout_ok(
             config,
-            &["rustup", "update", "nightly", "--no-self-update"],
+            &["rustup", "update", "nightly"],
             for_host!(
                 r"
   nightly-{} installed - 1.3.0 (hash-nightly-2)
@@ -127,7 +127,7 @@ fn update_all_no_update_whitespace() {
 #[test]
 fn update_works_without_term() {
     setup(&|config| {
-        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly", "--no-self-update"]);
+        let mut cmd = clitools::cmd(config, "rustup", &["update", "nightly"]);
         clitools::env(config, &mut cmd);
         cmd.env_remove("TERM");
 
@@ -234,13 +234,13 @@ fn custom_toolchain_cargo_fallback_proxy() {
         );
         expect_ok(config, &["rustup", "default", "mytoolchain"]);
 
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-stable-1.1.0");
 
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-beta-1.2.0");
 
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["cargo", "--version"], "hash-nightly-2");
     });
 }
@@ -262,21 +262,21 @@ fn custom_toolchain_cargo_fallback_run() {
         );
         expect_ok(config, &["rustup", "default", "mytoolchain"]);
 
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
             "hash-stable-1.1.0",
         );
 
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
             "hash-beta-1.2.0",
         );
 
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "mytoolchain", "cargo", "--version"],
@@ -379,7 +379,7 @@ fn rustup_failed_path_search_toolchain() {
 #[test]
 fn rustup_run_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "install", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "install", "stable"]);
         expect_err(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -391,7 +391,7 @@ fn rustup_run_not_installed() {
 #[test]
 fn rustup_run_install() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "install", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "install", "stable"]);
         expect_stderr_ok(
             config,
             &[
@@ -471,7 +471,7 @@ fn run_rls_when_not_available_in_toolchain() {
         );
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         expect_ok(config, &["rls", "--version"]);
@@ -519,7 +519,7 @@ fn rename_rls_before() {
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
 
         assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
         expect_ok(config, &["rls", "--version"]);
@@ -533,7 +533,7 @@ fn rename_rls_after() {
         expect_ok(config, &["rustup", "default", "nightly"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
 
         assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
@@ -548,7 +548,7 @@ fn rename_rls_add_old_name() {
         expect_ok(config, &["rustup", "default", "nightly"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
@@ -563,7 +563,7 @@ fn rename_rls_list() {
         expect_ok(config, &["rustup", "default", "nightly"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
         let out = run(config, "rustup", &["component", "list"], &[]);
@@ -579,7 +579,7 @@ fn rename_rls_preview_list() {
         expect_ok(config, &["rustup", "default", "nightly"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
 
         let out = run(config, "rustup", &["component", "list"], &[]);
@@ -595,7 +595,7 @@ fn rename_rls_remove() {
         expect_ok(config, &["rustup", "default", "nightly"]);
 
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update"]);
 
         expect_ok(config, &["rustup", "component", "add", "rls"]);
         expect_ok(config, &["rls", "--version"]);
@@ -677,7 +677,7 @@ fn update_unavailable_rustc() {
         // latest nightly is unavailable
         set_current_dist_date(config, "2015-01-02");
         // update should do nothing
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
     });
 }
@@ -717,7 +717,7 @@ fn update_nightly_even_with_incompat() {
 
         expect_component_executable(config, "rls");
         // update should bring us to latest nightly that does
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
         expect_component_executable(config, "rls");
     });
@@ -737,7 +737,7 @@ fn nightly_backtrack_skips_missing() {
         set_current_dist_date(config, "2019-09-18");
 
         // update should not change nightly, and should not error
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
     });
 }
@@ -958,13 +958,7 @@ fn deprecated_interfaces() {
         // In verbose mode we want the deprecated interfaces to complain
         expect_ok_contains(
             config,
-            &[
-                "rustup",
-                "--verbose",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
+            &["rustup", "--verbose", "install", "nightly"],
             "",
             "Please use `rustup toolchain install` instead",
         );
@@ -977,7 +971,7 @@ fn deprecated_interfaces() {
         // But if not verbose then they should *NOT* complain
         expect_not_stderr_ok(
             config,
-            &["rustup", "install", "nightly", "--no-self-update"],
+            &["rustup", "install", "nightly"],
             "Please use `rustup toolchain install` instead",
         );
         expect_not_stderr_ok(

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -31,11 +31,11 @@ pub fn setup(f: &dyn Fn(&Config)) {
 fn rustup_stable() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(
             config,
-            &["rustup", "update", "--no-self-update"],
+            &["rustup", "update"],
             for_host!(
                 r"
   stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
@@ -68,14 +68,11 @@ info: cleaning up downloads & tmp directories
 fn rustup_stable_quiet() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(
-            config,
-            &["rustup", "--quiet", "update", "stable", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "--quiet", "update", "stable"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(
             config,
-            &["rustup", "--quiet", "update", "--no-self-update"],
+            &["rustup", "--quiet", "update"],
             for_host!(
                 r"
   stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
@@ -108,10 +105,10 @@ info: cleaning up downloads & tmp directories
 fn rustup_stable_no_change() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok_ex(
             config,
-            &["rustup", "update", "--no-self-update"],
+            &["rustup", "update"],
             for_host!(
                 r"
   stable-{0} unchanged - 1.0.0 (hash-stable-1.0.0)
@@ -131,13 +128,13 @@ info: cleaning up downloads & tmp directories
 fn rustup_all_channels() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
         expect_ok_ex(
             config,
-            &["rustup", "update", "--no-self-update"],
+            &["rustup", "update"],
             for_host!(
                 r"
    stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
@@ -200,14 +197,14 @@ info: cleaning up downloads & tmp directories
 fn rustup_some_channels_up_to_date() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
         expect_ok_ex(
             config,
-            &["rustup", "update", "--no-self-update"],
+            &["rustup", "update"],
             for_host!(
                 r"
    stable-{0} updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
@@ -256,11 +253,11 @@ info: cleaning up downloads & tmp directories
 #[test]
 fn rustup_no_channels() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
         expect_ok_ex(
             config,
-            &["rustup", "update", "--no-self-update"],
+            &["rustup", "update"],
             r"",
             r"info: no updatable toolchains installed
 info: cleaning up downloads & tmp directories
@@ -302,7 +299,7 @@ info: default toolchain set to 'nightly-{0}'
 #[test]
 fn default_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(config, &["rustup", "override", "set", "nightly"]);
         expect_stderr_ok(
@@ -323,13 +320,7 @@ fn rustup_zstd() {
         set_current_dist_date(config, "2015-01-01");
         expect_stderr_ok(
             config,
-            &[
-                "rustup",
-                "--verbose",
-                "update",
-                "nightly",
-                "--no-self-update",
-            ],
+            &["rustup", "--verbose", "update", "nightly"],
             for_host!(r"dist/2015-01-01/rust-std-nightly-{0}.tar.zst"),
         );
     });
@@ -446,7 +437,7 @@ fn add_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(
             config,
             &[
@@ -470,7 +461,7 @@ fn remove_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(
             config,
             &[
@@ -501,7 +492,7 @@ fn remove_target_explicit() {
 #[test]
 fn list_targets_explicit() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(
             config,
             &["rustup", "target", "list", "--toolchain", "nightly"],
@@ -519,7 +510,7 @@ fn link() {
         expect_ok(config, &["rustup", "default", "custom"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
         expect_stdout_ok(config, &["rustup", "show"], "custom (default)");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustup", "show"], "custom");
     });
@@ -544,7 +535,7 @@ fn fallback_cargo_calls_correct_rustc() {
         let path = path.to_string_lossy();
         expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
         expect_ok(config, &["rustup", "default", "custom"]);
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
         expect_stdout_ok(config, &["cargo", "--version"], "hash-nightly-2");
 
@@ -618,7 +609,7 @@ nightly-{0} (default)
 fn show_multiple_toolchains() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok_ex(
             config,
             &["rustup", "show"],
@@ -710,7 +701,6 @@ fn show_multiple_toolchains_and_targets() {
                 "rustup",
                 "update",
                 &format!("stable-{}", clitools::MULTI_ARCH1),
-                "--no-self-update",
             ],
         );
         expect_ok_ex(
@@ -1170,10 +1160,7 @@ fn set_default_host_invalid_triple_valid_partial() {
 fn update_doesnt_update_non_tracking_channels() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(
-            config,
-            &["rustup", "update", "nightly-2015-01-01", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "update", "nightly-2015-01-01"]);
         let mut cmd = clitools::cmd(config, "rustup", &["update"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -1187,16 +1174,7 @@ fn update_doesnt_update_non_tracking_channels() {
 #[test]
 fn toolchain_install_is_like_update() {
     setup(&|config| {
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -1210,14 +1188,7 @@ fn toolchain_install_is_like_update_quiet() {
     setup(&|config| {
         expect_ok(
             config,
-            &[
-                "rustup",
-                "--quiet",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
+            &["rustup", "--quiet", "toolchain", "install", "nightly"],
         );
         expect_stdout_ok(
             config,
@@ -1232,7 +1203,7 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {
         expect_err(
             config,
-            &["rustup", "toolchain", "install", "--no-self-update"],
+            &["rustup", "toolchain", "install"],
             "arguments were not provided",
         );
     });
@@ -1241,16 +1212,7 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
 #[test]
 fn toolchain_update_is_like_update() {
     setup(&|config| {
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "update",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
         expect_stdout_ok(
             config,
             &["rustup", "run", "nightly", "rustc", "--version"],
@@ -1287,16 +1249,7 @@ fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
 fn proxy_toolchain_shorthand() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "update",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
         expect_stdout_ok(
             config,
@@ -1375,16 +1328,7 @@ fn add_remove_multiple_components() {
 fn file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
 
@@ -1400,16 +1344,7 @@ fn file_override() {
 fn env_override_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1431,16 +1366,7 @@ fn env_override_path() {
 fn plus_override_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1464,16 +1390,7 @@ fn plus_override_path() {
 fn file_override_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1501,16 +1418,7 @@ fn file_override_path() {
 fn proxy_override_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1531,16 +1439,7 @@ fn proxy_override_path() {
 fn file_override_path_relative() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1661,16 +1560,7 @@ fn file_override_path_xor_channel() {
 fn file_override_subdir() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
 
@@ -1692,13 +1582,7 @@ fn file_override_with_archive() {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly-2015-01-01",
-                "--no-self-update",
-            ],
+            &["rustup", "toolchain", "install", "nightly-2015-01-01"],
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
@@ -1717,13 +1601,7 @@ fn file_override_toml_format_select_installed_toolchain() {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly-2015-01-01",
-                "--no-self-update",
-            ],
+            &["rustup", "toolchain", "install", "nightly-2015-01-01"],
         );
 
         expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
@@ -1890,20 +1768,8 @@ channel = "nightly"
 fn directory_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
-        );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
@@ -1920,20 +1786,8 @@ fn directory_override_beats_file_override() {
 fn close_file_override_beats_far_directory_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
-        );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
@@ -1956,10 +1810,7 @@ fn close_file_override_beats_far_directory_override() {
 fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
         // not installing nightly
 
         expect_ok(config, &["rustup", "override", "set", "beta"]);
@@ -1977,20 +1828,8 @@ fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
 fn env_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
-        );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -2011,20 +1850,8 @@ fn env_override_beats_file_override() {
 fn plus_override_beats_file_override() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "beta", "--no-self-update"],
-        );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -2098,16 +1925,7 @@ fn file_override_with_target_info() {
 fn docs_with_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         let mut cmd = clitools::cmd(config, "rustup", &["doc", "--path"]);
         clitools::env(config, &mut cmd);
@@ -2132,16 +1950,7 @@ fn docs_with_path() {
 fn docs_topical_with_path() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
 
         for (topic, path) in mock::topical_doc_data::test_cases() {
             let mut cmd = clitools::cmd(config, "rustup", &["doc", "--path", topic]);
@@ -2273,7 +2082,7 @@ fn check_host_goes_away() {
         set_current_dist_date(config, "2019-12-10");
         expect_err(
             config,
-            &["rustup", "update", "nightly", "--no-self-update"],
+            &["rustup", "update", "nightly"],
             for_host!("target '{}' not found in channel"),
         );
     })
@@ -2328,7 +2137,6 @@ fn warn_on_unmatch_build() {
                 "toolchain",
                 "install",
                 &format!("nightly-{}", arch),
-                "--no-self-update",
             ],
             &format!(
                 r"warning: toolchain 'nightly-{0}' may not be able to run on this system.

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -446,6 +446,7 @@ fn update_no_change() {
 #[test]
 fn rustup_self_updates_trivial() {
     update_setup(&|config, _| {
+        expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
@@ -462,6 +463,7 @@ fn rustup_self_updates_trivial() {
 #[test]
 fn rustup_self_updates_with_specified_toolchain() {
     update_setup(&|config, _| {
+        expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
@@ -483,7 +485,7 @@ fn rustup_no_self_update_with_specified_toolchain() {
         let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
         let before_hash = calc_hash(&bin);
 
-        expect_ok(config, &["rustup", "update", "stable", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "stable"]);
 
         let after_hash = calc_hash(&bin);
 
@@ -494,6 +496,7 @@ fn rustup_no_self_update_with_specified_toolchain() {
 #[test]
 fn rustup_self_update_exact() {
     update_setup(&|config, _| {
+        expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         expect_ok_ex(
@@ -540,7 +543,7 @@ fn updater_is_deleted_after_running_rustup() {
         expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "self", "update"]);
 
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
 
         let setup = config
             .cargodir

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -70,7 +70,7 @@ fn install_toolchain_from_version() {
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stderr_ok(
             config,
             &["rustup", "default", "nightly"],
@@ -86,7 +86,7 @@ fn update_channel() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
@@ -94,11 +94,8 @@ fn update_channel() {
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(
-            config,
-            &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(
             config,
@@ -147,7 +144,7 @@ fn list_toolchains_with_none() {
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "list"]);
         expect_stdout_ok(
@@ -353,12 +350,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(
-            config,
-            &["rustup", "update", "nightly", "--no-self-update"],
-            "unchanged",
-        );
+        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
     });
 }
 
@@ -369,7 +362,7 @@ fn update_on_channel_when_date_has_changed() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
@@ -377,7 +370,7 @@ fn update_on_channel_when_date_has_changed() {
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_stdout_ok(
             config,
@@ -393,7 +386,7 @@ fn remove_toolchain_then_add_again() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -92,7 +92,6 @@ fn install_with_profile() {
                 "--profile",
                 "minimal",
                 "nightly",
-                "--no-self-update",
             ],
         );
         expect_ok(config, &["rustup", "default", "nightly"]);
@@ -103,7 +102,7 @@ fn install_with_profile() {
 
         // After an update, we should _still_ only have the profile-dictated components
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
 
         expect_component_executable(config, "rustup");
         expect_component_executable(config, "rustc");
@@ -114,7 +113,7 @@ fn install_with_profile() {
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stderr_ok(
             config,
             &["rustup", "default", "nightly"],
@@ -130,7 +129,7 @@ fn update_channel() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
@@ -138,11 +137,8 @@ fn update_channel() {
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_ok(
-            config,
-            &["rustup", "update", "beta-2015-01-01", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
         expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
         expect_stdout_ok(
             config,
@@ -181,7 +177,7 @@ fn list_toolchains() {
 fn list_toolchains_with_bogus_file() {
     // #520
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
 
         let name = "bogus_regular_file.txt";
         let path = config.rustupdir.join("toolchains").join(name);
@@ -205,7 +201,7 @@ fn list_toolchains_with_none() {
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
         expect_ok(config, &["rustup", "toolchain", "list"]);
         expect_stdout_ok(
@@ -223,10 +219,7 @@ fn add_remove_multiple_toolchains() {
             let tch1 = "beta";
             let tch2 = "nightly";
 
-            expect_ok(
-                config,
-                &["rustup", "toolchain", add, tch1, tch2, "--no-self-update"],
-            );
+            expect_ok(config, &["rustup", "toolchain", add, tch1, tch2]);
             expect_ok(config, &["rustup", "toolchain", "list"]);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
             expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
@@ -503,12 +496,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
-        expect_stdout_ok(
-            config,
-            &["rustup", "update", "nightly", "--no-self-update"],
-            "unchanged",
-        );
+        expect_ok(config, &["rustup", "update", "nightly"]);
+        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
     });
 }
 
@@ -519,7 +508,7 @@ fn update_on_channel_when_date_has_changed() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
@@ -527,7 +516,7 @@ fn update_on_channel_when_date_has_changed() {
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_stdout_ok(
             config,
@@ -543,7 +532,7 @@ fn remove_toolchain_then_add_again() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "beta"]);
         expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "beta"]);
         expect_ok(config, &["rustc", "--version"]);
     });
 }
@@ -557,7 +546,7 @@ fn upgrade_v1_to_v2() {
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
     });
 }
@@ -591,7 +580,7 @@ fn list_targets_no_toolchain() {
 #[test]
 fn list_targets_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_err(
             config,
             &["rustup", "target", "list", "--toolchain=nightly"],
@@ -794,7 +783,7 @@ fn add_target_bogus() {
 #[test]
 fn add_target_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_err(
             config,
             &[
@@ -1003,7 +992,7 @@ fn remove_target_host() {
 // Issue #304
 fn remove_target_missing_update_hash() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
 
         let file_name = format!("nightly-{}", this_host_triple());
         fs::remove_file(config.rustupdir.join("update-hashes").join(file_name)).unwrap();
@@ -1028,13 +1017,7 @@ fn warn_about_and_remove_stray_hash() {
 
         expect_stderr_ok(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
+            &["rustup", "toolchain", "install", "nightly"],
             &format!(
                 "removing stray hash found at '{}' in order to continue",
                 hash_path.display()
@@ -1079,7 +1062,7 @@ fn update_unavailable_std() {
         make_component_unavailable(config, "rust-std", &this_host_triple());
         expect_err(
             config,
-            &["rustup", "update", "nightly", "--no-self-update"],
+            &["rustup", "update", "nightly", ],
             for_host!(
                 "component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'"
             ),
@@ -1108,7 +1091,7 @@ Sometimes not all components are available in any given nightly. If you don't ne
 fn update_unavailable_force() {
     setup(&|config| {
         let trip = this_host_triple();
-        expect_ok(config, &["rustup", "update", "nightly", "--no-self-update"]);
+        expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(
             config,
             &[
@@ -1123,15 +1106,12 @@ fn update_unavailable_force() {
         make_component_unavailable(config, "rls-preview", &trip);
         expect_err(
             config,
-            &["rustup", "update", "nightly", "--no-self-update"],
+            &["rustup", "update", "nightly"],
             for_host!(
                 "component 'rls' for target '{0}' is unavailable for download for channel 'nightly'"
             ),
         );
-        expect_ok(
-            config,
-            &["rustup", "update", "nightly", "--force", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "update", "nightly", "--force"]);
     });
 }
 
@@ -1248,10 +1228,7 @@ fn target_list_ignores_unavailable_targets() {
         let target_list = &["rustup", "target", "list"];
         expect_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
         make_component_unavailable(config, "rust-std", clitools::CROSS_ARCH1);
-        expect_ok(
-            config,
-            &["rustup", "update", "nightly", "--force", "--no-self-update"],
-        );
+        expect_ok(config, &["rustup", "update", "nightly", "--force"]);
         expect_not_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
     })
 }
@@ -1259,13 +1236,7 @@ fn target_list_ignores_unavailable_targets() {
 #[test]
 fn install_with_components() {
     fn go(comp_args: &[&str]) {
-        let mut args = vec![
-            "rustup",
-            "toolchain",
-            "install",
-            "nightly",
-            "--no-self-update",
-        ];
+        let mut args = vec!["rustup", "toolchain", "install", "nightly"];
         args.extend_from_slice(comp_args);
 
         setup(&|config| {
@@ -1290,13 +1261,7 @@ fn install_with_components() {
 #[test]
 fn install_with_targets() {
     fn go(comp_args: &[&str]) {
-        let mut args = vec![
-            "rustup",
-            "toolchain",
-            "install",
-            "nightly",
-            "--no-self-update",
-        ];
+        let mut args = vec!["rustup", "toolchain", "install", "nightly"];
         args.extend_from_slice(comp_args);
 
         setup(&|config| {
@@ -1336,7 +1301,6 @@ fn install_with_component_and_target() {
                 "rls",
                 "-t",
                 clitools::CROSS_ARCH1,
-                "--no-self-update",
             ],
         );
         expect_stdout_ok(
@@ -1355,6 +1319,7 @@ fn install_with_component_and_target() {
 #[test]
 fn test_warn_if_complete_profile_is_used() {
     setup(&|config| {
+        expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_err(
             config,
             &[
@@ -1384,21 +1349,13 @@ fn test_complete_profile_skips_missing_when_forced() {
                 "toolchain",
                 "install",
                 "nightly",
-                "--no-self-update",
             ],
             for_host!("error: component 'rls' for target '{}' is unavailable for download for channel 'nightly'")
         );
         // Now try and force
         expect_stderr_ok(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "--force",
-                "nightly",
-                "--no-self-update",
-            ],
+            &["rustup", "toolchain", "install", "--force", "nightly"],
             for_host!("warning: Force-skipping unavailable component 'rls-{}'"),
         );
 
@@ -1462,7 +1419,7 @@ fn warn_on_invalid_signature() {
 
         expect_stderr_ok(
             config,
-            &["rustup", "update", "nightly", "--no-self-update"],
+            &["rustup", "update", "nightly", ],
             &format!(
                 "warning: Signature verification failed for 'file://{}/dist/channel-rust-nightly.toml'",
                 config.distdir.display(),
@@ -1494,30 +1451,13 @@ fn install_allow_downgrade() {
 
         // this dist has no rls and there is no newer one
         set_current_dist_date(config, "2019-09-14");
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-            ],
-        );
+        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-3");
         expect_component_not_executable(config, "rls");
 
         expect_err(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "--no-self-update",
-                "-c",
-                "rls",
-            ],
+            &["rustup", "toolchain", "install", "nightly", "-c", "rls"],
             &format!(
                 "component 'rls' for target '{}' is unavailable for download for channel 'nightly'",
                 trip,
@@ -1533,7 +1473,6 @@ fn install_allow_downgrade() {
                 "toolchain",
                 "install",
                 "nightly",
-                "--no-self-update",
                 "-c",
                 "rls",
                 "--allow-downgrade",
@@ -1559,7 +1498,6 @@ fn regression_2601() {
                 "nightly",
                 "--component",
                 "rust-src",
-                "--no-self-update",
             ],
         );
         // The bug exposed in #2601 was that the above would end up installing

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -177,6 +177,14 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
         &[],
     );
 
+    // Set the auto update mode to disable, as most tests do not want to update rustup itself during the test.
+    run(
+        &config,
+        "rustup",
+        &["set", "auto-self-update", "disable"],
+        &[],
+    );
+
     // Create some custom toolchains
     create_custom_toolchains(&config.customdir);
 


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/issues/2576

1. The PR supports three different modes of auto self update: enable/disable/check-only.
 - When enabled, commands such as install or update will update rustup itself. 
 - When disable, commands such as install or update will **not** update rustup itself. Only self udpate will update rustup itself. 
 - When check-only, commands such as install or update will **not** update rustup itself but will check for updates. Only self udpate will update rustup itself. 

2. This PR removes a large number of "--no-self-update" args in tests(setup will turn off auto self update by default.) 
3. Add tests for check-only and enable. 
4. add docs