### PR TITLE
Add license note for VS Build Tools

### DIFF
--- a/doc/src/installation/windows.md
+++ b/doc/src/installation/windows.md
@@ -11,7 +11,7 @@ using the [MinGW/MSYS2 toolchain] use the GNU build.
 
 When targeting the MSVC ABI, Rust additionally requires an [installation of
 Visual Studio 2013 (or later) or the Visual C++ Build Tools 2019][vs] so
-`rustc` can use its linker and libraries. The Build Tools require a Visual
+`rustc` can use its linker and libraries. The Visual C++ Build Tools require a Visual
 Studio license (either Community, Pro, or Enterprise).
 
 For Visual Studio, make sure to check the "C++

--- a/doc/src/installation/windows.md
+++ b/doc/src/installation/windows.md
@@ -11,7 +11,10 @@ using the [MinGW/MSYS2 toolchain] use the GNU build.
 
 When targeting the MSVC ABI, Rust additionally requires an [installation of
 Visual Studio 2013 (or later) or the Visual C++ Build Tools 2019][vs] so
-`rustc` can use its linker. For Visual Studio, make sure to check the "C++
+`rustc` can use its linker and libraries. The Build Tools require a Visual
+Studio license (either Community, Pro, or Enterprise).
+
+For Visual Studio, make sure to check the "C++
 tools" and "Windows 10 SDK" option. No additional software installation is
 necessary for basic use of the GNU build.
 


### PR DESCRIPTION
This PR adds a note about the Visual Studio Build Tools needing a Visual Studio Community, Pro or Enterprise license.

A future improvement might be to create an expanded section on the different options. Perhaps that walks through the requirements and the installation process.

Fixes #2867