### PR TITLE
Bump `clap` to 4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,17 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,37 +291,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
 dependencies = [
- "atty",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+dependencies = [
+ "anstream",
+ "anstyle",
  "bitflags",
  "clap_lex",
- "indexmap",
  "strsim",
- "termcolor",
  "terminal_size",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "3.2.5"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f7a2e0a962c45ce25afce14220bc24f9dade0a1787f185cecf96bfba7847cd8"
+checksum = "501ff0a401473ea1d4c3b125ff95506b62c5bc5768d818634195fbb7c4ad5ff4"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -903,15 +896,6 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1546,12 +1530,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "overload"
@@ -2384,15 +2362,6 @@ checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
 dependencies = [
  "rustix",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-dependencies = [
- "terminal_size",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,8 +46,8 @@ otel = [
 anyhow.workspace = true
 cfg-if = "1.0"
 chrono = "0.4"
-clap = { version = "3", features = ["wrap_help"] }
-clap_complete = "3"
+clap = { version = "4", features = ["wrap_help"] }
+clap_complete = "4"
 download = { path = "download", default-features = false }
 effective-limits = "0.5.5"
 enum-map = "2.5.0"

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -25,48 +25,35 @@ RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.26.0 (577bf51ae 2023-04-05)
 The installer for rustup
 
-USAGE:
-    rustup-init [OPTIONS]
+Usage: rustup-init [OPTIONS]
 
-OPTIONS:
-    -v, --verbose
-            Enable verbose output
-
-    -q, --quiet
-            Disable progress output
-
-    -y
-            Disable confirmation prompt.
-
-        --default-host <default-host>
-            Choose a default host triple
-
-        --default-toolchain <default-toolchain>
-            Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-
-        --profile <profile>
-            [default: default] [possible values: minimal, default, complete]
-
-    -c, --component <components>...
-            Component name to also install
-
-    -t, --target <targets>...
-            Target name to also install
-
-        --no-update-default-toolchain
-            Don't update any existing default toolchain after install
-
-        --no-modify-path
-            Don't configure the PATH environment variable
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
+Options:
+  -v, --verbose
+          Enable verbose output
+  -q, --quiet
+          Disable progress output
+  -y
+          Disable confirmation prompt.
+      --default-host <default-host>
+          Choose a default host triple
+      --default-toolchain <default-toolchain>
+          Choose a default toolchain to install. Use 'none' to not install any toolchains at all
+      --profile <profile>
+          [default: default] [possible values: minimal, default, complete]
+  -c, --component <components>...
+          Component name to also install
+  -t, --target <targets>...
+          Target name to also install
+      --no-update-default-toolchain
+          Don't update any existing default toolchain after install
+      --no-modify-path
+          Don't configure the PATH environment variable
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 EOF
 }
 

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,4 +1,4 @@
-pub(crate) static RUSTUP_HELP: &str = r"DISCUSSION:
+pub(crate) static RUSTUP_HELP: &str = r"Discussion:
     Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes
@@ -8,7 +8,7 @@ pub(crate) static RUSTUP_HELP: &str = r"DISCUSSION:
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust.";
 
-pub(crate) static SHOW_HELP: &str = r"DISCUSSION:
+pub(crate) static SHOW_HELP: &str = r"Discussion:
     Shows the name of the active toolchain and the version of `rustc`.
 
     If the active toolchain has installed support for additional
@@ -17,7 +17,7 @@ pub(crate) static SHOW_HELP: &str = r"DISCUSSION:
     If there are multiple toolchains installed then all installed
     toolchains are listed as well.";
 
-pub(crate) static SHOW_ACTIVE_TOOLCHAIN_HELP: &str = r"DISCUSSION:
+pub(crate) static SHOW_ACTIVE_TOOLCHAIN_HELP: &str = r"Discussion:
     Shows the name of the active toolchain.
 
     This is useful for figuring out the active tool chain from
@@ -26,7 +26,7 @@ pub(crate) static SHOW_ACTIVE_TOOLCHAIN_HELP: &str = r"DISCUSSION:
     You should use `rustc --print sysroot` to get the sysroot, or
     `rustc --version` to get the toolchain version.";
 
-pub(crate) static UPDATE_HELP: &str = r"DISCUSSION:
+pub(crate) static UPDATE_HELP: &str = r"Discussion:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.
@@ -34,16 +34,16 @@ pub(crate) static UPDATE_HELP: &str = r"DISCUSSION:
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`.";
 
-pub(crate) static INSTALL_HELP: &str = r"DISCUSSION:
+pub(crate) static INSTALL_HELP: &str = r"Discussion:
     Installs a specific rust toolchain.
 
     The 'install' command is an alias for 'rustup update <toolchain>'.";
 
-pub(crate) static DEFAULT_HELP: &str = r"DISCUSSION:
+pub(crate) static DEFAULT_HELP: &str = r"Discussion:
     Sets the default toolchain to the one specified. If the toolchain
     is not already installed then it is installed first.";
 
-pub(crate) static TOOLCHAIN_HELP: &str = r"DISCUSSION:
+pub(crate) static TOOLCHAIN_HELP: &str = r"Discussion:
     Many `rustup` commands deal with *toolchains*, a single
     installation of the Rust compiler. `rustup` supports multiple
     types of toolchains. The most basic track the official release
@@ -85,7 +85,7 @@ pub(crate) static TOOLCHAIN_HELP: &str = r"DISCUSSION:
     often used for developing Rust itself. For more information see
     `rustup toolchain help link`.";
 
-pub(crate) static TOOLCHAIN_LINK_HELP: &str = r"DISCUSSION:
+pub(crate) static TOOLCHAIN_LINK_HELP: &str = r"Discussion:
     'toolchain' is the custom name to be assigned to the new toolchain.
     Any name is permitted as long as it does not fully match an initial
     substring of a standard release channel. For example, you can use
@@ -104,7 +104,7 @@ pub(crate) static TOOLCHAIN_LINK_HELP: &str = r"DISCUSSION:
     If you now compile a crate in the current directory, the custom
     toolchain 'latest-stage1' will be used.";
 
-pub(crate) static OVERRIDE_HELP: &str = r"DISCUSSION:
+pub(crate) static OVERRIDE_HELP: &str = r"Discussion:
     Overrides configure Rustup to use a specific toolchain when
     running in a specific directory.
 
@@ -125,14 +125,14 @@ pub(crate) static OVERRIDE_HELP: &str = r"DISCUSSION:
     override and use the default toolchain again, `rustup override
     unset`.";
 
-pub(crate) static OVERRIDE_UNSET_HELP: &str = r"DISCUSSION:
+pub(crate) static OVERRIDE_UNSET_HELP: &str = r"Discussion:
     If `--path` argument is present, removes the override toolchain
     for the specified directory. If `--nonexistent` argument is
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory.";
 
-pub(crate) static RUN_HELP: &str = r"DISCUSSION:
+pub(crate) static RUN_HELP: &str = r"Discussion:
     Configures an environment to use the given toolchain and then runs
     the specified program. The command may be any program, not just
     rustc or cargo. This can be used for testing arbitrary toolchains
@@ -147,14 +147,14 @@ pub(crate) static RUN_HELP: &str = r"DISCUSSION:
 
         $ rustup run nightly cargo build";
 
-pub(crate) static DOC_HELP: &str = r"DISCUSSION:
+pub(crate) static DOC_HELP: &str = r"Discussion:
     Opens the documentation for the currently active toolchain with
     the default browser.
 
     By default, it opens the documentation index. Use the various
     flags to open specific pieces of documentation.";
 
-pub(crate) static COMPLETIONS_HELP: &str = r"DISCUSSION:
+pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
     Enable tab completion for Bash, Fish, Zsh, or PowerShell
     The script is output on `stdout`, allowing one to re-direct the
     output to the file of their choosing. Where you place the file

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{builder::PossibleValuesParser, AppSettings, Arg, ArgAction, Command};
+use clap::{builder::PossibleValuesParser, Arg, ArgAction, Command};
 
 use super::common;
 use super::self_update::{self, InstallOpts};
@@ -27,7 +27,6 @@ pub fn main() -> Result<utils::ExitCode> {
     let cli = Command::new("rustup-init")
         .version(common::version())
         .about("The installer for rustup")
-        .setting(AppSettings::DeriveDisplayOrder)
         .arg(
             Arg::new("verbose")
                 .short('v')
@@ -52,13 +51,13 @@ pub fn main() -> Result<utils::ExitCode> {
         .arg(
             Arg::new("default-host")
                 .long("default-host")
-                .takes_value(true)
+                .num_args(1)
                 .help("Choose a default host triple"),
         )
         .arg(
             Arg::new("default-toolchain")
                 .long("default-toolchain")
-                .takes_value(true)
+                .num_args(1)
                 .help("Choose a default toolchain to install. Use 'none' to not install any toolchains at all"),
         )
         .arg(
@@ -72,9 +71,8 @@ pub fn main() -> Result<utils::ExitCode> {
                 .help("Component name to also install")
                 .long("component")
                 .short('c')
-                .takes_value(true)
-                .multiple_values(true)
-                .use_value_delimiter(true)
+                .num_args(1..)
+                .value_delimiter(',')
                 .action(ArgAction::Append),
         )
         .arg(
@@ -82,9 +80,8 @@ pub fn main() -> Result<utils::ExitCode> {
                 .help("Target name to also install")
                 .long("target")
                 .short('t')
-                .takes_value(true)
-                .multiple_values(true)
-                .use_value_delimiter(true)
+                .num_args(1..)
+                .value_delimiter(',')
                 .action(ArgAction::Append),
         )
         .arg(
@@ -103,8 +100,8 @@ pub fn main() -> Result<utils::ExitCode> {
     let matches = match cli.try_get_matches_from(process().args_os()) {
         Ok(matches) => matches,
         Err(e)
-            if e.kind() == clap::ErrorKind::DisplayHelp
-                || e.kind() == clap::ErrorKind::DisplayVersion =>
+            if e.kind() == clap::error::ErrorKind::DisplayHelp
+                || e.kind() == clap::error::ErrorKind::DisplayVersion =>
         {
             write!(process().stdout().lock(), "{e}")?;
             return Ok(utils::ExitCode(0));

--- a/src/test.rs
+++ b/src/test.rs
@@ -121,7 +121,7 @@ pub fn this_host_triple() -> String {
         // For windows, this host may be different to the target: we may be
         // building with i686 toolchain, but on an x86_64 host, so run the
         // actual detection logic and trust it.
-        let tp = Box::new(currentprocess::TestProcess::default());
+        let tp = Box::<currentprocess::TestProcess>::default();
         return currentprocess::with(tp, || TargetTriple::from_host().unwrap().to_string());
     }
     let arch = if cfg!(target_arch = "x86") {

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -169,7 +169,7 @@ impl ConstState {
                 Some(ref path) => Ok(path.clone()),
 
                 None => {
-                    let dist_path = self.const_dist_dir.path().join(format!("{:?}", s));
+                    let dist_path = self.const_dist_dir.path().join(format!("{s:?}"));
                     create_mock_dist_server(&dist_path, s);
                     *lock = Some(dist_path.clone());
                     Ok(dist_path)

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -2,47 +2,34 @@ bin.name = "rustup-init"
 args = ["--help"]
 status.code = 0
 stdout = """
-rustup-init [..]
 The installer for rustup
 
-USAGE:
-    rustup-init[EXE] [OPTIONS]
+Usage: rustup-init[EXE] [OPTIONS]
 
-OPTIONS:
-    -v, --verbose
-            Enable verbose output
-
-    -q, --quiet
-            Disable progress output
-
-    -y
-            Disable confirmation prompt.
-
-        --default-host <default-host>
-            Choose a default host triple
-
-        --default-toolchain <default-toolchain>
-            Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-
-        --profile <profile>
-            [default: default] [possible values: minimal, default, complete]
-
-    -c, --component <components>...
-            Component name to also install
-
-    -t, --target <targets>...
-            Target name to also install
-
-        --no-update-default-toolchain
-            Don't update any existing default toolchain after install
-
-        --no-modify-path
-            Don't configure the PATH environment variable
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
+Options:
+  -v, --verbose
+          Enable verbose output
+  -q, --quiet
+          Disable progress output
+  -y
+          Disable confirmation prompt.
+      --default-host <default-host>
+          Choose a default host triple
+      --default-toolchain <default-toolchain>
+          Choose a default toolchain to install. Use 'none' to not install any toolchains at all
+      --profile <profile>
+          [default: default] [possible values: minimal, default, complete]
+  -c, --component <components>...
+          Component name to also install
+  -t, --target <targets>...
+          Target name to also install
+      --no-update-default-toolchain
+          Don't update any existing default toolchain after install
+      --no-modify-path
+          Don't configure the PATH environment variable
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -2,47 +2,34 @@ bin.name = "rustup-init.sh"
 args = ["--help"]
 status.code = 0
 stdout = """
-rustup-init [..]
 The installer for rustup
 
-USAGE:
-    rustup-init[EXE] [OPTIONS]
+Usage: rustup-init[EXE] [OPTIONS]
 
-OPTIONS:
-    -v, --verbose
-            Enable verbose output
-
-    -q, --quiet
-            Disable progress output
-
-    -y
-            Disable confirmation prompt.
-
-        --default-host <default-host>
-            Choose a default host triple
-
-        --default-toolchain <default-toolchain>
-            Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-
-        --profile <profile>
-            [default: default] [possible values: minimal, default, complete]
-
-    -c, --component <components>...
-            Component name to also install
-
-    -t, --target <targets>...
-            Target name to also install
-
-        --no-update-default-toolchain
-            Don't update any existing default toolchain after install
-
-        --no-modify-path
-            Don't configure the PATH environment variable
-
-    -h, --help
-            Print help information
-
-    -V, --version
-            Print version information
+Options:
+  -v, --verbose
+          Enable verbose output
+  -q, --quiet
+          Disable progress output
+  -y
+          Disable confirmation prompt.
+      --default-host <default-host>
+          Choose a default host triple
+      --default-toolchain <default-toolchain>
+          Choose a default toolchain to install. Use 'none' to not install any toolchains at all
+      --profile <profile>
+          [default: default] [possible values: minimal, default, complete]
+  -c, --component <components>...
+          Component name to also install
+  -t, --target <targets>...
+          Target name to also install
+      --no-update-default-toolchain
+          Don't update any existing default toolchain after install
+      --no-modify-path
+          Don't configure the PATH environment variable
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_check_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["check","--help"]
+args = ["check", "--help"]
 stdout = """
 ...
 Check for updates to Rust toolchains and rustup
 
-USAGE:
-    rustup[EXE] check
+Usage: rustup[EXE] check
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
@@ -1,20 +1,19 @@
 bin.name = "rustup"
-args = ["completions","--help"]
+args = ["completions", "--help"]
 stdout = """
 ...
 Generate tab-completion scripts for your shell
 
-USAGE:
-    rustup[EXE] completions [ARGS]
+Usage: rustup[EXE] completions [shell] [command]
 
-ARGS:
-    <shell>      [possible values: bash, elvish, fish, powershell, zsh]
-    <command>    [possible values: rustup, cargo]
+Arguments:
+  [shell]    [possible values: bash, elvish, fish, powershell, zsh]
+  [command]  [possible values: rustup, cargo]
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 
-DISCUSSION:
+Discussion:
     Enable tab completion for Bash, Fish, Zsh, or PowerShell
     The script is output on `stdout`, allowing one to re-direct the
     output to the file of their choosing. Where you place the file
@@ -118,7 +117,7 @@ DISCUSSION:
     completions into our profile simply use
 
         PS C:/> rustup completions powershell >>
-${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
+        ${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
 
     CARGO:
 

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_add_cmd_help_flag_stdout.toml
@@ -1,19 +1,18 @@
 bin.name = "rustup"
-args = ["component","add","--help"]
+args = ["component", "add", "--help"]
 stdout = """
 ...
 Add a component to a Rust toolchain
 
-USAGE:
-    rustup[EXE] component add [OPTIONS] <component>...
+Usage: rustup[EXE] component add [OPTIONS] <component>...
 
-ARGS:
-    <component>...    
+Arguments:
+  <component>...  
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-        --target <target>          
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+      --target <target>        
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -1,16 +1,15 @@
 bin.name = "rustup"
-args = ["component","list","--help"]
+args = ["component", "list", "--help"]
 stdout = """
 ...
 List installed and available components
 
-USAGE:
-    rustup[EXE] component list [OPTIONS]
+Usage: rustup[EXE] component list [OPTIONS]
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-        --installed                List only installed components
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+      --installed              List only installed components
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,19 +1,18 @@
 bin.name = "rustup"
-args = ["component","remove","--help"]
+args = ["component", "remove", "--help"]
 stdout = """
 ...
 Remove a component from a Rust toolchain
 
-USAGE:
-    rustup[EXE] component remove [OPTIONS] <component>...
+Usage: rustup[EXE] component remove [OPTIONS] <component>...
 
-ARGS:
-    <component>...    
+Arguments:
+  <component>...  
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-        --target <target>          
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+      --target <target>        
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
@@ -1,20 +1,19 @@
 bin.name = "rustup"
-args = ["default","--help"]
+args = ["default", "--help"]
 stdout = """
 ...
 Set the default toolchain
 
-USAGE:
-    rustup[EXE] default [toolchain]
+Usage: rustup[EXE] default [toolchain]
 
-ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
-                   see `rustup help toolchain`
+Arguments:
+  [toolchain]  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+               `rustup help toolchain`
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 
-DISCUSSION:
+Discussion:
     Sets the default toolchain to the one specified. If the toolchain
     is not already installed then it is installed first.
 """

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -1,41 +1,40 @@
 bin.name = "rustup"
-args = ["doc","--help"]
+args = ["doc", "--help"]
 stdout = """
 ...
 Open the documentation for the current toolchain
 
-USAGE:
-    rustup[EXE] doc [OPTIONS] [topic]
+Usage: rustup[EXE] doc [OPTIONS] [topic]
 
-ARGS:
-    <topic>    Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!',
-               'std::fs', 'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum',
-               'std::io::error::Result' etc...
+Arguments:
+  [topic]  Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!',
+           'std::fs', 'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum',
+           'std::io::error::Result' etc...
 
-OPTIONS:
-        --path                     Only print the path to the documentation
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-        --alloc                    The Rust core allocation and collections library
-        --book                     The Rust Programming Language book
-        --cargo                    The Cargo Book
-        --core                     The Rust Core Library
-        --edition-guide            The Rust Edition Guide
-        --nomicon                  The Dark Arts of Advanced and Unsafe Rust Programming
-        --proc_macro               A support library for macro authors when defining new macros
-        --reference                The Rust Reference
-        --rust-by-example          A collection of runnable examples that illustrate various Rust
-                                   concepts and standard libraries
-        --rustc                    The compiler for the Rust programming language
-        --rustdoc                  Documentation generator for Rust projects
-        --std                      Standard library API documentation
-        --test                     Support code for rustc's built in unit-test and
-                                   micro-benchmarking framework
-        --unstable-book            The Unstable Book
-        --embedded-book            The Embedded Rust Book
-    -h, --help                     Print help information
+Options:
+      --path                   Only print the path to the documentation
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+      --alloc                  The Rust core allocation and collections library
+      --book                   The Rust Programming Language book
+      --cargo                  The Cargo Book
+      --core                   The Rust Core Library
+      --edition-guide          The Rust Edition Guide
+      --nomicon                The Dark Arts of Advanced and Unsafe Rust Programming
+      --proc_macro             A support library for macro authors when defining new macros
+      --reference              The Rust Reference
+      --rust-by-example        A collection of runnable examples that illustrate various Rust
+                               concepts and standard libraries
+      --rustc                  The compiler for the Rust programming language
+      --rustdoc                Documentation generator for Rust projects
+      --std                    Standard library API documentation
+      --test                   Support code for rustc's built in unit-test and micro-benchmarking
+                               framework
+      --unstable-book          The Unstable Book
+      --embedded-book          The Embedded Rust Book
+  -h, --help                   Print help
 
-DISCUSSION:
+Discussion:
     Opens the documentation for the currently active toolchain with
     the default browser.
 

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -2,40 +2,38 @@ bin.name = "rustup"
 args = ["help"]
 status.code = 0
 stdout = """
-rustup [..]
 The Rust toolchain installer
 
-USAGE:
-    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
+Usage: rustup[EXE] [OPTIONS] [+toolchain] <COMMAND>
 
-ARGS:
-    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
-
-OPTIONS:
-    -v, --verbose    Enable verbose output
-    -q, --quiet      Disable progress output
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    show           Show the active and installed toolchains or profiles
-    update         Update Rust toolchains and rustup
-    check          Check for updates to Rust toolchains and rustup
-    default        Set the default toolchain
-    toolchain      Modify or query the installed toolchains
-    target         Modify a toolchain's supported targets
-    component      Modify a toolchain's installed components
-    override       Modify directory toolchain overrides
-    run            Run a command with an environment configured for a given toolchain
-    which          Display which binary will be run for a given command
-    doc            Open the documentation for the current toolchain
+Commands:
+  show         Show the active and installed toolchains or profiles
+  update       Update Rust toolchains and rustup
+  check        Check for updates to Rust toolchains and rustup
+  default      Set the default toolchain
+  toolchain    Modify or query the installed toolchains
+  target       Modify a toolchain's supported targets
+  component    Modify a toolchain's installed components
+  override     Modify directory toolchain overrides
+  run          Run a command with an environment configured for a given toolchain
+  which        Display which binary will be run for a given command
+  doc          Open the documentation for the current toolchain
 ...
-    self           Modify the rustup installation
-    set            Alter rustup settings
-    completions    Generate tab-completion scripts for your shell
-    help           Print this message or the help of the given subcommand(s)
+  self         Modify the rustup installation
+  set          Alter rustup settings
+  completions  Generate tab-completion scripts for your shell
+  help         Print this message or the help of the given subcommand(s)
 
-DISCUSSION:
+Arguments:
+  [+toolchain]  release channel (e.g. +stable) or custom toolchain to set override
+
+Options:
+  -v, --verbose  Enable verbose output
+  -q, --quiet    Disable progress output
+  -h, --help     Print help
+  -V, --version  Print version
+
+Discussion:
     Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -2,40 +2,38 @@ bin.name = "rustup"
 args = ["--help"]
 status.code = 0
 stdout = """
-rustup [..]
 The Rust toolchain installer
 
-USAGE:
-    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
+Usage: rustup[EXE] [OPTIONS] [+toolchain] <COMMAND>
 
-ARGS:
-    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
-
-OPTIONS:
-    -v, --verbose    Enable verbose output
-    -q, --quiet      Disable progress output
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    show           Show the active and installed toolchains or profiles
-    update         Update Rust toolchains and rustup
-    check          Check for updates to Rust toolchains and rustup
-    default        Set the default toolchain
-    toolchain      Modify or query the installed toolchains
-    target         Modify a toolchain's supported targets
-    component      Modify a toolchain's installed components
-    override       Modify directory toolchain overrides
-    run            Run a command with an environment configured for a given toolchain
-    which          Display which binary will be run for a given command
-    doc            Open the documentation for the current toolchain
+Commands:
+  show         Show the active and installed toolchains or profiles
+  update       Update Rust toolchains and rustup
+  check        Check for updates to Rust toolchains and rustup
+  default      Set the default toolchain
+  toolchain    Modify or query the installed toolchains
+  target       Modify a toolchain's supported targets
+  component    Modify a toolchain's installed components
+  override     Modify directory toolchain overrides
+  run          Run a command with an environment configured for a given toolchain
+  which        Display which binary will be run for a given command
+  doc          Open the documentation for the current toolchain
 ...
-    self           Modify the rustup installation
-    set            Alter rustup settings
-    completions    Generate tab-completion scripts for your shell
-    help           Print this message or the help of the given subcommand(s)
+  self         Modify the rustup installation
+  set          Alter rustup settings
+  completions  Generate tab-completion scripts for your shell
+  help         Print this message or the help of the given subcommand(s)
 
-DISCUSSION:
+Arguments:
+  [+toolchain]  release channel (e.g. +stable) or custom toolchain to set override
+
+Options:
+  -v, --verbose  Enable verbose output
+  -q, --quiet    Disable progress output
+  -h, --help     Print help
+  -V, --version  Print version
+
+Discussion:
     Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes

--- a/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_man_cmd_help_flag_stdout.toml
@@ -1,18 +1,16 @@
 bin.name = "rustup"
-args = ["man","--help"]
+args = ["man", "--help"]
 stdout = """
-...
 View the man page for a given command
 
-USAGE:
-    rustup[EXE] man [OPTIONS] <command>
+Usage: rustup[EXE] man [OPTIONS] <command>
 
-ARGS:
-    <command>    
+Arguments:
+  <command>  
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -1,48 +1,13 @@
 bin.name = "rustup"
 args = ["-v"]
 status.code = 1
-stdout = """
-rustup [..]
-The Rust toolchain installer
+stdout = ""
+stderr = """
+error: error: 'rustup[EXE]' requires a subcommand but one was not provided
+  [subcommands: dump-testament, show, install, uninstall, update, upgrade, up, check, default, toolchain, target, component, override, run, which, doc, docs, [..]self, set, completions, help]
 
-USAGE:
-    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
+Usage: rustup[EXE] [OPTIONS] [+toolchain] <COMMAND>
 
-ARGS:
-    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+For more information, try '--help'.
 
-OPTIONS:
-    -v, --verbose    Enable verbose output
-    -q, --quiet      Disable progress output
-    -h, --help       Print help information
-    -V, --version    Print version information
-
-SUBCOMMANDS:
-    show           Show the active and installed toolchains or profiles
-    update         Update Rust toolchains and rustup
-    check          Check for updates to Rust toolchains and rustup
-    default        Set the default toolchain
-    toolchain      Modify or query the installed toolchains
-    target         Modify a toolchain's supported targets
-    component      Modify a toolchain's installed components
-    override       Modify directory toolchain overrides
-    run            Run a command with an environment configured for a given toolchain
-    which          Display which binary will be run for a given command
-    doc            Open the documentation for the current toolchain
-...
-    self           Modify the rustup installation
-    set            Alter rustup settings
-    completions    Generate tab-completion scripts for your shell
-    help           Print this message or the help of the given subcommand(s)
-
-DISCUSSION:
-    Rustup installs The Rust Programming Language from the official
-    release channels, enabling you to easily switch between stable,
-    beta, and nightly compilers and keep them updated. It makes
-    cross-compiling simpler with binary builds of the standard library
-    for common platforms.
-
-    If you are new to Rust consider running `rustup doc --book` to
-    learn Rust.
 """
-stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_add_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["override","add","--help"]
+args = ["override", "add", "--help"]
 stdout = """
 ...
 Set the override toolchain for a directory
 
-USAGE:
-    rustup[EXE] override set [OPTIONS] <toolchain>
+Usage: rustup[EXE] override set [OPTIONS] <toolchain>
 
-ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
-                   see `rustup help toolchain`
+Arguments:
+  <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+               `rustup help toolchain`
 
-OPTIONS:
-        --path <path>    Path to the directory
-    -h, --help           Print help information
+Options:
+      --path <path>  Path to the directory
+  -h, --help         Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
@@ -1,22 +1,21 @@
 bin.name = "rustup"
-args = ["override","--help"]
+args = ["override", "--help"]
 stdout = """
 ...
 Modify directory toolchain overrides
 
-USAGE:
-    rustup[EXE] override <SUBCOMMAND>
+Usage: rustup[EXE] override <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  list   List directory toolchain overrides
+  set    Set the override toolchain for a directory
+  unset  Remove the override toolchain for a directory
+  help   Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    list     List directory toolchain overrides
-    set      Set the override toolchain for a directory
-    unset    Remove the override toolchain for a directory
-    help     Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help
 
-DISCUSSION:
+Discussion:
     Overrides configure Rustup to use a specific toolchain when
     running in a specific directory.
 

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_list_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["override","list","--help"]
+args = ["override", "list", "--help"]
 stdout = """
 ...
 List directory toolchain overrides
 
-USAGE:
-    rustup[EXE] override list
+Usage: rustup[EXE] override list
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["override","unset","--help"]
+args = ["override", "unset", "--help"]
 stdout = """
 ...
 Remove the override toolchain for a directory
 
-USAGE:
-    rustup[EXE] override unset [OPTIONS]
+Usage: rustup[EXE] override unset [OPTIONS]
 
-OPTIONS:
-        --path <path>    Path to the directory
-        --nonexistent    Remove override toolchain for all nonexistent directories
-    -h, --help           Print help information
+Options:
+      --path <path>  Path to the directory
+      --nonexistent  Remove override toolchain for all nonexistent directories
+  -h, --help         Print help
 
-DISCUSSION:
+Discussion:
     If `--path` argument is present, removes the override toolchain
     for the specified directory. If `--nonexistent` argument is
     present, removes the override toolchain for all nonexistent

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_set_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["override","set","--help"]
+args = ["override", "set", "--help"]
 stdout = """
 ...
 Set the override toolchain for a directory
 
-USAGE:
-    rustup[EXE] override set [OPTIONS] <toolchain>
+Usage: rustup[EXE] override set [OPTIONS] <toolchain>
 
-ARGS:
-    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information
-                   see `rustup help toolchain`
+Arguments:
+  <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+               `rustup help toolchain`
 
-OPTIONS:
-        --path <path>    Path to the directory
-    -h, --help           Print help information
+Options:
+      --path <path>  Path to the directory
+  -h, --help         Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["override","unset","--help"]
+args = ["override", "unset", "--help"]
 stdout = """
 ...
 Remove the override toolchain for a directory
 
-USAGE:
-    rustup[EXE] override unset [OPTIONS]
+Usage: rustup[EXE] override unset [OPTIONS]
 
-OPTIONS:
-        --path <path>    Path to the directory
-        --nonexistent    Remove override toolchain for all nonexistent directories
-    -h, --help           Print help information
+Options:
+      --path <path>  Path to the directory
+      --nonexistent  Remove override toolchain for all nonexistent directories
+  -h, --help         Print help
 
-DISCUSSION:
+Discussion:
     If `--path` argument is present, removes the override toolchain
     for the specified directory. If `--nonexistent` argument is
     present, removes the override toolchain for all nonexistent

--- a/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_run_cmd_help_flag_stdout.toml
@@ -1,22 +1,21 @@
 bin.name = "rustup"
-args = ["run","--help"]
+args = ["run", "--help"]
 stdout = """
 ...
 Run a command with an environment configured for a given toolchain
 
-USAGE:
-    rustup[EXE] run [OPTIONS] <toolchain> <command>...
+Usage: rustup[EXE] run [OPTIONS] <toolchain> <command>...
 
-ARGS:
-    <toolchain>     Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                    information see `rustup help toolchain`
-    <command>...    
+Arguments:
+  <toolchain>   Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                `rustup help toolchain`
+  <command>...  
 
-OPTIONS:
-        --install    Install the requested toolchain if needed
-    -h, --help       Print help information
+Options:
+      --install  Install the requested toolchain if needed
+  -h, --help     Print help
 
-DISCUSSION:
+Discussion:
     Configures an environment to use the given toolchain and then runs
     the specified program. The command may be any program, not just
     rustc or cargo. This can be used for testing arbitrary toolchains

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_help_flag_stdout.toml
@@ -1,19 +1,18 @@
 bin.name = "rustup"
-args = ["self","--help"]
+args = ["self", "--help"]
 stdout = """
 ...
 Modify the rustup installation
 
-USAGE:
-    rustup[EXE] self <SUBCOMMAND>
+Usage: rustup[EXE] self <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  update        Download and install updates to rustup
+  uninstall     Uninstall rustup.
+  upgrade-data  Upgrade the internal data format.
+  help          Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    update          Download and install updates to rustup
-    uninstall       Uninstall rustup.
-    upgrade-data    Upgrade the internal data format.
-    help            Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,14 +1,13 @@
 bin.name = "rustup"
-args = ["self","uninstall","--help"]
+args = ["self", "uninstall", "--help"]
 stdout = """
 ...
 Uninstall rustup.
 
-USAGE:
-    rustup[EXE] self uninstall [OPTIONS]
+Usage: rustup[EXE] self uninstall [OPTIONS]
 
-OPTIONS:
-    -y            
-    -h, --help    Print help information
+Options:
+  -y          
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_update_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["self","update","--help"]
+args = ["self", "update", "--help"]
 stdout = """
 ...
 Download and install updates to rustup
 
-USAGE:
-    rustup[EXE] self update
+Usage: rustup[EXE] self update
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["self","upgrade-data","--help"]
+args = ["self", "upgrade-data", "--help"]
 stdout = """
 ...
 Upgrade the internal data format.
 
-USAGE:
-    rustup[EXE] self upgrade-data
+Usage: rustup[EXE] self upgrade-data
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
@@ -1,16 +1,15 @@
 bin.name = "rustup"
-args = ["set","auto-self-update","--help"]
+args = ["set", "auto-self-update", "--help"]
 stdout = """
 ...
 The rustup auto self update mode
 
-USAGE:
-    rustup[EXE] set auto-self-update <auto-self-update-mode>
+Usage: rustup[EXE] set auto-self-update <auto-self-update-mode>
 
-ARGS:
-    <auto-self-update-mode>    [default: enable] [possible values: enable, disable, check-only]
+Arguments:
+  <auto-self-update-mode>  [default: enable] [possible values: enable, disable, check-only]
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
@@ -1,16 +1,15 @@
 bin.name = "rustup"
-args = ["set","default-host","--help"]
+args = ["set", "default-host", "--help"]
 stdout = """
 ...
 The triple used to identify toolchains when not specified
 
-USAGE:
-    rustup[EXE] set default-host <host_triple>
+Usage: rustup[EXE] set default-host <host_triple>
 
-ARGS:
-    <host_triple>    
+Arguments:
+  <host_triple>  
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
@@ -1,19 +1,18 @@
 bin.name = "rustup"
-args = ["set","--help"]
+args = ["set", "--help"]
 stdout = """
 ...
 Alter rustup settings
 
-USAGE:
-    rustup[EXE] set <SUBCOMMAND>
+Usage: rustup[EXE] set <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  default-host      The triple used to identify toolchains when not specified
+  profile           The default components installed
+  auto-self-update  The rustup auto self update mode
+  help              Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    default-host        The triple used to identify toolchains when not specified
-    profile             The default components installed
-    auto-self-update    The rustup auto self update mode
-    help                Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,16 +1,15 @@
 bin.name = "rustup"
-args = ["set","profile","--help"]
+args = ["set", "profile", "--help"]
 stdout = """
 ...
 The default components installed
 
-USAGE:
-    rustup[EXE] set profile <profile-name>
+Usage: rustup[EXE] set profile <profile-name>
 
-ARGS:
-    <profile-name>    [default: default] [possible values: minimal, default, complete]
+Arguments:
+  <profile-name>  [default: default] [possible values: minimal, default, complete]
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
@@ -1,17 +1,16 @@
 bin.name = "rustup"
-args = ["show","active-toolchain","--help"]
+args = ["show", "active-toolchain", "--help"]
 stdout = """
 ...
 Show the active toolchain
 
-USAGE:
-    rustup[EXE] show active-toolchain [OPTIONS]
+Usage: rustup[EXE] show active-toolchain [OPTIONS]
 
-OPTIONS:
-    -v, --verbose    Enable verbose output with rustc information
-    -h, --help       Print help information
+Options:
+  -v, --verbose  Enable verbose output with rustc information
+  -h, --help     Print help
 
-DISCUSSION:
+Discussion:
     Shows the name of the active toolchain.
 
     This is useful for figuring out the active tool chain from

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
@@ -1,23 +1,22 @@
 bin.name = "rustup"
-args = ["show","--help"]
+args = ["show", "--help"]
 stdout = """
 ...
 Show the active and installed toolchains or profiles
 
-USAGE:
-    rustup[EXE] show [OPTIONS] [SUBCOMMAND]
+Usage: rustup[EXE] show [OPTIONS] [COMMAND]
 
-OPTIONS:
-    -v, --verbose    Enable verbose output with rustc information for all installed toolchains
-    -h, --help       Print help information
+Commands:
+  active-toolchain  Show the active toolchain
+  home              Display the computed value of RUSTUP_HOME
+  profile           Show the current profile
+  help              Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    active-toolchain    Show the active toolchain
-    home                Display the computed value of RUSTUP_HOME
-    profile             Show the current profile
-    help                Print this message or the help of the given subcommand(s)
+Options:
+  -v, --verbose  Enable verbose output with rustc information for all installed toolchains
+  -h, --help     Print help
 
-DISCUSSION:
+Discussion:
     Shows the name of the active toolchain and the version of `rustc`.
 
     If the active toolchain has installed support for additional

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_home_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["show","home","--help"]
+args = ["show", "home", "--help"]
 stdout = """
 ...
 Display the computed value of RUSTUP_HOME
 
-USAGE:
-    rustup[EXE] show home
+Usage: rustup[EXE] show home
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
-args = ["show","profile","--help"]
+args = ["show", "profile", "--help"]
 stdout = """
 ...
 Show the current profile
 
-USAGE:
-    rustup[EXE] show profile
+Usage: rustup[EXE] show profile
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_add_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["target","add","--help"]
+args = ["target", "add", "--help"]
 stdout = """
 ...
 Add a target to a Rust toolchain
 
-USAGE:
-    rustup[EXE] target add [OPTIONS] <target>...
+Usage: rustup[EXE] target add [OPTIONS] <target>...
 
-ARGS:
-    <target>...    List of targets to install; \"all\" installs all available targets
+Arguments:
+  <target>...  List of targets to install; \"all\" installs all available targets
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_help_flag_stdout.toml
@@ -1,19 +1,18 @@
 bin.name = "rustup"
-args = ["target","--help"]
+args = ["target", "--help"]
 stdout = """
 ...
 Modify a toolchain's supported targets
 
-USAGE:
-    rustup[EXE] target <SUBCOMMAND>
+Usage: rustup[EXE] target <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  list    List installed and available targets
+  add     Add a target to a Rust toolchain
+  remove  Remove a target from a Rust toolchain
+  help    Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    list      List installed and available targets
-    add       Add a target to a Rust toolchain
-    remove    Remove a target from a Rust toolchain
-    help      Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_list_cmd_help_flag_stdout.toml
@@ -1,16 +1,15 @@
 bin.name = "rustup"
-args = ["target","list","--help"]
+args = ["target", "list", "--help"]
 stdout = """
 ...
 List installed and available targets
 
-USAGE:
-    rustup[EXE] target list [OPTIONS]
+Usage: rustup[EXE] target list [OPTIONS]
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-        --installed                List only installed targets
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+      --installed              List only installed targets
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["target","remove","--help"]
+args = ["target", "remove", "--help"]
 stdout = """
 ...
 Remove a target from a Rust toolchain
 
-USAGE:
-    rustup[EXE] target remove [OPTIONS] <target>...
+Usage: rustup[EXE] target remove [OPTIONS] <target>...
 
-ARGS:
-    <target>...    List of targets to uninstall
+Arguments:
+  <target>...  List of targets to uninstall
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -1,23 +1,22 @@
 bin.name = "rustup"
-args = ["toolchain","--help"]
+args = ["toolchain", "--help"]
 stdout = """
 ...
 Modify or query the installed toolchains
 
-USAGE:
-    rustup[EXE] toolchain <SUBCOMMAND>
+Usage: rustup[EXE] toolchain <COMMAND>
 
-OPTIONS:
-    -h, --help    Print help information
+Commands:
+  list       List installed toolchains
+  install    Install or update a given toolchain
+  uninstall  Uninstall a toolchain
+  link       Create a custom toolchain by symlinking to a directory
+  help       Print this message or the help of the given subcommand(s)
 
-SUBCOMMANDS:
-    list         List installed toolchains
-    install      Install or update a given toolchain
-    uninstall    Uninstall a toolchain
-    link         Create a custom toolchain by symlinking to a directory
-    help         Print this message or the help of the given subcommand(s)
+Options:
+  -h, --help  Print help
 
-DISCUSSION:
+Discussion:
     Many `rustup` commands deal with *toolchains*, a single
     installation of the Rust compiler. `rustup` supports multiple
     types of toolchains. The most basic track the official release

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -1,27 +1,25 @@
 bin.name = "rustup"
-args = ["toolchain","install","--help"]
+args = ["toolchain", "install", "--help"]
 stdout = """
-...
 Install or update a given toolchain
 
-USAGE:
-    rustup[EXE] toolchain install [OPTIONS] <toolchain>...
+Usage: rustup[EXE] toolchain install [OPTIONS] <toolchain>...
 
-ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                      information see `rustup help toolchain`
+Arguments:
+  <toolchain>...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                  `rustup help toolchain`
 
-OPTIONS:
-        --profile <profile>            [possible values: minimal, default, complete]
-    -c, --component <components>...    Add specific components on installation
-    -t, --target <targets>...          Add specific targets on installation
-        --no-self-update               Don't perform self update when running the`rustup toolchain
-                                       install` command
-        --force                        Force an update, even if some components are missing
-        --allow-downgrade              Allow rustup to downgrade the toolchain to satisfy your
-                                       component choice
-        --force-non-host               Install toolchains that require an emulator. See
-                                       https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-    -h, --help                         Print help information
+Options:
+      --profile <profile>          [possible values: minimal, default, complete]
+  -c, --component <components>...  Add specific components on installation
+  -t, --target <targets>...        Add specific targets on installation
+      --no-self-update             Don't perform self update when running the`rustup toolchain
+                                   install` command
+      --force                      Force an update, even if some components are missing
+      --allow-downgrade            Allow rustup to downgrade the toolchain to satisfy your component
+                                   choice
+      --force-non-host             Install toolchains that require an emulator. See
+                                   https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help                       Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
@@ -1,20 +1,19 @@
 bin.name = "rustup"
-args = ["toolchain","link","--help"]
+args = ["toolchain", "link", "--help"]
 stdout = """
 ...
 Create a custom toolchain by symlinking to a directory
 
-USAGE:
-    rustup[EXE] toolchain link <toolchain> <path>
+Usage: rustup[EXE] toolchain link <toolchain> <path>
 
-ARGS:
-    <toolchain>    Custom toolchain name
-    <path>         Path to the directory
+Arguments:
+  <toolchain>  Custom toolchain name
+  <path>       Path to the directory
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 
-DISCUSSION:
+Discussion:
     'toolchain' is the custom name to be assigned to the new toolchain.
     Any name is permitted as long as it does not fully match an initial
     substring of a standard release channel. For example, you can use

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
@@ -1,14 +1,13 @@
 bin.name = "rustup"
-args = ["toolchain","list","--help"]
+args = ["toolchain", "list", "--help"]
 stdout = """
 ...
 List installed toolchains
 
-USAGE:
-    rustup[EXE] toolchain list [OPTIONS]
+Usage: rustup[EXE] toolchain list [OPTIONS]
 
-OPTIONS:
-    -v, --verbose    Enable verbose output with toolchain information
-    -h, --help       Print help information
+Options:
+  -v, --verbose  Enable verbose output with toolchain information
+  -h, --help     Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,17 +1,16 @@
 bin.name = "rustup"
-args = ["toolchain","uninstall","--help"]
+args = ["toolchain", "uninstall", "--help"]
 stdout = """
 ...
 Uninstall a toolchain
 
-USAGE:
-    rustup[EXE] toolchain uninstall <toolchain>...
+Usage: rustup[EXE] toolchain uninstall <toolchain>...
 
-ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                      information see `rustup help toolchain`
+Arguments:
+  <toolchain>...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                  `rustup help toolchain`
 
-OPTIONS:
-    -h, --help    Print help information
+Options:
+  -h, --help  Print help
 """
 stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_unknown_arg_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_unknown_arg_stdout.toml
@@ -3,7 +3,7 @@ args = ["random"]
 status.code = 1
 stdout = ""
 stderr = """
-error: Invalid value \"random\" for '<+toolchain>': \"random\" is not a valid subcommand, so it was interpreted as a toolchain name, but it is also invalid. To override the toolchain using the 'rustup +toolchain' syntax, make sure to prefix the toolchain override with a '+'
+error: invalid value 'random' for '[+toolchain]': \"random\" is not a valid subcommand, so it was interpreted as a toolchain name, but it is also invalid. To override the toolchain using the 'rustup +toolchain' syntax, make sure to prefix the toolchain override with a '+'
 
-For more information try --help
+For more information, try '--help'.
 """

--- a/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_up_cmd_help_flag_stdout.toml
@@ -1,24 +1,23 @@
 bin.name = "rustup"
-args = ["up","--help"]
+args = ["up", "--help"]
 stdout = """
 ...
 Update Rust toolchains and rustup
 
-USAGE:
-    rustup[EXE] update [OPTIONS] [toolchain]...
+Usage: rustup[EXE] update [OPTIONS] [toolchain]...
 
-ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                      information see `rustup help toolchain`
+Arguments:
+  [toolchain]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                  `rustup help toolchain`
 
-OPTIONS:
-        --no-self-update    Don't perform self update when running the `rustup update` command
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See
-                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Print help information
+Options:
+      --no-self-update  Don't perform self update when running the `rustup update` command
+      --force           Force an update, even if some components are missing
+      --force-non-host  Install toolchains that require an emulator. See
+                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help            Print help
 
-DISCUSSION:
+Discussion:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.

--- a/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_update_cmd_help_flag_stdout.toml
@@ -1,24 +1,23 @@
 bin.name = "rustup"
-args = ["update","--help"]
+args = ["update", "--help"]
 stdout = """
 ...
 Update Rust toolchains and rustup
 
-USAGE:
-    rustup[EXE] update [OPTIONS] [toolchain]...
+Usage: rustup[EXE] update [OPTIONS] [toolchain]...
 
-ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                      information see `rustup help toolchain`
+Arguments:
+  [toolchain]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                  `rustup help toolchain`
 
-OPTIONS:
-        --no-self-update    Don't perform self update when running the `rustup update` command
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See
-                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Print help information
+Options:
+      --no-self-update  Don't perform self update when running the `rustup update` command
+      --force           Force an update, even if some components are missing
+      --force-non-host  Install toolchains that require an emulator. See
+                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help            Print help
 
-DISCUSSION:
+Discussion:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.

--- a/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_upgrade_cmd_help_flag_stdout.toml
@@ -1,24 +1,23 @@
 bin.name = "rustup"
-args = ["upgrade","--help"]
+args = ["upgrade", "--help"]
 stdout = """
 ...
 Update Rust toolchains and rustup
 
-USAGE:
-    rustup[EXE] update [OPTIONS] [toolchain]...
+Usage: rustup[EXE] update [OPTIONS] [toolchain]...
 
-ARGS:
-    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                      information see `rustup help toolchain`
+Arguments:
+  [toolchain]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                  `rustup help toolchain`
 
-OPTIONS:
-        --no-self-update    Don't perform self update when running the `rustup update` command
-        --force             Force an update, even if some components are missing
-        --force-non-host    Install toolchains that require an emulator. See
-                            https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-    -h, --help              Print help information
+Options:
+      --no-self-update  Don't perform self update when running the `rustup update` command
+      --force           Force an update, even if some components are missing
+      --force-non-host  Install toolchains that require an emulator. See
+                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help            Print help
 
-DISCUSSION:
+Discussion:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.

--- a/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_which_cmd_help_flag_stdout.toml
@@ -1,18 +1,17 @@
 bin.name = "rustup"
-args = ["which","--help"]
+args = ["which", "--help"]
 stdout = """
 ...
 Display which binary will be run for a given command
 
-USAGE:
-    rustup[EXE] which [OPTIONS] <command>
+Usage: rustup[EXE] which [OPTIONS] <command>
 
-ARGS:
-    <command>    
+Arguments:
+  <command>  
 
-OPTIONS:
-        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
-                                   information see `rustup help toolchain`
-    -h, --help                     Print help information
+Options:
+      --toolchain <toolchain>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
+                               information see `rustup help toolchain`
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -145,7 +145,7 @@ fn subcommand_required_for_target() {
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
         assert_eq!(out.status.code().unwrap(), 1);
-        assert!(str::from_utf8(&out.stdout).unwrap().contains("USAGE"));
+        assert!(str::from_utf8(&out.stderr).unwrap().contains("Usage"));
     });
 }
 
@@ -159,7 +159,7 @@ fn subcommand_required_for_toolchain() {
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
         assert_eq!(out.status.code().unwrap(), 1);
-        assert!(str::from_utf8(&out.stdout).unwrap().contains("USAGE"));
+        assert!(str::from_utf8(&out.stderr).unwrap().contains("Usage"));
     });
 }
 
@@ -173,7 +173,7 @@ fn subcommand_required_for_override() {
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
         assert_eq!(out.status.code().unwrap(), 1);
-        assert!(str::from_utf8(&out.stdout).unwrap().contains("USAGE"));
+        assert!(str::from_utf8(&out.stderr).unwrap().contains("Usage"));
     });
 }
 
@@ -187,7 +187,7 @@ fn subcommand_required_for_self() {
         let out = cmd.output().unwrap();
         assert!(!out.status.success());
         assert_eq!(out.status.code().unwrap(), 1);
-        assert!(str::from_utf8(&out.stdout).unwrap().contains("USAGE"));
+        assert!(str::from_utf8(&out.stderr).unwrap().contains("Usage"));
     });
 }
 
@@ -807,11 +807,11 @@ fn completion_bad_shell() {
     setup(&|config| {
         config.expect_err(
             &["rustup", "completions", "fake"],
-            r#"error: "fake" isn't a valid value for '<shell>'"#,
+            r#"error: invalid value 'fake' for '[shell]'"#,
         );
         config.expect_err(
             &["rustup", "completions", "fake", "cargo"],
-            r#"error: "fake" isn't a valid value for '<shell>'"#,
+            r#"error: invalid value 'fake' for '[shell]'"#,
         );
     });
 }
@@ -821,7 +821,7 @@ fn completion_bad_tool() {
     setup(&|config| {
         config.expect_err(
             &["rustup", "completions", "bash", "fake"],
-            r#"error: "fake" isn't a valid value for '<command>'"#,
+            r#"error: invalid value 'fake' for '[command]'"#,
         );
     });
 }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1029,7 +1029,7 @@ fn update_unavailable_std() {
     setup(&|config| {
         make_component_unavailable(config, "rust-std", &this_host_triple());
         config.expect_err(
-            &["rustup", "update", "nightly", ],
+            &["rustup", "update", "nightly"],
             for_host!(
                 "component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'"
             ),


### PR DESCRIPTION
Depends on #3064 (see https://github.com/rust-lang/rustup/pull/3064#issuecomment-1276929460)

fixes #3128 apparently