### PR TITLE
Remove use of hard links to symlinks on macOS.

### DIFF
--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -293,7 +293,15 @@ where
 }
 
 pub(crate) fn hard_or_symlink_file(src: &Path, dest: &Path) -> Result<()> {
-    if hardlink_file(src, dest).is_err() {
+    // Some mac filesystems can do hardlinks to symlinks, some can't.
+    // See rust-lang/rustup#3136 for why it's better never to use them.
+    #[cfg(target_os = "macos")]
+    let force_symlink = fs::symlink_metadata(src)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false);
+    #[cfg(not(target_os = "macos"))]
+    let force_symlink = false;
+    if force_symlink || hardlink_file(src, dest).is_err() {
         symlink_file(src, dest)?;
     }
     Ok(())


### PR DESCRIPTION
Fixes #3136 (macOS only) by checking to see if the source path being linked to is itself a symlink, and using a symlink rather than a hard link if it is.

Per the contributing guidelines:
- all tests pass except for `update_exact`, which I can't see how to make work given this has a development version.
- there are several nightly lints that fail, but they are all in parts of the code I haven't touched.
- rustfmt is happy with the few lines of new code.

I have field tested this by using it as the binary for homebrew's rustup-init, which places a symlink for rustup.

This is a first submission to the rust-lang tree for me. All comments welcome.