### PR TITLE
Fix lint

### DIFF
--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -623,8 +623,8 @@ where
     let mut vars: HashMap<String, String> = HashMap::default();
     self::env(config, &mut vars);
     vars.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
-    let mut arg_strings: Vec<Box<str>> = Vec::new();
-    arg_strings.push(name.to_owned().into_boxed_str());
+    let mut arg_strings: Vec<Box<str>> = vec![name.to_owned().into_boxed_str()];
+
     for arg in args {
         arg_strings.push(
             arg.as_ref()


### PR DESCRIPTION
I noticed this lint when going through the https://github.com/rust-lang/rustup/blob/master/CONTRIBUTING.md and running the suggested clippy command.

```shell
[nix-shell:~/code/rustup]$ cargo --version
cargo 1.55.0-nightly (9233aa06c 2021-06-22)
[nix-shell:~/code/rustup]$ cargo clippy --all --all-features --all-targets -- -D warnings

... elided output

error: calls to `push` immediately after creation
   --> tests/mock/clitools.rs:626:5
    |
626 | /     let mut arg_strings: Vec<Box<str>> = Vec::new();
627 | |     arg_strings.push(name.to_owned().into_boxed_str());
    | |_______________________________________________________^ help: consider using the `vec![]` macro: `let mut arg_strings: Vec<Box<str>> = vec![..];`
    |
    = note: `-D clippy::vec-init-then-push` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push
```