### PR TITLE
Fixes #2807 adds info message if self-update is disabled

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1028,6 +1028,11 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         check_rustup_update()?;
     }
 
+    if self_update::NEVER_SELF_UPDATE {
+        info!("self-update is disabled for this build of rustup");
+        info!("any updates to rustup will need to be fetched with your system package manager")
+    }
+
     Ok(utils::ExitCode(0))
 }
 


### PR DESCRIPTION
If self-update is disabled via features during build time, then
we should better info message during `update` that the `rustup`
itself is not updated.

## How did I test?

- `cargo build --features no-self-update`
- `mkdir home`
- `RUSTUP_HOME=home CARGO_HOME=home target/debug/rustup-init --no-modify-path -y`
- `RUSTUP_HOME=home CARGO_HOME=home ./home/bin/rustup update`

Output from the last command:

```
info: syncing channel updates for 'stable-x86_64-unknown-linux-gnu'

  stable-x86_64-unknown-linux-gnu unchanged - rustc 1.54.0 (a178d0322 2021-07-26)

info: cleaning up downloads & tmp directories
info: self-update is disabled for this build of rustup
info: any updates to rustup will need to be fetched with your system package manager
```