### PR TITLE
Change the order of enum in static array

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -62,9 +62,9 @@ pub enum CompressionKind {
 /// Each compression kind, in order of preference for use, from most desirable
 /// to least desirable.
 static COMPRESSION_KIND_PREFERENCE_ORDER: &[CompressionKind] = &[
-    CompressionKind::ZStd,
-    CompressionKind::XZ,
     CompressionKind::GZip,
+    CompressionKind::XZ,
+    CompressionKind::ZStd,
 ];
 
 impl CompressionKind {


### PR DESCRIPTION
Update the order of static array to synchronize with the `CompressionKind` enum in terms of readability.
```
#[derive(Clone, Copy, Debug, PartialEq)]
pub enum CompressionKind {
    GZip,
    XZ,
    ZStd,
}

/// Each compression kind, in order of preference for use, from most desirable
/// to least desirable.
static COMPRESSION_KIND_PREFERENCE_ORDER: &[CompressionKind] = &[
    CompressionKind::ZStd, // Better to change the order in terms of readability?
    CompressionKind::XZ,    
    CompressionKind::GZip,  
];

impl CompressionKind {
    const fn key_prefix(self) -> &'static str {
        match self {
            Self::GZip => "",
            Self::XZ => "xz_",
            Self::ZStd => "zst_",
        }
    }
}
```