### PR TITLE
Detect '-y' short option in rustup-init.sh more robustly

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -90,15 +90,32 @@ main() {
     local need_tty=yes
     for arg in "$@"; do
         case "$arg" in
-            -h|--help)
+            --help)
                 usage
                 exit 0
                 ;;
-            -y)
-                # user wants to skip the prompt -- we don't need /dev/tty
-                need_tty=no
-                ;;
             *)
+                OPTIND=1
+                if [ "${arg%%--*}" = "" ]; then
+                    # Long option (other than --help);
+                    # don't attempt to interpret it.
+                    continue
+                fi
+                while getopts :hy sub_arg "$arg"; do
+                    case "$sub_arg" in
+                        h)
+                            usage
+                            exit 0
+                            ;;
+                        y)
+                            # user wants to skip the prompt --
+                            # we don't need /dev/tty
+                            need_tty=no
+                            ;;
+                        *)
+                            ;;
+                        esac
+                done
                 ;;
         esac
     done


### PR DESCRIPTION
Fixes #2813 