### PR TITLE
doc: Recommend tracking Cargo.lock with rust-toolchain files

### DIFF
--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -111,7 +111,9 @@ that uses the new TOML encoding in the `rust-toolchain` file. You need to upgrad
 `rustup` to 1.23.0+.
 
 The `rust-toolchain.toml`/`rust-toolchain` files are suitable to check in to
-source control.
+source control. If that's done, `Cargo.lock` should probably be tracked too if
+the toolchain is pinned to a specific release, to avoid potential compatibility
+issues with dependencies.
 
 The toolchains named in these files have a more restricted form than `rustup`
 toolchains generally, and may only contain the names of the three release


### PR DESCRIPTION
 Current use-case where not doing this causes issues:

 ```
 cargo new ttt
 cd ttt
 sed -i '/edition/s;2021;2018;' Cargo.toml
 echo 'criterion = "0.3"' >> Cargo.toml
 echo '1.55' > rust-toolchain
 cargo check
 ```

 Issue triggered by an indirect dependency requiring a newer edition
 than what the pinned toolchain supports.