### PR TITLE
Correctly propagate subshell failures in rustup-init

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -73,6 +73,9 @@ main() {
 
     local _dir
     _dir="$(ensure mktemp -d)"
+    # Because the previous command ran in a subshell, we must manually propagate
+    # exit status.
+    [ $? -ne 0 ] && exit 1
     local _file="${_dir}/rustup-init${_ext}"
 
     local _ansi_escapes_are_valid=false

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -72,10 +72,11 @@ main() {
     local _url="${RUSTUP_UPDATE_ROOT}/dist/${_arch}/rustup-init${_ext}"
 
     local _dir
-    _dir="$(ensure mktemp -d)"
-    # Because the previous command ran in a subshell, we must manually propagate
-    # exit status.
-    [ $? -ne 0 ] && exit 1
+    if ! _dir="$(ensure mktemp -d)"; then
+        # Because the previous command ran in a subshell, we must manually
+        # propagate exit status.
+        exit 1
+    fi
     local _file="${_dir}/rustup-init${_ext}"
 
     local _ansi_escapes_are_valid=false


### PR DESCRIPTION
If `mktemp -d` were to fail in the current script, `rustup-init.sh` would report the error but keep running anyway. This fixes that by checking for a nonzero exit status and if so exiting the outer shell.