### PR TITLE
Support busybox-w32 in rustup-init.sh

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -135,7 +135,7 @@ main() {
         exit 1
     fi
 
-    if [ "$need_tty" = "yes" ]; then
+    if [ "$need_tty" = "yes" ] && [ ! -t 0 ]; then
         # The installer is going to want to ask for confirmation by
         # reading stdin.  This script was piped into `sh` though and
         # doesn't have stdin to pass to its children. Instead we're going

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -287,7 +287,7 @@ get_architecture() {
             _ostype=unknown-illumos
             ;;
 
-        MINGW* | MSYS* | CYGWIN*)
+        MINGW* | MSYS* | CYGWIN* | Windows_NT)
             _ostype=pc-windows-gnu
             ;;
 


### PR DESCRIPTION
[busybox-w32](https://frippery.org/busybox/) differs from currently-supported shells in some ways:
- `uname -s` is `Windows_NT` instead of anything currently recognized
- `/dev/tty` does not exist
  - The fix currently checks whether stdin is already a terminal, but could instead be checking that `/dev/tty` exists

On versions of Windows 10 where `curl` comes included, it's already preferred over busybox-w32's `wget`.