### PR TITLE
Fix file path separator decoded from manifest is not correct on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pem"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +1970,7 @@ dependencies = [
  "num_cpus",
  "opener",
  "openssl",
+ "path-slash",
  "pulldown-cmark",
  "rand 0.8.5",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ url = "2.1"
 wait-timeout = "0.2"
 xz2 = "0.1.3"
 zstd = "0.11"
+path-slash = "0.2.1"
 
 [dependencies.retry]
 default-features = false


### PR DESCRIPTION
While installing `rust-doc` component on Windows, I noticed the following log messages in the output.

```
info: retrying renaming 'C:\Users\rhysd\.rustup\tmp\d648r0b_lyhd2svq_dir\rust-docs\share/doc/rust/html' to 'C:\Users\rhysd\.rustup\toolchains\stable-x86_64-pc-windows-msvc\share/doc/rust/html'
```

This log message itself was not a problem, but some path separators were not correct `...\stable-x86_64-pc-windows-msvc\share/doc/rust/html`.

After taking a look at sources of rustup, I understood the cause was that the `share/doc/rust/html` part was decoded from `manifest.in` directly without converting path separators. This PR fixes it.