### PR TITLE
Make auto-self-update setting work when no-self-update feature is enabled

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1032,11 +1032,11 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         cfg.temp_cfg.clean();
     }
 
-    if !self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::CheckOnly {
+    if self_update_mode == SelfUpdateMode::CheckOnly {
         check_rustup_update()?;
     }
 
-    if self_update::NEVER_SELF_UPDATE && self_update_mode != SelfUpdateMode::Disable {
+    if self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::Enable {
         info!("self-update is disabled for this build of rustup");
         info!("any updates to rustup will need to be fetched with your system package manager")
     }
@@ -1610,8 +1610,7 @@ fn set_profile(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
 fn set_auto_self_update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
     cfg.set_auto_self_update(m.value_of("auto-self-update-mode").unwrap())?;
 
-    let new_self_update_mode = cfg.get_self_update_mode()?;
-    if self_update::NEVER_SELF_UPDATE && new_self_update_mode != SelfUpdateMode::Disable {
+    if self_update::NEVER_SELF_UPDATE && cfg.get_self_update_mode()? == SelfUpdateMode::Enable {
         let mut args = crate::process().args_os();
         let arg0 = args.next().map(PathBuf::from);
         let arg0 = arg0
@@ -1619,10 +1618,7 @@ fn set_auto_self_update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::Exit
             .and_then(|a| a.to_str())
             .ok_or(CLIError::NoExeName)?;
         warn!("{} is built with the no-self-update feature", arg0);
-        warn!(
-            "setting auto-self-update to {} won't lead to updates being checked",
-            new_self_update_mode.to_string(),
-        );
+        warn!("setting auto-self-update to enable won't lead to updates being checked");
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1032,8 +1032,9 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         cfg.temp_cfg.clean();
     }
 
-    if self_update_mode == SelfUpdateMode::CheckOnly {
-        check_rustup_update()?;
+    match (&self_update_mode, self_update::NEVER_SELF_UPDATE) {
+        (SelfUpdateMode::CheckOnly, _) | (SelfUpdateMode::Enable, true) => check_rustup_update()?,
+        (SelfUpdateMode::Disable, _) | (SelfUpdateMode::Enable, false) => {}
     }
 
     if self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::Enable {
@@ -1618,7 +1619,7 @@ fn set_auto_self_update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::Exit
             .and_then(|a| a.to_str())
             .ok_or(CLIError::NoExeName)?;
         warn!("{} is built with the no-self-update feature", arg0);
-        warn!("setting auto-self-update to enable won't lead to updates being checked");
+        warn!("setting auto-self-update to enable won't lead to updates being installed");
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1036,7 +1036,7 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         check_rustup_update()?;
     }
 
-    if self_update::NEVER_SELF_UPDATE {
+    if self_update::NEVER_SELF_UPDATE && self_update_mode != SelfUpdateMode::Disable {
         info!("self-update is disabled for this build of rustup");
         info!("any updates to rustup will need to be fetched with your system package manager")
     }
@@ -1608,16 +1608,23 @@ fn set_profile(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
 }
 
 fn set_auto_self_update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
-    if self_update::NEVER_SELF_UPDATE {
+    cfg.set_auto_self_update(m.value_of("auto-self-update-mode").unwrap())?;
+
+    let new_self_update_mode = cfg.get_self_update_mode()?;
+    if self_update::NEVER_SELF_UPDATE && new_self_update_mode != SelfUpdateMode::Disable {
         let mut args = crate::process().args_os();
         let arg0 = args.next().map(PathBuf::from);
         let arg0 = arg0
             .as_ref()
             .and_then(|a| a.to_str())
             .ok_or(CLIError::NoExeName)?;
-        warn!("{} is built with the no-self-update feature: setting auto-self-update will not have any effect.",arg0);
+        warn!("{} is built with the no-self-update feature", arg0);
+        warn!(
+            "setting auto-self-update to {} won't lead to updates being checked",
+            new_self_update_mode.to_string(),
+        );
     }
-    cfg.set_auto_self_update(m.value_of("auto-self-update-mode").unwrap())?;
+
     Ok(utils::ExitCode(0))
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1038,8 +1038,19 @@ fn update(cfg: &mut Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
     }
 
     if self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::Enable {
+        let mut args = crate::process().args_os();
+        let arg0 = args.next().map(PathBuf::from);
+        let arg0 = arg0
+            .as_ref()
+            .and_then(|a| a.to_str())
+            .ok_or(CLIError::NoExeName)?;
+
         info!("self-update is disabled for this build of rustup");
-        info!("any updates to rustup will need to be fetched with your system package manager")
+        info!("any updates to rustup will need to be fetched with your system package manager");
+        info!(
+            "to suppress this message, run `{} set auto-self-update disable`",
+            arg0,
+        );
     }
 
     Ok(utils::ExitCode(0))


### PR DESCRIPTION
Fixes #3040.

This patch series makes rustup work in the way that makes the most sense to me personally when built with self updates disabled. I've split four distinct, individually conservative changes I'd make into four patches. If you'd like me to drop or modify some of them, that's fine, of course. The first patch ("don't log on update if no-self-update is enabled but auto-self-update=disable") is the one that matters to me.

If you'd like docs or tests changes, I can do that, too, but no-self-update already doesn't seem to be covered by either. Enabling the feature causes the tests to fail even without these patches.