### PR TITLE
Bump the centos image version

### DIFF
--- a/.github/workflows/centos-fmt-clippy-on-all.yaml
+++ b/.github/workflows/centos-fmt-clippy-on-all.yaml
@@ -79,7 +79,7 @@ jobs:
             --tty \
             --init \
             --rm \
-            centos:6 \
+            centos:7 \
             sh ./ci/raw_init.sh
       - name: Run shell checks
         run: |

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -79,7 +79,7 @@ jobs:
             --tty \
             --init \
             --rm \
-            centos:6 \
+            centos:7 \
             sh ./ci/raw_init.sh
       - name: Run shell checks
         run: |


### PR DESCRIPTION
Bump the centos image and try to use the higher version GLIBC.
Otherwise, the CI will fail. See: https://github.com/rust-lang/rustup/actions/runs/4089637947/jobs/7052485676