### PR TITLE
Fix infinite recursion in bash completions when `rustc` is not in PATH

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1686,7 +1686,9 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
 
             writeln!(
                 &mut term2::stdout(),
-                "source $(rustc --print sysroot){}",
+                "if command -v rustc >/dev/null 2>&1; then\n\
+                    \tsource \"$(rustc --print sysroot)\"{}\n\
+                 fi",
                 script,
             )?;
         }


### PR DESCRIPTION
Previously, running `source /etc/bash_completion.d/cargo` would loop
forever:

```
Command 'rustc' not found, but can be installed with:

sudo snap install rustup  # version 1.24.3, or
sudo apt  install rustc   # version 1.47.0+dfsg1+llvm-1ubuntu1~20.04.1

See 'snap info rustup' for additional versions.

Command 'rustc' not found, but can be installed with:

sudo snap install rustup  # version 1.24.3, or
sudo apt  install rustc   # version 1.47.0+dfsg1+llvm-1ubuntu1~20.04.1

See 'snap info rustup' for additional versions.

Command 'rustc' not found, but can be installed with:
```

The issue was that `$(rustc --print sysroot)/etc/bash_completion.d/cargo`
will expand to `/etc/bash_completion.d/cargo` is rustc doesn't print
anything, which sources the same file over and over. This fixes it by
first checking that rustc exists.

This also adds quotes around the sysroot, to support spaces with
filenames.