### PR TITLE
Fix grammar in preinstall message.

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -153,7 +153,7 @@ home directory, located at:
 
 This can be modified with the RUSTUP_HOME environment variable.
 
-The Cargo home directory located at:
+The Cargo home directory is located at:
 
     {cargo_home}
 


### PR DESCRIPTION
Just noticed a small grammar issue/typo in the installation message while installing rust a few minutes ago.