### PR TITLE
Fix a markdown link in README

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -4,7 +4,7 @@ This directory contains rustup's documentation.
 
 ## Building the book
 
-Building the book requires [mdBook]. To get it:
+Building the book requires [mdBook](https://github.com/rust-lang/mdBook). To get it:
 
 ```console
 $ cargo install mdbook


### PR DESCRIPTION
It seems to miss a link.