### PR TITLE
Fix shell check warning

### DIFF
--- a/.github/workflows/centos-fmt-clippy-on-all.yaml
+++ b/.github/workflows/centos-fmt-clippy-on-all.yaml
@@ -82,9 +82,9 @@ jobs:
             sh ./ci/raw_init.sh
       - name: Run shell checks
         run: |
-          shellcheck -s dash -- rustup-init.sh
-          git ls-files -- '*.sh' | xargs shellcheck -s dash -e SC1090
-          git ls-files -- '*.bash' | xargs shellcheck -s bash -e SC1090
+          shellcheck -x -s dash -- rustup-init.sh
+          git ls-files -- '*.sh' | xargs shellcheck -x -s dash
+          git ls-files -- '*.bash' | xargs shellcheck -x -s bash
       - name: Run formatting checks
         run: |
           cargo fmt --all --check

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -82,9 +82,9 @@ jobs:
             sh ./ci/raw_init.sh
       - name: Run shell checks
         run: |
-          shellcheck -s dash -- rustup-init.sh
-          git ls-files -- '*.sh' | xargs shellcheck -s dash -e SC1090
-          git ls-files -- '*.bash' | xargs shellcheck -s bash -e SC1090
+          shellcheck -x -s dash -- rustup-init.sh
+          git ls-files -- '*.sh' | xargs shellcheck -x -s dash
+          git ls-files -- '*.bash' | xargs shellcheck -x -s bash
       - name: Run formatting checks
         run: |
           cargo fmt --all --check

--- a/ci/cirrus-templates/script.bash
+++ b/ci/cirrus-templates/script.bash
@@ -1,4 +1,4 @@
-#!/bin/bash                                                                                            
+#!/bin/bash
 
 set -ex
 
@@ -26,6 +26,7 @@ echo "Install Rustup using ./rustup-init.sh"
 
 sh rustup-init.sh --default-toolchain=stable --profile=minimal -y
 # It's the equivalent of `source`
+# shellcheck source=src/cli/self_update/env.sh
 source "$HOME"/.cargo/env
 
 echo "========="

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 script_dir=$(cd "$(dirname "$0")" && pwd)
+# shellcheck source=ci/shared.bash
 . "$script_dir/shared.bash"
 
 set -e

--- a/ci/raw_init.sh
+++ b/ci/raw_init.sh
@@ -3,5 +3,6 @@
 set -ex
 
 sh ./rustup-init.sh --default-toolchain none -y
+# shellcheck source=/dev/null
 . "$HOME"/.cargo/env
 rustup -Vv

--- a/ci/raw_init.sh
+++ b/ci/raw_init.sh
@@ -3,6 +3,6 @@
 set -ex
 
 sh ./rustup-init.sh --default-toolchain none -y
-# shellcheck source=/dev/null
+# shellcheck source=src/cli/self_update/env.sh
 . "$HOME"/.cargo/env
 rustup -Vv

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -597,7 +597,7 @@ check_help_for() {
     esac
 
     for _arg in "$@"; do
-        if ! "$_cmd" --help $_category | grep -q -- "$_arg"; then
+        if ! "$_cmd" --help "$_category" | grep -q -- "$_arg"; then
             return 1
         fi
     done


### PR DESCRIPTION
See: https://github.com/rust-lang/rustup/actions/runs/3622731921/jobs/6133180965
It may be that our shell checker is updated.

[SC1091](https://www.shellcheck.net/wiki/SC1091) is pretty annoying and it prints some warning in our test scripts. So I excluded it.