### PR TITLE
Improve error message when there is an error caused by override file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -673,13 +673,16 @@ impl Cfg {
             };
 
             if let Ok(contents) = contents {
-                let override_file = Cfg::parse_override_file(contents, parse_mode)?;
+                let add_file_context = || format!("in {}", toolchain_file.to_string_lossy());
+                let override_file = Cfg::parse_override_file(contents, parse_mode)
+                    .with_context(add_file_context)?;
                 if let Some(toolchain_name) = &override_file.toolchain.channel {
-                    let all_toolchains = self.list_toolchains()?;
+                    let all_toolchains = self.list_toolchains().with_context(add_file_context)?;
                     if !all_toolchains.iter().any(|s| s == toolchain_name) {
                         // The given name is not resolvable as a toolchain, so
                         // instead check it's plausible for installation later
-                        dist::validate_channel_name(toolchain_name)?;
+                        dist::validate_channel_name(toolchain_name)
+                            .with_context(add_file_context)?;
                     }
                 }
 


### PR DESCRIPTION
I had a weird error message after running `cargo test` this morning:   

```
error: error parsing override file: newline in string found at line 2 column 19
```

I checked cargo docs and couldn't find anything about an "override file". After some time I realized I had a typo in my `rust-toolchain.toml` file: 

```toml
[toolchain]
channel = "nightly
```

Anyways, long story short, I extended the error message so that it now includes the filename causing the error so that it's a bit less confusing for newbies. e.g.:

```
error: in /Users/redacted/code/project/rust-toolchain.toml: error parsing override file: newline in string found at line 2 column 19
```