### PR TITLE
Provide a better error when CWD is not available.

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -59,7 +59,7 @@ fn run_rustup_inner() -> Result<utils::ExitCode> {
 
     // Before we do anything else, ensure we know where we are and who we
     // are because otherwise we cannot proceed usefully.
-    process().current_dir()?;
+    utils::current_dir()?;
     utils::current_exe()?;
 
     // The name of arg0 determines how the program is going to behave

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -475,7 +475,7 @@ pub(crate) fn make_executable(path: &Path) -> Result<()> {
     inner(path)
 }
 
-pub(crate) fn current_dir() -> Result<PathBuf> {
+pub fn current_dir() -> Result<PathBuf> {
     process()
         .current_dir()
         .context(RustupError::LocatingWorkingDir)


### PR DESCRIPTION
This adds some context when rustup is unable to determine the current directory. Previously it would give a cryptic error:

```
error: No such file or directory (os error 2)
```

This should update it to provide an explanation:

```
error: Unable to proceed. Could not locate working directory.: No such file or directory (os error 2)
```
