### PR TITLE
Add rust-analyzer proxy.

### DIFF
--- a/doc/src/concepts/components.md
+++ b/doc/src/concepts/components.md
@@ -40,8 +40,10 @@ toolchains. The following is an overview of the different components:
 * `rust-docs` — This is a local copy of the [Rust documentation]. Use the
   `rustup doc` command to open the documentation in a web browser. Run `rustup
   doc --help` for more options.
-* `rls` — [RLS] is a language server that provides support for editors and
-  IDEs.
+* `rust-analyzer` — [rust-analyzer] is a language server that provides support
+  for editors and IDEs.
+* `rls` — [RLS] is a language server that is deprecated and has been replaced
+  by rust-analyzer.
 * `clippy` — [Clippy] is a lint tool that provides extra checks for common
   mistakes and stylistic choices.
 * `miri` — [Miri] is an experimental Rust interpreter, which can be used for
@@ -76,6 +78,7 @@ details.
 [build-std]: https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#build-std
 [miri]: https://github.com/rust-lang/miri/
 [RLS]: https://github.com/rust-lang/rls
+[rust-analyzer]: https://rust-analyzer.github.io/
 [rustdoc]: https://doc.rust-lang.org/rustdoc/
 [cargo]: https://doc.rust-lang.org/cargo/
 [clippy]: https://github.com/rust-lang/rust-clippy

--- a/doc/src/concepts/profiles.md
+++ b/doc/src/concepts/profiles.md
@@ -16,7 +16,7 @@ available at this time are `minimal`, `default`, and `complete`:
   `rustup`. This should never be used, as it includes *every* component ever
   included in the metadata and thus will almost always fail. If you are
   looking for a way to install devtools such as `miri` or IDE integration
-  tools (`rls`), you should use the `default` profile and
+  tools (`rust-analyzer`), you should use the `default` profile and
   install the needed additional components manually, either by using `rustup
   component add` or by using `-c` when installing the toolchain.
 

--- a/doc/src/concepts/proxies.md
+++ b/doc/src/concepts/proxies.md
@@ -16,8 +16,10 @@ The list of proxies is currently static in `rustup` and is as follows:
 
 - `rust-lldb`, `rust-gdb`, and `rust-gdbgui` are simple wrappers around the `lldb`, `gdb`, and `gdbgui` debuggers respectively. The wrappers enable some pretty-printing of Rust values and add some convenience features to the debuggers by means of their scripting interfaces.
 
-- `rls` is part of the Rust IDE integration tooling. It implements the language-server protocol to permit IDEs and editors such as Visual Studio Code, ViM, or Emacs, access to the semantics of the Rust code you are editing. It comes from the `rls` component.
+- `rust-analyzer` is part of the Rust IDE integration tooling. It implements the language-server protocol to permit IDEs and editors such as Visual Studio Code, ViM, or Emacs, access to the semantics of the Rust code you are editing. It comes from the `rust-analyzer` component.
 
 - `cargo-clippy` and `clippy-driver` are related to the `clippy` linting tool which provides extra checks for common mistakes and stylistic choices and it comes from the `clippy` component.
 
 - `cargo-miri` is an experimental interpreter for Rust's mid-level intermediate representation (MIR) and it comes from the `miri` component.
+
+- `rls` is a deprecated IDE tool that has been replaced by `rust-analyzer`. It comes from the `rls` component.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ pub static TOOLS: &[&str] = &[
     "rust-gdb",
     "rust-gdbgui",
     "rls",
+    "rust-analyzer",
     "cargo-clippy",
     "clippy-driver",
     "cargo-miri",
@@ -110,12 +111,12 @@ mod tests {
         for tool in DUP_TOOLS {
             assert!(is_proxyable_tools(tool).is_ok());
         }
-        let message = &"unknown proxy name: 'unknown-tool'; valid proxy names are 'rustc', \
-        'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'cargo-clippy', \
-        'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'";
-        assert!(is_proxyable_tools("unknown-tool")
-            .unwrap_err()
-            .to_string()
-            .eq(message));
+        let message = "unknown proxy name: 'unknown-tool'; valid proxy names are 'rustc', \
+        'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'rust-analyzer', \
+        'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'";
+        assert_eq!(
+            is_proxyable_tools("unknown-tool").unwrap_err().to_string(),
+            message
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,6 @@ pub static TOOLS: &[&str] = &[
     "rust-gdb",
     "rust-gdbgui",
     "rls",
-    "rust-analyzer",
     "cargo-clippy",
     "clippy-driver",
     "cargo-miri",
@@ -36,7 +35,7 @@ pub static TOOLS: &[&str] = &[
 // Tools which are commonly installed by Cargo as well as rustup. We take a bit
 // more care with these to ensure we don't overwrite the user's previous
 // installation.
-pub static DUP_TOOLS: &[&str] = &["rustfmt", "cargo-fmt"];
+pub static DUP_TOOLS: &[&str] = &["rust-analyzer", "rustfmt", "cargo-fmt"];
 
 // If the given name is one of the tools we proxy.
 pub fn is_proxyable_tools(tool: &str) -> Result<()> {
@@ -112,8 +111,8 @@ mod tests {
             assert!(is_proxyable_tools(tool).is_ok());
         }
         let message = "unknown proxy name: 'unknown-tool'; valid proxy names are 'rustc', \
-        'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'rust-analyzer', \
-        'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'";
+        'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', \
+        'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rust-analyzer', 'rustfmt', 'cargo-fmt'";
         assert_eq!(
             is_proxyable_tools("unknown-tool").unwrap_err().to_string(),
             message

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -411,7 +411,10 @@ fn rustup_failed_path_search() {
         expect_err(
             config,
             broken,
-            "unknown proxy name: 'fake_proxy'; valid proxy names are 'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rustfmt', 'cargo-fmt'",
+            "unknown proxy name: 'fake_proxy'; valid proxy names are \
+             'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', \
+             'rls', 'rust-analyzer', 'cargo-clippy', 'clippy-driver', 'cargo-miri', \
+             'rustfmt', 'cargo-fmt'",
         );
 
         // Hardlink will be automatically cleaned up by test setup code

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -413,8 +413,8 @@ fn rustup_failed_path_search() {
             broken,
             "unknown proxy name: 'fake_proxy'; valid proxy names are \
              'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', \
-             'rls', 'rust-analyzer', 'cargo-clippy', 'clippy-driver', 'cargo-miri', \
-             'rustfmt', 'cargo-fmt'",
+             'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', \
+             'rust-analyzer', 'rustfmt', 'cargo-fmt'",
         );
 
         // Hardlink will be automatically cleaned up by test setup code


### PR DESCRIPTION
This adds `rust-analyzer` as a proxy.

rust-analyzer is replacing RLS (see https://blog.rust-lang.org/2022/07/01/RLS-deprecation.html). As part of that process, I'd like to make rust-analyzer easier to run for non-VSCode users.

The `rust-analyzer` component has left preview mode as of https://github.com/rust-lang/rust/pull/98640, which should be part of the 1.64 stable release (September 22, 2022). I think it would be nice to have rustup support that around the same time.

The `rust-analyzer` proxy was previously added in #2408 and then backed out in #2560 due to being nightly-only.

There is some risk this could cause disruption if a user is relying on having `rust-analyzer` in their PATH and this gets in the way. I suspect (hope?) that isn't too common. We may want to consider holding off on releasing this until after the 1.64 release.
