### PR TITLE
Improve a help message for `rustup doc --rustdoc`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1515,7 +1515,7 @@ const DOCS_DATA: &[(&str, &str, &str,)] = &[
     ("reference", "The Rust Reference", "reference/index.html"),
     ("rust-by-example", "A collection of runnable examples that illustrate various Rust concepts and standard libraries", "rust-by-example/index.html"),
     ("rustc", "The compiler for the Rust programming language", "rustc/index.html"),
-    ("rustdoc", "Generate documentation for Rust projects", "rustdoc/index.html"),
+    ("rustdoc", "Documentation generator for Rust projects", "rustdoc/index.html"),
     ("std", "Standard library API documentation", "std/index.html"),
     ("test", "Support code for rustc's built in unit-test and micro-benchmarking framework", "test/index.html"),
     ("unstable-book", "The Unstable Book", "unstable-book/index.html"),


### PR DESCRIPTION
This PR improves a help message for `rustup doc --rustdoc`.

Any suggestions for a better message or other changes we should make in conjunction with this would be appreciated.
Many thanks.

### Reason

It's not a fatal problem, but the current help message "Generate documentation for Rust projects" reads for a moment as if the command itself has an action to generate documentation.