### PR TITLE
Renovate tweaks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,11 @@
     ],
     "labels": [
         "dependencies"
-    ]
+    ],
+    "lockFileMaintenance": {
+        "enabled": true
+    },
+    "prCreation": "not-pending",
+    "rangeStrategy": "replace",
+    "stabilityDays": 3
 }


### PR DESCRIPTION
- enable lockfile maintenance to update Cargo.lock without Cargo
- don't create PRs until checks have completed for the change
- wait 3 days for woops! on new releases
- prefer lockfile updates over changes to Cargo.toml

The last one I think is not working correctly for Cargo - not harmful, just still more noise than we'd prefer - I'm working with renovate to track this down.