### PR TITLE
Bump `clap` to 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /Cargo.lock
 /.settings
 /.idea/
+/.vscode/
 *~
 /**/target
 /home

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,15 +67,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,18 +308,36 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
- "term_size",
+ "clap_lex",
+ "indexmap",
+ "strsim",
+ "termcolor",
+ "terminal_size",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_complete"
+version = "3.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1716,6 +1725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+
+[[package]]
 name = "p256"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,6 +2192,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "chrono",
  "clap",
+ "clap_complete",
  "download",
  "effective-limits",
  "enum-map",
@@ -2202,7 +2218,7 @@ dependencies = [
  "serde",
  "sha2 0.10.6",
  "sharded-slab",
- "strsim 0.10.0",
+ "strsim",
  "tar",
  "tempfile",
  "term",
@@ -2580,12 +2596,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -2671,16 +2681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2690,13 +2690,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.11.0"
+name = "terminal_size"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "4c9afddd2cec1c0909f06b00ef33f94ab2cc0578c4a610aa208ddfec8aa2b43a"
 dependencies = [
- "term_size",
- "unicode-width",
+ "rustix",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+dependencies = [
+ "terminal_size",
 ]
 
 [[package]]
@@ -3014,12 +3023,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ no-self-update = []
 anyhow.workspace = true
 cfg-if = "1.0"
 chrono = "0.4"
-clap = {version = "2", features = ["wrap_help"]}
+clap = {version = "3", features = ["wrap_help"]}
+clap_complete = "3"
 download = {path = "download", default-features = false}
 effective-limits = "0.5.5"
 enum-map = "2.4.2"

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -67,7 +67,6 @@ OPTIONS:
 
     -V, --version
             Print version information
-
 EOF
 }
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -29,25 +29,45 @@ rustup-init 1.25.2 (8c4dad73d 2023-02-01)
 The installer for rustup
 
 USAGE:
-    rustup-init [FLAGS] [OPTIONS]
-
-FLAGS:
-    -v, --verbose                        Enable verbose output
-    -q, --quiet                          Disable progress output
-    -y                                   Disable confirmation prompt.
-        --no-update-default-toolchain    Don't update any existing default toolchain after install
-        --no-modify-path                 Don't configure the PATH environment variable
-    -h, --help                           Prints help information
-    -V, --version                        Prints version information
+    rustup-init [OPTIONS]
 
 OPTIONS:
-        --default-host <default-host>              Choose a default host triple
+    -v, --verbose
+            Enable verbose output
+
+    -q, --quiet
+            Disable progress output
+
+    -y
+            Disable confirmation prompt.
+
+        --default-host <default-host>
+            Choose a default host triple
+
         --default-toolchain <default-toolchain>
             Choose a default toolchain to install. Use 'none' to not install any toolchains at all
 
-        --profile <profile>                         [default: default]  [possible values: minimal, default, complete]
-    -c, --component <components>...                Component name to also install
-    -t, --target <targets>...                      Target name to also install
+        --profile <profile>
+            [default: default] [possible values: minimal, default, complete]
+
+    -c, --component <components>...
+            Component name to also install
+
+    -t, --target <targets>...
+            Target name to also install
+
+        --no-update-default-toolchain
+            Don't update any existing default toolchain after install
+
+        --no-modify-path
+            Don't configure the PATH environment variable
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+
 EOF
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -71,11 +71,11 @@ pub fn main() -> Result<utils::ExitCode> {
     let matches = match cli().try_get_matches_from(process().args_os()) {
         Ok(matches) => Ok(matches),
         Err(err) if err.kind() == DisplayHelp => {
-            writeln!(process().stdout().lock(), "{err}")?;
+            write!(process().stdout().lock(), "{err}")?;
             return Ok(utils::ExitCode(0));
         }
         Err(err) if err.kind() == DisplayVersion => {
-            writeln!(process().stdout().lock(), "{err}")?;
+            write!(process().stdout().lock(), "{err}")?;
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
 
             fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
@@ -107,7 +107,7 @@ pub fn main() -> Result<utils::ExitCode> {
             ]
             .contains(&err.kind())
             {
-                writeln!(process().stdout().lock(), "{err}")?;
+                write!(process().stdout().lock(), "{err}")?;
                 return Ok(utils::ExitCode(1));
             }
             Err(err)

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -128,72 +128,96 @@ pub fn main() -> Result<utils::ExitCode> {
     cfg.check_metadata_version()?;
 
     Ok(match matches.subcommand() {
-        Some(("dump-testament", _)) => common::dump_testament()?,
-        Some(("show", c)) => match c.subcommand() {
-            Some(("active-toolchain", m)) => handle_epipe(show_active_toolchain(cfg, m))?,
-            Some(("home", _)) => handle_epipe(show_rustup_home(cfg))?,
-            Some(("profile", _)) => handle_epipe(show_profile(cfg))?,
-            Some(("keys", _)) => handle_epipe(show_keys(cfg))?,
-            _ => handle_epipe(show(cfg, c))?,
-        },
-        Some(("install", m)) => deprecated("toolchain install", cfg, m, update)?,
-        Some(("update", m)) => update(cfg, m)?,
-        Some(("check", _)) => check_updates(cfg)?,
-        Some(("uninstall", m)) => deprecated("toolchain uninstall", cfg, m, toolchain_remove)?,
-        Some(("default", m)) => default_(cfg, m)?,
-        Some(("toolchain", c)) => match c.subcommand() {
-            Some(("install", m)) => update(cfg, m)?,
-            Some(("list", m)) => handle_epipe(toolchain_list(cfg, m))?,
-            Some(("link", m)) => toolchain_link(cfg, m)?,
-            Some(("uninstall", m)) => toolchain_remove(cfg, m)?,
-            _ => unreachable!(),
-        },
-        Some(("target", c)) => match c.subcommand() {
-            Some(("list", m)) => handle_epipe(target_list(cfg, m))?,
-            Some(("add", m)) => target_add(cfg, m)?,
-            Some(("remove", m)) => target_remove(cfg, m)?,
-            _ => unreachable!(),
-        },
-        Some(("component", c)) => match c.subcommand() {
-            Some(("list", m)) => handle_epipe(component_list(cfg, m))?,
-            Some(("add", m)) => component_add(cfg, m)?,
-            Some(("remove", m)) => component_remove(cfg, m)?,
-            _ => unreachable!(),
-        },
-        Some(("override", c)) => match c.subcommand() {
-            Some(("list", _)) => handle_epipe(common::list_overrides(cfg))?,
-            Some(("set", m)) => override_add(cfg, m)?,
-            Some(("unset", m)) => override_remove(cfg, m)?,
-            _ => unreachable!(),
-        },
-        Some(("run", m)) => run(cfg, m)?,
-        Some(("which", m)) => which(cfg, m)?,
-        Some(("doc", m)) => doc(cfg, m)?,
-        Some(("man", m)) => man(cfg, m)?,
-        Some(("self", c)) => match c.subcommand() {
-            Some(("update", _)) => self_update::update(cfg)?,
-            Some(("uninstall", m)) => self_uninstall(m)?,
-            _ => unreachable!(),
-        },
-        Some(("set", c)) => match c.subcommand() {
-            Some(("default-host", m)) => set_default_host_triple(cfg, m)?,
-            Some(("profile", m)) => set_profile(cfg, m)?,
-            Some(("auto-self-update", m)) => set_auto_self_update(cfg, m)?,
-            _ => unreachable!(),
-        },
-        Some(("completions", c)) => {
-            if let Some(&shell) = c.get_one::<Shell>("shell") {
-                (output_completion_script(
-                    shell,
-                    c.get_one::<CompletionCommand>("command")
-                        .copied()
-                        .unwrap_or(CompletionCommand::Rustup),
-                ))?
-            } else {
-                unreachable!()
+        Some(s) => match s {
+            ("dump-testament", _) => common::dump_testament()?,
+            ("show", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("active-toolchain", m) => handle_epipe(show_active_toolchain(cfg, m))?,
+                    ("home", _) => handle_epipe(show_rustup_home(cfg))?,
+                    ("profile", _) => handle_epipe(show_profile(cfg))?,
+                    ("keys", _) => handle_epipe(show_keys(cfg))?,
+                    _ => handle_epipe(show(cfg, c))?,
+                },
+                None => handle_epipe(show(cfg, c))?,
+            },
+            ("install", m) => deprecated("toolchain install", cfg, m, update)?,
+            ("update", m) => update(cfg, m)?,
+            ("check", _) => check_updates(cfg)?,
+            ("uninstall", m) => deprecated("toolchain uninstall", cfg, m, toolchain_remove)?,
+            ("default", m) => default_(cfg, m)?,
+            ("toolchain", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("install", m) => update(cfg, m)?,
+                    ("list", m) => handle_epipe(toolchain_list(cfg, m))?,
+                    ("link", m) => toolchain_link(cfg, m)?,
+                    ("uninstall", m) => toolchain_remove(cfg, m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("target", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("list", m) => handle_epipe(target_list(cfg, m))?,
+                    ("add", m) => target_add(cfg, m)?,
+                    ("remove", m) => target_remove(cfg, m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("component", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("list", m) => handle_epipe(component_list(cfg, m))?,
+                    ("add", m) => component_add(cfg, m)?,
+                    ("remove", m) => component_remove(cfg, m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("override", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("list", _) => handle_epipe(common::list_overrides(cfg))?,
+                    ("set", m) => override_add(cfg, m)?,
+                    ("unset", m) => override_remove(cfg, m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("run", m) => run(cfg, m)?,
+            ("which", m) => which(cfg, m)?,
+            ("doc", m) => doc(cfg, m)?,
+            ("man", m) => man(cfg, m)?,
+            ("self", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("update", _) => self_update::update(cfg)?,
+                    ("uninstall", m) => self_uninstall(m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("set", c) => match c.subcommand() {
+                Some(s) => match s {
+                    ("default-host", m) => set_default_host_triple(cfg, m)?,
+                    ("profile", m) => set_profile(cfg, m)?,
+                    ("auto-self-update", m) => set_auto_self_update(cfg, m)?,
+                    _ => unreachable!(),
+                },
+                None => unreachable!(),
+            },
+            ("completions", c) => {
+                if let Some(&shell) = c.get_one::<Shell>("shell") {
+                    output_completion_script(
+                        shell,
+                        c.get_one::<CompletionCommand>("command")
+                            .copied()
+                            .unwrap_or(CompletionCommand::Rustup),
+                    )?
+                } else {
+                    unreachable!()
+                }
             }
-        }
-        _ => unreachable!(),
+            _ => unreachable!(),
+        },
+        None => unreachable!(),
     })
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -71,11 +71,11 @@ pub fn main() -> Result<utils::ExitCode> {
     let matches = match cli().try_get_matches_from(process().args_os()) {
         Ok(matches) => Ok(matches),
         Err(err) if err.kind() == DisplayHelp => {
-            writeln!(process().stdout().lock(), "{}", err)?;
+            writeln!(process().stdout().lock(), "{err}")?;
             return Ok(utils::ExitCode(0));
         }
         Err(err) if err.kind() == DisplayVersion => {
-            writeln!(process().stdout().lock(), "{}", err)?;
+            writeln!(process().stdout().lock(), "{err}")?;
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
 
             fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
@@ -107,7 +107,7 @@ pub fn main() -> Result<utils::ExitCode> {
             ]
             .contains(&err.kind())
             {
-                writeln!(process().stdout().lock(), "{}", err)?;
+                writeln!(process().stdout().lock(), "{err}")?;
                 return Ok(utils::ExitCode(1));
             }
             Err(err)
@@ -206,16 +206,6 @@ pub(crate) fn cli() -> Command<'static> {
         .arg_required_else_help(true)
         .arg(
             verbose_arg("Enable verbose output"),
-        )
-        .help_template(
-            "\
-{name} {version}
-{about}
-
-USAGE:
-    {usage}
-
-{all-args}",
         )
         .arg(
             Arg::new("quiet")
@@ -351,7 +341,6 @@ USAGE:
                     Arg::new("toolchain")
                         .help(TOOLCHAIN_ARG_HELP)
                         .required(false)
-                        .takes_value(true),
                 ),
         )
         .subcommand(
@@ -392,7 +381,7 @@ USAGE:
                                 .takes_value(true)
                                 .multiple_values(true)
                                 .use_value_delimiter(true)
-                                .action(ArgAction::Append),
+                            .action(ArgAction::Append),
                         )
                         .arg(
                             Arg::new("targets")
@@ -401,8 +390,8 @@ USAGE:
                                 .short('t')
                                 .takes_value(true)
                                 .multiple_values(true)
-                                .multiple_occurrences(true)
-                                .use_value_delimiter(true),
+                                .use_value_delimiter(true)
+                                .action(ArgAction::Append),
                         )
                         .arg(
                             Arg::new("no-self-update")
@@ -1520,7 +1509,7 @@ fn override_remove(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
             info!("override toolchain for '{}' removed", path);
         } else {
             info!("no override toolchain for '{}'", path);
-            if !m.get_one::<String>("path").is_some() && !m.get_flag("nonexistent") {
+            if m.get_one::<String>("path").is_none() && !m.get_flag("nonexistent") {
                 info!(
                     "you may use `--path <path>` option to remove override toolchain \
                      for a specific path"

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -105,7 +105,7 @@ pub fn main() -> Result<utils::ExitCode> {
             if e.kind() == clap::ErrorKind::DisplayHelp
                 || e.kind() == clap::ErrorKind::DisplayVersion =>
         {
-            writeln!(process().stdout().lock(), "{e}")?;
+            write!(process().stdout().lock(), "{e}")?;
             return Ok(utils::ExitCode(0));
         }
         Err(e) => return Err(e.into()),

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -27,16 +27,6 @@ pub fn main() -> Result<utils::ExitCode> {
         .version(common::version())
         .about("The installer for rustup")
         .setting(AppSettings::DeriveDisplayOrder)
-        .help_template(
-            "\
-{name} {version}
-{about}
-
-USAGE:
-    {usage}
-
-{all-args}",
-        )
         .arg(
             Arg::new("verbose")
                 .short('v')
@@ -68,7 +58,7 @@ USAGE:
             Arg::new("default-toolchain")
                 .long("default-toolchain")
                 .takes_value(true)
-                .help("Choose a default toolchain to install"),
+                .help("Choose a default toolchain to install. Use 'none' to not install any toolchains at all"),
         )
         .arg(
             Arg::new("profile")
@@ -93,7 +83,8 @@ USAGE:
                 .short('t')
                 .takes_value(true)
                 .multiple_values(true)
-                .use_value_delimiter(true),
+                .use_value_delimiter(true)
+                .action(ArgAction::Append),
         )
         .arg(
             Arg::new("no-update-default-toolchain")

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{App, AppSettings, Arg};
+use clap::{builder::PossibleValuesParser, AppSettings, Arg, ArgAction, Command};
 
 use super::common;
 use super::self_update::{self, InstallOpts};
@@ -22,106 +22,126 @@ pub fn main() -> Result<utils::ExitCode> {
         return Ok(utils::ExitCode(0));
     }
 
-    // NOTICE: If you change anything here, please make the same changes in rustup-init.sh.
-    let cli = App::new("rustup-init")
+    // NOTICE: If you change anything here, please make the same changes in rustup-init.sh
+    let cli = Command::new("rustup-init")
         .version(common::version())
         .about("The installer for rustup")
         .setting(AppSettings::DeriveDisplayOrder)
+        .help_template(
+            "\
+{name} {version}
+{about}
+
+USAGE:
+    {usage}
+
+{all-args}",
+        )
         .arg(
-            Arg::with_name("verbose")
-                .short("v")
+            Arg::new("verbose")
+                .short('v')
                 .long("verbose")
-                .help("Enable verbose output"),
+                .help("Enable verbose output")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name("quiet")
+            Arg::new("quiet")
                 .conflicts_with("verbose")
-                .short("q")
+                .short('q')
                 .long("quiet")
-                .help("Disable progress output"),
+                .help("Disable progress output")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name("no-prompt")
-                .short("y")
-                .help("Disable confirmation prompt."),
+            Arg::new("no-prompt")
+                .short('y')
+                .help("Disable confirmation prompt.")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name("default-host")
+            Arg::new("default-host")
                 .long("default-host")
                 .takes_value(true)
                 .help("Choose a default host triple"),
         )
         .arg(
-            Arg::with_name("default-toolchain")
+            Arg::new("default-toolchain")
                 .long("default-toolchain")
                 .takes_value(true)
-                .help("Choose a default toolchain to install. Use 'none' to not install any toolchains at all"),
+                .help("Choose a default toolchain to install"),
         )
         .arg(
-            Arg::with_name("profile")
+            Arg::new("profile")
                 .long("profile")
-                .possible_values(Profile::names())
+                .value_parser(PossibleValuesParser::new(Profile::names()))
                 .default_value(Profile::default_name()),
         )
         .arg(
-            Arg::with_name("components")
+            Arg::new("components")
                 .help("Component name to also install")
                 .long("component")
-                .short("c")
+                .short('c')
                 .takes_value(true)
-                .multiple(true)
-                .use_delimiter(true),
+                .multiple_values(true)
+                .use_value_delimiter(true)
+                .action(ArgAction::Append),
         )
         .arg(
-            Arg::with_name("targets")
+            Arg::new("targets")
                 .help("Target name to also install")
                 .long("target")
-                .short("target")
+                .short('t')
                 .takes_value(true)
-                .multiple(true)
-                .use_delimiter(true),
+                .multiple_values(true)
+                .use_value_delimiter(true),
         )
         .arg(
-            Arg::with_name("no-update-default-toolchain")
+            Arg::new("no-update-default-toolchain")
                 .long("no-update-default-toolchain")
-                .help("Don't update any existing default toolchain after install"),
+                .help("Don't update any existing default toolchain after install")
+                .action(ArgAction::SetTrue),
         )
         .arg(
-            Arg::with_name("no-modify-path")
+            Arg::new("no-modify-path")
                 .long("no-modify-path")
-                .help("Don't configure the PATH environment variable"),
+                .help("Don't configure the PATH environment variable")
+                .action(ArgAction::SetTrue),
         );
 
-    let matches = match cli.get_matches_from_safe(process().args_os()) {
+    let matches = match cli.try_get_matches_from(process().args_os()) {
         Ok(matches) => matches,
         Err(e)
-            if e.kind == clap::ErrorKind::HelpDisplayed
-                || e.kind == clap::ErrorKind::VersionDisplayed =>
+            if e.kind() == clap::ErrorKind::DisplayHelp
+                || e.kind() == clap::ErrorKind::DisplayVersion =>
         {
-            writeln!(process().stdout().lock(), "{}", e.message)?;
+            writeln!(process().stdout().lock(), "{e}")?;
             return Ok(utils::ExitCode(0));
         }
         Err(e) => return Err(e.into()),
     };
-    let no_prompt = matches.is_present("no-prompt");
-    let verbose = matches.is_present("verbose");
-    let quiet = matches.is_present("quiet");
-    let default_host = matches.value_of("default-host").map(ToOwned::to_owned);
-    let default_toolchain = matches.value_of("default-toolchain").map(ToOwned::to_owned);
+    let no_prompt = matches.get_flag("no-prompt");
+    let verbose = matches.get_flag("verbose");
+    let quiet = matches.get_flag("quiet");
+    let default_host = matches
+        .get_one::<String>("default-host")
+        .map(ToOwned::to_owned);
+    let default_toolchain = matches
+        .get_one::<String>("default-toolchain")
+        .map(ToOwned::to_owned);
     let profile = matches
-        .value_of("profile")
+        .get_one::<String>("profile")
         .expect("Unreachable: Clap should supply a default");
-    let no_modify_path = matches.is_present("no-modify-path");
-    let no_update_toolchain = matches.is_present("no-update-default-toolchain");
+    let no_modify_path = matches.get_flag("no-modify-path");
+    let no_update_toolchain = matches.get_flag("no-update-default-toolchain");
 
     let components: Vec<_> = matches
-        .values_of("components")
-        .map(|v| v.collect())
+        .get_many::<String>("components")
+        .map(|v| v.map(|s| &**s).collect())
         .unwrap_or_else(Vec::new);
 
     let targets: Vec<_> = matches
-        .values_of("targets")
-        .map(|v| v.collect())
+        .get_many::<String>("targets")
+        .map(|v| v.map(|s| &**s).collect())
         .unwrap_or_else(Vec::new);
 
     let opts = InstallOpts {

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -44,6 +44,5 @@ OPTIONS:
 
     -V, --version
             Print version information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -6,24 +6,44 @@ rustup-init [..]
 The installer for rustup
 
 USAGE:
-    rustup-init[EXE] [FLAGS] [OPTIONS]
-
-FLAGS:
-    -v, --verbose                        Enable verbose output
-    -q, --quiet                          Disable progress output
-    -y                                   Disable confirmation prompt.
-        --no-update-default-toolchain    Don't update any existing default toolchain after install
-        --no-modify-path                 Don't configure the PATH environment variable
-    -h, --help                           Prints help information
-    -V, --version                        Prints version information
+    rustup-init[EXE] [OPTIONS]
 
 OPTIONS:
-        --default-host <default-host>              Choose a default host triple
+    -v, --verbose
+            Enable verbose output
+
+    -q, --quiet
+            Disable progress output
+
+    -y
+            Disable confirmation prompt.
+
+        --default-host <default-host>
+            Choose a default host triple
+
         --default-toolchain <default-toolchain>
             Choose a default toolchain to install. Use 'none' to not install any toolchains at all
 
-        --profile <profile>                         [default: default]  [possible values: minimal, default, complete]
-    -c, --component <components>...                Component name to also install
-    -t, --target <targets>...                      Target name to also install
+        --profile <profile>
+            [default: default] [possible values: minimal, default, complete]
+
+    -c, --component <components>...
+            Component name to also install
+
+    -t, --target <targets>...
+            Target name to also install
+
+        --no-update-default-toolchain
+            Don't update any existing default toolchain after install
+
+        --no-modify-path
+            Don't configure the PATH environment variable
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -44,6 +44,5 @@ OPTIONS:
 
     -V, --version
             Print version information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -6,24 +6,44 @@ rustup-init [..]
 The installer for rustup
 
 USAGE:
-    rustup-init[EXE] [FLAGS] [OPTIONS]
-
-FLAGS:
-    -v, --verbose                        Enable verbose output
-    -q, --quiet                          Disable progress output
-    -y                                   Disable confirmation prompt.
-        --no-update-default-toolchain    Don't update any existing default toolchain after install
-        --no-modify-path                 Don't configure the PATH environment variable
-    -h, --help                           Prints help information
-    -V, --version                        Prints version information
+    rustup-init[EXE] [OPTIONS]
 
 OPTIONS:
-        --default-host <default-host>              Choose a default host triple
+    -v, --verbose
+            Enable verbose output
+
+    -q, --quiet
+            Disable progress output
+
+    -y
+            Disable confirmation prompt.
+
+        --default-host <default-host>
+            Choose a default host triple
+
         --default-toolchain <default-toolchain>
             Choose a default toolchain to install. Use 'none' to not install any toolchains at all
 
-        --profile <profile>                         [default: default]  [possible values: minimal, default, complete]
-    -c, --component <components>...                Component name to also install
-    -t, --target <targets>...                      Target name to also install
+        --profile <profile>
+            [default: default] [possible values: minimal, default, complete]
+
+    -c, --component <components>...
+            Component name to also install
+
+    -t, --target <targets>...
+            Target name to also install
+
+        --no-update-default-toolchain
+            Don't update any existing default toolchain after install
+
+        --no-modify-path
+            Don't configure the PATH environment variable
+
+    -h, --help
+            Print help information
+
+    -V, --version
+            Print version information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Check for updates to Rust toolchains and rustup
 USAGE:
     rustup[EXE] check
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
@@ -7,12 +7,12 @@ Generate tab-completion scripts for your shell
 USAGE:
     rustup[EXE] completions [ARGS]
 
-FLAGS:
-    -h, --help    Prints help information
-
 ARGS:
-    <shell>       [possible values: zsh, bash, fish, powershell, elvish]
-    <command>     [possible values: rustup, cargo]
+    <shell>      [possible values: bash, elvish, fish, powershell, zsh]
+    <command>    [possible values: rustup, cargo]
+
+OPTIONS:
+    -h, --help    Print help information
 
 DISCUSSION:
     Enable tab completion for Bash, Fish, Zsh, or PowerShell
@@ -134,5 +134,6 @@ ${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
     ZSH:
 
         $ rustup completions zsh cargo > ~/.zfunc/_cargo
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
@@ -134,6 +134,5 @@ ${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
     ZSH:
 
         $ rustup completions zsh cargo > ~/.zfunc/_cargo
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
@@ -15,6 +15,5 @@ OPTIONS:
                                    information see `rustup help toolchain`
         --target <target>          
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
@@ -7,15 +7,14 @@ Add a component to a Rust toolchain
 USAGE:
     rustup[EXE] component add [OPTIONS] <component>...
 
-FLAGS:
-    -h, --help    Prints help information
-
-OPTIONS:
-        --target <target>          
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
-
 ARGS:
     <component>...    
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+        --target <target>          
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -5,14 +5,13 @@ stdout = """
 List installed and available components
 
 USAGE:
-    rustup[EXE] component list [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help         Prints help information
-        --installed    List only installed components
+    rustup[EXE] component list [OPTIONS]
 
 OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+        --installed                List only installed components
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -12,6 +12,5 @@ OPTIONS:
                                    information see `rustup help toolchain`
         --installed                List only installed components
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
@@ -15,6 +15,5 @@ OPTIONS:
                                    information see `rustup help toolchain`
         --target <target>          
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
@@ -7,15 +7,14 @@ Remove a component from a Rust toolchain
 USAGE:
     rustup[EXE] component remove [OPTIONS] <component>...
 
-FLAGS:
-    -h, --help    Prints help information
-
-OPTIONS:
-        --target <target>          
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
-
 ARGS:
     <component>...    
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+        --target <target>          
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
@@ -17,6 +17,5 @@ OPTIONS:
 DISCUSSION:
     Sets the default toolchain to the one specified. If the toolchain
     is not already installed then it is installed first.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
@@ -7,15 +7,16 @@ Set the default toolchain
 USAGE:
     rustup[EXE] default [toolchain]
 
-FLAGS:
-    -h, --help    Prints help information
-
 ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                   toolchain`
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
+                   see `rustup help toolchain`
+
+OPTIONS:
+    -h, --help    Print help information
 
 DISCUSSION:
     Sets the default toolchain to the one specified. If the toolchain
     is not already installed then it is installed first.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -41,6 +41,5 @@ DISCUSSION:
 
     By default, it opens the documentation index. Use the various
     flags to open specific pieces of documentation.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -5,35 +5,35 @@ stdout = """
 Open the documentation for the current toolchain
 
 USAGE:
-    rustup[EXE] doc [FLAGS] [OPTIONS] [topic]
-
-FLAGS:
-        --alloc              The Rust core allocation and collections library
-        --book               The Rust Programming Language book
-        --cargo              The Cargo Book
-        --core               The Rust Core Library
-        --edition-guide      The Rust Edition Guide
-        --embedded-book      The Embedded Rust Book
-    -h, --help               Prints help information
-        --nomicon            The Dark Arts of Advanced and Unsafe Rust Programming
-        --path               Only print the path to the documentation
-        --proc_macro         A support library for macro authors when defining new macros
-        --reference          The Rust Reference
-        --rust-by-example    A collection of runnable examples that illustrate various Rust concepts and standard
-                             libraries
-        --rustc              The compiler for the Rust programming language
-        --rustdoc            Documentation generator for Rust projects
-        --std                Standard library API documentation
-        --test               Support code for rustc's built in unit-test and micro-benchmarking framework
-        --unstable-book      The Unstable Book
-
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
+    rustup[EXE] doc [OPTIONS] [topic]
 
 ARGS:
-    <topic>    Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!', 'std::fs',
-               'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum', 'std::io::error::Result' etc...
+    <topic>    Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!',
+               'std::fs', 'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum',
+               'std::io::error::Result' etc...
+
+OPTIONS:
+        --path                     Only print the path to the documentation
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+        --alloc                    The Rust core allocation and collections library
+        --book                     The Rust Programming Language book
+        --cargo                    The Cargo Book
+        --core                     The Rust Core Library
+        --edition-guide            The Rust Edition Guide
+        --nomicon                  The Dark Arts of Advanced and Unsafe Rust Programming
+        --proc_macro               A support library for macro authors when defining new macros
+        --reference                The Rust Reference
+        --rust-by-example          A collection of runnable examples that illustrate various Rust
+                                   concepts and standard libraries
+        --rustc                    The compiler for the Rust programming language
+        --rustdoc                  Documentation generator for Rust projects
+        --std                      Standard library API documentation
+        --test                     Support code for rustc's built in unit-test and
+                                   micro-benchmarking framework
+        --unstable-book            The Unstable Book
+        --embedded-book            The Embedded Rust Book
+    -h, --help                     Print help information
 
 DISCUSSION:
     Opens the documentation for the currently active toolchain with
@@ -41,5 +41,6 @@ DISCUSSION:
 
     By default, it opens the documentation index. Use the various
     flags to open specific pieces of documentation.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -44,6 +44,5 @@ DISCUSSION:
 
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -6,16 +6,16 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup[EXE] [FLAGS] [+toolchain] <SUBCOMMAND>
-
-FLAGS:
-    -v, --verbose    Enable verbose output
-    -q, --quiet      Disable progress output
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    rustup[EXE] [OPTIONS] [+toolchain] [SUBCOMMAND]
 
 ARGS:
     <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+
+OPTIONS:
+    -v, --verbose    Enable verbose output
+    -q, --quiet      Disable progress output
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
     show           Show the active and installed toolchains or profiles
@@ -33,7 +33,7 @@ SUBCOMMANDS:
     self           Modify the rustup installation
     set            Alter rustup settings
     completions    Generate tab-completion scripts for your shell
-    help           Prints this message or the help of the given subcommand(s)
+    help           Print this message or the help of the given subcommand(s)
 
 DISCUSSION:
     Rustup installs The Rust Programming Language from the official
@@ -44,5 +44,6 @@ DISCUSSION:
 
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -44,6 +44,5 @@ DISCUSSION:
 
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -6,16 +6,16 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup[EXE] [FLAGS] [+toolchain] <SUBCOMMAND>
-
-FLAGS:
-    -v, --verbose    Enable verbose output
-    -q, --quiet      Disable progress output
-    -h, --help       Prints help information
-    -V, --version    Prints version information
+    rustup[EXE] [OPTIONS] [+toolchain] [SUBCOMMAND]
 
 ARGS:
     <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+
+OPTIONS:
+    -v, --verbose    Enable verbose output
+    -q, --quiet      Disable progress output
+    -h, --help       Print help information
+    -V, --version    Print version information
 
 SUBCOMMANDS:
     show           Show the active and installed toolchains or profiles
@@ -33,7 +33,7 @@ SUBCOMMANDS:
     self           Modify the rustup installation
     set            Alter rustup settings
     completions    Generate tab-completion scripts for your shell
-    help           Prints this message or the help of the given subcommand(s)
+    help           Print this message or the help of the given subcommand(s)
 
 DISCUSSION:
     Rustup installs The Rust Programming Language from the official
@@ -44,5 +44,6 @@ DISCUSSION:
 
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ View the man page for a given command
 USAGE:
     rustup[EXE] man [OPTIONS] <command>
 
-FLAGS:
-    -h, --help    Prints help information
-
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
-
 ARGS:
     <command>    
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ OPTIONS:
         --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
                                    information see `rustup help toolchain`
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ Set the override toolchain for a directory
 USAGE:
     rustup[EXE] override set [OPTIONS] <toolchain>
 
-FLAGS:
-    -h, --help    Prints help information
+ARGS:
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
+                   see `rustup help toolchain`
 
 OPTIONS:
         --path <path>    Path to the directory
+    -h, --help           Print help information
 
-ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                   toolchain`
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ ARGS:
 OPTIONS:
         --path <path>    Path to the directory
     -h, --help           Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
@@ -7,14 +7,14 @@ Modify directory toolchain overrides
 USAGE:
     rustup[EXE] override <SUBCOMMAND>
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
 
 SUBCOMMANDS:
     list     List directory toolchain overrides
     set      Set the override toolchain for a directory
     unset    Remove the override toolchain for a directory
-    help     Prints this message or the help of the given subcommand(s)
+    help     Print this message or the help of the given subcommand(s)
 
 DISCUSSION:
     Overrides configure Rustup to use a specific toolchain when
@@ -36,5 +36,6 @@ DISCUSSION:
     To see the active toolchain use `rustup show`. To remove the
     override and use the default toolchain again, `rustup override
     unset`.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
@@ -36,6 +36,5 @@ DISCUSSION:
     To see the active toolchain use `rustup show`. To remove the
     override and use the default toolchain again, `rustup override
     unset`.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ List directory toolchain overrides
 USAGE:
     rustup[EXE] override list
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
@@ -5,14 +5,12 @@ stdout = """
 Remove the override toolchain for a directory
 
 USAGE:
-    rustup[EXE] override unset [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help           Prints help information
-        --nonexistent    Remove override toolchain for all nonexistent directories
+    rustup[EXE] override unset [OPTIONS]
 
 OPTIONS:
         --path <path>    Path to the directory
+        --nonexistent    Remove override toolchain for all nonexistent directories
+    -h, --help           Print help information
 
 DISCUSSION:
     If `--path` argument is present, removes the override toolchain
@@ -20,5 +18,6 @@ DISCUSSION:
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
@@ -18,6 +18,5 @@ DISCUSSION:
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ Set the override toolchain for a directory
 USAGE:
     rustup[EXE] override set [OPTIONS] <toolchain>
 
-FLAGS:
-    -h, --help    Prints help information
+ARGS:
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
+                   see `rustup help toolchain`
 
 OPTIONS:
         --path <path>    Path to the directory
+    -h, --help           Print help information
 
-ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                   toolchain`
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ ARGS:
 OPTIONS:
         --path <path>    Path to the directory
     -h, --help           Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
@@ -5,14 +5,12 @@ stdout = """
 Remove the override toolchain for a directory
 
 USAGE:
-    rustup[EXE] override unset [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help           Prints help information
-        --nonexistent    Remove override toolchain for all nonexistent directories
+    rustup[EXE] override unset [OPTIONS]
 
 OPTIONS:
         --path <path>    Path to the directory
+        --nonexistent    Remove override toolchain for all nonexistent directories
+    -h, --help           Print help information
 
 DISCUSSION:
     If `--path` argument is present, removes the override toolchain
@@ -20,5 +18,6 @@ DISCUSSION:
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
@@ -18,6 +18,5 @@ DISCUSSION:
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
@@ -5,16 +5,16 @@ stdout = """
 Run a command with an environment configured for a given toolchain
 
 USAGE:
-    rustup[EXE] run [FLAGS] <toolchain> <command>...
-
-FLAGS:
-    -h, --help       Prints help information
-        --install    Install the requested toolchain if needed
+    rustup[EXE] run [OPTIONS] <toolchain> <command>...
 
 ARGS:
-    <toolchain>     Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                    toolchain`
+    <toolchain>     Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                    information see `rustup help toolchain`
     <command>...    
+
+OPTIONS:
+        --install    Install the requested toolchain if needed
+    -h, --help       Print help information
 
 DISCUSSION:
     Configures an environment to use the given toolchain and then runs
@@ -30,5 +30,6 @@ DISCUSSION:
         $ cargo +nightly build
 
         $ rustup run nightly cargo build
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
@@ -30,6 +30,5 @@ DISCUSSION:
         $ cargo +nightly build
 
         $ rustup run nightly cargo build
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
@@ -15,6 +15,5 @@ SUBCOMMANDS:
     uninstall       Uninstall rustup.
     upgrade-data    Upgrade the internal data format.
     help            Print this message or the help of the given subcommand(s)
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
@@ -7,13 +7,14 @@ Modify the rustup installation
 USAGE:
     rustup[EXE] self <SUBCOMMAND>
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
 
 SUBCOMMANDS:
     update          Download and install updates to rustup
     uninstall       Uninstall rustup.
     upgrade-data    Upgrade the internal data format.
-    help            Prints this message or the help of the given subcommand(s)
+    help            Print this message or the help of the given subcommand(s)
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -5,10 +5,11 @@ stdout = """
 Uninstall rustup.
 
 USAGE:
-    rustup[EXE] self uninstall [FLAGS]
+    rustup[EXE] self uninstall [OPTIONS]
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
     -y            
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -10,6 +10,5 @@ USAGE:
 OPTIONS:
     -y            
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Download and install updates to rustup
 USAGE:
     rustup[EXE] self update
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Upgrade the internal data format.
 USAGE:
     rustup[EXE] self upgrade-data
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
@@ -12,6 +12,5 @@ ARGS:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
@@ -7,11 +7,11 @@ The rustup auto self update mode
 USAGE:
     rustup[EXE] set auto-self-update <auto-self-update-mode>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
 ARGS:
-    <auto-self-update-mode>     [default: enable]  [possible values: enable, disable, check-only]
+    <auto-self-update-mode>    [default: enable] [possible values: enable, disable, check-only]
+
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
@@ -7,11 +7,11 @@ The triple used to identify toolchains when not specified
 USAGE:
     rustup[EXE] set default-host <host_triple>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
 ARGS:
     <host_triple>    
+
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
@@ -12,6 +12,5 @@ ARGS:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
@@ -7,13 +7,14 @@ Alter rustup settings
 USAGE:
     rustup[EXE] set <SUBCOMMAND>
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
 
 SUBCOMMANDS:
-    auto-self-update    The rustup auto self update mode
     default-host        The triple used to identify toolchains when not specified
-    help                Prints this message or the help of the given subcommand(s)
     profile             The default components installed
+    auto-self-update    The rustup auto self update mode
+    help                Print this message or the help of the given subcommand(s)
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
@@ -15,6 +15,5 @@ SUBCOMMANDS:
     profile             The default components installed
     auto-self-update    The rustup auto self update mode
     help                Print this message or the help of the given subcommand(s)
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -7,11 +7,11 @@ The default components installed
 USAGE:
     rustup[EXE] set profile <profile-name>
 
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
 ARGS:
-    <profile-name>     [default: default]  [possible values: minimal, default, complete]
+    <profile-name>    [default: default] [possible values: minimal, default, complete]
+
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -12,6 +12,5 @@ ARGS:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
@@ -5,11 +5,11 @@ stdout = """
 Show the active toolchain
 
 USAGE:
-    rustup[EXE] show active-toolchain [FLAGS]
+    rustup[EXE] show active-toolchain [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
+OPTIONS:
     -v, --verbose    Enable verbose output with rustc information
+    -h, --help       Print help information
 
 DISCUSSION:
     Shows the name of the active toolchain.
@@ -19,5 +19,6 @@ DISCUSSION:
 
     You should use `rustc --print sysroot` to get the sysroot, or
     `rustc --version` to get the toolchain version.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
@@ -19,6 +19,5 @@ DISCUSSION:
 
     You should use `rustc --print sysroot` to get the sysroot, or
     `rustc --version` to get the toolchain version.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
@@ -26,6 +26,5 @@ DISCUSSION:
 
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
@@ -5,18 +5,18 @@ stdout = """
 Show the active and installed toolchains or profiles
 
 USAGE:
-    rustup[EXE] show [FLAGS] [SUBCOMMAND]
+    rustup[EXE] show [OPTIONS] [SUBCOMMAND]
 
-FLAGS:
+OPTIONS:
     -v, --verbose    Enable verbose output with rustc information for all installed toolchains
-    -h, --help       Prints help information
+    -h, --help       Print help information
 
 SUBCOMMANDS:
     active-toolchain    Show the active toolchain
     home                Display the computed value of RUSTUP_HOME
     profile             Show the current profile
     keys                Display the known PGP keys
-    help                Prints this message or the help of the given subcommand(s)
+    help                Print this message or the help of the given subcommand(s)
 
 DISCUSSION:
     Shows the name of the active toolchain and the version of `rustc`.
@@ -26,5 +26,6 @@ DISCUSSION:
 
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Display the computed value of RUSTUP_HOME
 USAGE:
     rustup[EXE] show home
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Display the known PGP keys
 USAGE:
     rustup[EXE] show keys
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -7,7 +7,8 @@ Show the current profile
 USAGE:
     rustup[EXE] show profile
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -9,6 +9,5 @@ USAGE:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ OPTIONS:
         --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
                                    information see `rustup help toolchain`
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ Add a target to a Rust toolchain
 USAGE:
     rustup[EXE] target add [OPTIONS] <target>...
 
-FLAGS:
-    -h, --help    Prints help information
-
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
-
 ARGS:
     <target>...    List of targets to install; \"all\" installs all available targets
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
@@ -7,13 +7,14 @@ Modify a toolchain's supported targets
 USAGE:
     rustup[EXE] target <SUBCOMMAND>
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
 
 SUBCOMMANDS:
     list      List installed and available targets
     add       Add a target to a Rust toolchain
     remove    Remove a target from a Rust toolchain
-    help      Prints this message or the help of the given subcommand(s)
+    help      Print this message or the help of the given subcommand(s)
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
@@ -15,6 +15,5 @@ SUBCOMMANDS:
     add       Add a target to a Rust toolchain
     remove    Remove a target from a Rust toolchain
     help      Print this message or the help of the given subcommand(s)
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
@@ -5,14 +5,13 @@ stdout = """
 List installed and available targets
 
 USAGE:
-    rustup[EXE] target list [FLAGS] [OPTIONS]
-
-FLAGS:
-    -h, --help         Prints help information
-        --installed    List only installed targets
+    rustup[EXE] target list [OPTIONS]
 
 OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+        --installed                List only installed targets
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
@@ -12,6 +12,5 @@ OPTIONS:
                                    information see `rustup help toolchain`
         --installed                List only installed targets
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ Remove a target from a Rust toolchain
 USAGE:
     rustup[EXE] target remove [OPTIONS] <target>...
 
-FLAGS:
-    -h, --help    Prints help information
+ARGS:
+    <target>...    List of targets to uninstall
 
 OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+    -h, --help                     Print help information
 
-ARGS:
-    <target>...    
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ OPTIONS:
         --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
                                    information see `rustup help toolchain`
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -7,15 +7,15 @@ Modify or query the installed toolchains
 USAGE:
     rustup[EXE] toolchain <SUBCOMMAND>
 
-FLAGS:
-    -h, --help    Prints help information
+OPTIONS:
+    -h, --help    Print help information
 
 SUBCOMMANDS:
     list         List installed toolchains
     install      Install or update a given toolchain
     uninstall    Uninstall a toolchain
     link         Create a custom toolchain by symlinking to a directory
-    help         Prints this message or the help of the given subcommand(s)
+    help         Print this message or the help of the given subcommand(s)
 
 DISCUSSION:
     Many `rustup` commands deal with *toolchains*, a single
@@ -58,5 +58,6 @@ DISCUSSION:
     rustup can also manage symlinked local toolchain builds, which are
     often used for developing Rust itself. For more information see
     `rustup toolchain help link`.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -58,6 +58,5 @@ DISCUSSION:
     rustup can also manage symlinked local toolchain builds, which are
     often used for developing Rust itself. For more information see
     `rustup toolchain help link`.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -23,6 +23,5 @@ OPTIONS:
         --force-non-host               Install toolchains that require an emulator. See
                                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
     -h, --help                         Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -5,23 +5,24 @@ stdout = """
 Install or update a given toolchain
 
 USAGE:
-    rustup[EXE] toolchain install [FLAGS] [OPTIONS] <toolchain>...
-
-FLAGS:
-        --allow-downgrade    Allow rustup to downgrade the toolchain to satisfy your component choice
-        --force              Force an update, even if some components are missing
-        --force-non-host     Install toolchains that require an emulator. See https://github.com/rust-
-                             lang/rustup/wiki/Non-host-toolchains
-    -h, --help               Prints help information
-        --no-self-update     Don't perform self update when running the`rustup toolchain install` command
-
-OPTIONS:
-    -c, --component <components>...    Add specific components on installation
-        --profile <profile>             [possible values: minimal, default, complete]
-    -t, --target <targets>...          Add specific targets on installation
+    rustup[EXE] toolchain install [OPTIONS] <toolchain>...
 
 ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                      toolchain`
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                      information see `rustup help toolchain`
+
+OPTIONS:
+        --profile <profile>            [possible values: minimal, default, complete]
+    -c, --component <components>...    Add specific components on installation
+    -t, --target <targets>...          Add specific targets on installation
+        --no-self-update               Don't perform self update when running the`rustup toolchain
+                                       install` command
+        --force                        Force an update, even if some components are missing
+        --allow-downgrade              Allow rustup to downgrade the toolchain to satisfy your
+                                       component choice
+        --force-non-host               Install toolchains that require an emulator. See
+                                       https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+    -h, --help                         Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
@@ -32,6 +32,5 @@ DISCUSSION:
 
     If you now compile a crate in the current directory, the custom
     toolchain 'latest-stage1' will be used.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
@@ -7,12 +7,12 @@ Create a custom toolchain by symlinking to a directory
 USAGE:
     rustup[EXE] toolchain link <toolchain> <path>
 
-FLAGS:
-    -h, --help    Prints help information
-
 ARGS:
     <toolchain>    Custom toolchain name
     <path>         Path to the directory
+
+OPTIONS:
+    -h, --help    Print help information
 
 DISCUSSION:
     'toolchain' is the custom name to be assigned to the new toolchain.
@@ -32,5 +32,6 @@ DISCUSSION:
 
     If you now compile a crate in the current directory, the custom
     toolchain 'latest-stage1' will be used.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
@@ -10,6 +10,5 @@ USAGE:
 OPTIONS:
     -v, --verbose    Enable verbose output with toolchain information
     -h, --help       Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
@@ -5,10 +5,11 @@ stdout = """
 List installed toolchains
 
 USAGE:
-    rustup[EXE] toolchain list [FLAGS]
+    rustup[EXE] toolchain list [OPTIONS]
 
-FLAGS:
-    -h, --help       Prints help information
+OPTIONS:
     -v, --verbose    Enable verbose output with toolchain information
+    -h, --help       Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -7,11 +7,12 @@ Uninstall a toolchain
 USAGE:
     rustup[EXE] toolchain uninstall <toolchain>...
 
-FLAGS:
-    -h, --help    Prints help information
-
 ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                      toolchain`
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                      information see `rustup help toolchain`
+
+OPTIONS:
+    -h, --help    Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -13,6 +13,5 @@ ARGS:
 
 OPTIONS:
     -h, --help    Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
@@ -5,18 +5,18 @@ stdout = """
 Update Rust toolchains and rustup
 
 USAGE:
-    rustup[EXE] update [FLAGS] [toolchain]...
-
-FLAGS:
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
-                            lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Prints help information
-        --no-self-update    Don't perform self update when running the `rustup update` command
+    rustup[EXE] update [OPTIONS] [toolchain]...
 
 ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                      toolchain`
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                      information see `rustup help toolchain`
+
+OPTIONS:
+        --no-self-update    Don't perform self update when running the `rustup update` command
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See
+                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Print help information
 
 DISCUSSION:
     With no toolchain specified, the `update` command updates each of
@@ -25,5 +25,6 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
@@ -25,6 +25,5 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
@@ -5,18 +5,18 @@ stdout = """
 Update Rust toolchains and rustup
 
 USAGE:
-    rustup[EXE] update [FLAGS] [toolchain]...
-
-FLAGS:
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
-                            lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Prints help information
-        --no-self-update    Don't perform self update when running the `rustup update` command
+    rustup[EXE] update [OPTIONS] [toolchain]...
 
 ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                      toolchain`
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                      information see `rustup help toolchain`
+
+OPTIONS:
+        --no-self-update    Don't perform self update when running the `rustup update` command
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See
+                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Print help information
 
 DISCUSSION:
     With no toolchain specified, the `update` command updates each of
@@ -25,5 +25,6 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
@@ -25,6 +25,5 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
@@ -5,18 +5,18 @@ stdout = """
 Update Rust toolchains and rustup
 
 USAGE:
-    rustup[EXE] update [FLAGS] [toolchain]...
-
-FLAGS:
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
-                            lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Prints help information
-        --no-self-update    Don't perform self update when running the `rustup update` command
+    rustup[EXE] update [OPTIONS] [toolchain]...
 
 ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
-                      toolchain`
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                      information see `rustup help toolchain`
+
+OPTIONS:
+        --no-self-update    Don't perform self update when running the `rustup update` command
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See
+                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Print help information
 
 DISCUSSION:
     With no toolchain specified, the `update` command updates each of
@@ -25,5 +25,6 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
@@ -25,6 +25,5 @@ DISCUSSION:
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.
-
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
@@ -7,14 +7,13 @@ Display which binary will be run for a given command
 USAGE:
     rustup[EXE] which [OPTIONS] <command>
 
-FLAGS:
-    -h, --help    Prints help information
-
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
-                                   `rustup help toolchain`
-
 ARGS:
     <command>    
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                                   information see `rustup help toolchain`
+    -h, --help                     Print help information
+
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
@@ -14,6 +14,5 @@ OPTIONS:
         --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
                                    information see `rustup help toolchain`
     -h, --help                     Print help information
-
 """
 stderr = ""

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -806,11 +806,11 @@ fn completion_bad_shell() {
     setup(&|config| {
         config.expect_err(
             &["rustup", "completions", "fake"],
-            "error: 'fake' isn't a valid value for '<shell>'",
+            r#"error: "fake" isn't a valid value for '<shell>'"#,
         );
         config.expect_err(
             &["rustup", "completions", "fake", "cargo"],
-            "error: 'fake' isn't a valid value for '<shell>'",
+            r#"error: "fake" isn't a valid value for '<shell>'"#,
         );
     });
 }
@@ -820,7 +820,7 @@ fn completion_bad_tool() {
     setup(&|config| {
         config.expect_err(
             &["rustup", "completions", "bash", "fake"],
-            "error: 'fake' isn't a valid value for '<command>'",
+            r#"error: "fake" isn't a valid value for '<command>'"#,
         );
     });
 }
@@ -946,7 +946,7 @@ fn override_by_toolchain_on_the_command_line() {
         );
         config.expect_err(
             &["rustup", "@stable", "which", "rustc"],
-            "Invalid value for '<+toolchain>': Toolchain overrides must begin with '+'",
+            r#"Invalid value "@stable" for '<+toolchain>': Toolchain overrides must begin with '+'"#,
         );
         config.expect_stderr_ok(
             &["rustup", "+stable", "set", "profile", "minimal"],

--- a/tests/suite/cli_ui.rs
+++ b/tests/suite/cli_ui.rs
@@ -8,11 +8,11 @@ fn rustup_ui_doc_text_tests() {
     // Copy rustup-init to rustup so that the tests can run it.
     fs::copy(rustup_init, &rustup).unwrap();
     t.register_bin("rustup", &rustup);
-    t.case("tests/cli-ui/rustup/*.toml");
+    t.case("tests/suite/cli-ui/rustup/*.toml");
     #[cfg(target_os = "windows")]
     {
         // On windows, we don't have man command, so skip the test.
-        t.skip("tests/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml");
+        t.skip("tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml");
     }
 }
 
@@ -53,6 +53,6 @@ fn rustup_init_ui_doc_text_tests() {
         .unwrap();
 
         // Make sure that the help output of rustup-init and rustup-init.sh are the same.
-        assert!(rustup_init_help_std_out == rustup_init_sh_help_std_out)
+        assert_eq!(rustup_init_help_std_out, rustup_init_sh_help_std_out)
     }
 }


### PR DESCRIPTION
Bump `clap` to v3 which fixes incorrect executable name printing in subcommand's help texts on Windows (it comes as `rustup.exe-subcommand` in v2). I don't think this issue was reported to `rustup` but https://github.com/clap-rs/clap/pull/3693
Add `clap_complete` as some of `clap`'s functionality was moved into this crate.
Fix related tests.

close https://github.com/rust-lang/rustup/issues/2920