### PR TITLE
Avoid removing partial paths when uninstalling

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -949,7 +949,7 @@ pub(crate) fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
     info!("removing cargo home");
 
     // Remove CARGO_HOME/bin from PATH
-    do_remove_from_path()?;
+    do_remove_from_paths()?;
     do_remove_from_programs()?;
 
     // Delete everything in CARGO_HOME *except* the rustup bin

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -485,7 +485,7 @@ where
         .and_then(|old_path| f(old_path, OsString::from(path_str).encode_wide().collect())))
 }
 
-pub(crate) fn do_remove_from_path() -> Result<()> {
+pub(crate) fn do_remove_from_paths() -> Result<()> {
     let new_path = _with_path_cargo_home_bin(_remove_from_path)?;
     _apply_new_path(new_path)
 }


### PR DESCRIPTION
Fixes #2967

* Adds a regression test
* Changes the behaviour of `do_remove_from_paths` so that it only removes full lines
* Added normalization of whitespaces (this could also be moved to a separate PR, or removed entirely)

One thing I'm not 100% sure about is whether it's okay to call `.lines()` and then later re-build the file with `.join("\n")`. For example in the case of CRLF line breaks, this would certainly rewrite the file entirely. Is this a concern for the Unix implementation?

I'm fairly sure this still needs some work, but the overall idea is correct, I believe. Feedback welcome :) 