### PR TITLE
Correct mistake in musl sccache fetcher

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+target

--- a/ci/docker/scripts/sccache.bash
+++ b/ci/docker/scripts/sccache.bash
@@ -8,12 +8,13 @@ SHA="26fd04c1273952cc2a0f359a71c8a1857137f0ee3634058b3f4a63b69fc8eb7f"
 DL_URL="https://github.com/mozilla/sccache/releases/download"
 BIN_DIR=/usr/local/bin
 TEMP_DIR=$(mktemp -d)
+TAR_NAME="sccache-${VERSION}-${TARGET}.tar.gz"
 
 cd "${TEMP_DIR}"
 mkdir -p "${BIN_DIR}"
 
-curl -sSL -O "${DL_URL}/${VERSION}/sccache-${VERSION}-${TARGET}.tar.gz"
-echo "${SHA}  sccache-${VERSION}-${TARGET}.tar.gz" | sha256sum --check -
-tar -xzf - --strip-components 1
+curl -sSL -O "${DL_URL}/${VERSION}/${TAR_NAME}"
+echo "${SHA}  ${TAR_NAME}" | sha256sum --check -
+tar -xzf "${TAR_NAME}" --strip-components 1
 cp sccache "${BIN_DIR}/sccache"
 chmod +x "${BIN_DIR}/sccache"


### PR DESCRIPTION
This PR primarily exists to fix a bug exposed by #2814 but also it adds a `.dockerignore` file because without it we send all of `.git` and in the case of a normal working tree also `target` to the docker daemon which is slow and unnecessary.