### PR TITLE
Update `opener` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
+
+[[package]]
 name = "buf_redux"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,10 +1217,11 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "opener"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
+checksum = "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952"
 dependencies = [
+ "bstr",
  "winapi",
 ]
 
@@ -1541,6 +1553,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ home = {git = "https://github.com/rbtcollins/home", rev = "a243ee2fbee6022c57d56
 lazy_static = "1"
 libc = "0.2"
 num_cpus = "1.13"
-opener = "0.4.0"
+opener = "0.5.0"
 # Used by `curl` or `reqwest` backend although it isn't imported
 # by our rustup.
 openssl = {version = "0.10", optional = true}

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -416,7 +416,7 @@ pub fn read_dir(name: &'static str, path: &Path) -> Result<fs::ReadDir> {
 }
 
 pub fn open_browser(path: &Path) -> Result<()> {
-    opener::open(path).context("couldn't open browser")
+    opener::open_browser(path).context("couldn't open browser")
 }
 
 pub fn set_permissions(path: &Path, perms: fs::Permissions) -> Result<()> {


### PR DESCRIPTION
This PR updates the `opener` crate, which fixes some issues with opening docs with the `rustup doc` command.

Fixes #2206, #2642