### PR TITLE
Update home usage to new env fn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -974,8 +974,9 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.3"
-source = "git+https://github.com/rbtcollins/home?rev=a243ee2fbee6022c57d56f5aa79aefe194eabe53#a243ee2fbee6022c57d56f5aa79aefe194eabe53"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ effective-limits = "0.5.3"
 enum-map = "2.0.3"
 flate2 = "1"
 git-testament = "0.2"
-home = {git = "https://github.com/rbtcollins/home", rev = "a243ee2fbee6022c57d56f5aa79aefe194eabe53"}
+home = "0.5.4"
 lazy_static = "1"
 libc = "0.2"
 num_cpus = "1.13"
@@ -127,3 +127,4 @@ lto = true
 # Reduce build time by setting proc-macro crates non optimized.
 [profile.release.build-override]
 opt-level = 0
+

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -55,7 +55,7 @@ use varsource::*;
 /// The real trait is CurrentProcess; HomeProcess is a single trait because
 /// Box<T> only allows autotraits to be added to it; so we use a subtrait to add
 /// home::Env in.
-pub trait HomeProcess: CurrentProcess + home::Env {
+pub trait HomeProcess: CurrentProcess + home::env::Env {
     fn clone_boxed(&self) -> Box<dyn HomeProcess>;
 }
 
@@ -63,7 +63,7 @@ pub trait HomeProcess: CurrentProcess + home::Env {
 
 impl<T> HomeProcess for T
 where
-    T: 'static + CurrentProcess + home::Env + Clone,
+    T: 'static + CurrentProcess + home::env::Env + Clone,
 {
     fn clone_boxed(&self) -> Box<dyn HomeProcess + 'static> {
         Box::new(T::clone(self))

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Once;
 use std::sync::{Arc, Mutex};
 
+use home::env as home;
 use rand::{thread_rng, Rng};
 
 pub(crate) mod argsource;
@@ -55,7 +56,7 @@ use varsource::*;
 /// The real trait is CurrentProcess; HomeProcess is a single trait because
 /// Box<T> only allows autotraits to be added to it; so we use a subtrait to add
 /// home::Env in.
-pub trait HomeProcess: CurrentProcess + home::env::Env {
+pub trait HomeProcess: CurrentProcess + home::Env {
     fn clone_boxed(&self) -> Box<dyn HomeProcess>;
 }
 
@@ -63,7 +64,7 @@ pub trait HomeProcess: CurrentProcess + home::env::Env {
 
 impl<T> HomeProcess for T
 where
-    T: 'static + CurrentProcess + home::env::Env + Clone,
+    T: 'static + CurrentProcess + home::Env + Clone,
 {
     fn clone_boxed(&self) -> Box<dyn HomeProcess + 'static> {
         Box::new(T::clone(self))

--- a/src/currentprocess/homethunk.rs
+++ b/src/currentprocess/homethunk.rs
@@ -4,25 +4,27 @@ use std::io;
 use std::ops::Deref;
 use std::path::PathBuf;
 
+use home::env as home;
+
 use super::CurrentDirSource;
 use super::HomeProcess;
 use super::OSProcess;
 use super::TestProcess;
 use super::VarSource;
 
-impl home::env::Env for Box<dyn HomeProcess + 'static> {
+impl home::Env for Box<dyn HomeProcess + 'static> {
     fn home_dir(&self) -> Option<PathBuf> {
         (**self).home_dir()
     }
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
-        home::env::Env::current_dir(&(**self))
+        home::Env::current_dir(&(**self))
     }
     fn var_os(&self, key: &str) -> Option<OsString> {
-        home::env::Env::var_os(&(**self), key)
+        home::Env::var_os(&(**self), key)
     }
 }
 
-impl home::env::Env for TestProcess {
+impl home::Env for TestProcess {
     fn home_dir(&self) -> Option<PathBuf> {
         self.var("HOME").ok().map(|v| v.into())
     }
@@ -34,14 +36,14 @@ impl home::env::Env for TestProcess {
     }
 }
 
-impl home::env::Env for OSProcess {
+impl home::Env for OSProcess {
     fn home_dir(&self) -> Option<PathBuf> {
-        home::env::OS_ENV.home_dir()
+        home::OS_ENV.home_dir()
     }
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
-        home::env::OS_ENV.current_dir()
+        home::OS_ENV.current_dir()
     }
     fn var_os(&self, key: &str) -> Option<OsString> {
-        home::env::OS_ENV.var_os(key)
+        home::OS_ENV.var_os(key)
     }
 }

--- a/src/currentprocess/homethunk.rs
+++ b/src/currentprocess/homethunk.rs
@@ -10,19 +10,19 @@ use super::OSProcess;
 use super::TestProcess;
 use super::VarSource;
 
-impl home::Env for Box<dyn HomeProcess + 'static> {
+impl home::env::Env for Box<dyn HomeProcess + 'static> {
     fn home_dir(&self) -> Option<PathBuf> {
         (**self).home_dir()
     }
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
-        home::Env::current_dir(&(**self))
+        home::env::Env::current_dir(&(**self))
     }
     fn var_os(&self, key: &str) -> Option<OsString> {
-        home::Env::var_os(&(**self), key)
+        home::env::Env::var_os(&(**self), key)
     }
 }
 
-impl home::Env for TestProcess {
+impl home::env::Env for TestProcess {
     fn home_dir(&self) -> Option<PathBuf> {
         self.var("HOME").ok().map(|v| v.into())
     }
@@ -34,14 +34,14 @@ impl home::Env for TestProcess {
     }
 }
 
-impl home::Env for OSProcess {
+impl home::env::Env for OSProcess {
     fn home_dir(&self) -> Option<PathBuf> {
-        home::OS_ENV.home_dir()
+        home::env::OS_ENV.home_dir()
     }
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
-        home::OS_ENV.current_dir()
+        home::env::OS_ENV.current_dir()
     }
     fn var_os(&self, key: &str) -> Option<OsString> {
-        home::OS_ENV.var_os(key)
+        home::env::OS_ENV.var_os(key)
     }
 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -5,6 +5,7 @@ use std::io::{self, BufReader, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Context, Result};
+use home::env as home;
 use retry::delay::{jitter, Fibonacci};
 use retry::{retry, OperationResult};
 use sha2::Sha256;
@@ -493,11 +494,11 @@ pub(crate) fn to_absolute<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 }
 
 pub(crate) fn home_dir() -> Option<PathBuf> {
-    home::env::home_dir_with_env(&home_process())
+    home::home_dir_with_env(&home_process())
 }
 
 pub(crate) fn cargo_home() -> Result<PathBuf> {
-    home::env::cargo_home_with_env(&home_process()).context("failed to determine cargo home")
+    home::cargo_home_with_env(&home_process()).context("failed to determine cargo home")
 }
 
 // Creates a ~/.rustup folder
@@ -524,7 +525,7 @@ fn rustup_home_in_user_dir() -> Result<PathBuf> {
 }
 
 pub(crate) fn rustup_home() -> Result<PathBuf> {
-    home::env::rustup_home_with_env(&home_process()).context("failed to determine rustup home dir")
+    home::rustup_home_with_env(&home_process()).context("failed to determine rustup home dir")
 }
 
 pub(crate) fn format_path_for_display(path: &str) -> String {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -493,11 +493,11 @@ pub(crate) fn to_absolute<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
 }
 
 pub(crate) fn home_dir() -> Option<PathBuf> {
-    home::home_dir_from(&home_process())
+    home::env::home_dir_with_env(&home_process())
 }
 
 pub(crate) fn cargo_home() -> Result<PathBuf> {
-    home::cargo_home_from(&home_process()).context("failed to determine cargo home")
+    home::env::cargo_home_with_env(&home_process()).context("failed to determine cargo home")
 }
 
 // Creates a ~/.rustup folder
@@ -524,7 +524,7 @@ fn rustup_home_in_user_dir() -> Result<PathBuf> {
 }
 
 pub(crate) fn rustup_home() -> Result<PathBuf> {
-    home::rustup_home_from(&home_process()).context("failed to determine rustup home dir")
+    home::env::rustup_home_with_env(&home_process()).context("failed to determine rustup home dir")
 }
 
 pub(crate) fn format_path_for_display(path: &str) -> String {


### PR DESCRIPTION
This is the corresponding PR for https://github.com/brson/home/pull/29 which updates how rustup uses the `home` crates `Env` features for testing. 

This is still a draft PR pending a new release of the home crate with the new features.

cc @kinnison 