### PR TITLE
Don't show deprecation warning without OS

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -17,9 +17,7 @@ use super::{
     self_update::{check_rustup_update, SelfUpdateMode},
 };
 use crate::cli::errors::CLIError;
-use crate::dist::dist::{
-    PartialTargetTriple, PartialToolchainDesc, Profile, TargetTriple, ToolchainDesc,
-};
+use crate::dist::dist::{PartialTargetTriple, PartialToolchainDesc, Profile, TargetTriple};
 use crate::dist::manifest::Component;
 use crate::errors::RustupError;
 use crate::process;
@@ -959,8 +957,8 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
 
             if toolchain_has_triple {
                 let host_arch = TargetTriple::from_host_or_build();
-                if let Ok(toolchain_desc) = ToolchainDesc::from_str(name) {
-                    let target_triple = toolchain_desc.target;
+                if let Ok(partial_toolchain_desc) = PartialToolchainDesc::from_str(name) {
+                    let target_triple = partial_toolchain_desc.resolve(&host_arch)?.target;
                     if !forced && !host_arch.can_run(&target_triple)? {
                         err!("DEPRECATED: future versions of rustup will require --force-non-host to install a non-host toolchain as the default.");
                         warn!(

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -2147,6 +2147,31 @@ warning: If you meant to build software to target that platform, perhaps try `ru
     });
 }
 
+#[test]
+fn dont_warn_on_partial_build() {
+    setup(&|config| {
+        let triple = this_host_triple();
+        let arch = triple.split('-').next().unwrap();
+        let mut cmd = clitools::cmd(
+            config,
+            "rustup",
+            &["toolchain", "install", &format!("nightly-{}", arch)],
+        );
+        clitools::env(config, &mut cmd);
+        let out = cmd.output().unwrap();
+        assert!(out.status.success());
+        let stderr = String::from_utf8(out.stderr).unwrap();
+        assert!(stderr.contains(&format!(
+            r"info: syncing channel updates for 'nightly-{0}'",
+            triple
+        )));
+        assert!(!stderr.contains(&format!(
+            r"warning: toolchain 'nightly-{0}' may not be able to run on this system.",
+            arch
+        )));
+    })
+}
+
 /// Checks that `rust-toolchain.toml` files are considered
 #[test]
 fn rust_toolchain_toml() {


### PR DESCRIPTION
Closes #2837. Don't show a deprecation warning when an OS isn't present in the `PartialTargetTriple`. This way running `rustup install stable-x86_64` won't throw a warning.

Let me know if there's anything I should change here, thanks!