### PR TITLE
Symlink rustup-init when in no self update mode

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -680,7 +680,11 @@ fn install_bins() -> Result<()> {
     if rustup_path.exists() {
         utils::remove_file("rustup-bin", &rustup_path)?;
     }
-    utils::copy_file(&this_exe_path, &rustup_path)?;
+    if cfg!(feature = "no-self-update") {
+        utils::symlink_file(&this_exe_path, &rustup_path)?;
+    } else {
+        utils::copy_file(&this_exe_path, &rustup_path)?;
+    }
     utils::make_executable(&rustup_path)?;
     install_proxies()
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -165,6 +165,7 @@ Cargo's bin directory, located at:
     {cargo_home_bin}
 
 ",
+            pre_install_msg_linking!(),
             $platform_msg,
             r#"
 
@@ -173,6 +174,26 @@ these changes will be reverted.
 "#
         )
     };
+}
+
+#[cfg(feature = "no-self-update")]
+macro_rules! pre_install_msg_linking {
+    () => {
+        r"
+These commands will be symlinked to `rustup-init`.
+
+`WARNING` - if the path to `rustup-init` changes, your Rust install
+will cease to function.
+
+"
+    }
+}
+
+#[cfg(not(feature = "no-self-update"))]
+macro_rules! pre_install_msg_linking {
+    () => {
+        ""
+    }
 }
 
 #[cfg(not(windows))]

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -306,7 +306,7 @@ pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
     std::os::unix::fs::symlink(src, dest).with_context(|| RustupError::LinkingFile {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
@@ -314,7 +314,7 @@ fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
     // we are supposed to not use symlink on windows
     Err(anyhow!(RustupError::LinkingFile {
         src: PathBuf::from(src),


### PR DESCRIPTION
When we are in no self update configuration, it's likely that we have an externally managed rustup binary. During rustup setup it copies the rustup binary into ~/.cargo/bin/, which then means that rustup will *never* be updated in the future, even if it can update toolchains.

When we have compiled the no self update mode, we can assume external management of rustup and in that situation we should symlink back to rustup instead of copying.

An example use case is that for OpenSUSE we plan to package and provide rustup for developers as an alternate method to get rustup. Because our packages manage the updates of rustup, we want no self update, and we want users who use rustup to link back to the rustup in /usr/bin/rustup which ensures they get updates from their base system. 

Alternately, we could use a difference feature flag for this change rather than no-self-update. 