### PR TITLE
Fix broken aarch64-unknown-linux-gnu GitHub Actions

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,4 @@
 FROM rust-aarch64-unknown-linux-gnu
 
-ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnueabi-gcc \
-    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnueabi-gcc
+ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-gcc


### PR DESCRIPTION
I found that rustup master CI keeps failing. https://github.com/rust-lang/rustup/actions/runs/3197393101/jobs/5220541587
This cause by https://github.com/rust-lang/rust/commit/d0142ce27a31fd1da9f2bf4b295840e3a969d295#diff-38eddf433d93f44424b7c45d25a2984569af2a2d4eebfe47b7c9e2492dddf9b4
We have to update it.