### PR TITLE
install: improve heuristic for deprecation warning

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -962,7 +962,7 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
                 let host_arch = TargetTriple::from_host_or_build();
                 if let Ok(toolchain_desc) = ToolchainDesc::from_str(name) {
                     let target_triple = toolchain_desc.target;
-                    if !forced && host_arch.ne(&target_triple) {
+                    if !forced && !host_arch.can_run(&target_triple)? {
                         err!("DEPRECATED: future versions of rustup will require --force-non-host to install a non-host toolchain as the default.");
                         warn!(
                             "toolchain '{}' may not be able to run on this system.",


### PR DESCRIPTION
Nominally this will fix #2773 and fix #2765

Basically adjust the heuristic from just "host != target" to account for Windows a little more.