### PR TITLE
Add rust-gdbgui to the list of proxied tools

### DIFF
--- a/doc/src/concepts/proxies.md
+++ b/doc/src/concepts/proxies.md
@@ -14,7 +14,7 @@ The list of proxies is currently static in `rustup` and is as follows:
 
 - `cargo` is the Rust package manager which downloads your Rust package’s dependencies, compiles your packages, makes distributable packages, and uploads them to crates.io (the Rust community’s package registry). It comes from the `cargo` component.
 
-- `rust-lldb` and `rust-gdb` are simple wrappers around the `lldb` and `gdb` debuggers respectively. The wrappers enable some pretty-printing of Rust values and add some convenience features to the debuggers by means of their scripting interfaces.
+- `rust-lldb`, `rust-gdb`, and `rust-gdbgui` are simple wrappers around the `lldb`, `gdb`, and `gdbgui` debuggers respectively. The wrappers enable some pretty-printing of Rust values and add some convenience features to the debuggers by means of their scripting interfaces.
 
 - `rls` is part of the Rust IDE integration tooling. It implements the language-server protocol to permit IDEs and editors such as Visual Studio Code, ViM, or Emacs, access to the semantics of the Rust code you are editing. It comes from the `rls` component.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub static TOOLS: &[&str] = &[
     "cargo",
     "rust-lldb",
     "rust-gdb",
+    "rust-gdbgui",
     "rls",
     "cargo-clippy",
     "clippy-driver",
@@ -48,7 +49,7 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
     match binary_prefix {
         "rustc" | "rustdoc" => Some("rustc"),
         "cargo" => Some("cargo"),
-        "rust-lldb" | "rust-gdb" => Some("rustc"), // These are not always available
+        "rust-lldb" | "rust-gdb" | "rust-gdbgui" => Some("rustc"), // These are not always available
         "rls" => Some("rls"),
         "cargo-clippy" => Some("clippy"),
         "clippy-driver" => Some("clippy"),

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -325,7 +325,7 @@ fn rustup_failed_path_search() {
         expect_err(
             config,
             broken,
-            &"unknown proxy name: 'fake_proxy'; valid proxy names are 'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'".to_string(),
+            &"unknown proxy name: 'fake_proxy'; valid proxy names are 'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'".to_string(),
         );
 
         // Hardlink will be automatically cleaned up by test setup code

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -92,6 +92,9 @@ info: default toolchain set to 'stable-{0}'
                 .cargodir
                 .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
             let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+            let rust_gdbgui = config
+                .cargodir
+                .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
             #[cfg(windows)]
             fn check(path: &Path) {
                 assert!(path.exists());
@@ -111,6 +114,7 @@ info: default toolchain set to 'stable-{0}'
             check(&cargo);
             check(&rust_lldb);
             check(&rust_gdb);
+            check(&rust_gdbgui);
         })
     });
 }
@@ -165,12 +169,16 @@ fn uninstall_deletes_bins() {
             .cargodir
             .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
         let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rust_gdbgui = config
+            .cargodir
+            .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
         assert!(!rustup.exists());
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
         assert!(!cargo.exists());
         assert!(!rust_lldb.exists());
         assert!(!rust_gdb.exists());
+        assert!(!rust_gdbgui.exists());
     });
 }
 
@@ -185,6 +193,7 @@ fn uninstall_works_if_some_bins_dont_exist() {
             .cargodir
             .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
         let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rust_gdbgui = config.cargodir.join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
 
         fs::remove_file(&rustc).unwrap();
         fs::remove_file(&cargo).unwrap();
@@ -197,6 +206,7 @@ fn uninstall_works_if_some_bins_dont_exist() {
         assert!(!cargo.exists());
         assert!(!rust_lldb.exists());
         assert!(!rust_gdb.exists());
+        assert!(!rust_gdbgui.exists());
     });
 }
 
@@ -263,11 +273,15 @@ fn uninstall_self_delete_works() {
             .cargodir
             .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
         let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rust_gdbgui = config
+            .cargodir
+            .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
         assert!(!cargo.exists());
         assert!(!rust_lldb.exists());
         assert!(!rust_gdb.exists());
+        assert!(!rust_gdbgui.exists());
     });
 }
 


### PR DESCRIPTION
Attempts to complete https://github.com/rust-lang/rustup/pull/1950 which was
closed due to inactivity.

It appears that everywhere the rust-gdb wrapper script is available so is the rust-gdbgui.
https://github.com/rust-lang/rust/blob/a435b49e86d16e98dcc6595dd471f95e823f41aa/src/bootstrap/dist.rs#L513