### PR TITLE
Remove macOS aarch-64 xcode-select directory.

### DIFF
--- a/.github/workflows/macos-builds-on-all.yaml
+++ b/.github/workflows/macos-builds-on-all.yaml
@@ -78,13 +78,6 @@ jobs:
 
           # Can't run tests: cross-compiling
           echo "SKIP_TESTS=yes" >> $GITHUB_ENV
-
-          # Use the beta compiler
-          sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer/
-
-          # Set SDK environment variables
-          echo "SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)" >> $GITHUB_ENV
         if: matrix.target == 'aarch64-apple-darwin'
       - name: Ensure we have our goal target installed
         run: |

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -78,13 +78,6 @@ jobs:
 
           # Can't run tests: cross-compiling
           echo "SKIP_TESTS=yes" >> $GITHUB_ENV
-
-          # Use the beta compiler
-          sudo xcode-select -s /Applications/Xcode_12.2.app/Contents/Developer/
-
-          # Set SDK environment variables
-          echo "SDKROOT=$(xcrun -sdk macosx11.0 --show-sdk-path)" >> $GITHUB_ENV
-          echo "MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.0 --show-sdk-platform-version)" >> $GITHUB_ENV
         if: matrix.target == 'aarch64-apple-darwin'
       - name: Ensure we have our goal target installed
         run: |


### PR DESCRIPTION
12.2 is likely out of date, and it is breaking PR builds. It likely
isn't required to use the beta compiler anymore[1], so we'll ~~just remove
the line altogether.~~ specify xcode 13.0 and SDK 11.3.

1 - see this [version table](https://en.wikipedia.org/wiki/Xcode#Xcode_11.x_-_13.x_(since_SwiftUI_framework)) on wikipedia

If successful, fixes https://github.com/rust-lang/rustup/issues/2875.