### PR TITLE
Make clippy happy

### DIFF
--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -349,7 +349,7 @@ fn unpack_without_first_dir<'a, R: Read>(
         /// has been fully dispatched.
         fn flush_ios<'a, R: std::io::Read, P: AsRef<Path>>(
             io_executor: &mut dyn Executor,
-            mut directories: &mut HashMap<PathBuf, DirStatus>,
+            directories: &mut HashMap<PathBuf, DirStatus>,
             mut sender_entry: Option<&mut SenderEntry<'a, '_, R>>,
             full_path: P,
         ) -> Result<bool> {
@@ -357,7 +357,7 @@ fn unpack_without_first_dir<'a, R: Read>(
             for mut op in io_executor.completed().collect::<Vec<_>>() {
                 // TODO capture metrics
                 filter_result(&mut op)?;
-                trigger_children(&*io_executor, &mut directories, op)?;
+                trigger_children(&*io_executor, directories, op)?;
             }
             // Maybe stream a file incrementally
             if let Some(sender) = sender_entry.as_mut() {

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -685,7 +685,7 @@ fn update_from_dist_<'a>(
     // bunch of the tests, which (inexplicably) use 2015-01-01 as their manifest dates.
     let first_manifest = Utc.from_utc_date(&NaiveDate::from_ymd(2014, 12, 20));
     let old_manifest = old_date
-        .and_then(|date| utc_from_manifest_date(date))
+        .and_then(utc_from_manifest_date)
         .unwrap_or(first_manifest);
     let last_manifest = if allow_downgrade {
         first_manifest

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -52,7 +52,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
         );
 
         if toolchain.starts_with("nightly") {
-            let _ = write!(buf, "{}", nightly_tips.to_string());
+            let _ = write!(buf, "{}", nightly_tips);
         }
 
         let _ = write!(
@@ -73,7 +73,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
         );
 
         if toolchain.starts_with("nightly") {
-            let _ = write!(buf, "{}", nightly_tips.to_string());
+            let _ = write!(buf, "{}", nightly_tips);
         }
         let _ = write!(
             buf,

--- a/src/fallback_settings.rs
+++ b/src/fallback_settings.rs
@@ -6,17 +6,9 @@ use anyhow::{Context, Result};
 
 use crate::utils::utils;
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Default)]
 pub struct FallbackSettings {
     pub default_toolchain: Option<String>,
-}
-
-impl Default for FallbackSettings {
-    fn default() -> Self {
-        Self {
-            default_toolchain: None,
-        }
-    }
 }
 
 impl FallbackSettings {


### PR DESCRIPTION
- derive default for FallbackSettings 
- replace the closure with the function itself 
- remove unnecessary to_string 
- remove unnecessary mut ref 