### PR TITLE
Add Fig as an autocomplete method

### DIFF
--- a/doc/src/installation/index.md
+++ b/doc/src/installation/index.md
@@ -100,3 +100,12 @@ For `zsh`, you must then add the following line in your `~/.zshrc` before
 ```zsh
 fpath+=~/.zfunc
 ```
+
+### Fig
+
+You can also get IDE-style autocompletions for rustup with [Fig](https://fig.io/) <a href="https://fig.io/" target="_blank"><img src="https://fig.io/badges/Logo.svg" width="15" height="15"/></a>. It works in bash, zsh, and fish.
+
+To install, run:
+
+```shell
+brew install fig


### PR DESCRIPTION
Hey there! [Fig](https://fig.io) provides autocomplete for 300+ CLI tools including rustup. It looks like this:

<img width="400" alt="image" src="https://user-images.githubusercontent.com/4949076/181364401-1839e34b-73e7-46e6-b519-132c91a707cb.png">

We think this will make users more efficient with rustup CLI, so we would love to have Fig listed as an autocomplete method in your docs. Thanks so much and please let me know if you have any questions!