### PR TITLE
Upgrade rustup to the 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Daniel Silverstone <dsilvers@digital-scurf.org>", "Diggory Blake <diggsey@googlemail.com>"]
 build = "build.rs"
 description = "Manage multiple rust installations with ease"
-edition = "2018"
+edition = "2021"
 homepage = "https://github.com/rust-lang/rustup"
 keywords = ["rustup", "multirust", "install", "proxy"]
 license = "MIT OR Apache-2.0"

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -36,9 +36,25 @@ runtest () {
   cargo test --locked --release --target "$TARGET" "${FEATURES[@]}" "$@"
 }
 
+run_download_pkg_test() {
+  features=('--no-default-features' '--features' 'curl-backend,reqwest-backend,reqwest-default-tls')
+  case "$TARGET" in
+    # these platforms aren't supported by ring:
+    powerpc* ) ;;
+    mips* ) ;;
+    riscv* ) ;;
+    s390x* ) ;;
+    aarch64-pc-windows-msvc ) ;;
+    # default case, build with rustls enabled
+    * ) features+=('--features' 'reqwest-rustls-tls') ;;
+  esac
+
+  cargo test --locked --release --target "$TARGET" "${features[@]}" -p download
+}
+
 if [ -z "$SKIP_TESTS" ]; then
   cargo run --locked --release --target "$TARGET" "${FEATURES[@]}" -- --dump-testament
-  runtest -p download
+  run_download_pkg_test 
   runtest --bin rustup-init
   runtest --lib --all
   runtest --doc --all

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 authors = ["Brian Anderson <banderson@mozilla.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT/Apache-2.0"
 name = "download"
 version = "0.6.9"

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -529,7 +529,6 @@ impl Component {
     }
 
     pub(crate) fn new_with_target(pkg_with_target: &str, is_extension: bool) -> Option<Self> {
-        use std::convert::TryFrom;
         for (pos, _) in pkg_with_target.match_indices('-') {
             let pkg = &pkg_with_target[0..pos];
             let target = &pkg_with_target[pos + 1..];


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/issues/2944

We should follow up with the latest edition.