### PR TITLE
(toolchain): Toolchain names must not be empty

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -457,6 +457,10 @@ impl Cfg {
             })?;
         }
 
+        if name.is_empty() {
+            anyhow::bail!("toolchain names must not be empty");
+        }
+
         Toolchain::from(self, name)
     }
 

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -843,6 +843,19 @@ fn add_target_custom_toolchain() {
 }
 
 #[test]
+fn cannot_add_empty_named_custom_toolchain() {
+    setup(&|config| {
+        let path = config.customdir.join("custom-1");
+        let path = path.to_string_lossy();
+        expect_err(
+            config,
+            &["rustup", "toolchain", "link", "", &path],
+            "toolchain names must not be empty",
+        );
+    });
+}
+
+#[test]
 fn add_target_again() {
     setup(&|config| {
         expect_ok(config, &["rustup", "default", "nightly"]);


### PR DESCRIPTION
This fixes a problem where if you did `toolchain link "" ...`
then the `toolchains` dir was broken.

This fixes #2982

Signed-off-by: Daniel Silverstone <dsilvers@digital-scurf.org>