### PR TITLE
globally introduce #![deny(unreachable_pub)]

### DIFF
--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -8,9 +8,9 @@ pub(crate) const SUPPORTED_CONFIG_VERSIONS: [&str; 1] = ["1"];
 pub(crate) const DEFAULT_CONFIG_VERSION: &str = "1";
 
 #[derive(Clone, Debug)]
-pub struct Config {
-    pub config_version: String,
-    pub components: Vec<Component>,
+pub(crate) struct Config {
+    pub(crate) config_version: String,
+    pub(crate) components: Vec<Component>,
 }
 
 impl Config {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(rust_2018_idioms)]
+#![deny(unreachable_pub)]
 #![allow(
     clippy::too_many_arguments,
     clippy::type_complexity,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -73,14 +73,14 @@ impl SettingsFile {
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Settings {
-    pub version: String,
-    pub default_host_triple: Option<String>,
-    pub default_toolchain: Option<String>,
-    pub profile: Option<Profile>,
-    pub overrides: BTreeMap<String, String>,
-    pub pgp_keys: Option<String>,
-    pub auto_self_update: Option<SelfUpdateMode>,
+pub(crate) struct Settings {
+    pub(crate) version: String,
+    pub(crate) default_host_triple: Option<String>,
+    pub(crate) default_toolchain: Option<String>,
+    pub(crate) profile: Option<Profile>,
+    pub(crate) overrides: BTreeMap<String, String>,
+    pub(crate) pgp_keys: Option<String>,
+    pub(crate) auto_self_update: Option<SelfUpdateMode>,
 }
 
 impl Default for Settings {


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/issues/2730


I know we don't want to use pub(crate) in pub(crate) struct, but it looks like this lint suggests we do. Do you have any comments on how to handle it?