### PR TITLE
Use Build Tools installer instead of Visual Studio

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -166,7 +166,7 @@ pub(crate) enum ContinueInstall {
 /// but the rustup install should not be continued at this time.
 pub(crate) fn try_install_msvc(opts: &InstallOpts<'_>) -> Result<ContinueInstall> {
     // download the installer
-    let visual_studio_url = utils::parse_url("https://aka.ms/vs/17/release/vs_community.exe")?;
+    let visual_studio_url = utils::parse_url("https://aka.ms/vs/17/release/vs_buildtools.exe")?;
 
     let tempdir = tempfile::Builder::new()
         .prefix("rustup-visualstudio")


### PR DESCRIPTION
This PR changes Visual Studio installer from `vs_community.exe` to `vs_buildtools.exe`.
I think this has the following advantages:

* Less download size and disk usage
* Visual Studio GUI doesn't launch after installation