### PR TITLE
Prevent need to refetch for v1 manifests

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -95,7 +95,7 @@ fn run_rustup_inner() -> Result<utils::ExitCode> {
         }
         Some(n) => {
             if TOOLS.iter().chain(DUP_TOOLS.iter()).any(|&name| name == n) {
-                proxy_mode::main()
+                proxy_mode::main(n)
             } else {
                 Err(anyhow!(format!(
                     "unknown proxy name: '{}'; valid proxy names are {}",

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -1,31 +1,22 @@
 use std::ffi::OsString;
-use std::path::PathBuf;
 use std::process;
 
 use anyhow::Result;
 
 use super::common::set_globals;
-use super::errors::*;
 use super::job;
 use super::self_update;
 use crate::command::run_command_for_dir;
 use crate::utils::utils::{self, ExitCode};
 use crate::Cfg;
 
-pub fn main() -> Result<ExitCode> {
+pub fn main(arg0: &str) -> Result<ExitCode> {
     self_update::cleanup_self_updater()?;
 
     let ExitCode(c) = {
         let _setup = job::setup();
 
-        let mut args = crate::process().args_os();
-
-        let arg0 = args.next().map(PathBuf::from);
-        let arg0 = arg0
-            .as_ref()
-            .and_then(|a| a.file_name())
-            .and_then(std::ffi::OsStr::to_str);
-        let arg0 = arg0.ok_or(CLIError::NoExeName)?;
+        let mut args = crate::process().args_os().skip(1);
 
         // Check for a toolchain specifier.
         let arg1 = args.next();

--- a/src/config.rs
+++ b/src/config.rs
@@ -715,8 +715,10 @@ impl Cfg {
             let manifest = if let Some(manifest) = distributable.get_manifest()? {
                 manifest
             } else {
-                // If we can't read the manifest we'd best try and install
-                return Ok(false);
+                // We can't read the manifest.  If this is a v1 install that's understandable
+                // and we assume the components are all good, otherwise we need to have a go
+                // at re-fetching the manifest to try again.
+                return Ok(distributable.guess_v1_manifest());
             };
             match (distributable.list_components(), components_requested) {
                 // If the toolchain does not support components but there were components requested, bubble up the error


### PR DESCRIPTION
As raised in #2777 rustup is re-syncing (fetching the channel checksum) on each run pre-1.8 when overridden to do so.

This results in (a) slowdown and (b) confusion.  This PR fixes that by guessing V1 installs since they're subtly different from v2 installs (ignoring the lack of manifest file which we try and self-heal on v2 installs so couldn't use as the indicator).

This should fix #2777 