### PR TITLE
Add DisplayVersion for rustup to registry on Windows.

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -523,10 +523,14 @@ pub(crate) fn do_add_to_programs() -> Result<()> {
         vtype: RegType::REG_SZ,
     };
 
+    let current_version: &str = env!("CARGO_PKG_VERSION");
+
     key.set_raw_value("UninstallString", &reg_value)
         .context("Failed to set uninstall string")?;
     key.set_value("DisplayName", &"Rustup: the Rust toolchain installer")
         .context("Failed to set display name")?;
+    key.set_value("DisplayVersion", &current_version)
+        .context("Failed to set display version")?;
 
     Ok(())
 }


### PR DESCRIPTION
Hello! I'm a contributor to the Windows Package Manager Community Repository ([microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)), and we recently had an issue posted to that repo which revealed that Rustup was not publishing a `DisplayVersion` to Add and Remove Programs during its install (although it was posting its `DisplayName`). 

The `DisplayVersion` is how winget and other tools determine when updates to software are needed, so it is highly recommended to set it whenever possible. This PR does just that, by making it so when Rustup is installed, it adds its version number to the registry alongside its name. 

This is the most Rust I've ever written, so let me know if I did something wrong and I can fix it :)

Tested: manually by compiling a new version of Rustup and installing it in a VM. If this needs more strenuous tests, I'm happy to oblige.

Resolves: https://github.com/rust-lang/rustup/issues/3055