### PR TITLE
Update package cpufeatures to 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,9 +348,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]


### PR DESCRIPTION
# The problem

`rustup` does not work on machines without AVX2 instructions.

```
strom@mac rustup % rustup -V
rustup 1.25.1 (bb60b1e89 2022-07-12)
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.66.0 (69f9c33d7 2022-12-12)`

strom@mac rustup % rustup check
zsh: illegal hardware instruction  rustup check

strom@mac rustup % rustup update
info: syncing channel updates for 'stable-x86_64-apple-darwin'
zsh: illegal hardware instruction  rustup update
```

# The cause

`rustup` depends on crates [`sha-1`](https://crates.io/crates/sha-1) and [`sha2`](https://crates.io/crates/sha2) which themselves depend on the crate [`cpufeatures`](https://crates.io/crates/cpufeatures). The [`cpufeatures`](https://crates.io/crates/cpufeatures) crate had a bug where it was incorrectly reporting that a machine supports AVX2 instructions when in fact it does not. That bug was fixed in [RustCrypto#792](https://github.com/RustCrypto/utils/pull/792) which landed with v0.2.3. However `rustup` is still locked to v0.2.2 which is broken.

# The solution

The issue can be solved by updating the lock file. This PR is the result of the following cargo command:

```
strom@mac rustup % cargo update -p cpufeatures          
    Updating crates.io index
    Updating cpufeatures v0.2.2 -> v0.2.5
```

With the [`cpufeatures`](https://crates.io/crates/cpufeatures) package updated to the latest [SemVer](https://semver.org/) compatible version the problem goes away.

```
strom@mac rustup % home/bin/rustup -V
rustup unknown (2850e7e29 2023-01-10) dirty 1 modification
info: This is the version for the rustup toolchain manager, not the rustc compiler.
info: The currently active `rustc` version is `rustc 1.66.0 (69f9c33d7 2022-12-12)`

strom@mac rustup % home/bin/rustup check
stable-x86_64-apple-darwin - Update available : 1.66.0 (69f9c33d7 2022-12-12) -> 1.66.1 (90743e729 2023-01-10)
rustup - Up to date : 1.25.1
```

## References

Fixes #3083
Fixes [rust#100161](https://github.com/rust-lang/rust/issues/100161)