### PR TITLE
diskio: don't send logging to stdout

### DIFF
--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -269,7 +269,7 @@ impl<'a> Executor for Threaded<'a> {
             ));
         }
         if prev_files > 50 {
-            println!("{} deferred IO operations", prev_files);
+            eprintln!("{} deferred IO operations", prev_files);
         }
         let buf: Vec<u8> = vec![0; prev_files];
         // Cheap wrap-around correctness check - we have 20k files, more than


### PR DESCRIPTION
This interferes with commands like e.g. `rustup which`, which sometimes receive this on stdout.

This looks like logging that probably belongs on stderr instead.