### PR TITLE
Use TLSv1.3 with curl if specified at all

### DIFF
--- a/doc/src/installation/index.md
+++ b/doc/src/installation/index.md
@@ -49,7 +49,7 @@ installation of `rustup` and then install `nightly` along with `clippy` or
 `miri`, first install `rustup` without a toolchain:
 
 ```console
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
+curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain none -y
 ```
 
 Next you can install `nightly` allowing `rustup` to downgrade until it finds

--- a/www/index.html
+++ b/www/index.html
@@ -28,7 +28,7 @@
 <div id="platform-instructions-unix" class="instructions display-none">
   <p>Run the following in your terminal, then follow the onscreen instructions.</p>
     <div class="copy-container">
-      <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+      <pre class="rustup-command">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</pre>
       <button id="copy-button-unix" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
         <div class="copy-icon">
           <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">
@@ -49,7 +49,7 @@
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
-    <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+    <pre class="rustup-command">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</pre>
     <button id="copy-button-win32" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
       <div class="copy-icon">
         <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">
@@ -70,7 +70,7 @@
   </p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
-    <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+    <pre class="rustup-command">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</pre>
     <button id="copy-button-win64" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
       <div class="copy-icon">
         <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">
@@ -104,7 +104,7 @@
   <div>
     <p>If you are running Unix,<br/>run the following in your terminal, then follow the onscreen instructions.</p>
     <div class="copy-container">
-      <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+      <pre class="rustup-command">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</pre>
       <button id="copy-button-unknown" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
         <div class="copy-icon">
           <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">
@@ -143,7 +143,7 @@
     <p>To install Rust, if you are running Unix,<br/>run the following
     in your terminal, then follow the onscreen instructions.</p>
     <div class="copy-container">
-      <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+      <pre class="rustup-command">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</pre>
       <button id="copy-button-default" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
         <div class="copy-icon">
           <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">

--- a/www/rustup.js
+++ b/www/rustup.js
@@ -2,7 +2,7 @@
 
 var platforms = ["default", "unknown", "win32", "win64", "unix"];
 var platform_override = null;
-var rustup_install_command = "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh";
+var rustup_install_command = "curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh";
 
 function detect_platform() {
     "use strict";


### PR DESCRIPTION
The curl option specified to use TLSv1.2 explicity while nowadays 1.3
is availalble and recommended.
Switch to specifying 1.3 instead of 1.2 for the command that downloads 
the install script. The rustup-init.sh script itself it left with the 
ciphersuite selection plus 1.2 and fallbacks as is.

See https://github.com/rust-lang/book/pull/3130