### PR TITLE
Do not allow `none` as custom toolchain name

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -465,7 +465,7 @@ pub struct CustomToolchain<'a>(&'a Toolchain<'a>);
 
 impl<'a> CustomToolchain<'a> {
     pub fn new(toolchain: &'a Toolchain<'a>) -> Result<CustomToolchain<'a>> {
-        if toolchain.is_custom() {
+        if toolchain.is_custom() && toolchain.name() != "none" {
             Ok(CustomToolchain(toolchain))
         } else {
             Err(anyhow!(format!(

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -513,6 +513,12 @@ fn link() {
         expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_stdout_ok(config, &["rustup", "show"], "custom");
+        // should not allow 'none' for custom toolchain name
+        expect_err(
+            config,
+            &["rustup", "toolchain", "link", "none", &path],
+            "error: invalid custom toolchain name: 'none'",
+        );
     });
 }
 


### PR DESCRIPTION
Fix #3130 

Throws when `none` is used for custom toolchain name.