### PR TITLE
Unify the msg of the prompt when downloading self-update

### DIFF
--- a/doc/src/basics.md
+++ b/doc/src/basics.md
@@ -21,8 +21,8 @@ info: installing component 'rustc'
 info: installing component 'rust-std'
 info: installing component 'rust-docs'
 info: installing component 'cargo'
-info: checking for self-updates
-info: downloading self-updates
+info: checking for self-update
+info: downloading self-update
 
   stable updated: rustc 1.7.0 (a5d1e7a59 2016-02-29)
 
@@ -49,8 +49,8 @@ This will not download new toolchains:
 
 ```console
 $ rustup self update
-info: checking for self-updates
-info: downloading self-updates
+info: checking for self-update
+info: downloading self-update
 ```
 
 ### Disabling self updates on a per-invocation basis

--- a/doc/src/concepts/channels.md
+++ b/doc/src/concepts/channels.md
@@ -77,8 +77,8 @@ will be updated in addition to stable:
 $ rustup update
 info: syncing channel updates for 'stable'
 info: syncing channel updates for 'nightly'
-info: checking for self-updates
-info: downloading self-updates
+info: checking for self-update
+info: downloading self-update
 
    stable unchanged: rustc 1.7.0 (a5d1e7a59 2016-02-29)
   nightly unchanged: rustc 1.9.0-nightly (02310fd31 2016-03-19)

--- a/doc/src/environment-variables.md
+++ b/doc/src/environment-variables.md
@@ -17,7 +17,7 @@
   Deprecated. Use `RUSTUP_DIST_SERVER` instead.
 
 - `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup`) Sets
-  the root URL for downloading self-updates.
+  the root URL for downloading self-update.
 
 - `RUSTUP_IO_THREADS` *unstable* (defaults to reported cpu count). Sets the
   number of threads to perform close IO in. Set to `1` to force

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1132,7 +1132,7 @@ pub(crate) fn prepare_update() -> Result<Option<PathBuf>> {
     let current_version = env!("CARGO_PKG_VERSION");
 
     // Get available version
-    info!("checking for self-updates");
+    info!("checking for self-update");
     let available_version = get_available_rustup_version()?;
 
     // If up-to-date

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -114,7 +114,7 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
-info: checking for self-updates
+info: checking for self-update
 info: downloading self-update
 "
                 ),

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -299,7 +299,7 @@ fn uninstall_doesnt_leave_gc_file() {
 #[test]
 fn update_exact() {
     let version = env!("CARGO_PKG_VERSION");
-    let expected_output = "info: checking for self-updates
+    let expected_output = "info: checking for self-update
 info: downloading self-update
 "
     .to_string();
@@ -439,7 +439,7 @@ fn update_no_change() {
 ",
                 version
             ),
-            r"info: checking for self-updates
+            r"info: checking for self-update
 ",
         );
     });
@@ -512,7 +512,7 @@ fn rustup_self_update_exact() {
             ),
             for_host!(
                 r"info: syncing channel updates for 'stable-{0}'
-info: checking for self-updates
+info: checking for self-update
 info: downloading self-update
 info: cleaning up downloads & tmp directories
 "

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -566,7 +566,7 @@ where
     A: AsRef<OsStr>,
 {
     // Only the rustup alias is currently ready for in-process testing:
-    // - -init performs self-updates which monkey with global external state.
+    // - -init performs self-update which monkey with global external state.
     // - proxies themselves behave appropriately the proxied output needs to be
     //   collected for assertions to be made on it as our tests traverse layers.
     // - self update executions cannot run in-process because on windows the


### PR DESCRIPTION
We prompt for `self-updates` on `rustup update` but `self-update` on `rustup self update`. We should unify it.