### PR TITLE
Fix all clippy::vec-init-then-push

### DIFF
--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -637,8 +637,7 @@ where
     let mut vars: HashMap<String, String> = HashMap::default();
     self::env(config, &mut vars);
     vars.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
-    let mut arg_strings: Vec<Box<str>> = Vec::new();
-    arg_strings.push(name.to_owned().into_boxed_str());
+    let mut arg_strings: Vec<Box<str>> = vec![name.to_owned().into_boxed_str()];
     for arg in args {
         arg_strings.push(
             arg.as_ref()


### PR DESCRIPTION
Fixes this lint error:

    % cargo +nightly clippy --all --all-targets -- -D warnings
    error: calls to `push` immediately after creation
       --> tests/mock/clitools.rs:640:5
        |
    640 | /     let mut arg_strings: Vec<Box<str>> = Vec::new();
    641 | |     arg_strings.push(name.to_owned().into_boxed_str());
        | |_______________________________________________________^ help: consider using the `vec![]` macro: `let mut arg_strings: Vec<Box<str>> = vec![..];`
        |
        = note: `-D clippy::vec-init-then-push` implied by `-D warnings`
        = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#vec_init_then_push