### PR TITLE
Visual Studio: Add the English language pack

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -126,6 +126,8 @@ pub(crate) fn try_install_msvc() -> Result<()> {
     cmd.arg("--wait")
         // Display an interactive GUI focused on installing just the selected components.
         .arg("--focusedUi")
+        // Add the English language pack
+        .args(["--addProductLang", "En-us"])
         // Add the linker and C runtime libraries.
         .args(["--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"]);
 


### PR DESCRIPTION
Rust needs the English language pack to be installed in order to get the rustc linker output messages right.