### PR TITLE
Make all utils functions and structs crate-private and cleanup unused functions

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -249,7 +249,7 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, Result<UpdateStatus>
     Ok(())
 }
 
-pub fn update_all_channels(
+pub(crate) fn update_all_channels(
     cfg: &Cfg,
     do_self_update: bool,
     force_update: bool,
@@ -327,7 +327,7 @@ pub fn self_update_permitted(explicit: bool) -> Result<SelfUpdatePermission> {
     }
 }
 
-pub fn self_update<F>(before_restart: F) -> Result<utils::ExitCode>
+pub(crate) fn self_update<F>(before_restart: F) -> Result<utils::ExitCode>
 where
     F: FnOnce() -> Result<utils::ExitCode>,
 {
@@ -354,7 +354,7 @@ where
     Ok(utils::ExitCode(0))
 }
 
-pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(&toolchain)?;
     let components = distributable.list_components()?;
@@ -378,7 +378,7 @@ pub fn list_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(&toolchain)?;
     let components = distributable.list_components()?;
@@ -397,7 +397,7 @@ pub fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCo
     Ok(utils::ExitCode(0))
 }
 
-pub fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(&toolchain)?;
     let components = distributable.list_components()?;
@@ -415,7 +415,7 @@ pub fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-pub fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(&toolchain)?;
     let components = distributable.list_components()?;
@@ -460,7 +460,7 @@ fn print_toolchain_path(
     Ok(())
 }
 
-pub fn list_toolchains(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
+pub(crate) fn list_toolchains(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
     let toolchains = cfg.list_toolchains()?;
     if toolchains.is_empty() {
         writeln!(process().stdout(), "no installed toolchains")?;
@@ -495,7 +495,7 @@ pub fn list_toolchains(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-pub fn list_overrides(cfg: &Cfg) -> Result<utils::ExitCode> {
+pub(crate) fn list_overrides(cfg: &Cfg) -> Result<utils::ExitCode> {
     let overrides = cfg.settings_file.with(|s| Ok(s.overrides.clone()))?;
 
     if overrides.is_empty() {
@@ -538,7 +538,7 @@ pub fn version() -> &'static str {
     &RENDERED
 }
 
-pub fn dump_testament() -> Result<utils::ExitCode> {
+pub(crate) fn dump_testament() -> Result<utils::ExitCode> {
     use git_testament::GitModification::*;
     writeln!(
         process().stdout(),

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -73,7 +73,7 @@ impl DownloadTracker {
         self
     }
 
-    pub fn handle_notification(&mut self, n: &Notification<'_>) -> bool {
+    pub(crate) fn handle_notification(&mut self, n: &Notification<'_>) -> bool {
         match *n {
             Notification::Install(In::Utils(Un::DownloadContentLengthReceived(content_len))) => {
                 self.content_length_received(content_len);
@@ -219,7 +219,7 @@ impl DownloadTracker {
         }
     }
 
-    pub fn push_unit(&mut self, new_unit: Unit) {
+    pub(crate) fn push_unit(&mut self, new_unit: Unit) {
         self.units.push(new_unit);
     }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -70,7 +70,7 @@ use crate::utils::Notification;
 use crate::{Cfg, UpdateStatus};
 use crate::{DUP_TOOLS, TOOLS};
 use os::*;
-pub use os::{delete_rustup_and_cargo_home, run_update, self_replace};
+pub(crate) use os::{delete_rustup_and_cargo_home, run_update, self_replace};
 #[cfg(windows)]
 pub use windows::complete_windows_uninstall;
 
@@ -324,7 +324,7 @@ fn canonical_cargo_home() -> Result<Cow<'static, str>> {
 /// Installing is a simple matter of copying the running binary to
 /// `CARGO_HOME`/bin, hard-linking the various Rust tools to it,
 /// and adding `CARGO_HOME`/bin to PATH.
-pub fn install(
+pub(crate) fn install(
     no_prompt: bool,
     verbose: bool,
     quiet: bool,
@@ -862,7 +862,7 @@ fn _install_selection<'a>(
     })
 }
 
-pub fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
+pub(crate) fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
     if NEVER_SELF_UPDATE {
         err!("self-uninstall is disabled for this build of rustup");
         err!("you should probably use your system package manager to uninstall rustup");
@@ -978,7 +978,7 @@ pub fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
 /// (and on windows this process will not be running to do it),
 /// rustup-init is stored in `CARGO_HOME`/bin, and then deleted next
 /// time rustup runs.
-pub fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
+pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
     use common::SelfUpdatePermission::*;
     let update_permitted = if NEVER_SELF_UPDATE {
         HardFail

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -12,7 +12,7 @@ use crate::utils::Notification;
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because
 // sudo is configured not to change $HOME. Don't let that bogosity happen.
-pub fn do_anti_sudo_check(no_prompt: bool) -> Result<utils::ExitCode> {
+pub(crate) fn do_anti_sudo_check(no_prompt: bool) -> Result<utils::ExitCode> {
     pub fn home_mismatch() -> (bool, PathBuf, PathBuf) {
         let fallback = || (false, PathBuf::new(), PathBuf::new());
         // test runner should set this, nothing else
@@ -126,7 +126,7 @@ pub fn do_remove_from_programs() -> Result<()> {
 
 /// Tell the upgrader to replace the rustup bins, then delete
 /// itself.
-pub fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
+pub(crate) fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
     let status = Command::new(setup_path)
         .arg("--self-replace")
         .status()
@@ -142,7 +142,7 @@ pub fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
 /// This function is as the final step of a self-upgrade. It replaces
 /// `CARGO_HOME`/bin/rustup with the running exe, and updates the the
 /// links to it.
-pub fn self_replace() -> Result<utils::ExitCode> {
+pub(crate) fn self_replace() -> Result<utils::ExitCode> {
     install_bins()?;
 
     Ok(utils::ExitCode(0))

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,7 +7,7 @@ use anyhow::{Context, Result};
 use crate::errors::*;
 use crate::utils::utils::ExitCode;
 
-pub fn run_command_for_dir<S: AsRef<OsStr>>(
+pub(crate) fn run_command_for_dir<S: AsRef<OsStr>>(
     mut cmd: Command,
     arg0: &str,
     args: &[S],

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,7 +246,7 @@ pub struct Cfg {
 }
 
 impl Cfg {
-    pub fn from_env(notify_handler: Arc<dyn Fn(Notification<'_>)>) -> Result<Self> {
+    pub(crate) fn from_env(notify_handler: Arc<dyn Fn(Notification<'_>)>) -> Result<Self> {
         // Set up the rustup home directory
         let rustup_dir = utils::rustup_home()?;
 
@@ -359,7 +359,7 @@ impl Cfg {
     }
 
     /// construct a download configuration
-    pub fn download_cfg<'a>(
+    pub(crate) fn download_cfg<'a>(
         &'a self,
         notify_handler: &'a dyn Fn(crate::dist::Notification<'_>),
     ) -> DownloadCfg<'a> {

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -139,7 +139,7 @@ impl Package for DirectoryPackage {
 pub struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
 
 impl<'a> TarPackage<'a> {
-    pub fn new<R: Read>(
+    pub(crate) fn new<R: Read>(
         stream: R,
         temp_cfg: &'a temp::Cfg,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
@@ -551,7 +551,7 @@ impl<'a> Package for TarPackage<'a> {
 pub struct TarGzPackage<'a>(TarPackage<'a>);
 
 impl<'a> TarGzPackage<'a> {
-    pub fn new<R: Read>(
+    pub(crate) fn new<R: Read>(
         stream: R,
         temp_cfg: &'a temp::Cfg,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
@@ -587,7 +587,7 @@ impl<'a> Package for TarGzPackage<'a> {
 pub struct TarXzPackage<'a>(TarPackage<'a>);
 
 impl<'a> TarXzPackage<'a> {
-    pub fn new<R: Read>(
+    pub(crate) fn new<R: Read>(
         stream: R,
         temp_cfg: &'a temp::Cfg,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
@@ -623,7 +623,7 @@ impl<'a> Package for TarXzPackage<'a> {
 pub struct TarZStdPackage<'a>(TarPackage<'a>);
 
 impl<'a> TarZStdPackage<'a> {
-    pub fn new<R: Read>(
+    pub(crate) fn new<R: Read>(
         stream: R,
         temp_cfg: &'a temp::Cfg,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -168,7 +168,7 @@ impl<'a> Transaction<'a> {
     pub fn temp(&self) -> &'a temp::Cfg {
         self.temp_cfg
     }
-    pub fn notify_handler(&self) -> &'a dyn Fn(Notification<'_>) {
+    pub(crate) fn notify_handler(&self) -> &'a dyn Fn(Notification<'_>) {
         self.notify_handler
     }
 }

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -379,7 +379,7 @@ impl Manifestation {
     }
 
     /// Installation using the legacy v1 manifest format
-    pub fn update_v1(
+    pub(crate) fn update_v1(
         &self,
         new_manifest: &[String],
         update_hash: Option<&Path>,

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -54,7 +54,7 @@ impl<'a> From<temp::Notification<'a>> for Notification<'a> {
 }
 
 impl<'a> Notification<'a> {
-    pub fn level(&self) -> NotificationLevel {
+    pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
             Temp(n) => n.level(),

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -49,7 +49,7 @@ pub struct File<'a> {
 }
 
 impl<'a> Notification<'a> {
-    pub fn level(&self) -> NotificationLevel {
+    pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
             CreatingRoot(_) | CreatingFile(_) | CreatingDirectory(_) => NotificationLevel::Verbose,

--- a/src/install.rs
+++ b/src/install.rs
@@ -86,7 +86,11 @@ impl<'a> InstallMethod<'a> {
         }
     }
 
-    pub fn run(self, path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<bool> {
+    pub(crate) fn run(
+        self,
+        path: &Path,
+        notify_handler: &dyn Fn(Notification<'_>),
+    ) -> Result<bool> {
         if path.exists() {
             // Don't uninstall first for Dist method
             match self {
@@ -147,6 +151,6 @@ impl<'a> InstallMethod<'a> {
     }
 }
 
-pub fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
+pub(crate) fn uninstall(path: &Path, notify_handler: &dyn Fn(Notification<'_>)) -> Result<()> {
     utils::remove_dir("install", path, notify_handler)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ pub use crate::currentprocess::*;
 pub use crate::errors::*;
 pub use crate::notifications::*;
 pub use crate::toolchain::*;
-pub use crate::utils::{notify, toml_utils};
+pub(crate) use crate::utils::toml_utils;
 
 #[macro_use]
 extern crate rs_tracing;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -56,7 +56,7 @@ impl<'a> From<temp::Notification<'a>> for Notification<'a> {
 }
 
 impl<'a> Notification<'a> {
-    pub fn level(&self) -> NotificationLevel {
+    pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
             Install(n) => n.level(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -108,7 +108,7 @@ impl Settings {
         }
     }
 
-    pub fn remove_override(
+    pub(crate) fn remove_override(
         &mut self,
         path: &Path,
         notify_handler: &dyn Fn(Notification<'_>),
@@ -117,7 +117,7 @@ impl Settings {
         self.overrides.remove(&key).is_some()
     }
 
-    pub fn add_override(
+    pub(crate) fn add_override(
         &mut self,
         path: &Path,
         toolchain: String,
@@ -128,7 +128,7 @@ impl Settings {
         self.overrides.insert(key, toolchain);
     }
 
-    pub fn dir_override(
+    pub(crate) fn dir_override(
         &self,
         dir: &Path,
         notify_handler: &dyn Fn(Notification<'_>),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,11 +1,11 @@
 ///!  Utility functions for Rustup
-pub mod notifications;
+pub(crate) mod notifications;
 pub mod raw;
-pub mod toml_utils;
-pub mod tty;
-pub mod units;
+pub(crate) mod toml_utils;
+pub(crate) mod tty;
+pub(crate) mod units;
 #[allow(clippy::module_inception)]
 pub mod utils;
 
-pub use crate::utils::notifications::Notification;
-pub mod notify;
+pub(crate) use crate::utils::notifications::Notification;
+pub(crate) mod notify;

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -43,7 +43,7 @@ pub enum Notification<'a> {
 }
 
 impl<'a> Notification<'a> {
-    pub fn level(&self) -> NotificationLevel {
+    pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
             SetDefaultBufferSize(_) => NotificationLevel::Debug,

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -1,5 +1,5 @@
 #[derive(Debug)]
-pub enum NotificationLevel {
+pub(crate) enum NotificationLevel {
     Verbose,
     Info,
     Warn,

--- a/src/utils/toml_utils.rs
+++ b/src/utils/toml_utils.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use thiserror::Error as ThisError;
 
-pub fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {
+fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Result<toml::Value> {
     table
         .remove(key)
         .ok_or_else(|| anyhow!(format!("missing key: '{}'", path.to_owned() + key)))
@@ -11,7 +11,7 @@ pub fn get_value(table: &mut toml::value::Table, key: &str, path: &str) -> Resul
 #[error("expected type: '{0}' for '{1}'")]
 struct ExpectedType(&'static str, String);
 
-pub fn get_string(table: &mut toml::value::Table, key: &str, path: &str) -> Result<String> {
+pub(crate) fn get_string(table: &mut toml::value::Table, key: &str, path: &str) -> Result<String> {
     if let toml::Value::String(s) = get_value(table, key, path)? {
         Ok(s)
     } else {
@@ -19,7 +19,7 @@ pub fn get_string(table: &mut toml::value::Table, key: &str, path: &str) -> Resu
     }
 }
 
-pub fn get_opt_string(
+pub(crate) fn get_opt_string(
     table: &mut toml::value::Table,
     key: &str,
     path: &str,
@@ -35,7 +35,7 @@ pub fn get_opt_string(
     }
 }
 
-pub fn get_bool(table: &mut toml::value::Table, key: &str, path: &str) -> Result<bool> {
+pub(crate) fn get_bool(table: &mut toml::value::Table, key: &str, path: &str) -> Result<bool> {
     get_value(table, key, path).and_then(|v| {
         if let toml::Value::Boolean(b) = v {
             Ok(b)
@@ -45,7 +45,7 @@ pub fn get_bool(table: &mut toml::value::Table, key: &str, path: &str) -> Result
     })
 }
 
-pub fn get_table(
+pub(crate) fn get_table(
     table: &mut toml::value::Table,
     key: &str,
     path: &str,
@@ -61,7 +61,7 @@ pub fn get_table(
     }
 }
 
-pub fn get_array(
+pub(crate) fn get_array(
     table: &mut toml::value::Table,
     key: &str,
     path: &str,

--- a/src/utils/tty.rs
+++ b/src/utils/tty.rs
@@ -1,21 +1,21 @@
 // Copied from rustc. isatty crate did not work as expected
 #[cfg(unix)]
-pub fn stderr_isatty() -> bool {
+pub(crate) fn stderr_isatty() -> bool {
     isatty(libc::STDERR_FILENO)
 }
 
 #[cfg(windows)]
-pub fn stderr_isatty() -> bool {
+pub(crate) fn stderr_isatty() -> bool {
     isatty(winapi::um::winbase::STD_ERROR_HANDLE)
 }
 
 #[cfg(unix)]
-pub fn stdout_isatty() -> bool {
+pub(crate) fn stdout_isatty() -> bool {
     isatty(libc::STDOUT_FILENO)
 }
 
 #[cfg(windows)]
-pub fn stdout_isatty() -> bool {
+pub(crate) fn stdout_isatty() -> bool {
     isatty(winapi::um::winbase::STD_OUTPUT_HANDLE)
 }
 

--- a/src/utils/units.rs
+++ b/src/utils/units.rs
@@ -6,19 +6,19 @@ pub enum Unit {
     IO,
 }
 
-pub enum UnitMode {
+pub(crate) enum UnitMode {
     Norm,
     Rate,
 }
 
 /// Human readable size (some units)
-pub enum Size {
+pub(crate) enum Size {
     B(usize, UnitMode),
     IO(usize, UnitMode),
 }
 
 impl Size {
-    pub fn new(size: usize, unit: Unit, unitmode: UnitMode) -> Self {
+    pub(crate) fn new(size: usize, unit: Unit, unitmode: UnitMode) -> Self {
         match unit {
             Unit::B => Self::B(size, unitmode),
             Unit::IO => Self::IO(size, unitmode),


### PR DESCRIPTION
part of  https://github.com/rust-lang/rustup/issues/2730
Because we use some methods in our tests, we need to set it to pub.