### PR TITLE
Add support for loongarch64

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -370,6 +370,9 @@ get_architecture() {
         riscv64)
             _cputype=riscv64gc
             ;;
+        loongarch64)
+            _cputype=loongarch64
+            ;;
         *)
             err "unknown CPU type: $_cputype"
 

--- a/src/dist/triple.rs
+++ b/src/dist/triple.rs
@@ -22,6 +22,7 @@ static LIST_ARCHS: &[&str] = &[
     "powerpc64le",
     "riscv64gc",
     "s390x",
+    "loongarch64",
 ];
 static LIST_OSES: &[&str] = &[
     "pc-windows",

--- a/src/test.rs
+++ b/src/test.rs
@@ -99,6 +99,8 @@ pub fn this_host_triple() -> String {
         "riscv64gc"
     } else if cfg!(target_arch = "aarch64") {
         "aarch64"
+    } else if cfg!(target_arch = "loongarch64") {
+        "loongarch64"
     } else {
         unimplemented!()
     };


### PR DESCRIPTION
The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.

Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html

Related PRs:
libc: https://github.com/rust-lang/libc/pull/2765
 cc:  https://github.com/rust-lang/cc-rs/pull/637
rust: https://github.com/rust-lang/rust/pull/96971