### PR TITLE
add support for `.rust-toolchain.toml`

### DIFF
--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -77,10 +77,15 @@ case for nightly-only software that pins to a revision from the release
 archives.
 
 In these cases the toolchain can be named in the project's directory in a file
-called `.rust-toolchain.toml`, `rust-toolchain.toml` or `rust-toolchain`.
-If multiple files are present in a directory, the latter present one is used
-for backwards compatibility. The files use the [TOML] format and have the
-following layout:
+called `.rust-toolchain.toml`, `rust-toolchain.toml` or `rust-toolchain`.  If
+multiple files are present in a directory, the following precedence will be
+applied for backwards compatibility:
+
+1. `rust-toolchain`
+2. `rust-toolchain.toml`
+3. `.rust-toolchain.toml`
+
+The files use the [TOML] format and have the following layout:
 
 [TOML]: https://toml.io/
 

--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -77,9 +77,10 @@ case for nightly-only software that pins to a revision from the release
 archives.
 
 In these cases the toolchain can be named in the project's directory in a file
-called `rust-toolchain.toml` or `rust-toolchain`. If both files are present in
-a directory, the latter is used for backwards compatibility. The files use the
-[TOML] format and have the following layout:
+called `.rust-toolchain.toml`, `rust-toolchain.toml` or `rust-toolchain`.
+If multiple files are present in a directory, the latter present one is used
+for backwards compatibility. The files use the [TOML] format and have the
+following layout:
 
 [TOML]: https://toml.io/
 
@@ -110,10 +111,10 @@ it means you're running `rustup` pre-1.23.0 and trying to interact with a projec
 that uses the new TOML encoding in the `rust-toolchain` file. You need to upgrade
 `rustup` to 1.23.0+.
 
-The `rust-toolchain.toml`/`rust-toolchain` files are suitable to check in to
-source control. If that's done, `Cargo.lock` should probably be tracked too if
-the toolchain is pinned to a specific release, to avoid potential compatibility
-issues with dependencies.
+The `.rust-toolchain.toml`/`rust-toolchain.toml`/`rust-toolchain` files are
+suitable to check in to source control. If that's done, `Cargo.lock` should
+probably be tracked too if the toolchain is pinned to a specific release, to
+avoid potential compatibility issues with dependencies.
 
 ### Toolchain file settings
 

--- a/doc/src/overrides.md
+++ b/doc/src/overrides.md
@@ -99,7 +99,8 @@ For backwards compatibility, `rust-toolchain` files also support a legacy
 format that only contains a toolchain name without any TOML encoding, e.g.
 just `nightly-2021-01-21`. The file has to be encoded in US-ASCII in this case
 (if you are on Windows, check the encoding and that it does not start with a
-BOM). The legacy format is not available in `rust-toolchain.toml` files.
+BOM). The legacy format is not available in `.rust-toolchain.toml`/
+`rust-toolchain.toml` files.
 
 If you see the following error (when running `rustc`, `cargo` or other command)
 

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -137,13 +137,19 @@ impl<'a> Display for Notification<'a> {
             PlainVerboseMessage(r) => write!(f, "{}", r),
             MultipleToolchainFiles(rust_toolchain_paths) => {
                 assert!(rust_toolchain_paths.len() > 1);
-                let used_path = rust_toolchain_paths[0];
-                let all_paths = rust_toolchain_paths
-                    .iter()
-                    .skip(1)
-                    .fold(format!("`{}`", used_path.display()), |all_paths, path| {
-                        format!("{} and `{}`", all_paths, path.display())
-                    });
+                let canonicalize_when_possible =
+                    |path: &Path| path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+                let used_path = canonicalize_when_possible(rust_toolchain_paths[0]);
+                let all_paths = rust_toolchain_paths.iter().skip(1).fold(
+                    format!("`{}`", used_path.display()),
+                    |all_paths, path| {
+                        format!(
+                            "{} and `{}`",
+                            all_paths,
+                            canonicalize_when_possible(path).display()
+                        )
+                    },
+                );
                 write!(
                     f,
                     "both {} exist. Using `{}`",


### PR DESCRIPTION
This PR adds support for `.rust-toolchain.toml` files like described in #3182.
I'm not sure if this is the normal procedure or is a RFC needed?