### PR TITLE
Warn when running under Rosetta emulation

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -20,10 +20,11 @@ use crate::currentprocess::{
     terminalsource,
     varsource::VarSource,
 };
+use crate::dist::dist::{TargetTriple, ToolchainDesc};
+use crate::install::UpdateStatus;
 use crate::utils::notifications as util_notifications;
 use crate::utils::notify::NotificationLevel;
 use crate::utils::utils;
-use crate::{dist::dist::ToolchainDesc, install::UpdateStatus};
 use crate::{
     dist::notifications as dist_notifications, toolchain::distributable::DistributableToolchain,
 };
@@ -672,5 +673,16 @@ pub(crate) fn ignorable_error(error: &'static str, no_prompt: bool) -> Result<()
         Ok(())
     } else {
         Err(error)
+    }
+}
+
+/// Warns if rustup is running under emulation, such as macOS Rosetta
+pub(crate) fn warn_if_host_is_emulated() {
+    if TargetTriple::is_host_emulated() {
+        warn!(
+            "Rustup is not running natively. It's running under emulation of {}.",
+            TargetTriple::from_host_or_build()
+        );
+        warn!("For best compatibility and performance you should reinstall rustup for your native CPU.");
     }
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -841,6 +841,8 @@ fn maybe_upgrade_data(cfg: &Cfg, m: &ArgMatches) -> Result<bool> {
 }
 
 fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
+    common::warn_if_host_is_emulated();
+
     if let Some(toolchain) = m.get_one::<MaybeResolvableToolchainName>("toolchain") {
         match toolchain.to_owned() {
             MaybeResolvableToolchainName::None => {
@@ -918,6 +920,7 @@ fn check_updates(cfg: &Cfg) -> Result<utils::ExitCode> {
 }
 
 fn update(cfg: &mut Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
+    common::warn_if_host_is_emulated();
     let self_update_mode = cfg.get_self_update_mode()?;
     // Priority: no-self-update feature > self_update_mode > no-self-update args.
     // Update only if rustup does **not** have the no-self-update feature,
@@ -1051,6 +1054,8 @@ fn which(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
 
 #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
 fn show(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
+    common::warn_if_host_is_emulated();
+
     let verbose = m.get_flag("verbose");
 
     // Print host triple

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -589,6 +589,8 @@ fn do_pre_install_sanity_checks(no_prompt: bool) -> Result<()> {
 }
 
 fn do_pre_install_options_sanity_checks(opts: &InstallOpts<'_>) -> Result<()> {
+    common::warn_if_host_is_emulated();
+
     // Verify that the installation options are vaguely sane
     (|| {
         let host_triple = opts
@@ -1058,6 +1060,8 @@ pub(crate) fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
 /// rustup-init is stored in `CARGO_HOME`/bin, and then deleted next
 /// time rustup runs.
 pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
+    common::warn_if_host_is_emulated();
+
     use common::SelfUpdatePermission::*;
     let update_permitted = if NEVER_SELF_UPDATE {
         HardFail

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -232,6 +232,28 @@ impl TargetTriple {
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
+    pub(crate) fn is_host_emulated() -> bool {
+        false
+    }
+
+    /// Detects Rosetta emulation on macOS
+    #[cfg(target_os = "macos")]
+    pub(crate) fn is_host_emulated() -> bool {
+        unsafe {
+            let mut ret: libc::c_int = 0;
+            let mut size = std::mem::size_of::<libc::c_int>() as libc::size_t;
+            let err = libc::sysctlbyname(
+                b"sysctl.proc_translated\0".as_ptr().cast(),
+                (&mut ret) as *mut _ as *mut libc::c_void,
+                &mut size,
+                std::ptr::null_mut(),
+                0,
+            );
+            err == 0 && ret != 0
+        }
+    }
+
     pub(crate) fn from_host() -> Option<Self> {
         #[cfg(windows)]
         fn inner() -> Option<TargetTriple> {


### PR DESCRIPTION
I've noticed there's a footgun on macOS: if an existing Intel Rust installation has been migrated to a new ARM Mac, it keeps thinking it's running on an `x86_64-apple-darwin` target, because it's being automatically emulated by Rosetta.

This happens to work most of the time, except that it badly breaks builds using `openssl` and a few other C libraries, because on aarch64 Macs they aren't available in x64_64 versions, and users get super confusing linker errors.

I've added a check of `sysctl.proc_translated` (LLVM uses it too) and warnings to `rustup default`, `rustup update`, and `rustup self update` that the host triple Rustup thinks it's using is an emulated one.
