### PR TITLE
Support `--verbose` for `rustup show`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -214,10 +214,7 @@ pub(crate) fn cli() -> App<'static, 'static> {
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
-            Arg::with_name("verbose")
-                .help("Enable verbose output")
-                .short("v")
-                .long("verbose"),
+            verbose_arg("Enable verbose output"),
         )
         .arg(
             Arg::with_name("quiet")
@@ -253,11 +250,7 @@ pub(crate) fn cli() -> App<'static, 'static> {
                         .about("Show the active toolchain")
                         .after_help(SHOW_ACTIVE_TOOLCHAIN_HELP)
                         .arg(
-                            Arg::with_name("verbose")
-                                .help("Enable verbose output with rustc information")
-                                .takes_value(false)
-                                .short("v")
-                                .long("verbose"),
+                            verbose_arg("Enable verbose output with rustc information"),
                         ),
                 )
                 .subcommand(
@@ -360,11 +353,7 @@ pub(crate) fn cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .about("List installed toolchains")
                         .arg(
-                            Arg::with_name("verbose")
-                                .help("Enable verbose output with toolchain information")
-                                .takes_value(false)
-                                .short("v")
-                                .long("verbose"),
+                            verbose_arg("Enable verbose output with toolchain information"),
                         ),
                 )
                 .subcommand(
@@ -744,6 +733,14 @@ pub(crate) fn cli() -> App<'static, 'static> {
                     .default_value_ifs(&completion_defaults[..]),
             ),
     )
+}
+
+fn verbose_arg<'a, 'b>(help: &'b str) -> Arg<'a, 'b> {
+    Arg::with_name("verbose")
+        .help(help)
+        .takes_value(false)
+        .short("v")
+        .long("verbose")
 }
 
 fn maybe_upgrade_data(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<bool> {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1068,6 +1068,42 @@ fn show_active_toolchain() {
 }
 
 #[test]
+fn show_with_verbose() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        expect_ok(config, &["rustup", "update", "nightly-2015-01-01"]);
+        expect_ok_ex(
+            config,
+            &["rustup", "show", "--verbose"],
+            for_host_and_home!(
+                config,
+                r"Default host: {0}
+rustup home:  {1}
+
+installed toolchains
+--------------------
+
+nightly-2015-01-01-{0}
+1.2.0 (hash-nightly-1)
+
+nightly-{0} (default)
+1.3.0 (hash-nightly-2)
+
+
+active toolchain
+----------------
+
+nightly-{0} (default)
+1.3.0 (hash-nightly-2)
+
+"
+            ),
+            r"",
+        );
+    });
+}
+
+#[test]
 fn show_active_toolchain_with_verbose() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);


### PR DESCRIPTION
Which prints rustc info for each installed toolchain. I've added a test that you can look at to see some example output.

In case you want to see example output "for real", here is how it looks when I run it locally on my machine:

<details>
  <summary>Click to expand</summary>

```
Default host: aarch64-apple-darwin
rustup home:  /Users/martin/.rustup

installed toolchains
--------------------

stable-aarch64-apple-darwin (default)
rustc 1.60.0 (7737e0b5c 2022-04-04)

nightly-2021-06-01-aarch64-apple-darwin
rustc 1.54.0-nightly (657bc0188 2021-05-31)

nightly-2021-09-01-aarch64-apple-darwin
rustc 1.56.0-nightly (29ef6cf16 2021-08-31)

nightly-2021-10-01-aarch64-apple-darwin
rustc 1.57.0-nightly (aa7aca3b9 2021-09-30)

nightly-2021-10-07-aarch64-apple-darwin
rustc 1.57.0-nightly (0eabf25b9 2021-10-06)

nightly-2021-10-10-aarch64-apple-darwin
rustc 1.57.0-nightly (a8f2463c6 2021-10-09)

nightly-2021-10-11-aarch64-apple-darwin
rustc 1.57.0-nightly (41dfaaa3c 2021-10-10)

nightly-2021-10-13-aarch64-apple-darwin
rustc 1.57.0-nightly (d7c97a02d 2021-10-12)

nightly-2021-10-15-aarch64-apple-darwin
rustc 1.57.0-nightly (e1e9319d9 2021-10-14)

nightly-2021-10-16-aarch64-apple-darwin
rustc 1.57.0-nightly (c1026539b 2021-10-15)

nightly-2021-10-17-aarch64-apple-darwin
rustc 1.57.0-nightly (4e89811b4 2021-10-16)

nightly-2021-10-18-aarch64-apple-darwin
rustc 1.58.0-nightly (1f12ac872 2021-10-17)

nightly-2021-10-19-aarch64-apple-darwin
rustc 1.58.0-nightly (bd41e09da 2021-10-18)

nightly-2021-10-20-aarch64-apple-darwin
rustc 1.58.0-nightly (1af55d19c 2021-10-19)

nightly-2021-10-23-aarch64-apple-darwin
rustc 1.58.0-nightly (514b38779 2021-10-22)

nightly-2021-11-01-aarch64-apple-darwin
rustc 1.58.0-nightly (ff0e14829 2021-10-31)

nightly-2022-01-01-aarch64-apple-darwin
rustc 1.59.0-nightly (cfa3fe5af 2021-12-31)

nightly-2022-01-09-aarch64-apple-darwin
rustc 1.60.0-nightly (a7e2e3396 2022-01-08)

nightly-2022-01-10-aarch64-apple-darwin
rustc 1.60.0-nightly (092e1c9d2 2022-01-09)

nightly-2022-01-11-aarch64-apple-darwin
rustc 1.60.0-nightly (89b9f7b28 2022-01-10)

nightly-2022-01-15-aarch64-apple-darwin
rustc 1.60.0-nightly (ad46af247 2022-01-14)

nightly-2022-01-17-aarch64-apple-darwin
rustc 1.60.0-nightly (bd3cb5256 2022-01-16)

nightly-2022-01-18-aarch64-apple-darwin
rustc 1.60.0-nightly (ee5d8d37b 2022-01-17)

nightly-2022-01-19-aarch64-apple-darwin
rustc 1.60.0-nightly (9ad5d82f8 2022-01-18)

nightly-2022-01-20-aarch64-apple-darwin
rustc 1.60.0-nightly (5e57faa78 2022-01-19)

nightly-2022-03-31-aarch64-apple-darwin
rustc 1.61.0-nightly (c5cf08d37 2022-03-30)

nightly-aarch64-apple-darwin
rustc 1.63.0-nightly (cd282d7f7 2022-05-18)

1.49-aarch64-apple-darwin
rustc 1.49.0 (e1884a8e3 2020-12-29)

1.51-aarch64-apple-darwin
rustc 1.51.0 (2fd73fabe 2021-03-23)

1.53-aarch64-apple-darwin
rustc 1.53.0 (53cb7b09b 2021-06-17)

1.56-aarch64-apple-darwin
rustc 1.56.1 (59eed8a2a 2021-11-01)

1.58-aarch64-apple-darwin
rustc 1.58.1 (db9d1b20b 2022-01-20)

1.59-aarch64-apple-darwin
(rustc does not exist)

93518
rustc 1.62.0-nightly (3a08bd787 2022-05-12)

WherePredicate-bound_param
rustc 1.62.0-nightly (3a08bd787 2022-05-12)

generic-bounds
rustc 1.62.0-nightly (3a08bd787 2022-05-12)

no-assert
rustc 1.62.0-nightly (3a08bd787 2022-05-12)

stage1
rustc 1.62.0-nightly (3a08bd787 2022-05-12)

1.54.0-aarch64-apple-darwin
rustc 1.54.0 (a178d0322 2021-07-26)


active toolchain
----------------

stable-aarch64-apple-darwin (default)
rustc 1.60.0 (7737e0b5c 2022-04-04)
```
  
</details>

