### PR TITLE
Add illumos/OpenIndiana platform check in rustup.js

### DIFF
--- a/www/rustup.js
+++ b/www/rustup.js
@@ -32,6 +32,7 @@ function detect_platform() {
     if (navigator.platform == "FreeBSD amd64") {os = "unix";}
     if (navigator.platform == "NetBSD x86_64") {os = "unix";}
     if (navigator.platform == "NetBSD amd64") {os = "unix";}
+    if (navigator.platform == "SunOS i86pc") {os = "unix";}
 
     // I wish I knew by now, but I don't. Try harder.
     if (os == "unknown") {
@@ -49,6 +50,7 @@ function detect_platform() {
         if (navigator.oscpu.indexOf("Linux")!=-1) {os = "unix";}
         if (navigator.oscpu.indexOf("FreeBSD")!=-1) {os = "unix";}
         if (navigator.oscpu.indexOf("NetBSD")!=-1) {os = "unix";}
+        if (navigator.oscpu.indexOf("SunOS")!=-1) {os = "unix";}
     }
 
     return os;


### PR DESCRIPTION
On OpenIndiana (illumos), [rustup.rs](https://rustup.rs/) currently shows that it doesn't recognize the platform:

![rusup-illumos-not-supported-resized](https://user-images.githubusercontent.com/1067001/129223484-dcf3cfac-4ca3-4c5b-aa58-c9c0ef50e6ec.png)

This change clears the confusion and adds the missing platform check to rustup.js:

![rustup-illumos-support-resized](https://user-images.githubusercontent.com/1067001/129224086-3b35abad-4113-4864-90bf-834d37277377.png)

I'm tagging @jclulow to verify if the platform checks added are thorough enough but also to verify that the [curl command itself works on OpenIndiana](https://github.com/rust-lang/rustup/issues/2189#issuecomment-735007324). On OpenIndiana 5.11, I get a wall of `local: not found` errors but piping it into bash does make it work. I can try to look into the script later

Cheers!

