### PR TITLE
docs: Fix some formatting nits

### DIFF
--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -27,7 +27,7 @@ use varsource::*;
 /// This provides replacements env::arg*, env::var*, and the standard files
 /// io::std* with traits that are customisable for tests. As a result any macros
 /// or code that have non-pluggable usage of those are incompatible with
-/// CurrentProcess and must not be used. That includes [e]println! as well as
+/// CurrentProcess and must not be used. That includes \[e\]println! as well as
 /// third party crates.
 ///
 /// CurrentProcess is used via an instance in a thread local variable; when

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -10,7 +10,7 @@
 //!
 //! See tests/channel-rust-nightly-example.toml for an example.
 //!
-//! Docs: https://forge.rust-lang.org/infra/channel-layout.html
+//! Docs: <https://forge.rust-lang.org/infra/channel-layout.html>
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,7 +18,7 @@ pub const TOOLSTATE_MSG: &str =
      Then you can use the toolchain with commands such as:\n\n    \
      cargo +nightly-2018-12-27 build";
 
-/// A type erasing thunk for the retry crate to permit use with anyhow. See https://github.com/dtolnay/anyhow/issues/149
+/// A type erasing thunk for the retry crate to permit use with anyhow. See <https://github.com/dtolnay/anyhow/issues/149>
 #[derive(Debug, ThisError)]
 #[error(transparent)]
 pub struct OperationError(pub anyhow::Error);


### PR DESCRIPTION
I built this with nightly 2021-05-10 and it said:

```
  warning: unresolved link to `e`
    --> src/currentprocess.rs:30:57
     |
  30 | /// CurrentProcess and must not be used. That includes [e]println! as well as
     |                                                         ^ no item named `e` in scope
     |
     = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default
     = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`

  warning: this URL is not a hyperlink
    --> src/dist/manifest.rs:13:11
     |
  13 | //! Docs: https://forge.rust-lang.org/infra/channel-layout.html
     |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://forge.rust-lang.org/infra/channel-layout.html>`
     |
     = note: `#[warn(rustdoc::bare_urls)]` on by default
     = note: bare URLs are not automatically turned into clickable links

  warning: this URL is not a hyperlink
    --> src/errors.rs:21:77
     |
  21 | /// A type erasing thunk for the retry crate to permit use with anyhow. See https://github.com/dtolnay/anyhow/issues/149
     |                                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use an automatic link instead: `<https://github.com/dtolnay/anyhow/issues/149>`
     |
     = note: bare URLs are not automatically turned into clickable links
```