### PR TITLE
flake: Add nix flake and envrc for developers

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /home
 /local-rustup
 /snapcraft
+flake.lock

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+# This is a cheap nix flake for direnv use for developing
+# Rustup if you are running on NixOS.
+#
+# We deliberately don't commit a flake.lock because we only
+# provide this for developers, not as a way to have rustup
+# built for NixOS.
+
+{
+  inputs = { flake-utils.url = "github:numtide/flake-utils"; };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            stdenv
+            openssl
+            pkg-config
+          ];
+        };
+      });
+}


### PR DESCRIPTION
This adds a flake.nix and direnv's envrc for developing rustup
on a NixOS host.  This is explicitly *NOT* for constructing rustup
for NixOS users.

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>