### PR TITLE
Offer to auto install VS 2022

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -369,7 +369,7 @@ pub(crate) fn install(
     if let Some(plan) = do_msvc_check(&opts) {
         if no_prompt {
             warn!("installing msvc toolchain without its prerequisites");
-        } else if plan == VsInstallPlan::Automatic {
+        } else if !quiet && plan == VsInstallPlan::Automatic {
             md(&mut term, MSVC_AUTO_INSTALL_MESSAGE);
             if common::confirm(
                 "Automatically download and install Visual Studio 2022 Community edition? (Y/n)",
@@ -383,7 +383,7 @@ pub(crate) fn install(
                     return Ok(utils::ExitCode(0));
                 }
             }
-        } else if plan == VsInstallPlan::Manual {
+        } else {
             md(&mut term, MSVC_MESSAGE);
             md(&mut term, MSVC_MANUAL_INSTALL_MESSAGE);
             if !common::confirm("\nContinue? (y/N)", false)? {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -372,7 +372,7 @@ pub(crate) fn install(
         } else if !quiet && plan == VsInstallPlan::Automatic {
             md(&mut term, MSVC_AUTO_INSTALL_MESSAGE);
             if common::confirm(
-                "Automatically download and install Visual Studio 2022 Community edition? (Y/n)",
+                "\nAutomatically download and install Visual Studio 2022 Community edition? (Y/n)",
                 true,
             )? {
                 try_install_msvc()?;

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -110,6 +110,8 @@ pub(crate) fn try_install_msvc() -> Result<()> {
     let visual_studio = tempdir.path().join("vs_setup.exe");
     let download_tracker = RefCell::new(DownloadTracker::new().with_display_progress(true));
     download_tracker.borrow_mut().download_finished();
+
+    info!("downloading Visual Studio installer");
     utils::download_file(&visual_studio_url, &visual_studio, None, &move |n| {
         download_tracker
             .borrow_mut()
@@ -144,6 +146,8 @@ pub(crate) fn try_install_msvc() -> Result<()> {
             "Microsoft.VisualStudio.Component.Windows11SDK.22000",
         ]);
     }
+    info!("running the Visual Studio install");
+    info!("rustup will continue once Visual Studio installation is complete\n");
     let exit_status = cmd
         .spawn()
         .and_then(|mut child| child.wait())


### PR DESCRIPTION
This PR aims to improve installation on MSVC hosts when the user does not have Visual Studio already installed. The default workflow will download and install VS 2022 unless the user declines.

For all other cases (e.g. Visual Studio is installed but lacks the required components) it falls back to the current manual install message. This could be further improved in the future but on reflection I think I'd like to work out the new VS install case first because I feel this will have the biggest impact. Users who are already familiar with Visual Studio will have an easier time understanding the install instructions.

See #2947