### PR TITLE
Add support for [env] in rust-toolchain.toml

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1165,11 +1165,11 @@ fn show(cfg: &Cfg) -> Result<utils::ExitCode> {
 
         match active_toolchain {
             Ok(atc) => match atc {
-                (ref toolchain, Some(ref reason)) => {
+                (ref toolchain, _, Some(ref reason)) => {
                     writeln!(t, "{} ({})", toolchain.name(), reason)?;
                     writeln!(t, "{}", toolchain.rustc_version())?;
                 }
-                (ref toolchain, None) => {
+                (ref toolchain, _, None) => {
                     writeln!(t, "{} (default)", toolchain.name())?;
                     writeln!(t, "{}", toolchain.rustc_version())?;
                 }
@@ -1221,7 +1221,7 @@ fn show_active_toolchain(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCod
                 return Err(e);
             }
         }
-        Ok((toolchain, reason)) => {
+        Ok((toolchain, _, reason)) => {
             if let Some(reason) = reason {
                 writeln!(process().stdout(), "{} ({})", toolchain.name(), reason)?;
             } else {
@@ -1376,7 +1376,7 @@ fn explicit_or_dir_toolchain<'a>(cfg: &'a Cfg, m: &ArgMatches<'_>) -> Result<Too
     }
 
     let cwd = utils::current_dir()?;
-    let (toolchain, _) = cfg.toolchain_for_dir(&cwd)?;
+    let (toolchain, _, _) = cfg.toolchain_for_dir(&cwd)?;
 
     Ok(toolchain)
 }

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -437,7 +437,7 @@ pub fn expect_component_not_executable(config: &Config, cmd: &str) {
     }
 }
 
-fn print_command(args: &[&str], out: &SanitizedOutput) {
+pub fn print_command(args: &[&str], out: &SanitizedOutput) {
     print!("\n>");
     for arg in args {
         if arg.contains(' ') {
@@ -452,7 +452,7 @@ fn print_command(args: &[&str], out: &SanitizedOutput) {
     print_indented("out.stderr", &out.stderr);
 }
 
-fn print_indented(heading: &str, text: &str) {
+pub fn print_indented(heading: &str, text: &str) {
     let mut lines = text.lines().count();
     // The standard library treats `a\n` and `a` as both being one line.
     // This is confusing when the test fails because of a missing newline.

--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -67,6 +67,11 @@ fn main() {
                 writeln!(out, "{}", arg.to_string_lossy()).unwrap();
             }
         }
+        Some("--print-env") => {
+            for (k, v) in env::vars() {
+                println!("{} = {}", k, v);
+            }
+        }
         _ => panic!("bad mock proxy commandline"),
     }
 }


### PR DESCRIPTION
Fixes #2883.

Should probably not be merged until the open questions from #2883 are resolved, and notably the implication of the discussion in https://github.com/rust-lang/rustup/issues/2793 is taken into account.