### PR TITLE
Optimization: parse manifest only once

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -739,21 +739,21 @@ impl Cfg {
             let components_requested = !components.is_empty() || !targets.is_empty();
             // If we're here, the toolchain exists on disk and is a dist toolchain
             // so we should attempt to load its manifest
-            let manifest = if let Some(manifest) = distributable.get_manifest()? {
-                manifest
+            let desc = if let Some(desc) = distributable.get_toolchain_desc_with_manifest()? {
+                desc
             } else {
                 // We can't read the manifest.  If this is a v1 install that's understandable
                 // and we assume the components are all good, otherwise we need to have a go
                 // at re-fetching the manifest to try again.
                 return Ok(distributable.guess_v1_manifest());
             };
-            match (distributable.list_components(), components_requested) {
+            match (desc.list_components(), components_requested) {
                 // If the toolchain does not support components but there were components requested, bubble up the error
                 (Err(e), true) => Err(e),
                 // Otherwise check if all the components we want are installed
                 (Ok(installed_components), _) => Ok(components.iter().all(|name| {
                     installed_components.iter().any(|status| {
-                        let cname = status.component.short_name(&manifest);
+                        let cname = status.component.short_name(&desc.manifest);
                         let cname = cname.as_str();
                         let cnameim = status.component.short_name_in_manifest();
                         let cnameim = cnameim.as_str();

--- a/src/test.rs
+++ b/src/test.rs
@@ -97,6 +97,8 @@ pub fn this_host_triple() -> String {
         "x86_64"
     } else if cfg!(target_arch = "riscv64") {
         "riscv64gc"
+    } else if cfg!(target_arch = "aarch64") {
+        "aarch64"
     } else {
         unimplemented!()
     };


### PR DESCRIPTION
I was building a project which invoked `cargo` multiple times, and noticed that a no-op build (i.e. a build with no local changes) was surprisingly slow.

Generating a flamegraph of one `cargo` call, I noticed the following:

<img width="1512" alt="Screen Shot 2021-11-10 at 1 40 11 PM" src="https://user-images.githubusercontent.com/745333/141173576-3df9f5cb-87ca-49f2-952c-601e372f3b2b.png">

About half the work is done in `Manifestation::load_manifest`, which is called twice to parse *the same* 700K TOML file ([here](https://github.com/rust-lang/rustup/blob/master/src/config.rs#L742) and [here](https://github.com/rust-lang/rustup/blob/master/src/config.rs#L750)).

This PR adds a new `struct` in `toolchain.rs` which encapsulates this parsed manifest plus other relevant data.  This `struct` is then used in `config.rs` to eliminate the double-parsing.

I also use this `struct` to clean up duplicate code in `toolchain.rs`, e.g. [this comment](https://github.com/rust-lang/rustup/blob/master/src/toolchain.rs#L874):
```
// Overlapping code with get_manifest :/.
```

I see a 15-25% speedup in a no-op build, depending on the project!

- [X] Tests all pass (at least on my machine!)
- [X] No new `clippy` lints (there are a few pre-existing lints in areas I haven't touched)
- [X] `rustfmt` run