### PR TITLE
Don't add toolchain bin to PATH on Windows

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -453,6 +453,25 @@ impl<'a> InstalledCommonToolchain<'a> {
             path_entries.push(cargo_home.join("bin"));
         }
 
+        if cfg!(target_os = "windows") {
+            // Historically rustup has included the bin directory in PATH to
+            // work around some bugs (see
+            // https://github.com/rust-lang/rustup/pull/3178 for more
+            // information). This shouldn't be needed anymore, and it causes
+            // problems because calling tools recursively (like `cargo
+            // +nightly metadata` from within a cargo subcommand). The
+            // recursive call won't work because it is not executing the
+            // proxy, so the `+` toolchain override doesn't work.
+            //
+            // This is opt-in to allow us to get more real-world testing.
+            if process()
+                .var_os("RUSTUP_WINDOWS_PATH_ADD_BIN")
+                .map_or(true, |s| s == "1")
+            {
+                path_entries.push(self.0.path.join("bin"));
+            }
+        }
+
         env_var::prepend_path("PATH", path_entries, cmd);
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -453,10 +453,6 @@ impl<'a> InstalledCommonToolchain<'a> {
             path_entries.push(cargo_home.join("bin"));
         }
 
-        if cfg!(target_os = "windows") {
-            path_entries.push(self.0.path.join("bin"));
-        }
-
         env_var::prepend_path("PATH", path_entries, cmd);
     }
 }

--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -61,6 +61,18 @@ fn main() {
             let rustc = &format!("rustc{}", EXE_SUFFIX);
             Command::new(rustc).arg("--version").status().unwrap();
         }
+        Some("--recursive-cargo-subcommand") => {
+            Command::new("cargo-foo")
+                .arg("--recursive-cargo")
+                .status()
+                .unwrap();
+        }
+        Some("--recursive-cargo") => {
+            Command::new("cargo")
+                .args(&["+nightly", "--version"])
+                .status()
+                .unwrap();
+        }
         Some("--echo-args") => {
             let mut out = io::stderr();
             for arg in args {
@@ -71,7 +83,7 @@ fn main() {
             let mut out = io::stderr();
             writeln!(out, "{}", std::env::var("PATH").unwrap()).unwrap();
         }
-        _ => panic!("bad mock proxy commandline"),
+        arg => panic!("bad mock proxy commandline: {:?}", arg),
     }
 }
 

--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -62,16 +62,18 @@ fn main() {
             Command::new(rustc).arg("--version").status().unwrap();
         }
         Some("--recursive-cargo-subcommand") => {
-            Command::new("cargo-foo")
+            let status = Command::new("cargo-foo")
                 .arg("--recursive-cargo")
                 .status()
                 .unwrap();
+            assert!(status.success());
         }
         Some("--recursive-cargo") => {
-            Command::new("cargo")
+            let status = Command::new("cargo")
                 .args(&["+nightly", "--version"])
                 .status()
                 .unwrap();
+            assert!(status.success());
         }
         Some("--echo-args") => {
             let mut out = io::stderr();

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -547,6 +547,49 @@ fn fallback_cargo_calls_correct_rustc() {
     });
 }
 
+// Checks that cargo can recursively invoke itself with rustup shorthand (via
+// the proxy).
+//
+// This involves a series of chained commands:
+//
+// 1. Calls `cargo --recursive-cargo-subcommand`
+// 2. The rustup `cargo` proxy launches, and launches the "mock" nightly cargo exe.
+// 3. The nightly "mock" cargo sees --recursive-cargo-subcommand, and launches
+//    `cargo-foo --recursive-cargo`
+// 4. `cargo-foo` sees `--recursive-cargo` and launches `cargo +nightly --version`
+// 5. The rustup `cargo` proxy launches, and launches the "mock" nightly cargo exe.
+// 6. The nightly "mock" cargo sees `--version` and prints the version.
+//
+// Previously, rustup would place the toolchain's `bin` directory in PATH for
+// Windows due to some DLL issues. However, those aren't necessary anymore.
+// If the toolchain `bin` directory is in PATH, then this test would fail in
+// step 5 because the `cargo` executable would be the "mock" nightly cargo,
+// and the first argument would be `+nightly` which would be an error.
+#[test]
+fn recursive_cargo() {
+    test(&|config| {
+        config.with_scenario(Scenario::ArchivesV2, &|config| {
+            config.expect_ok(&["rustup", "default", "nightly"]);
+
+            // We need an intermediary to run cargo itself.
+            // The "mock" cargo can't do that because on Windows it will check
+            // for a `cargo.exe` in the current directory before checking PATH.
+            //
+            // The solution here is to copy from the "mock" `cargo.exe` into
+            // `~/.cargo/bin/cargo-foo`. This is just for convenience to avoid
+            // needing to build another executable just for this test.
+            let output = config.run("rustup", &["which", "cargo"], &[]);
+            let real_mock_cargo = output.stdout.trim();
+            let cargo_bin_path = config.cargodir.join("bin");
+            let cargo_subcommand = cargo_bin_path.join(format!("cargo-foo{}", EXE_SUFFIX));
+            fs::create_dir_all(&cargo_bin_path).unwrap();
+            fs::copy(&real_mock_cargo, &cargo_subcommand).unwrap();
+
+            config.expect_stdout_ok(&["cargo", "--recursive-cargo-subcommand"], "hash-nightly-2");
+        });
+    });
+}
+
 #[test]
 fn show_home() {
     test(&|config| {


### PR DESCRIPTION
This removes the addition of the `<toolchain>/bin` directory to PATH on Windows. This fixes it so that recursive invocations of tools like `cargo` will use the rustup proxies instead of executing the original `<toolchain>/bin` executable, allowing those recursive invocations to do things like use `+toolchain` shorthands.

There is a bit of a long history for this behavior:
1. Originally, rustup would put `.cargo/bin` and `<toolchain>/bin` prepended to PATH.
2. #812 changed it to remove the `<toolchain>/bin` 
    * This was changed because as described in #809, when using a toolchain link, rustup will fall back to "nightly" if `cargo` is not in the toolchain. However, that would result in `cargo +stage1 ...` always using nightly.
3.  The `<toolchain>/bin` was added again in #1093, trying to fix rust-lang/cargo#3394. There, `cargo test` of the cargo project itself was not working. The reason isn't listed in the bug. I don't think it is an issue anymore, as cargo's testsuite now explicitly circumvents the rustup wrappers.
    * There were some other issues such as `cargo install clippy`. This would put a `cargo-clippy` binary in `~/.cargo/bin`. That binary needed to launch and load clippy-driver, which needed to load rustc-driver. Without PATH munging, this would fail. I don't think this is an issue anymore, since clippy is no longer distributed like that.
4. #2978 changed it so that the order of PATH was preserved. However, that introduced a problem now that `~/.cargo/bin` ended up behind the `<toolchain>/bin`, re-introducing the problem where recursive calls don't see the proxies. 

Fixes #3036
