### PR TITLE
docs: Edit "Basic usage" page

### DIFF
--- a/doc/src/basics.md
+++ b/doc/src/basics.md
@@ -28,7 +28,7 @@ info: downloading self-updates
 
 ```
 
-## Keeping rustup up to date
+## Keeping `rustup` up to date
 
 Running `rustup update` also checks for updates to `rustup` itself and automatically
 installs the latest version. To manually update `rustup` only,
@@ -40,7 +40,8 @@ info: checking for self-updates
 info: downloading self-updates
 ```
 
-> **Note**: `rustup` will automatically update itself at the end of any toolchain installation as well.
+> #### Disable automatic self-updates
+> `rustup` will automatically update itself at the end of any toolchain installation.
 > You can prevent this automatic behaviour by passing the `--no-self-update` argument
 > when running `rustup update` or `rustup toolchain install`.
 

--- a/doc/src/basics.md
+++ b/doc/src/basics.md
@@ -10,13 +10,12 @@ install --help` for specifics on installing [toolchains].
 ## Keeping Rust up to date
 
 Rust is distributed on three different [release channels]: stable, beta, and
-nightly. `rustup` is configured to use the stable channel by default, which
-represents the latest release of Rust, and is released every six weeks.
+nightly. `rustup` uses the stable channel by default, which
+represents the latest release of Rust. Stable publishes new releases every six weeks.
 
 [release channels]: concepts/channels.md
 
-When a new version of Rust is released, you can type `rustup update` to update
-to it:
+When a new version of Rust is released, simply type `rustup update` to update:
 
 ```console
 $ rustup update
@@ -40,10 +39,9 @@ This is the essence of `rustup`.
 
 ## Keeping rustup up to date
 
-Running `rustup update` also checks for updates to `rustup` and automatically
-installs the latest version. To manually check for updates and install the
-latest version of `rustup` without updating installed toolchains type `rustup
-self update`:
+Running `rustup update` also checks for updates to `rustup` itself and automatically
+installs the latest version. To manually update `rustup` only,
+without updating installed toolchains, type `rustup self update`:
 
 ```console
 $ rustup self update
@@ -51,7 +49,7 @@ info: checking for self-updates
 info: downloading self-updates
 ```
 
-**Note**: `rustup` will automatically update itself at the end of any
-toolchain installation as well.  You can prevent this automatic behaviour by
-passing the `--no-self-update` argument when running `rustup update` or
-`rustup toolchain install`.
+> **Note**: `rustup` will automatically update itself at the end of any toolchain installation as well.
+> You can prevent this automatic behaviour by passing the `--no-self-update` argument
+> when running `rustup update` or `rustup toolchain install`.
+

--- a/doc/src/basics.md
+++ b/doc/src/basics.md
@@ -1,12 +1,5 @@
 # Basic usage
 
-The `rustup` command-line has a built-in help system that provides more
-information about each command. Run `rustup help` for an overview. Detailed
-help for each subcommand is also available. For example, run `rustup toolchain
-install --help` for specifics on installing [toolchains].
-
-[toolchains]: concepts/toolchains.md
-
 ## Keeping Rust up to date
 
 Rust is distributed on three different [release channels]: stable, beta, and
@@ -35,8 +28,6 @@ info: downloading self-updates
 
 ```
 
-This is the essence of `rustup`.
-
 ## Keeping rustup up to date
 
 Running `rustup update` also checks for updates to `rustup` itself and automatically
@@ -52,4 +43,13 @@ info: downloading self-updates
 > **Note**: `rustup` will automatically update itself at the end of any toolchain installation as well.
 > You can prevent this automatic behaviour by passing the `--no-self-update` argument
 > when running `rustup update` or `rustup toolchain install`.
+
+## Help system
+
+The `rustup` command-line has a built-in help system that provides more
+information about each command. Run `rustup help` for an overview. Detailed
+help for each subcommand is also available. For example, run `rustup toolchain
+install --help` for specifics on installing [toolchains].
+
+[toolchains]: concepts/toolchains.md
 


### PR DESCRIPTION
Makes edits throughout for clarity, concision, and formatting.

Moves the help section to the bottom of the page.

Uses the block quote syntax for the note on disabling automatic self-updates.