### PR TITLE
Use correct format to load TTF files

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -21,14 +21,14 @@
     font-family: 'Work Sans';
     font-style: normal;
     font-weight: 500;
-    src: local('Work Sans Medium'), url("fonts/WorkSans-Medium.ttf") format('ttf');
+    src: local('Work Sans Medium'), url("fonts/WorkSans-Medium.ttf") format('truetype');
 }
 
 @font-face {
     font-family: 'Inconsolata';
     font-style: normal;
     font-weight: 400;
-    src: local('Inconsolata Regular'), url("fonts/Inconsolata-Regular.ttf") format('ttf');
+    src: local('Inconsolata Regular'), url("fonts/Inconsolata-Regular.ttf") format('truetype');
 }
 
 body {


### PR DESCRIPTION
I got a bunch of warnings when visiting the website on my Firefox saying `downloadable font: no supported format found`. The root cause is that using `ttf` is an invalid format for `@font-face`, you can [see](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) the valid specifiers here. However this does change the install box font quite drastically when the font is actually loaded:

### Before

![image](https://user-images.githubusercontent.com/2280539/136551469-6a4736ee-b6a7-44bb-b99b-6e6e15c5c9a4.png)

### After

![image](https://user-images.githubusercontent.com/2280539/136551514-1ce271ef-2585-4242-ad9c-11a0c8cd6796.png)

In my case it was using my preferred monospace font, DejaVu Sans Mono since I do not have the rest of the fonts for the `pre`.
