### PR TITLE
Bump recursion limit to 20

### DIFF
--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 
 use crate::process;
 
-pub const RUST_RECURSION_COUNT_MAX: u32 = 5;
+pub const RUST_RECURSION_COUNT_MAX: u32 = 20;
 
 #[allow(unused)]
 pub fn append_path(name: &str, value: Vec<PathBuf>, cmd: &mut Command) {


### PR DESCRIPTION
Infinite recursion will conveniently hit any limit, so will still be
detected. But non-infinite cases can hit >5 without too much trouble
when custom build scripts invoke cargo, or when custom toolchains
themselves call into cargo (or both at the same time), so let's raise
the bar slightly.

See also https://discord.com/channels/442252698964721669/463480252723888159/859585370689896460