### PR TITLE
Support building rustup for Windows arm64

### DIFF
--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -29,6 +29,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+          - target: aarch64-pc-windows-msvc
+            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -62,7 +64,7 @@ jobs:
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=${{ matrix.skip_tests }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         target:
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc # skip-pr skip-stable
           - x86_64-pc-windows-gnu # skip-pr
         include:
           - target: x86_64-pc-windows-gnu
@@ -29,8 +30,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-          - target: aarch64-pc-windows-msvc
-            skip_tests: yes
+          - target: aarch64-pc-windows-msvc # skip-pr skip-stable
+            skip_tests: yes # skip-pr skip-stable
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -26,8 +26,6 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-          - target: aarch64-pc-windows-msvc
-            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -26,6 +26,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+          - target: aarch64-pc-windows-msvc
+            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -59,7 +61,7 @@ jobs:
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=${{ matrix.skip_tests }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -29,8 +29,6 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-          - target: aarch64-pc-windows-msvc
-            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -29,6 +29,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+          - target: aarch64-pc-windows-msvc
+            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -62,7 +64,7 @@ jobs:
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=${{ matrix.skip_tests }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.67"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
+checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
 dependencies = [
  "jobserver",
 ]

--- a/ci/actions-templates/README.md
+++ b/ci/actions-templates/README.md
@@ -67,6 +67,7 @@ system.
 | x86_64-pc-windows-gnu         | No         | One   | No     | Yes        |
 | i686-pc-windows-msvc          | No         | One   | No     | No         |
 | i686-pc-windows-gnu           | No         | One   | No     | No         |
+| aarch64-pc-windows-msvc       | Yes        | Two   | No     | Yes        |
 
 We also have a clippy/shellcheck target which runs on x86_64 linux and is
 run in all cases. It does a `cargo fmt` check, a `cargo clippy` check on the

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -28,7 +28,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
-          - aarch64-pc-windows-msvc # skip-pr skip-master skip-stable
+          - aarch64-pc-windows-msvc # skip-pr skip-stable
           - x86_64-pc-windows-gnu # skip-pr
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
@@ -38,8 +38,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
-          - target: aarch64-pc-windows-msvc
-            skip_tests: yes
+          - target: aarch64-pc-windows-msvc # skip-pr skip-stable
+            skip_tests: yes # skip-pr skip-stable
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -28,6 +28,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
+          - aarch64-pc-windows-msvc # skip-pr skip-master skip-stable
           - x86_64-pc-windows-gnu # skip-pr
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
@@ -37,6 +38,8 @@ jobs:
           - target: i686-pc-windows-gnu
             mingwdir: mingw32
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z
+          - target: aarch64-pc-windows-msvc
+            skip_tests: yes
     steps:
       - uses: actions/checkout@v2
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -70,7 +73,7 @@ jobs:
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
           echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "SKIP_TESTS=" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "SKIP_TESTS=${{ matrix.skip_tests }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Cache cargo registry and git trees
         uses: actions/cache@v2
         with:

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -20,6 +20,7 @@ case "$TARGET" in
   mips* ) ;;
   riscv* ) ;;
   s390x* ) ;;
+  aarch64-pc-windows-msvc ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
 esac

--- a/doc/src/installation/windows.md
+++ b/doc/src/installation/windows.md
@@ -16,7 +16,7 @@ tools" and "Windows 10 SDK" option. No additional software installation is
 necessary for basic use of the GNU build.
 
 By default `rustup` on Windows configures Rust to target the MSVC ABI, that is
-a target triple of either `i686-pc-windows-msvc` or `x86_64-pc-windows-msvc`
+a target triple of either `i686-pc-windows-msvc`, `x86_64-pc-windows-msvc`, or `aarch64-pc-windows-msvc`
 depending on the CPU architecture of the host Windows OS. The toolchains that
 `rustup` chooses to install, unless told otherwise through the [toolchain
 specification], will be compiled to run on that target triple host and will

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -234,6 +234,7 @@ impl TargetTriple {
             // First detect architecture
             const PROCESSOR_ARCHITECTURE_AMD64: u16 = 9;
             const PROCESSOR_ARCHITECTURE_INTEL: u16 = 0;
+            const PROCESSOR_ARCHITECTURE_ARM64: u16 = 12;
 
             let mut sys_info;
             unsafe {
@@ -244,6 +245,7 @@ impl TargetTriple {
             let arch = match unsafe { sys_info.u.s() }.wProcessorArchitecture {
                 PROCESSOR_ARCHITECTURE_AMD64 => "x86_64",
                 PROCESSOR_ARCHITECTURE_INTEL => "i686",
+                PROCESSOR_ARCHITECTURE_ARM64 => "aarch64",
                 _ => return None,
             };
 


### PR DESCRIPTION
This PR adds support for building rustup for Windows arm64 using aarch64-pc-windows-msvc toolchain.

Things to note:

* CI templates are present but do not run builds on Windows arm64 yet
* Ring still does not support Windows arm64. See https://github.com/briansmith/ring/issues/1167

See #2612 for discussion