### PR TITLE
Let Clap wrap help texts automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
+ "term_size",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -2399,11 +2400,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
+ "term_size",
  "unicode-width",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ no-self-update = []
 anyhow = "1.0.31"
 cfg-if = "1.0"
 chrono = "0.4"
-clap = "2"
+clap = {version = "2", features = ["wrap_help"]}
 download = {path = "download", default-features = false}
 effective-limits = "0.5.3"
 enum-map = "2.0.3"


### PR DESCRIPTION
This makes the `rustup help show` and other help texts much more readable on my terminal.

This enables the optional `wrap_help` feature in Clap. For me, `rustup help show` looks like this without the feature:

![image](https://user-images.githubusercontent.com/89623/190111730-d427dbcb-b114-4e0b-a04a-a7103849d95c.png)

With `wrap_help`, I see

![image](https://user-images.githubusercontent.com/89623/190111892-7d2b5e92-9c4e-45e0-9cc9-5fd897aaab81.png)

I find the second much nicer to read. (I'm a fan of wrapping lines, I maintain the underlying [Textwrap](https://lib.rs/textwrap) library used by Clap :smile:)