### PR TITLE
Add support for fish shell and continue adding support for non-posix compliant shells. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /local-rustup
 /snapcraft
 flake.lock
+.vscode/

--- a/src/cli/self_update/env.fish
+++ b/src/cli/self_update/env.fish
@@ -1,0 +1,1 @@
+contains {cargo_bin} $fish_user_paths; or set -Ua fish_user_paths {cargo_bin}

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -81,19 +81,7 @@ pub(crate) fn do_remove_from_path() -> Result<()> {
 
 pub(crate) fn do_add_to_path() -> Result<()> {
     for sh in shell::get_available_shells() {
-        let source_cmd = sh.source_string()?;
-        let source_cmd_with_newline = format!("\n{}", &source_cmd);
-
-        for rc in sh.update_rcs() {
-            let cmd_to_write = match utils::read_file("rcfile", &rc) {
-                Ok(contents) if contents.contains(&source_cmd) => continue,
-                Ok(contents) if !contents.ends_with('\n') => &source_cmd_with_newline,
-                _ => &source_cmd,
-            };
-
-            utils::append_file("rcfile", &rc, cmd_to_write)
-                .with_context(|| format!("could not amend shell profile: '{}'", rc.display()))?;
-        }
+        sh.add_to_path()?;
     }
 
     remove_legacy_paths()?;

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -54,24 +54,7 @@ pub(crate) fn delete_rustup_and_cargo_home() -> Result<()> {
 
 pub(crate) fn do_remove_from_path() -> Result<()> {
     for sh in shell::get_available_shells() {
-        let source_bytes = format!("{}\n", sh.source_string()?).into_bytes();
-
-        // Check more files for cleanup than normally are updated.
-        for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
-            let file = utils::read_file("rcfile", rc)?;
-            let file_bytes = file.into_bytes();
-            // FIXME: This is whitespace sensitive where it should not be.
-            if let Some(idx) = file_bytes
-                .windows(source_bytes.len())
-                .position(|w| w == source_bytes.as_slice())
-            {
-                // Here we rewrite the file without the offending line.
-                let mut new_bytes = file_bytes[..idx].to_vec();
-                new_bytes.extend(&file_bytes[idx + source_bytes.len()..]);
-                let new_file = String::from_utf8(new_bytes).unwrap();
-                utils::write_file("rcfile", rc, &new_file)?;
-            }
-        }
+        sh.remove_from_path()?;
     }
 
     remove_legacy_paths()?;

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -99,7 +99,8 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     env::remove_var("RUSTUP_TOOLCHAIN");
     env::remove_var("SHELL");
     env::remove_var("ZDOTDIR");
-    // clap does its own terminal colour probing, and that isn't
+    env::remove_var("XDG_DATA_DIRS");
+    // clap does it's own terminal colour probing, and that isn't
     // trait-controllable, but it does honour the terminal. To avoid testing
     // claps code, lie about whatever terminal this process was started under.
     env::set_var("TERM", "dumb");

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -637,8 +637,7 @@ where
     let mut vars: HashMap<String, String> = HashMap::default();
     self::env(config, &mut vars);
     vars.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
-    let mut arg_strings: Vec<Box<str>> = Vec::new();
-    arg_strings.push(name.to_owned().into_boxed_str());
+    let mut arg_strings: Vec<Box<str>> = vec![name.to_owned().into_boxed_str()];
     for arg in args {
         arg_strings.push(
             arg.as_ref()


### PR DESCRIPTION
Closes #478.

This further contributes to Jubilee Young's efforts to add support for non-posix compliant shells by adding `add_to_path` and `remove_from_path` methods to the UnixShell trait. This removes the bulk of code from unix.rs. 

As part of this, support for fish shell is also added by writing to $HOME/.config/fish/conf.d/cargo.fish as recommended by [fish shell issue 3170](https://github.com/fish-shell/fish-shell/issues/3170).

Any recommendations for further tests and changes to how the fish path should be handled are welcome.