### PR TITLE
clippy::uninlined_format_args: Apply clippy suggestions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,9 +15,9 @@ fn main() {
     println!("cargo:rerun-if-env-changed=RUSTUP_OVERRIDE_BUILD_TRIPLE");
     println!("cargo:rerun-if-env-changed=TARGET");
     match from_build() {
-        Ok(triple) => eprintln!("Computed build based partial target triple: {:#?}", triple),
+        Ok(triple) => eprintln!("Computed build based partial target triple: {triple:#?}"),
         Err(s) => {
-            eprintln!("Unable to parse target '{}' as a PartialTargetTriple", s);
+            eprintln!("Unable to parse target '{s}' as a PartialTargetTriple");
             eprintln!(
                 "If you are attempting to bootstrap a new target you may need to adjust the\n\
                permitted values found in src/dist/triple.rs"
@@ -26,5 +26,5 @@ fn main() {
         }
     }
     let target = env::var("TARGET").unwrap();
-    println!("cargo:rustc-env=TARGET={}", target);
+    println!("cargo:rustc-env=TARGET={target}");
 }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -374,7 +374,7 @@ pub mod reqwest_be {
         let mut req = client.get(url.as_str());
 
         if resume_from != 0 {
-            req = req.header(header::RANGE, format!("bytes={}-", resume_from));
+            req = req.header(header::RANGE, format!("bytes={resume_from}-"));
         }
 
         Ok(req.send()?)
@@ -391,7 +391,7 @@ pub mod reqwest_be {
         if url.scheme() == "file" {
             let src = url
                 .to_file_path()
-                .map_err(|_| DownloadError::Message(format!("bogus file url: '{}'", url)))?;
+                .map_err(|_| DownloadError::Message(format!("bogus file url: '{url}'")))?;
             if !src.is_file() {
                 // Because some of rustup's logic depends on checking
                 // the error when a downloaded file doesn't exist, make

--- a/download/tests/download-curl-resume.rs
+++ b/download/tests/download-curl-resume.rs
@@ -34,7 +34,7 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
 
     let addr = serve_file(b"xxx45".to_vec());
 
-    let from_url = format!("http://{}", addr).parse().unwrap();
+    let from_url = format!("http://{addr}").parse().unwrap();
 
     let callback_partial = AtomicBool::new(false);
     let callback_len = Mutex::new(None);

--- a/download/tests/download-reqwest-resume.rs
+++ b/download/tests/download-reqwest-resume.rs
@@ -40,7 +40,7 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
 
     let addr = serve_file(b"xxx45".to_vec());
 
-    let from_url = format!("http://{}", addr).parse().unwrap();
+    let from_url = format!("http://{addr}").parse().unwrap();
 
     let callback_partial = AtomicBool::new(false);
     let callback_len = Mutex::new(None);

--- a/download/tests/support/mod.rs
+++ b/download/tests/support/mod.rs
@@ -50,7 +50,7 @@ async fn run_server(addr_tx: Sender<SocketAddr>, addr: SocketAddr, contents: Vec
     addr_tx.send(addr).unwrap();
 
     if let Err(e) = server.await {
-        eprintln!("server error: {}", e);
+        eprintln!("server error: {e}");
     }
 }
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -24,7 +24,7 @@ use crate::{Cfg, Notification, Toolchain, UpdateStatus};
 pub(crate) const WARN_COMPLETE_PROFILE: &str = "downloading with complete profile isn't recommended unless you are a developer of the rust language";
 
 pub(crate) fn confirm(question: &str, default: bool) -> Result<bool> {
-    write!(process().stdout(), "{} ", question)?;
+    write!(process().stdout(), "{question} ")?;
     let _ = std::io::stdout().flush();
     let input = read_line()?;
 
@@ -68,7 +68,7 @@ pub(crate) fn confirm_advanced() -> Result<Confirm> {
 }
 
 pub(crate) fn question_str(question: &str, default: &str) -> Result<String> {
-    writeln!(process().stdout(), "{} [{}]", question, default)?;
+    writeln!(process().stdout(), "{question} [{default}]")?;
     let _ = std::io::stdout().flush();
     let input = read_line()?;
 
@@ -83,7 +83,7 @@ pub(crate) fn question_str(question: &str, default: &str) -> Result<String> {
 
 pub(crate) fn question_bool(question: &str, default: bool) -> Result<bool> {
     let default_text = if default { "(Y/n)" } else { "(y/N)" };
-    writeln!(process().stdout(), "{} {}", question, default_text)?;
+    writeln!(process().stdout(), "{question} {default_text}")?;
 
     let _ = std::io::stdout().flush();
     let input = read_line()?;
@@ -132,7 +132,7 @@ impl NotifyOnConsole {
             }
         };
         let level = n.level();
-        for n in format!("{}", n).lines() {
+        for n in format!("{n}").lines() {
             match level {
                 NotificationLevel::Verbose => {
                     if self.verbose {
@@ -234,17 +234,17 @@ fn show_channel_updates(cfg: &Cfg, toolchains: Vec<(String, Result<UpdateStatus>
     for (name, banner, width, color, version, previous_version) in data {
         let padding = max_width - width;
         let padding: String = " ".repeat(padding);
-        let _ = write!(t, "  {}", padding);
+        let _ = write!(t, "  {padding}");
         let _ = t.attr(term2::Attr::Bold);
         if let Some(color) = color {
             let _ = t.fg(color);
         }
-        let _ = write!(t, "{} ", name);
-        let _ = write!(t, "{}", banner);
+        let _ = write!(t, "{name} ");
+        let _ = write!(t, "{banner}");
         let _ = t.reset();
-        let _ = write!(t, " - {}", version);
+        let _ = write!(t, " - {version}");
         if let Some(previous_version) = previous_version {
-            let _ = write!(t, " (from {})", previous_version);
+            let _ = write!(t, " (from {previous_version})");
         }
         let _ = writeln!(t);
     }
@@ -354,10 +354,10 @@ pub(crate) fn list_targets(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode>
                 .expect("rust-std should have a target");
             if component.installed {
                 let _ = t.attr(term2::Attr::Bold);
-                let _ = writeln!(t, "{} (installed)", target);
+                let _ = writeln!(t, "{target} (installed)");
                 let _ = t.reset();
             } else if component.available {
-                let _ = writeln!(t, "{}", target);
+                let _ = writeln!(t, "{target}");
             }
         }
     }
@@ -377,7 +377,7 @@ pub(crate) fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<utils:
                 .as_ref()
                 .expect("rust-std should have a target");
             if component.installed {
-                writeln!(t, "{}", target)?;
+                writeln!(t, "{target}")?;
             }
         }
     }
@@ -392,10 +392,10 @@ pub(crate) fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCo
         let name = component.name;
         if component.installed {
             t.attr(term2::Attr::Bold)?;
-            writeln!(t, "{} (installed)", name)?;
+            writeln!(t, "{name} (installed)")?;
             t.reset()?;
         } else if component.available {
-            writeln!(t, "{}", name)?;
+            writeln!(t, "{name}")?;
         }
     }
 

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -211,7 +211,7 @@ impl DownloadTracker {
                     ),
                 };
 
-                let _ = write!(self.term, "{}", output);
+                let _ = write!(self.term, "{output}");
                 // Since stdout is typically line-buffered and we don't print a newline, we manually flush.
                 let _ = self.term.flush();
                 self.displayed_charcount = Some(output.chars().count());
@@ -250,10 +250,10 @@ impl fmt::Display for Display {
             return f.write_str("Unknown");
         }
         match format_dhms(secs) {
-            (0, 0, 0, s) => write!(f, "{:2.0}s", s),
-            (0, 0, m, s) => write!(f, "{:2.0}m {:2.0}s", m, s),
-            (0, h, m, s) => write!(f, "{:2.0}h {:2.0}m {:2.0}s", h, m, s),
-            (d, h, m, s) => write!(f, "{:3.0}d {:2.0}h {:2.0}m {:2.0}s", d, h, m, s),
+            (0, 0, 0, s) => write!(f, "{s:2.0}s"),
+            (0, 0, m, s) => write!(f, "{m:2.0}m {s:2.0}s"),
+            (0, h, m, s) => write!(f, "{h:2.0}h {m:2.0}m {s:2.0}s"),
+            (d, h, m, s) => write!(f, "{d:3.0}d {h:2.0}h {m:2.0}m {s:2.0}s"),
         }
     }
 }

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -29,10 +29,7 @@ fn maybe_suggest_toolchain(bad_name: &str) -> String {
     }
 
     if NUMBERED.is_match(bad_name) {
-        return format!(
-            ". Toolchain numbers tend to have three parts, e.g. {}.0",
-            bad_name
-        );
+        return format!(". Toolchain numbers tend to have three parts, e.g. {bad_name}.0");
     }
 
     // Suggest only for very small differences

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -48,7 +48,7 @@ impl<'a, T: Terminal + 'a> LineWrapper<'a, T> {
         }
 
         // Write the word
-        let _ = write!(self.w, "{}", word);
+        let _ = write!(self.w, "{word}");
         self.pos += word_len;
     }
     fn write_space(&mut self) {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -55,8 +55,7 @@ where
         "Eventually this command will be a true alias.  Until then:",
     ));
     (cfg.notify_handler)(Notification::PlainVerboseMessage(&format!(
-        "  Please use `rustup {}` instead",
-        instead
+        "  Please use `rustup {instead}` instead"
     )));
     callee(cfg, matches)
 }
@@ -72,7 +71,7 @@ pub fn main() -> Result<utils::ExitCode> {
             message,
             ..
         }) => {
-            writeln!(process().stdout().lock(), "{}", message)?;
+            writeln!(process().stdout().lock(), "{message}")?;
             return Ok(utils::ExitCode(0));
         }
         Err(clap::Error {
@@ -80,7 +79,7 @@ pub fn main() -> Result<utils::ExitCode> {
             message,
             ..
         }) => {
-            writeln!(process().stdout().lock(), "{}", message)?;
+            writeln!(process().stdout().lock(), "{message}")?;
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
 
             fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
@@ -114,7 +113,7 @@ pub fn main() -> Result<utils::ExitCode> {
                 ]
                 .contains(kind)
                 {
-                    writeln!(process().stdout().lock(), "{}", message)?;
+                    writeln!(process().stdout().lock(), "{message}")?;
                     return Ok(utils::ExitCode(1));
                 }
             }
@@ -815,7 +814,7 @@ fn update_bare_triple_check(cfg: &Cfg, name: &str) -> Result<()> {
                     "\nyou may use one of the following toolchains:"
                 )?;
                 for n in &candidates {
-                    writeln!(process().stdout(), "{}", n)?;
+                    writeln!(process().stdout(), "{n}")?;
                 }
                 writeln!(process().stdout(),)?;
             }
@@ -832,7 +831,7 @@ fn default_bare_triple_check(cfg: &Cfg, name: &str) -> Result<()> {
         let default_name = default.map(|t| t.name().to_string()).unwrap_or_default();
         if let Ok(mut desc) = PartialToolchainDesc::from_str(&default_name) {
             desc.target = triple;
-            let maybe_toolchain = format!("{}", desc);
+            let maybe_toolchain = format!("{desc}");
             let toolchain = cfg.get_toolchain(maybe_toolchain.as_ref(), false)?;
             if toolchain.name() == default_name {
                 warn!(
@@ -903,7 +902,7 @@ fn check_updates(cfg: &Cfg) -> Result<utils::ExitCode> {
                 let current_version = distributable.show_version()?;
                 let dist_version = distributable.show_dist_version()?;
                 let _ = t.attr(term2::Attr::Bold);
-                write!(t, "{} - ", name)?;
+                write!(t, "{name} - ")?;
                 match (current_version, dist_version) {
                     (None, None) => {
                         let _ = t.fg(term2::color::RED);
@@ -913,19 +912,19 @@ fn check_updates(cfg: &Cfg) -> Result<utils::ExitCode> {
                         let _ = t.fg(term2::color::GREEN);
                         write!(t, "Up to date")?;
                         let _ = t.reset();
-                        writeln!(t, " : {}", cv)?;
+                        writeln!(t, " : {cv}")?;
                     }
                     (Some(cv), Some(dv)) => {
                         let _ = t.fg(term2::color::YELLOW);
                         write!(t, "Update available")?;
                         let _ = t.reset();
-                        writeln!(t, " : {} -> {}", cv, dv)?;
+                        writeln!(t, " : {cv} -> {dv}")?;
                     }
                     (None, Some(dv)) => {
                         let _ = t.fg(term2::color::YELLOW);
                         write!(t, "Update available")?;
                         let _ = t.reset();
-                        writeln!(t, " : (Unknown version) -> {}", dv)?;
+                        writeln!(t, " : (Unknown version) -> {dv}")?;
                     }
                 }
             }
@@ -1141,9 +1140,9 @@ fn show(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         let default_name = default_name?;
         for it in installed_toolchains {
             if default_name == it {
-                writeln!(t, "{} (default)", it)?;
+                writeln!(t, "{it} (default)")?;
             } else {
-                writeln!(t, "{}", it)?;
+                writeln!(t, "{it}")?;
             }
             if verbose {
                 if let Ok(toolchain) = cfg.get_toolchain(&it, false) {
@@ -1203,9 +1202,9 @@ fn show(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
                 {
                     writeln!(t, "no active toolchain")?;
                 } else if let Some(cause) = err.source() {
-                    writeln!(t, "(error: {}, {})", err, cause)?;
+                    writeln!(t, "(error: {err}, {cause})")?;
                 } else {
-                    writeln!(t, "(error: {})", err)?;
+                    writeln!(t, "(error: {err})")?;
                 }
             }
         }
@@ -1220,7 +1219,7 @@ fn show(cfg: &Cfg, m: &ArgMatches<'_>) -> Result<utils::ExitCode> {
         E: From<term::Error> + From<std::io::Error>,
     {
         t.attr(term2::Attr::Bold)?;
-        writeln!(t, "{}", s)?;
+        writeln!(t, "{s}")?;
         writeln!(t, "{}", "-".repeat(s.len()))?;
         writeln!(t)?;
         t.reset()?;
@@ -1665,7 +1664,7 @@ impl FromStr for CompletionCommand {
                 let completion_options = COMPLETIONS
                     .iter()
                     .map(|&(v, _)| v)
-                    .fold("".to_owned(), |s, v| format!("{}{}, ", s, v));
+                    .fold("".to_owned(), |s, v| format!("{s}{v}, "));
                 Err(format!(
                     "[valid values: {}]",
                     completion_options.trim_end_matches(", ")
@@ -1678,7 +1677,7 @@ impl FromStr for CompletionCommand {
 impl fmt::Display for CompletionCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match COMPLETIONS.iter().find(|&(_, cmd)| cmd == self) {
-            Some(&(val, _)) => write!(f, "{}", val),
+            Some(&(val, _)) => write!(f, "{val}"),
             None => unreachable!(),
         }
     }
@@ -1709,9 +1708,8 @@ fn output_completion_script(shell: Shell, command: CompletionCommand) -> Result<
             writeln!(
                 term2::stdout(),
                 "if command -v rustc >/dev/null 2>&1; then\n\
-                    \tsource \"$(rustc --print sysroot)\"{}\n\
+                    \tsource \"$(rustc --print sysroot)\"{script}\n\
                  fi",
-                script,
             )?;
         }
     }

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -19,7 +19,7 @@ fn index_html(doc: &DocData<'_>, wpath: &Path) -> Option<PathBuf> {
 }
 
 fn dir_into_vec(dir: &Path) -> Result<Vec<OsString>> {
-    let entries = fs::read_dir(dir).with_context(|| format!("Failed to read_dir {:?}", dir))?;
+    let entries = fs::read_dir(dir).with_context(|| format!("Failed to read_dir {dir:?}"))?;
     let mut v = Vec::new();
     for entry in entries {
         let entry = entry?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -190,11 +190,11 @@ impl PgpPublicKey {
                     wait = every;
                 }
                 wait -= 1;
-                write!(ret, "{:02X}", b)?;
+                write!(ret, "{b:02X}")?;
             }
             Ok(ret)
         }
-        let mut ret = vec![format!("from {}", self)];
+        let mut ret = vec![format!("from {self}")];
         let cert = self.cert();
         let keyid = format_hex(cert.keyid().as_bytes(), "-", 4)?;
         let algo = cert.primary_key().pk_algo();
@@ -206,8 +206,8 @@ impl PgpPublicKey {
             .primary_userid()
             .map(|u| u.userid().to_string())
             .unwrap_or_else(|_| "<No User ID>".into());
-        ret.push(format!("  {:?}/{} - {}", algo, keyid, uid0));
-        ret.push(format!("  Fingerprint: {}", fpr));
+        ret.push(format!("  {algo:?}/{keyid} - {uid0}"));
+        ret.push(format!("  Fingerprint: {fpr}"));
         Ok(ret)
     }
 }

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -164,7 +164,7 @@ where
 
     PROCESS.with(|p| {
         if let Some(old_p) = &*p.borrow() {
-            panic!("current process already set {:?}", old_p);
+            panic!("current process already set {old_p:?}");
         }
         *p.borrow_mut() = Some(process);
         let result = f();

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -269,7 +269,7 @@ impl<'a> Executor for Threaded<'a> {
             ));
         }
         if prev_files > 50 {
-            eprintln!("{} deferred IO operations", prev_files);
+            eprintln!("{prev_files} deferred IO operations");
         }
         let buf: Vec<u8> = vec![0; prev_files];
         // Cheap wrap-around correctness check - we have 20k files, more than

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -39,7 +39,7 @@ impl Components {
         self.prefix.rel_manifest_file(COMPONENTS_FILE)
     }
     fn rel_component_manifest(&self, name: &str) -> PathBuf {
-        self.prefix.rel_manifest_file(&format!("manifest-{}", name))
+        self.prefix.rel_manifest_file(&format!("manifest-{name}"))
     }
     fn read_version(&self) -> Result<Option<String>> {
         let p = self.prefix.manifest_file(VERSION_FILE);

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -66,7 +66,7 @@ fn validate_installer_version(path: &Path) -> Result<()> {
     if v == INSTALLER_VERSION {
         Ok(())
     } else {
-        Err(anyhow!(format!("unsupported installer version: {}", v)))
+        Err(anyhow!(format!("unsupported installer version: {v}")))
     }
 }
 
@@ -208,7 +208,7 @@ fn unpack_ram(
     };
 
     if minimum_ram > unpack_ram {
-        panic!("RUSTUP_UNPACK_RAM must be larger than {}", minimum_ram);
+        panic!("RUSTUP_UNPACK_RAM must be larger than {minimum_ram}");
     } else {
         unpack_ram
     }
@@ -445,7 +445,7 @@ fn unpack_without_first_dir<'a, R: Read>(
                     Item::write_file(full_path.clone(), mode, content)
                 }
             }
-            _ => bail!(format!("tar entry kind '{:?}' is not supported", kind)),
+            _ => bail!(format!("tar entry kind '{kind:?}' is not supported")),
         };
 
         let item = loop {

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -56,7 +56,7 @@ impl Config {
 
         for (i, v) in arr.into_iter().enumerate() {
             if let toml::Value::Table(t) = v {
-                let path = format!("{}[{}]", path, i);
+                let path = format!("{path}[{i}]");
                 result.push(Component::from_toml(t, &path, false)?);
             }
         }

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -40,7 +40,7 @@ static TOOLCHAIN_CHANNELS: &[&str] = &[
 fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &str) -> String {
     assert!(!cs.is_empty());
     let mut buf = vec![];
-    let suggestion = format!("    rustup toolchain add {} --profile minimal", toolchain);
+    let suggestion = format!("    rustup toolchain add {toolchain} --profile minimal");
     let nightly_tips = "Sometimes not all components are available in any given nightly. ";
 
     if cs.len() == 1 {
@@ -52,13 +52,12 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
         );
 
         if toolchain.starts_with("nightly") {
-            let _ = write!(buf, "{}", nightly_tips);
+            let _ = write!(buf, "{nightly_tips}");
         }
 
         let _ = write!(
             buf,
-            "If you don't need the component, you could try a minimal installation with:\n\n{}",
-            suggestion
+            "If you don't need the component, you could try a minimal installation with:\n\n{suggestion}"
         );
     } else {
         let cs_str = cs
@@ -68,17 +67,15 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
             .join(", ");
         let _ = write!(
             buf,
-            "some components unavailable for download for channel '{}': {}",
-            toolchain, cs_str
+            "some components unavailable for download for channel '{toolchain}': {cs_str}"
         );
 
         if toolchain.starts_with("nightly") {
-            let _ = write!(buf, "{}", nightly_tips);
+            let _ = write!(buf, "{nightly_tips}");
         }
         let _ = write!(
             buf,
-            "If you don't need the components, you could try a minimal installation with:\n\n{}",
-            suggestion
+            "If you don't need the components, you could try a minimal installation with:\n\n{suggestion}"
         );
     }
 
@@ -461,9 +458,9 @@ impl PartialToolchainDesc {
         let os = self.target.os.unwrap_or(host_os);
 
         let trip = if let Some(env) = env {
-            format!("{}-{}-{}", arch, os, env)
+            format!("{arch}-{os}-{env}")
         } else {
-            format!("{}-{}", arch, os)
+            format!("{arch}-{os}")
         };
 
         Ok(ToolchainDesc {
@@ -520,7 +517,7 @@ impl ToolchainDesc {
     pub(crate) fn package_dir(&self, dist_root: &str) -> String {
         match self.date {
             None => dist_root.to_string(),
-            Some(ref date) => format!("{}/{}", dist_root, date),
+            Some(ref date) => format!("{dist_root}/{date}"),
         }
     }
 
@@ -541,7 +538,7 @@ impl ToolchainDesc {
 pub(crate) fn validate_channel_name(name: &str) -> Result<()> {
     let toolchain = PartialToolchainDesc::from_str(name)?;
     if toolchain.has_triple() {
-        Err(anyhow!(format!("target triple in channel name '{}'", name)))
+        Err(anyhow!(format!("target triple in channel name '{name}'")))
     } else {
         Ok(())
     }
@@ -601,16 +598,16 @@ impl fmt::Display for PartialToolchainDesc {
         write!(f, "{}", &self.channel)?;
 
         if let Some(ref date) = self.date {
-            write!(f, "-{}", date)?;
+            write!(f, "-{date}")?;
         }
         if let Some(ref arch) = self.target.arch {
-            write!(f, "-{}", arch)?;
+            write!(f, "-{arch}")?;
         }
         if let Some(ref os) = self.target.os {
-            write!(f, "-{}", os)?;
+            write!(f, "-{os}")?;
         }
         if let Some(ref env) = self.target.env {
-            write!(f, "-{}", env)?;
+            write!(f, "-{env}")?;
         }
 
         Ok(())
@@ -622,7 +619,7 @@ impl fmt::Display for ToolchainDesc {
         write!(f, "{}", &self.channel)?;
 
         if let Some(ref date) = self.date {
-            write!(f, "-{}", date)?;
+            write!(f, "-{date}")?;
         }
         write!(f, "-{}", self.target)?;
 
@@ -643,7 +640,7 @@ impl fmt::Display for Profile {
 pub(crate) fn valid_profile_names() -> String {
     Profile::names()
         .iter()
-        .map(|s| format!("'{}'", s))
+        .map(|s| format!("'{s}'"))
         .collect::<Vec<_>>()
         .join(", ")
 }
@@ -812,7 +809,7 @@ fn update_from_dist_<'a>(
                 // starting at one date earlier than the current manifest's date.
                 let toolchain_date = toolchain.date.as_ref().unwrap_or(&fetched);
                 let try_next = utc_from_manifest_date(toolchain_date)
-                    .unwrap_or_else(|| panic!("Malformed manifest date: {:?}", toolchain_date))
+                    .unwrap_or_else(|| panic!("Malformed manifest date: {toolchain_date:?}"))
                     .pred();
 
                 if try_next < last_manifest {
@@ -1013,10 +1010,7 @@ fn try_update_from_dist_<'a>(
     }
     if download_not_exists {
         result.with_context(|| {
-            format!(
-                "could not download nonexistent rust version `{}`",
-                toolchain_str
-            )
+            format!("could not download nonexistent rust version `{toolchain_str}`")
         })
     } else {
         result
@@ -1071,7 +1065,7 @@ fn dl_v1_manifest(download: DownloadCfg<'_>, toolchain: &ToolchainDesc) -> Resul
     let manifest_str = utils::read_file("manifest", &manifest_file)?;
     let urls = manifest_str
         .lines()
-        .map(|s| format!("{}/{}", root_url, s))
+        .map(|s| format!("{root_url}/{s}"))
         .collect();
 
     Ok(urls)
@@ -1126,9 +1120,7 @@ mod tests {
             let parsed = input.parse::<ParsedToolchainDesc>();
             assert!(
                 parsed.is_ok(),
-                "expected parsing of `{}` to succeed: {:?}",
-                input,
-                parsed
+                "expected parsing of `{input}` to succeed: {parsed:?}"
             );
 
             let expected = ParsedToolchainDesc {
@@ -1136,7 +1128,7 @@ mod tests {
                 date: date.map(String::from),
                 target: target.map(String::from),
             };
-            assert_eq!(parsed.unwrap(), expected, "input: `{}`", input);
+            assert_eq!(parsed.unwrap(), expected, "input: `{input}`");
         }
 
         let failure_cases = vec!["anything", "00.0000.000", "3", "", "--", "0.0.0-"];
@@ -1145,18 +1137,15 @@ mod tests {
             let parsed = input.parse::<ParsedToolchainDesc>();
             assert!(
                 parsed.is_err(),
-                "expected parsing of `{}` to fail: {:?}",
-                input,
-                parsed
+                "expected parsing of `{input}` to fail: {parsed:?}"
             );
 
-            let error_message = format!("invalid toolchain name: '{}'", input);
+            let error_message = format!("invalid toolchain name: '{input}'");
 
             assert_eq!(
                 parsed.unwrap_err().to_string(),
                 error_message,
-                "input: `{}`",
-                input
+                "input: `{input}`"
             );
         }
     }
@@ -1224,11 +1213,11 @@ mod tests {
         ];
 
         for (host, compatible, incompatible) in CASES {
-            println!("host={}", host);
+            println!("host={host}");
             let host = TargetTriple::new(host);
             assert!(host.can_run(&host).unwrap(), "host wasn't self-compatible");
             for other in compatible.iter() {
-                println!("compatible with {}", other);
+                println!("compatible with {other}");
                 let other = TargetTriple::new(other);
                 assert!(
                     host.can_run(&other).unwrap(),
@@ -1236,7 +1225,7 @@ mod tests {
                 );
             }
             for other in incompatible.iter() {
-                println!("incompatible with {}", other);
+                println!("incompatible with {other}");
                 let other = TargetTriple::new(other);
                 assert!(
                     !host.can_run(&other).unwrap(),

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -156,7 +156,7 @@ impl<'a> DownloadCfg<'a> {
 
         let signature = self
             .download_signature(url)
-            .with_context(|| format!("failed to download signature file {}", url))?;
+            .with_context(|| format!("failed to download signature file {url}"))?;
 
         let file_path: &Path = file;
         let content = std::fs::File::open(file_path).with_context(|| RustupError::ReadingFile {
@@ -170,10 +170,7 @@ impl<'a> DownloadCfg<'a> {
             let key = &self.pgp_keys[keyidx];
             Ok(key)
         } else {
-            Err(anyhow!(format!(
-                "signature verification failed for {}",
-                url
-            )))
+            Err(anyhow!(format!("signature verification failed for {url}")))
         }
     }
 

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -244,7 +244,7 @@ impl Manifest {
     pub fn get_package(&self, name: &str) -> Result<&Package> {
         self.packages
             .get(name)
-            .ok_or_else(|| anyhow!(format!("package not found: '{}'", name)))
+            .ok_or_else(|| anyhow!(format!("package not found: '{name}'")))
     }
 
     pub(crate) fn get_rust_version(&self) -> Result<&str> {
@@ -277,7 +277,7 @@ impl Manifest {
         let profile = self
             .profiles
             .get(&profile)
-            .ok_or_else(|| anyhow!(format!("profile not found: '{}'", profile)))?;
+            .ok_or_else(|| anyhow!(format!("profile not found: '{profile}'")))?;
 
         let rust_pkg = self.get_package("rust")?.get_target(Some(target))?;
         let result = profile
@@ -328,8 +328,7 @@ impl Manifest {
         for name in self.renames.values() {
             if !self.packages.contains_key(name) {
                 bail!(format!(
-                    "server sent a broken manifest: missing package for the target of a rename {}",
-                    name
+                    "server sent a broken manifest: missing package for the target of a rename {name}"
                 ));
             }
         }
@@ -405,8 +404,8 @@ impl Package {
                 if let Some(t) = target {
                     tpkgs
                         .get(t)
-                        .ok_or_else(|| anyhow!(format!("target '{}' not found in channel.  \
-                        Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets", t)))
+                        .ok_or_else(|| anyhow!(format!("target '{t}' not found in channel.  \
+                        Perhaps check https://doc.rust-lang.org/nightly/rustc/platform-support.html for available targets")))
                 } else {
                     Err(anyhow!("no target specified"))
                 }
@@ -498,7 +497,7 @@ impl TargetedPackage {
 
         for (i, v) in arr.into_iter().enumerate() {
             if let toml::Value::Table(t) = v {
-                let path = format!("{}[{}]", path, i);
+                let path = format!("{path}[{i}]");
                 result.push(Component::from_toml(t, &path, is_extension)?);
             }
         }
@@ -585,7 +584,7 @@ impl Component {
     pub(crate) fn name(&self, manifest: &Manifest) -> String {
         let pkg = self.short_name(manifest);
         if let Some(ref t) = self.target {
-            format!("{}-{}", pkg, t)
+            format!("{pkg}-{t}")
         } else {
             pkg
         }
@@ -600,9 +599,9 @@ impl Component {
     pub(crate) fn description(&self, manifest: &Manifest) -> String {
         let pkg = self.short_name(manifest);
         if let Some(ref t) = self.target {
-            format!("'{}' for target '{}'", pkg, t)
+            format!("'{pkg}' for target '{t}'")
         } else {
-            format!("'{}'", pkg)
+            format!("'{pkg}'")
         }
     }
     pub fn short_name_in_manifest(&self) -> &String {
@@ -611,7 +610,7 @@ impl Component {
     pub(crate) fn name_in_manifest(&self) -> String {
         let pkg = self.short_name_in_manifest();
         if let Some(ref t) = self.target {
-            format!("{}-{}", pkg, t)
+            format!("{pkg}-{t}")
         } else {
             pkg.to_string()
         }

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -96,7 +96,7 @@ impl<'a> Display for Notification<'a> {
             Temp(n) => n.fmt(f),
             Utils(n) => n.fmt(f),
             Extracting(_, _) => write!(f, "extracting..."),
-            ComponentAlreadyInstalled(c) => write!(f, "component {} is up to date", c),
+            ComponentAlreadyInstalled(c) => write!(f, "component {c} is up to date"),
             CantReadUpdateHash(path) => write!(
                 f,
                 "can't read update hash file: '{}', can't skip update...",
@@ -105,44 +105,44 @@ impl<'a> Display for Notification<'a> {
             NoUpdateHash(path) => write!(f, "no update hash at: '{}'", path.display()),
             ChecksumValid(_) => write!(f, "checksum passed"),
             SignatureValid(url, key) => (|| {
-                writeln!(f, "Good signature from on {} from:", url)?;
+                writeln!(f, "Good signature from on {url} from:")?;
                 for l in key.show_key().map_err(|_| std::fmt::Error)?.iter() {
-                    writeln!(f, "{}", l)?;
+                    writeln!(f, "{l}")?;
                 }
                 Ok(())
             })(),
             FileAlreadyDownloaded => write!(f, "reusing previously downloaded file"),
             CachedFileChecksumFailed => write!(f, "bad checksum for cached download"),
             RollingBack => write!(f, "rolling back changes"),
-            ExtensionNotInstalled(c) => write!(f, "extension '{}' was not installed", c),
-            NonFatalError(e) => write!(f, "{}", e),
+            ExtensionNotInstalled(c) => write!(f, "extension '{c}' was not installed"),
+            NonFatalError(e) => write!(f, "{e}"),
             MissingInstalledComponent(c) => {
-                write!(f, "during uninstall component {} was not found", c)
+                write!(f, "during uninstall component {c} was not found")
             }
             DownloadingComponent(c, h, t) => {
                 if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "downloading component '{}'", c)
+                    write!(f, "downloading component '{c}'")
                 } else {
                     write!(f, "downloading component '{}' for '{}'", c, t.unwrap())
                 }
             }
             InstallingComponent(c, h, t) => {
                 if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "installing component '{}'", c)
+                    write!(f, "installing component '{c}'")
                 } else {
                     write!(f, "installing component '{}' for '{}'", c, t.unwrap())
                 }
             }
             RemovingComponent(c, h, t) => {
                 if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "removing component '{}'", c)
+                    write!(f, "removing component '{c}'")
                 } else {
                     write!(f, "removing component '{}' for '{}'", c, t.unwrap())
                 }
             }
             RemovingOldComponent(c, h, t) => {
                 if Some(h) == t.as_ref() || t.is_none() {
-                    write!(f, "removing previous version of component '{}'", c)
+                    write!(f, "removing previous version of component '{c}'")
                 } else {
                     write!(
                         f,
@@ -152,12 +152,12 @@ impl<'a> Display for Notification<'a> {
                     )
                 }
             }
-            DownloadingManifest(t) => write!(f, "syncing channel updates for '{}'", t),
+            DownloadingManifest(t) => write!(f, "syncing channel updates for '{t}'"),
             DownloadedManifest(date, Some(version)) => {
-                write!(f, "latest update on {}, rust version {}", date, version)
+                write!(f, "latest update on {date}, rust version {version}")
             }
             DownloadedManifest(date, None) => {
-                write!(f, "latest update on {}, no rust version", date)
+                write!(f, "latest update on {date}, no rust version")
             }
             DownloadingLegacyManifest => write!(f, "manifest not found. trying legacy manifest"),
             ManifestChecksumFailedHack => {
@@ -165,9 +165,9 @@ impl<'a> Display for Notification<'a> {
             }
             ComponentUnavailable(pkg, toolchain) => {
                 if let Some(tc) = toolchain {
-                    write!(f, "component '{}' is not available on target '{}'", pkg, tc)
+                    write!(f, "component '{pkg}' is not available on target '{tc}'")
                 } else {
-                    write!(f, "component '{}' is not available", pkg)
+                    write!(f, "component '{pkg}' is not available")
                 }
             }
             StrayHash(path) => write!(
@@ -192,10 +192,10 @@ impl<'a> Display for Notification<'a> {
                     .join("', '")
             ),
             ForcingUnavailableComponent(component) => {
-                write!(f, "Force-skipping unavailable component '{}'", component)
+                write!(f, "Force-skipping unavailable component '{component}'")
             }
-            SignatureInvalid(url) => write!(f, "Signature verification failed for '{}'", url),
-            RetryingDownload(url) => write!(f, "retrying download for '{}'", url),
+            SignatureInvalid(url) => write!(f, "Signature verification failed for '{url}'"),
+            RetryingDownload(url) => write!(f, "retrying download for '{url}'"),
         }
     }
 }

--- a/src/dist/triple.rs
+++ b/src/dist/triple.rs
@@ -67,7 +67,7 @@ impl PartialTargetTriple {
         // Prepending `-` makes this next regex easier since
         // we can count  on all triple components being
         // delineated by it.
-        let name = format!("-{}", name);
+        let name = format!("-{name}");
         lazy_static! {
             static ref PATTERN: String = format!(
                 r"^(?:-({}))?(?:-({}))?(?:-({}))?$",
@@ -118,8 +118,7 @@ mod test {
             let partial_target_triple = PartialTargetTriple::new(input);
             assert!(
                 partial_target_triple.is_some(),
-                "expected `{}` to create some partial target triple; got None",
-                input
+                "expected `{input}` to create some partial target triple; got None"
             );
 
             let expected = PartialTargetTriple {
@@ -128,12 +127,7 @@ mod test {
                 env: env.map(String::from),
             };
 
-            assert_eq!(
-                partial_target_triple.unwrap(),
-                expected,
-                "input: `{}`",
-                input
-            );
+            assert_eq!(partial_target_triple.unwrap(), expected, "input: `{input}`");
         }
 
         let failure_cases = vec![
@@ -154,9 +148,7 @@ mod test {
             let partial_target_triple = PartialTargetTriple::new(input);
             assert!(
                 partial_target_triple.is_none(),
-                "expected `{}` to be `None`, was: `{:?}`",
-                input,
-                partial_target_triple
+                "expected `{input}` to be `None`, was: `{partial_target_triple:?}`"
             );
         }
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -96,7 +96,7 @@ pub enum RustupError {
     )]
     ToolchainNotSelected,
     #[error("toolchain '{}' does not contain component {}{}{}", .name, .component, if let Some(suggestion) = .suggestion {
-        format!("; did you mean '{}'?", suggestion)
+        format!("; did you mean '{suggestion}'?")
     } else {
         "".to_string()
     }, if .component.contains("rust-std") {
@@ -131,7 +131,7 @@ fn remove_component_msg(cs: &Component, manifest: &Manifest, toolchain: &str) ->
             "    rustup component remove --toolchain {}{} {}",
             toolchain,
             if let Some(target) = cs.target.as_ref() {
-                format!(" --target {}", target)
+                format!(" --target {target}")
             } else {
                 String::default()
             },
@@ -189,9 +189,8 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
             .join("\n");
         let _ = write!(
             buf,
-            "some components unavailable for download for channel '{}': {}\n\
-            If you don't need the components, you can remove them with:\n\n{}\n\n{}",
-            toolchain, cs_str, remove_msg, TOOLSTATE_MSG,
+            "some components unavailable for download for channel '{toolchain}': {cs_str}\n\
+            If you don't need the components, you can remove them with:\n\n{remove_msg}\n\n{TOOLSTATE_MSG}",
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub fn is_proxyable_tools(tool: &str) -> Result<()> {
             TOOLS
                 .iter()
                 .chain(DUP_TOOLS.iter())
-                .map(|s| format!("'{}'", s))
+                .map(|s| format!("'{s}'"))
                 .collect::<Vec<_>>()
                 .join(", ")
         )))

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -97,38 +97,35 @@ impl<'a> Display for Notification<'a> {
             Utils(n) => n.fmt(f),
             Temp(n) => n.fmt(f),
             SetDefaultToolchain("none") => write!(f, "default toolchain unset"),
-            SetDefaultToolchain(name) => write!(f, "default toolchain set to '{}'", name),
+            SetDefaultToolchain(name) => write!(f, "default toolchain set to '{name}'"),
             SetOverrideToolchain(path, name) => write!(
                 f,
                 "override toolchain for '{}' set to '{}'",
                 path.display(),
                 name
             ),
-            SetProfile(name) => write!(f, "profile set to '{}'", name),
-            SetSelfUpdate(mode) => write!(f, "auto-self-update mode set to '{}'", mode),
-            LookingForToolchain(name) => write!(f, "looking for installed toolchain '{}'", name),
+            SetProfile(name) => write!(f, "profile set to '{name}'"),
+            SetSelfUpdate(mode) => write!(f, "auto-self-update mode set to '{mode}'"),
+            LookingForToolchain(name) => write!(f, "looking for installed toolchain '{name}'"),
             ToolchainDirectory(path, _) => write!(f, "toolchain directory: '{}'", path.display()),
-            UpdatingToolchain(name) => write!(f, "updating existing install for '{}'", name),
-            InstallingToolchain(name) => write!(f, "installing toolchain '{}'", name),
-            InstalledToolchain(name) => write!(f, "toolchain '{}' installed", name),
-            UsingExistingToolchain(name) => write!(f, "using existing install for '{}'", name),
-            UninstallingToolchain(name) => write!(f, "uninstalling toolchain '{}'", name),
-            UninstalledToolchain(name) => write!(f, "toolchain '{}' uninstalled", name),
-            ToolchainNotInstalled(name) => write!(f, "no toolchain installed for '{}'", name),
+            UpdatingToolchain(name) => write!(f, "updating existing install for '{name}'"),
+            InstallingToolchain(name) => write!(f, "installing toolchain '{name}'"),
+            InstalledToolchain(name) => write!(f, "toolchain '{name}' installed"),
+            UsingExistingToolchain(name) => write!(f, "using existing install for '{name}'"),
+            UninstallingToolchain(name) => write!(f, "uninstalling toolchain '{name}'"),
+            UninstalledToolchain(name) => write!(f, "toolchain '{name}' uninstalled"),
+            ToolchainNotInstalled(name) => write!(f, "no toolchain installed for '{name}'"),
             UpdateHashMatches => write!(f, "toolchain is already up to date"),
             UpgradingMetadata(from_ver, to_ver) => write!(
                 f,
-                "upgrading metadata version from '{}' to '{}'",
-                from_ver, to_ver
+                "upgrading metadata version from '{from_ver}' to '{to_ver}'"
             ),
-            MetadataUpgradeNotNeeded(ver) => write!(
-                f,
-                "nothing to upgrade: metadata version is already '{}'",
-                ver
-            ),
-            WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{}'", ver),
-            ReadMetadataVersion(ver) => write!(f, "read metadata version: '{}'", ver),
-            NonFatalError(e) => write!(f, "{}", e),
+            MetadataUpgradeNotNeeded(ver) => {
+                write!(f, "nothing to upgrade: metadata version is already '{ver}'")
+            }
+            WritingMetadataVersion(ver) => write!(f, "writing metadata version: '{ver}'"),
+            ReadMetadataVersion(ver) => write!(f, "read metadata version: '{ver}'"),
+            NonFatalError(e) => write!(f, "{e}"),
             UpgradeRemovesToolchains => write!(
                 f,
                 "this upgrade will remove all existing toolchains. you will need to reinstall them"
@@ -138,7 +135,7 @@ impl<'a> Display for Notification<'a> {
                 "expected file does not exist to uninstall: {}",
                 p.display()
             ),
-            PlainVerboseMessage(r) => write!(f, "{}", r),
+            PlainVerboseMessage(r) => write!(f, "{r}"),
             DuplicateToolchainFile {
                 rust_toolchain,
                 rust_toolchain_toml,

--- a/src/test.rs
+++ b/src/test.rs
@@ -122,9 +122,9 @@ pub fn this_host_triple() -> String {
     };
 
     if let Some(env) = env {
-        format!("{}-{}-{}", arch, os, env)
+        format!("{arch}-{os}-{env}")
     } else {
-        format!("{}-{}", arch, os)
+        format!("{arch}-{os}")
     }
 }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -311,7 +311,7 @@ fn install_msg(bin: &str, toolchain: &str, is_default: bool) -> String {
             if is_default {
                 String::new()
             } else {
-                format!(" --toolchain {}", toolchain)
+                format!(" --toolchain {toolchain}")
             }
         }),
         None => String::new(),
@@ -327,7 +327,7 @@ impl<'a> InstalledCommonToolchain<'a> {
             if binary_str.to_lowercase().ends_with(EXE_SUFFIX) {
                 binary.as_ref().to_owned()
             } else {
-                OsString::from(format!("{}{}", binary_str, EXE_SUFFIX))
+                OsString::from(format!("{binary_str}{EXE_SUFFIX}"))
             }
         } else {
             // Very weird case. Non-unicode command.
@@ -355,7 +355,7 @@ impl<'a> InstalledCommonToolchain<'a> {
                             .iter()
                             .find(|cs| cs.component.short_name(&manifest) == component_name)
                             .unwrap_or_else(|| {
-                                panic!("component {} should be in the manifest", component_name)
+                                panic!("component {component_name} should be in the manifest")
                             });
                         if !component_status.available {
                             return Err(anyhow!(format!(
@@ -484,7 +484,7 @@ impl<'a> CustomToolchain<'a> {
         pathbuf.pop();
         pathbuf.push("bin");
         utils::assert_is_directory(&pathbuf)?;
-        pathbuf.push(format!("rustc{}", EXE_SUFFIX));
+        pathbuf.push(format!("rustc{EXE_SUFFIX}"));
         utils::assert_is_file(&pathbuf)?;
 
         if link {
@@ -604,7 +604,7 @@ impl<'a> DistributableToolchain<'a> {
         }
         let installed_primary = primary_toolchain.as_installed_common()?;
 
-        let src_file = self.0.path.join("bin").join(format!("cargo{}", EXE_SUFFIX));
+        let src_file = self.0.path.join("bin").join(format!("cargo{EXE_SUFFIX}"));
 
         // MAJOR HACKS: Copy cargo.exe to its own directory on windows before
         // running it. This is so that the fallback cargo, when it in turn runs
@@ -897,7 +897,7 @@ impl<'a> DistributableToolchain<'a> {
         // a v1 manifest install.  The v1 components are not called the same
         // in a v2 install.
         for component in V1_COMMON_COMPONENT_LIST {
-            let manifest = format!("manifest-{}", component);
+            let manifest = format!("manifest-{component}");
             let manifest_path = prefix.manifest_file(&manifest);
             if !utils::path_exists(manifest_path) {
                 return false;

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -74,7 +74,7 @@ impl<'a> Display for Notification<'a> {
             CreatingDirectory(name, path) => {
                 write!(f, "creating {} directory: '{}'", name, path.display())
             }
-            Error(e) => write!(f, "error: '{}'", e),
+            Error(e) => write!(f, "error: '{e}'"),
             LinkingDirectory(_, dest) => write!(f, "linking directory from: '{}'", dest.display()),
             CopyingDirectory(src, _) => write!(f, "copying directory from: '{}'", src.display()),
             RemovingDirectory(name, path) => {
@@ -91,8 +91,8 @@ impl<'a> Display for Notification<'a> {
                 "using up to {} of RAM to unpack components",
                 units::Size::new(*size, units::Unit::B, units::UnitMode::Norm)
             ),
-            DownloadingFile(url, _) => write!(f, "downloading file from: '{}'", url),
-            DownloadContentLengthReceived(len) => write!(f, "download size is: '{}'", len),
+            DownloadingFile(url, _) => write!(f, "downloading file from: '{url}'"),
+            DownloadContentLengthReceived(len) => write!(f, "download size is: '{len}'"),
             DownloadDataReceived(data) => write!(f, "received some data of size {}", data.len()),
             DownloadPushUnit(_) => Ok(()),
             DownloadPopUnit => Ok(()),

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -97,7 +97,7 @@ pub fn append_file(dest: &Path, line: &str) -> io::Result<()> {
         .create(true)
         .open(dest)?;
 
-    writeln!(dest_file, "{}", line)?;
+    writeln!(dest_file, "{line}")?;
 
     dest_file.sync_data()?;
 

--- a/src/utils/units.rs
+++ b/src/utils/units.rs
@@ -47,7 +47,7 @@ impl Display for Size {
                 } else if size >= KI {
                     write!(f, "{:5.1} KiB{}", size / KI, suffix)
                 } else {
-                    write!(f, "{:3.0} B{}", size, suffix)
+                    write!(f, "{size:3.0} B{suffix}")
                 }
             }
             Size::IO(size, unitmode) => {
@@ -68,7 +68,7 @@ impl Display for Size {
                 } else if size >= K {
                     write!(f, "{:5.1} kilo-{}", size / K, suffix)
                 } else {
-                    write!(f, "{:3.0} {}", size, suffix)
+                    write!(f, "{size:3.0} {suffix}")
                 }
             }
         }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -76,14 +76,14 @@ pub(crate) fn write_line(
     path: &Path,
     line: &str,
 ) -> Result<()> {
-    writeln!(file, "{}", line).with_context(|| RustupError::WritingFile {
+    writeln!(file, "{line}").with_context(|| RustupError::WritingFile {
         name,
         path: path.to_path_buf(),
     })
 }
 
 pub(crate) fn write_str(name: &'static str, file: &mut File, path: &Path, s: &str) -> Result<()> {
-    write!(file, "{}", s).with_context(|| RustupError::WritingFile {
+    write!(file, "{s}").with_context(|| RustupError::WritingFile {
         name,
         path: path.to_path_buf(),
     })
@@ -255,7 +255,7 @@ fn download_file_(
 }
 
 pub(crate) fn parse_url(url: &str) -> Result<Url> {
-    Url::parse(url).with_context(|| format!("failed to parse url: {}", url))
+    Url::parse(url).with_context(|| format!("failed to parse url: {url}"))
 }
 
 pub(crate) fn assert_is_file(path: &Path) -> Result<()> {

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -222,9 +222,8 @@ fn check_updates_self() {
                 config,
                 &["rustup", "check"],
                 &format!(
-                    r"rustup - Update available : {} -> {}
-",
-                    current_version, test_version
+                    r"rustup - Update available : {current_version} -> {test_version}
+"
                 ),
             );
         },
@@ -242,9 +241,8 @@ fn check_updates_self_no_change() {
                 config,
                 &["rustup", "check"],
                 &format!(
-                    r"rustup - Up to date : {}
-",
-                    current_version
+                    r"rustup - Up to date : {current_version}
+"
                 ),
             );
         },
@@ -498,7 +496,7 @@ fn list_overrides() {
             &format!(
                 "{:<40}\t{:<20}\n",
                 cwd_formatted,
-                &format!("nightly-{}", trip)
+                &format!("nightly-{trip}")
             ),
             r"",
         );
@@ -535,7 +533,7 @@ fn list_overrides_with_nonexistent() {
             &format!(
                 "{:<40}\t{:<20}\n\n",
                 path_formatted + " (not a directory)",
-                &format!("nightly-{}", trip)
+                &format!("nightly-{trip}")
             ),
             "info: you may remove overrides for non-existent directories with
 `rustup override unset --nonexistent`\n",

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -389,8 +389,8 @@ fn rustup_failed_path_search() {
     setup(&|config| {
         use std::env::consts::EXE_SUFFIX;
 
-        let rustup_path = config.exedir.join(&format!("rustup{}", EXE_SUFFIX));
-        let tool_path = config.exedir.join(&format!("fake_proxy{}", EXE_SUFFIX));
+        let rustup_path = config.exedir.join(&format!("rustup{EXE_SUFFIX}"));
+        let tool_path = config.exedir.join(&format!("fake_proxy{EXE_SUFFIX}"));
         utils::hardlink_file(&rustup_path, &tool_path)
             .expect("Failed to create fake proxy for test");
 
@@ -426,8 +426,8 @@ fn rustup_failed_path_search_toolchain() {
     setup(&|config| {
         use std::env::consts::EXE_SUFFIX;
 
-        let rustup_path = config.exedir.join(&format!("rustup{}", EXE_SUFFIX));
-        let tool_path = config.exedir.join(&format!("cargo-miri{}", EXE_SUFFIX));
+        let rustup_path = config.exedir.join(&format!("rustup{EXE_SUFFIX}"));
+        let tool_path = config.exedir.join(&format!("cargo-miri{EXE_SUFFIX}"));
         utils::hardlink_file(&rustup_path, &tool_path)
             .expect("Failed to create fake cargo-miri for test");
 
@@ -505,7 +505,7 @@ fn toolchains_are_resolved_early() {
         expect_stderr_ok(
             config,
             &["rustup", "default", &full_toolchain],
-            &format!("info: using existing install for '{}'", full_toolchain),
+            &format!("info: using existing install for '{full_toolchain}'"),
         );
     });
 }
@@ -539,7 +539,7 @@ fn rls_exists_in_toolchain() {
         expect_ok(config, &["rustup", "default", "stable"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
-        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        assert!(config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
         expect_ok(config, &["rls", "--version"]);
     });
 }
@@ -610,7 +610,7 @@ fn rename_rls_before() {
         set_current_dist_date(config, "2015-01-02");
         expect_ok(config, &["rustup", "update"]);
 
-        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        assert!(config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
         expect_ok(config, &["rls", "--version"]);
     });
 }
@@ -625,7 +625,7 @@ fn rename_rls_after() {
         expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
 
-        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        assert!(config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
         expect_ok(config, &["rls", "--version"]);
     });
 }
@@ -640,7 +640,7 @@ fn rename_rls_add_old_name() {
         expect_ok(config, &["rustup", "update"]);
         expect_ok(config, &["rustup", "component", "add", "rls"]);
 
-        assert!(config.exedir.join(format!("rls{}", EXE_SUFFIX)).exists());
+        assert!(config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
         expect_ok(config, &["rls", "--version"]);
     });
 }
@@ -692,7 +692,7 @@ fn rename_rls_remove() {
         expect_err(
             config,
             &["rls", "--version"],
-            &format!("'rls{}' is not installed", EXE_SUFFIX),
+            &format!("'rls{EXE_SUFFIX}' is not installed"),
         );
 
         expect_ok(config, &["rustup", "component", "add", "rls"]);
@@ -701,7 +701,7 @@ fn rename_rls_remove() {
         expect_err(
             config,
             &["rls", "--version"],
-            &format!("'rls{}' is not installed", EXE_SUFFIX),
+            &format!("'rls{EXE_SUFFIX}' is not installed"),
         );
     });
 }

--- a/tests/cli-paths.rs
+++ b/tests/cli-paths.rs
@@ -29,14 +29,14 @@ export PATH="$HOME/apple/bin"
     const POSIX_SH: &str = "env";
 
     fn source(dir: impl Display, sh: impl Display) -> String {
-        format!(". \"{dir}/{sh}\"\n", dir = dir, sh = sh)
+        format!(". \"{dir}/{sh}\"\n")
     }
 
     // In 1.23 we used `source` instead of `.` by accident.  This is not POSIX
     // so we want to ensure that if we put this into someone's dot files, then
     // with newer rustups we will revert that.
     fn non_posix_source(dir: impl Display, sh: impl Display) -> String {
-        format!("source \"{dir}/{sh}\"\n", dir = dir, sh = sh)
+        format!("source \"{dir}/{sh}\"\n")
     }
 
     #[test]
@@ -321,7 +321,7 @@ export PATH="$HOME/apple/bin"
             assert!(cmd.output().unwrap().status.success());
 
             let new_profile = fs::read_to_string(&profile).unwrap();
-            let expected = format!("{}. \"$HOME/.cargo/env\"\n", FAKE_RC);
+            let expected = format!("{FAKE_RC}. \"$HOME/.cargo/env\"\n");
             assert_eq!(new_profile, expected);
 
             let mut cmd = clitools::cmd(config, "rustup", ["self", "uninstall", "-y"]);

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -524,10 +524,10 @@ fn fallback_cargo_calls_correct_rustc() {
     setup(&|config| {
         // Hm, this is the _only_ test that assumes that toolchain proxies
         // exist in CARGO_HOME. Adding that proxy here.
-        let rustup_path = config.exedir.join(format!("rustup{}", EXE_SUFFIX));
+        let rustup_path = config.exedir.join(format!("rustup{EXE_SUFFIX}"));
         let cargo_bin_path = config.cargodir.join("bin");
         fs::create_dir_all(&cargo_bin_path).unwrap();
-        let rustc_path = cargo_bin_path.join(format!("rustc{}", EXE_SUFFIX));
+        let rustc_path = cargo_bin_path.join(format!("rustc{EXE_SUFFIX}"));
         fs::hard_link(&rustup_path, &rustc_path).unwrap();
 
         // Install a custom toolchain and a nightly toolchain for the cargo fallback
@@ -1967,7 +1967,7 @@ fn docs_with_path() {
         clitools::env(config, &mut cmd);
 
         let out = cmd.output().unwrap();
-        let path = format!("share{0}doc{0}rust{0}html", MAIN_SEPARATOR);
+        let path = format!("share{MAIN_SEPARATOR}doc{MAIN_SEPARATOR}rust{MAIN_SEPARATOR}html");
         assert!(String::from_utf8(out.stdout).unwrap().contains(&path));
 
         let mut cmd = clitools::cmd(
@@ -1997,10 +1997,7 @@ fn docs_topical_with_path() {
             let out_str = String::from_utf8(out.stdout).unwrap();
             assert!(
                 out_str.contains(&path),
-                "comparing path\ntopic: '{}'\nexpected path: '{}'\noutput: {}\n\n\n",
-                topic,
-                path,
-                out_str,
+                "comparing path\ntopic: '{topic}'\nexpected path: '{path}'\noutput: {out_str}\n\n\n",
             );
         }
     });
@@ -2168,16 +2165,10 @@ fn warn_on_unmatch_build() {
         let arch = clitools::MULTI_ARCH1;
         expect_stderr_ok(
             config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                &format!("nightly-{}", arch),
-            ],
+            &["rustup", "toolchain", "install", &format!("nightly-{arch}")],
             &format!(
-                r"warning: toolchain 'nightly-{0}' may not be able to run on this system.
-warning: If you meant to build software to target that platform, perhaps try `rustup target add {0}` instead?",
-                arch,
+                r"warning: toolchain 'nightly-{arch}' may not be able to run on this system.
+warning: If you meant to build software to target that platform, perhaps try `rustup target add {arch}` instead?",
             ),
         );
     });
@@ -2191,19 +2182,17 @@ fn dont_warn_on_partial_build() {
         let mut cmd = clitools::cmd(
             config,
             "rustup",
-            ["toolchain", "install", &format!("nightly-{}", arch)],
+            ["toolchain", "install", &format!("nightly-{arch}")],
         );
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
         assert!(out.status.success());
         let stderr = String::from_utf8(out.stderr).unwrap();
         assert!(stderr.contains(&format!(
-            r"info: syncing channel updates for 'nightly-{0}'",
-            triple
+            r"info: syncing channel updates for 'nightly-{triple}'"
         )));
         assert!(!stderr.contains(&format!(
-            r"warning: toolchain 'nightly-{0}' may not be able to run on this system.",
-            arch
+            r"warning: toolchain 'nightly-{arch}' may not be able to run on this system."
         )));
     })
 }

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -98,7 +98,7 @@ info: default toolchain set to 'stable-{0}'
             }
 
             for tool in TOOLS.iter().chain(DUP_TOOLS.iter()) {
-                let path = &config.cargodir.join(&format!("bin/{}{}", tool, EXE_SUFFIX));
+                let path = &config.cargodir.join(&format!("bin/{tool}{EXE_SUFFIX}"));
                 check(path);
             }
         })
@@ -111,7 +111,7 @@ fn install_twice() {
         with_saved_path(&|| {
             expect_ok(config, &["rustup-init", "-y"]);
             expect_ok(config, &["rustup-init", "-y"]);
-            let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+            let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
             assert!(rustup.exists());
         })
     });
@@ -147,17 +147,15 @@ fn uninstall_deletes_bins() {
         // no-modify-path isn't needed here, as the test-dir-path isn't present
         // in the registry, so the no-change code path will be triggered.
         expect_ok(config, &["rustup", "self", "uninstall", "-y"]);
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
-        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = config
-            .cargodir
-            .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
         let rust_gdbgui = config
             .cargodir
-            .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
+            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
         assert!(!rustup.exists());
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
@@ -171,17 +169,15 @@ fn uninstall_deletes_bins() {
 #[test]
 fn uninstall_works_if_some_bins_dont_exist() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
-        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = config
-            .cargodir
-            .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
         let rust_gdbgui = config
             .cargodir
-            .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
+            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
 
         fs::remove_file(&rustc).unwrap();
         fs::remove_file(&cargo).unwrap();
@@ -225,7 +221,7 @@ fn uninstall_deletes_cargo_home() {
 #[test]
 fn uninstall_fails_if_not_installed() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         fs::remove_file(&rustup).unwrap();
         expect_err(
             config,
@@ -242,7 +238,7 @@ fn uninstall_fails_if_not_installed() {
 #[cfg_attr(target_os = "macos", ignore)] // FIXME #1515
 fn uninstall_self_delete_works() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         let mut cmd = Command::new(rustup.clone());
         cmd.args(["self", "uninstall", "-y"]);
         clitools::env(config, &mut cmd);
@@ -254,16 +250,14 @@ fn uninstall_self_delete_works() {
         assert!(!rustup.exists());
         assert!(!config.cargodir.exists());
 
-        let rustc = config.cargodir.join(&format!("bin/rustc{}", EXE_SUFFIX));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{}", EXE_SUFFIX));
-        let cargo = config.cargodir.join(&format!("bin/cargo{}", EXE_SUFFIX));
-        let rust_lldb = config
-            .cargodir
-            .join(&format!("bin/rust-lldb{}", EXE_SUFFIX));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{}", EXE_SUFFIX));
+        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
         let rust_gdbgui = config
             .cargodir
-            .join(&format!("bin/rust-gdbgui{}", EXE_SUFFIX));
+            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
         assert!(!cargo.exists());
@@ -309,7 +303,7 @@ info: downloading self-update
         expect_ok_ex(
             config,
             &["rustup", "self", "update"],
-            &format!("  rustup updated - {} (from {})\n\n", version, version,),
+            &format!("  rustup updated - {version} (from {version})\n\n",),
             &expected_output,
         )
     });
@@ -337,7 +331,7 @@ fn update_but_delete_existing_updater_first() {
         // The updater is stored in a known location
         let setup = config
             .cargodir
-            .join(&format!("bin/rustup-init{}", EXE_SUFFIX));
+            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
 
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
@@ -346,7 +340,7 @@ fn update_but_delete_existing_updater_first() {
         raw::write_file(&setup, "").unwrap();
         expect_ok(config, &["rustup", "self", "update"]);
 
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         assert!(rustup.exists());
     });
 }
@@ -357,8 +351,8 @@ fn update_download_404() {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         let trip = this_host_triple();
-        let dist_dir = self_dist.join(&format!("archive/{}/{}", TEST_VERSION, trip));
-        let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
+        let dist_dir = self_dist.join(&format!("archive/{TEST_VERSION}/{trip}"));
+        let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
 
         fs::remove_file(dist_exe).unwrap();
 
@@ -390,7 +384,7 @@ fn update_updates_rustup_bin() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         // Running the self update command on the installed binary,
@@ -434,10 +428,9 @@ fn update_no_change() {
             config,
             &["rustup", "self", "update"],
             &format!(
-                r"  rustup unchanged - {}
+                r"  rustup unchanged - {version}
 
-",
-                version
+"
             ),
             r"info: checking for self-update
 ",
@@ -451,7 +444,7 @@ fn rustup_self_updates_trivial() {
         expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update"]);
@@ -468,7 +461,7 @@ fn rustup_self_updates_with_specified_toolchain() {
         expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update", "stable"]);
@@ -484,7 +477,7 @@ fn rustup_no_self_update_with_specified_toolchain() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update", "stable"]);
@@ -533,7 +526,7 @@ fn updater_leaves_itself_for_later_deletion() {
 
         let setup = config
             .cargodir
-            .join(&format!("bin/rustup-init{}", EXE_SUFFIX));
+            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(setup.exists());
     });
 }
@@ -549,7 +542,7 @@ fn updater_is_deleted_after_running_rustup() {
 
         let setup = config
             .cargodir
-            .join(&format!("bin/rustup-init{}", EXE_SUFFIX));
+            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(!setup.exists());
     });
 }
@@ -565,7 +558,7 @@ fn updater_is_deleted_after_running_rustc() {
 
         let setup = config
             .cargodir
-            .join(&format!("bin/rustup-init{}", EXE_SUFFIX));
+            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(!setup.exists());
     });
 }
@@ -587,8 +580,8 @@ fn rustup_still_works_after_update() {
 #[test]
 fn as_rustup_setup() {
     clitools::setup(Scenario::Empty, &|config| {
-        let init = config.exedir.join(format!("rustup-init{}", EXE_SUFFIX));
-        let setup = config.exedir.join(format!("rustup-setup{}", EXE_SUFFIX));
+        let init = config.exedir.join(format!("rustup-init{EXE_SUFFIX}"));
+        let setup = config.exedir.join(format!("rustup-setup{EXE_SUFFIX}"));
         fs::copy(&init, &setup).unwrap();
         expect_ok(
             config,
@@ -715,11 +708,11 @@ fn readline_no_stdin() {
 fn rustup_init_works_with_weird_names() {
     // Browsers often rename bins to e.g. rustup-init(2).exe.
     clitools::setup(Scenario::SimpleV2, &|config| {
-        let old = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
-        let new = config.exedir.join(&format!("rustup-init(2){}", EXE_SUFFIX));
+        let old = config.exedir.join(&format!("rustup-init{EXE_SUFFIX}"));
+        let new = config.exedir.join(&format!("rustup-init(2){EXE_SUFFIX}"));
         utils::rename_file("test", &old, &new, &|_: Notification<'_>| {}).unwrap();
         expect_ok(config, &["rustup-init(2)", "-y", "--no-modify-path"]);
-        let rustup = config.cargodir.join(&format!("bin/rustup{}", EXE_SUFFIX));
+        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
         assert!(rustup.exists());
     });
 }
@@ -805,7 +798,7 @@ fn rls_proxy_set_up_after_install() {
 #[test]
 fn rls_proxy_set_up_after_update() {
     update_setup(&|config, _| {
-        let rls_path = config.cargodir.join(format!("bin/rls{}", EXE_SUFFIX));
+        let rls_path = config.cargodir.join(format!("bin/rls{EXE_SUFFIX}"));
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
         fs::remove_file(&rls_path).unwrap();
         expect_ok(config, &["rustup", "self", "update"]);
@@ -823,7 +816,7 @@ fn update_does_not_overwrite_rustfmt() {
         // Since we just did a fresh install rustfmt will exist. Let's emulate
         // it not existing in this test though by removing it just after our
         // installation.
-        let rustfmt_path = config.cargodir.join(format!("bin/rustfmt{}", EXE_SUFFIX));
+        let rustfmt_path = config.cargodir.join(format!("bin/rustfmt{EXE_SUFFIX}"));
         assert!(rustfmt_path.exists());
         fs::remove_file(&rustfmt_path).unwrap();
         raw::write_file(&rustfmt_path, "").unwrap();
@@ -864,7 +857,7 @@ fn update_installs_clippy_cargo_and() {
 
         let cargo_clippy_path = config
             .cargodir
-            .join(format!("bin/cargo-clippy{}", EXE_SUFFIX));
+            .join(format!("bin/cargo-clippy{EXE_SUFFIX}"));
         assert!(cargo_clippy_path.exists());
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -1498,8 +1498,7 @@ fn install_allow_downgrade() {
             config,
             &["rustup", "toolchain", "install", "nightly", "-c", "rls"],
             &format!(
-                "component 'rls' for target '{}' is unavailable for download for channel 'nightly'",
-                trip,
+                "component 'rls' for target '{trip}' is unavailable for download for channel 'nightly'",
             ),
         );
         expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-3");

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -218,7 +218,7 @@ fn bonus_component(name: &'static str, contents: Arc<Vec<u8>>) -> MockPackage {
             components: vec![],
             installer: MockInstallerBuilder {
                 components: vec![MockComponentBuilder {
-                    name: format!("{}-x86_64-apple-darwin", name),
+                    name: format!("{name}-x86_64-apple-darwin"),
                     files: vec![MockFile::new_arc("bin/bonus", contents)],
                 }],
             },
@@ -478,7 +478,7 @@ fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> Result<Url
         dist_server, toolchain.channel
     );
 
-    Url::parse(&url).map_err(|e| anyhow!(format!("{:?}", e)))
+    Url::parse(&url).map_err(|e| anyhow!(format!("{e:?}")))
 }
 
 fn uninstall(
@@ -553,7 +553,7 @@ fn setup_from_dist_server(
         temp_cfg: &temp_cfg,
         download_dir: &prefix.path().to_owned().join("downloads"),
         notify_handler: &|event| {
-            println!("{}", event);
+            println!("{event}");
         },
         pgp_keys: &[PgpPublicKey::FromEnvironment(
             "test-key".into(),
@@ -2210,7 +2210,7 @@ fn handle_corrupt_partial_downloads() {
         .unwrap();
         let partial_path = download_cfg
             .download_dir
-            .join(format!("{}.partial", target_hash));
+            .join(format!("{target_hash}.partial"));
         utils_raw::write_file(
             &partial_path,
             "file will be resumed from here and not match hash",

--- a/tests/dist_install.rs
+++ b/tests/dist_install.rs
@@ -285,7 +285,7 @@ fn component_bad_version() {
     let e = Components::open(prefix).unwrap_err();
     assert_eq!(
         "unsupported metadata version in existing installation: 100",
-        format!("{}", e)
+        format!("{e}")
     );
 }
 

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -151,14 +151,14 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
 
     create_mock_dist_server(&config.distdir, s);
 
-    let build_path = exe_dir.join(format!("rustup-init{}", EXE_SUFFIX));
+    let build_path = exe_dir.join(format!("rustup-init{EXE_SUFFIX}"));
 
-    let rustup_path = config.exedir.join(format!("rustup{}", EXE_SUFFIX));
-    let setup_path = config.exedir.join(format!("rustup-init{}", EXE_SUFFIX));
-    let rustc_path = config.exedir.join(format!("rustc{}", EXE_SUFFIX));
-    let cargo_path = config.exedir.join(format!("cargo{}", EXE_SUFFIX));
-    let rls_path = config.exedir.join(format!("rls{}", EXE_SUFFIX));
-    let rust_lldb_path = config.exedir.join(format!("rust-lldb{}", EXE_SUFFIX));
+    let rustup_path = config.exedir.join(format!("rustup{EXE_SUFFIX}"));
+    let setup_path = config.exedir.join(format!("rustup-init{EXE_SUFFIX}"));
+    let rustc_path = config.exedir.join(format!("rustc{EXE_SUFFIX}"));
+    let cargo_path = config.exedir.join(format!("cargo{EXE_SUFFIX}"));
+    let rls_path = config.exedir.join(format!("rls{EXE_SUFFIX}"));
+    let rust_lldb_path = config.exedir.join(format!("rust-lldb{EXE_SUFFIX}"));
 
     copy_binary(&build_path, &rustup_path).unwrap();
     hard_link(&rustup_path, setup_path).unwrap();
@@ -199,9 +199,9 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
 
 fn create_local_update_server(self_dist: &Path, config: &mut Config, version: &str) {
     let trip = this_host_triple();
-    let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
-    let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
-    let rustup_bin = config.exedir.join(&format!("rustup-init{}", EXE_SUFFIX));
+    let dist_dir = self_dist.join(&format!("archive/{version}/{trip}"));
+    let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
+    let rustup_bin = config.exedir.join(&format!("rustup-init{EXE_SUFFIX}"));
 
     fs::create_dir_all(dist_dir).unwrap();
     output_release_file(self_dist, "1", version);
@@ -239,8 +239,8 @@ pub fn self_update_setup(f: &dyn Fn(&Config, &Path), version: &str) {
         create_local_update_server(self_dist, config, version);
 
         let trip = this_host_triple();
-        let dist_dir = self_dist.join(&format!("archive/{}/{}", version, trip));
-        let dist_exe = dist_dir.join(&format!("rustup-init{}", EXE_SUFFIX));
+        let dist_dir = self_dist.join(&format!("archive/{version}/{trip}"));
+        let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
 
         // Modify the exe so it hashes different
         raw::append_file(&dist_exe, "").unwrap();
@@ -252,10 +252,9 @@ pub fn self_update_setup(f: &dyn Fn(&Config, &Path), version: &str) {
 pub fn output_release_file(dist_dir: &Path, schema: &str, version: &str) {
     let contents = format!(
         r#"
-schema-version = "{}"
-version = "{}"
-"#,
-        schema, version
+schema-version = "{schema}"
+version = "{version}"
+"#
     );
     let file = dist_dir.join("release-stable.toml");
     utils::write_file("release", &file, &contents).unwrap();
@@ -441,9 +440,9 @@ pub(crate) fn print_command(args: &[&str], out: &SanitizedOutput) {
     print!("\n>");
     for arg in args {
         if arg.contains(' ') {
-            print!(" {:?}", arg);
+            print!(" {arg:?}");
         } else {
-            print!(" {}", arg);
+            print!(" {arg}");
         }
     }
     println!();
@@ -485,7 +484,7 @@ where
     I: IntoIterator<Item = A>,
     A: AsRef<OsStr>,
 {
-    let exe_path = config.exedir.join(format!("{}{}", name, EXE_SUFFIX));
+    let exe_path = config.exedir.join(format!("{name}{EXE_SUFFIX}"));
     let mut cmd = Command::new(exe_path);
     cmd.args(args);
     cmd.current_dir(&*config.workdir.borrow());
@@ -614,7 +613,7 @@ where
         stderr: String::from_utf8(out.stderr).unwrap(),
     };
 
-    println!("inprocess: {}", inprocess);
+    println!("inprocess: {inprocess}");
     println!("status: {:?}", out.status);
     println!("----- stdout\n{}", output.stdout);
     println!("----- stderr\n{}", output.stderr);
@@ -696,7 +695,7 @@ where
                     // This is an ETXTBSY situation
                     std::thread::sleep(std::time::Duration::from_millis(250));
                 } else {
-                    panic!("Unable to run test command: {:?}", e);
+                    panic!("Unable to run test command: {e:?}");
                 }
             }
         }
@@ -770,7 +769,7 @@ impl Release {
             channel: channel.to_string(),
             date: date.to_string(),
             version: version.to_string(),
-            hash: format!("hash-{}-{}", channel, suffix),
+            hash: format!("hash-{channel}-{suffix}"),
             available: true,
             multi_arch: false,
             rls: RlsStatus::Available,
@@ -1069,7 +1068,7 @@ fn build_mock_channel(
 
         MockPackage {
             name,
-            version: format!("{} ({})", version, version_hash),
+            version: format!("{version} ({version_hash})"),
             targets: target_pkgs.collect(),
         }
     });
@@ -1176,7 +1175,7 @@ fn build_mock_unavailable_channel(
         .iter()
         .map(|name| MockPackage {
             name,
-            version: format!("{} ({})", version, version_hash),
+            version: format!("{version} ({version_hash})"),
             targets: vec![MockTargetedPackage {
                 target: host_triple.clone(),
                 available: false,
@@ -1197,9 +1196,9 @@ fn build_mock_unavailable_channel(
 fn build_mock_std_installer(trip: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
         components: vec![MockComponentBuilder {
-            name: format!("rust-std-{}", trip),
+            name: format!("rust-std-{trip}"),
             files: vec![MockFile::new(
-                format!("lib/rustlib/{}/libstd.rlib", trip),
+                format!("lib/rustlib/{trip}/libstd.rlib"),
                 b"",
             )],
         }],
@@ -1209,10 +1208,10 @@ fn build_mock_std_installer(trip: &str) -> MockInstallerBuilder {
 fn build_mock_cross_std_installer(target: &str, date: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
         components: vec![MockComponentBuilder {
-            name: format!("rust-std-{}", target),
+            name: format!("rust-std-{target}"),
             files: vec![
-                MockFile::new(format!("lib/rustlib/{}/lib/libstd.rlib", target), b""),
-                MockFile::new(format!("lib/rustlib/{}/lib/{}", target, date), b""),
+                MockFile::new(format!("lib/rustlib/{target}/lib/libstd.rlib"), b""),
+                MockFile::new(format!("lib/rustlib/{target}/lib/{date}"), b""),
             ],
         }],
     }
@@ -1278,9 +1277,9 @@ fn build_mock_rust_doc_installer() -> MockInstallerBuilder {
 fn build_mock_rust_analysis_installer(trip: &str) -> MockInstallerBuilder {
     MockInstallerBuilder {
         components: vec![MockComponentBuilder {
-            name: format!("rust-analysis-{}", trip),
+            name: format!("rust-analysis-{trip}"),
             files: vec![MockFile::new(
-                format!("lib/rustlib/{}/analysis/libfoo.json", trip),
+                format!("lib/rustlib/{trip}/analysis/libfoo.json"),
                 b"",
             )],
         }],
@@ -1318,7 +1317,7 @@ fn mock_bin(name: &str, version: &str, version_hash: &str) -> Vec<MockFile> {
             // Create a temp directory to hold the source and the output
             let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
             let source_path = tempdir.path().join("in.rs");
-            let dest_path = tempdir.path().join(&format!("out{}", EXE_SUFFIX));
+            let dest_path = tempdir.path().join(&format!("out{EXE_SUFFIX}"));
 
             // Write the source
             let source = include_bytes!("mock_bin_src.rs");
@@ -1347,10 +1346,10 @@ fn mock_bin(name: &str, version: &str, version_hash: &str) -> Vec<MockFile> {
         };
     }
 
-    let name = format!("bin/{}{}", name, EXE_SUFFIX);
+    let name = format!("bin/{name}{EXE_SUFFIX}");
     vec![
-        MockFile::new(format!("{}.version", name), version.as_bytes()),
-        MockFile::new(format!("{}.version-hash", name), version_hash.as_bytes()),
+        MockFile::new(format!("{name}.version"), version.as_bytes()),
+        MockFile::new(format!("{name}.version-hash"), version_hash.as_bytes()),
         MockFile::new_arc(name, MOCK_BIN.clone()).executable(true),
     ]
 }

--- a/tests/mock/dist.rs
+++ b/tests/mock/dist.rs
@@ -21,37 +21,37 @@ pub fn change_channel_date(dist_server: &Url, channel: &str, date: &str) {
     let path = dist_server.to_file_path().unwrap();
 
     // V2
-    let manifest_name = format!("dist/channel-rust-{}", channel);
-    let manifest_path = path.join(format!("{}.toml", manifest_name));
-    let hash_path = path.join(format!("{}.toml.sha256", manifest_name));
-    let sig_path = path.join(format!("{}.toml.asc", manifest_name));
+    let manifest_name = format!("dist/channel-rust-{channel}");
+    let manifest_path = path.join(format!("{manifest_name}.toml"));
+    let hash_path = path.join(format!("{manifest_name}.toml.sha256"));
+    let sig_path = path.join(format!("{manifest_name}.toml.asc"));
 
-    let archive_manifest_name = format!("dist/{}/channel-rust-{}", date, channel);
-    let archive_manifest_path = path.join(format!("{}.toml", archive_manifest_name));
-    let archive_hash_path = path.join(format!("{}.toml.sha256", archive_manifest_name));
-    let archive_sig_path = path.join(format!("{}.toml.asc", archive_manifest_name));
+    let archive_manifest_name = format!("dist/{date}/channel-rust-{channel}");
+    let archive_manifest_path = path.join(format!("{archive_manifest_name}.toml"));
+    let archive_hash_path = path.join(format!("{archive_manifest_name}.toml.sha256"));
+    let archive_sig_path = path.join(format!("{archive_manifest_name}.toml.asc"));
 
     let _ = hard_link(archive_manifest_path, manifest_path);
     let _ = hard_link(archive_hash_path, hash_path);
     let _ = hard_link(archive_sig_path, sig_path);
 
     // V1
-    let manifest_name = format!("dist/channel-rust-{}", channel);
+    let manifest_name = format!("dist/channel-rust-{channel}");
     let manifest_path = path.join(&manifest_name);
-    let hash_path = path.join(format!("{}.sha256", manifest_name));
-    let sig_path = path.join(format!("{}.asc", manifest_name));
+    let hash_path = path.join(format!("{manifest_name}.sha256"));
+    let sig_path = path.join(format!("{manifest_name}.asc"));
 
-    let archive_manifest_name = format!("dist/{}/channel-rust-{}", date, channel);
+    let archive_manifest_name = format!("dist/{date}/channel-rust-{channel}");
     let archive_manifest_path = path.join(&archive_manifest_name);
-    let archive_hash_path = path.join(format!("{}.sha256", archive_manifest_name));
-    let archive_sig_path = path.join(format!("{}.asc", archive_manifest_name));
+    let archive_hash_path = path.join(format!("{archive_manifest_name}.sha256"));
+    let archive_sig_path = path.join(format!("{archive_manifest_name}.asc"));
 
     let _ = hard_link(archive_manifest_path, manifest_path);
     let _ = hard_link(archive_hash_path, hash_path);
     let _ = hard_link(archive_sig_path, sig_path);
 
     // Copy all files that look like rust-* for the v1 installers
-    let archive_path = path.join(format!("dist/{}", date));
+    let archive_path = path.join(format!("dist/{date}"));
     for dir in fs::read_dir(archive_path).unwrap() {
         let dir = dir.unwrap();
         if dir.file_name().to_str().unwrap().contains("rust-") {
@@ -205,8 +205,8 @@ impl MockDistServer {
             format!("{}-{}", package.name, channel.name)
         };
         let installer_dir = workdir.join(&installer_name);
-        let installer_tarball = archive_dir.join(format!("{}{}", installer_name, format));
-        let installer_hash = archive_dir.join(format!("{}{}.sha256", installer_name, format));
+        let installer_tarball = archive_dir.join(format!("{installer_name}{format}"));
+        let installer_hash = archive_dir.join(format!("{installer_name}{format}.sha256"));
 
         fs::create_dir_all(&installer_dir).unwrap();
 
@@ -258,8 +258,8 @@ impl MockDistServer {
 
         // Copy from the archive to the main dist directory
         if package.name == "rust" {
-            let main_installer_tarball = dist_dir.join(format!("{}{}", installer_name, format));
-            let main_installer_hash = dist_dir.join(format!("{}{}.sha256", installer_name, format));
+            let main_installer_tarball = dist_dir.join(format!("{installer_name}{format}"));
+            let main_installer_hash = dist_dir.join(format!("{installer_name}{format}.sha256"));
             hard_link(installer_tarball, main_installer_tarball).unwrap();
             hard_link(installer_hash, main_installer_hash).unwrap();
         }
@@ -284,7 +284,7 @@ impl MockDistServer {
         let manifest_path = self.path.join(&manifest_name);
         write_file(&manifest_path, &buf);
 
-        let hash_path = self.path.join(format!("{}.sha256", manifest_name));
+        let hash_path = self.path.join(format!("{manifest_name}.sha256"));
         create_hash(&manifest_path, &hash_path);
 
         // Also copy the manifest and hash into the archive folder
@@ -292,14 +292,14 @@ impl MockDistServer {
         let archive_manifest_path = self.path.join(&archive_manifest_name);
         hard_link(manifest_path, archive_manifest_path).unwrap();
 
-        let archive_hash_path = self.path.join(format!("{}.sha256", archive_manifest_name));
+        let archive_hash_path = self.path.join(format!("{archive_manifest_name}.sha256"));
         hard_link(&hash_path, archive_hash_path).unwrap();
 
         let signature = create_signature(buf.as_bytes()).unwrap();
-        let sig_path = self.path.join(format!("{}.asc", manifest_name));
+        let sig_path = self.path.join(format!("{manifest_name}.asc"));
         write_file(&sig_path, &signature);
 
-        let archive_sig_path = self.path.join(format!("{}.asc", archive_manifest_name));
+        let archive_sig_path = self.path.join(format!("{archive_manifest_name}.asc"));
         hard_link(sig_path, archive_sig_path).unwrap();
     }
 
@@ -436,30 +436,28 @@ impl MockDistServer {
         toml_manifest.insert(String::from("profiles"), toml::Value::Table(toml_profiles));
 
         let manifest_name = format!("dist/channel-rust-{}", channel.name);
-        let manifest_path = self.path.join(format!("{}.toml", manifest_name));
+        let manifest_path = self.path.join(format!("{manifest_name}.toml"));
         let manifest_content = toml::to_string(&toml_manifest).unwrap();
         write_file(&manifest_path, &manifest_content);
 
-        let hash_path = self.path.join(format!("{}.toml.sha256", manifest_name));
+        let hash_path = self.path.join(format!("{manifest_name}.toml.sha256"));
         create_hash(&manifest_path, &hash_path);
 
         // Also copy the manifest and hash into the archive folder
         let archive_manifest_name = format!("dist/{}/channel-rust-{}", channel.date, channel.name);
-        let archive_manifest_path = self.path.join(format!("{}.toml", archive_manifest_name));
+        let archive_manifest_path = self.path.join(format!("{archive_manifest_name}.toml"));
         hard_link(&manifest_path, archive_manifest_path).unwrap();
 
         let archive_hash_path = self
             .path
-            .join(format!("{}.toml.sha256", archive_manifest_name));
+            .join(format!("{archive_manifest_name}.toml.sha256"));
         hard_link(hash_path, archive_hash_path).unwrap();
 
         let signature = create_signature(manifest_content.as_bytes()).unwrap();
-        let sig_path = self.path.join(format!("{}.toml.asc", manifest_name));
+        let sig_path = self.path.join(format!("{manifest_name}.toml.asc"));
         write_file(&sig_path, &signature);
 
-        let archive_sig_path = self
-            .path
-            .join(format!("{}.toml.asc", archive_manifest_name));
+        let archive_sig_path = self.path.join(format!("{archive_manifest_name}.toml.asc"));
         hard_link(sig_path, archive_sig_path).unwrap();
     }
 }


### PR DESCRIPTION
`cargo clippy` now suggests that one uses lined arguments for `format!` and friends, when possible:

https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args

> Added in: 1.66.0

`CONTRIBUTING.md` suggests one runs this, before publishing a change:
```bash
cargo clippy --all --all-targets --all-features -- -D warnings`
```
But, at the moment, this command generated more than a thousand warnings for me on `master`.

This change is just `cargo clippy --fix`, with flags to only show `clippy::uninlined_format_args`, followed by `cargo fmt`.