### PR TITLE
fix one doc typo

### DIFF
--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,4 @@
-///!  Utility functions for Rustup
+//!  Utility functions for Rustup
 pub(crate) mod notifications;
 pub mod raw;
 pub(crate) mod toml_utils;


### PR DESCRIPTION
and run clippy

it has to be a typo right? why would anyone label the `notification` mod as "!  Utility functions for Rustup"? If it is then **this is gotta be my most valuable discover of all time** 🤣 
