### PR TITLE
Bump pulldown-cmark version to 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
  "bitflags",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ opener = "0.5.0"
 # Used by `curl` or `reqwest` backend although it isn't imported
 # by our rustup.
 openssl = {version = "0.10", optional = true}
-pulldown-cmark = {version = "0.8", default-features = false}
+pulldown-cmark = {version = "0.9", default-features = false}
 rand = "0.8"
 regex = "1"
 remove_dir_all = "0.7.0"

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -123,7 +123,7 @@ impl<'a, T: Terminal + io::Write + 'a> LineFormatter<'a, T> {
             Tag::Paragraph => {
                 self.wrapper.write_line();
             }
-            Tag::Heading(_level) => {
+            Tag::Heading(_level, _identifier, _classes) => {
                 self.push_attr(Attr::Bold);
                 self.wrapper.write_line();
             }
@@ -160,7 +160,7 @@ impl<'a, T: Terminal + io::Write + 'a> LineFormatter<'a, T> {
             Tag::Paragraph => {
                 self.wrapper.write_line();
             }
-            Tag::Heading(_level) => {
+            Tag::Heading(_level, _identifier, _classes) => {
                 self.wrapper.write_line();
                 self.pop_attr();
             }


### PR DESCRIPTION
Bump the out-of-date pulldown-cmark version from v0.8 to v0.9.
You can check out this [release note](https://github.com/raphlinus/pulldown-cmark/releases/tag/v0.9.0) to see more.
One change that may affect rustup is that `pulldown now optionally supports custom header ids and classes for headers. Set ENABLE_HEADING_ATTRIBUTES in the options to enable.`
But we do not use it. So I think it's OK to bump.
