### PR TITLE
Warn on unknown key in toolchain file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "scopeguard",
  "semver",
  "serde",
+ "serde_ignored",
  "sha2",
  "sharded-slab",
  "strsim 0.10.0",
@@ -1879,6 +1880,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ url = "2.1"
 wait-timeout = "0.2"
 xz2 = "0.1.3"
 zstd = "0.6"
+serde_ignored = "0.1.2"
 
 [dependencies.retry]
 default-features = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -715,7 +715,11 @@ impl Cfg {
                 }
             }
             _ => {
-                let override_file = toml::from_str::<OverrideFile>(contents)
+                let mut toml_deserializer = toml::Deserializer::new(contents);
+                let override_file: OverrideFile =
+                    serde_ignored::deserialize(&mut toml_deserializer, |path| {
+                        warn!("Unknown property in toolchain file: {}", path);
+                    })
                     .context(OverrideFileConfigError::Parsing)?;
 
                 if override_file.is_empty() {


### PR DESCRIPTION
Closes #2876

I took the conservative approach of only displaying a warning when an unknown key is found, so that an older version of rustup can still parse future toolchain files with unknown keys.
