### PR TITLE
clippy::needless_borrow: Apply clippy suggestions

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -712,7 +712,7 @@ fn customize_install(mut opts: InstallOpts<'_>) -> Result<InstallOpts<'_>> {
 fn install_bins() -> Result<()> {
     let bin_path = utils::cargo_home()?.join("bin");
     let this_exe_path = utils::current_exe()?;
-    let rustup_path = bin_path.join(&format!("rustup{EXE_SUFFIX}"));
+    let rustup_path = bin_path.join(format!("rustup{EXE_SUFFIX}"));
 
     utils::ensure_dir_exists("bin", &bin_path, &|_: Notification<'_>| {})?;
     // NB: Even on Linux we can't just copy the new binary over the (running)
@@ -1088,8 +1088,8 @@ fn parse_new_rustup_version(version: String) -> String {
 
 pub(crate) fn prepare_update() -> Result<Option<PathBuf>> {
     let cargo_home = utils::cargo_home()?;
-    let rustup_path = cargo_home.join(&format!("bin{MAIN_SEPARATOR}rustup{EXE_SUFFIX}"));
-    let setup_path = cargo_home.join(&format!("bin{MAIN_SEPARATOR}rustup-init{EXE_SUFFIX}"));
+    let rustup_path = cargo_home.join(format!("bin{MAIN_SEPARATOR}rustup{EXE_SUFFIX}"));
+    let setup_path = cargo_home.join(format!("bin{MAIN_SEPARATOR}rustup-init{EXE_SUFFIX}"));
 
     if !rustup_path.exists() {
         return Err(CLIError::NotSelfInstalled { p: cargo_home }.into());
@@ -1212,7 +1212,7 @@ pub(crate) fn check_rustup_update() -> Result<()> {
 
 pub(crate) fn cleanup_self_updater() -> Result<()> {
     let cargo_home = utils::cargo_home()?;
-    let setup = cargo_home.join(&format!("bin/rustup-init{EXE_SUFFIX}"));
+    let setup = cargo_home.join(format!("bin/rustup-init{EXE_SUFFIX}"));
 
     if setup.exists() {
         utils::remove_file("setup", &setup)?;

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -342,7 +342,7 @@ pub(crate) fn perform<F: Fn(usize)>(item: &mut Item, chunk_complete_callback: F)
                     write_file(&item.full_path, contents, item.mode)
                 }
                 FileBuffer::Threaded(ref mut contents) => {
-                    write_file(&item.full_path, &contents, item.mode)
+                    write_file(&item.full_path, contents, item.mode)
                 }
             }
         }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -510,7 +510,7 @@ pub(crate) fn create_rustup_home() -> Result<()> {
     }
 
     let home = rustup_home_in_user_dir()?;
-    fs::create_dir_all(&home).context("unable to create ~/.rustup")?;
+    fs::create_dir_all(home).context("unable to create ~/.rustup")?;
 
     Ok(())
 }

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -529,7 +529,7 @@ fn install_stops_if_rustc_exists() {
         .tempdir()
         .unwrap();
     // Create fake executable
-    let fake_exe = temp_dir.path().join(&format!("{}{}", "rustc", EXE_SUFFIX));
+    let fake_exe = temp_dir.path().join(format!("{}{}", "rustc", EXE_SUFFIX));
     raw::append_file(&fake_exe, "").unwrap();
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
@@ -560,7 +560,7 @@ fn install_stops_if_cargo_exists() {
         .tempdir()
         .unwrap();
     // Create fake executable
-    let fake_exe = temp_dir.path().join(&format!("{}{}", "cargo", EXE_SUFFIX));
+    let fake_exe = temp_dir.path().join(format!("{}{}", "cargo", EXE_SUFFIX));
     raw::append_file(&fake_exe, "").unwrap();
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
@@ -591,7 +591,7 @@ fn with_no_prompt_install_succeeds_if_rustc_exists() {
         .tempdir()
         .unwrap();
     // Create fake executable
-    let fake_exe = temp_dir.path().join(&format!("{}{}", "rustc", EXE_SUFFIX));
+    let fake_exe = temp_dir.path().join(format!("{}{}", "rustc", EXE_SUFFIX));
     raw::append_file(&fake_exe, "").unwrap();
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 

--- a/tests/cli-misc.rs
+++ b/tests/cli-misc.rs
@@ -389,8 +389,8 @@ fn rustup_failed_path_search() {
     setup(&|config| {
         use std::env::consts::EXE_SUFFIX;
 
-        let rustup_path = config.exedir.join(&format!("rustup{EXE_SUFFIX}"));
-        let tool_path = config.exedir.join(&format!("fake_proxy{EXE_SUFFIX}"));
+        let rustup_path = config.exedir.join(format!("rustup{EXE_SUFFIX}"));
+        let tool_path = config.exedir.join(format!("fake_proxy{EXE_SUFFIX}"));
         utils::hardlink_file(&rustup_path, &tool_path)
             .expect("Failed to create fake proxy for test");
 
@@ -426,8 +426,8 @@ fn rustup_failed_path_search_toolchain() {
     setup(&|config| {
         use std::env::consts::EXE_SUFFIX;
 
-        let rustup_path = config.exedir.join(&format!("rustup{EXE_SUFFIX}"));
-        let tool_path = config.exedir.join(&format!("cargo-miri{EXE_SUFFIX}"));
+        let rustup_path = config.exedir.join(format!("rustup{EXE_SUFFIX}"));
+        let tool_path = config.exedir.join(format!("cargo-miri{EXE_SUFFIX}"));
         utils::hardlink_file(&rustup_path, &tool_path)
             .expect("Failed to create fake cargo-miri for test");
 

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -336,7 +336,7 @@ fn add_target() {
         );
         expect_ok(config, &["rustup", "default", "nightly"]);
         expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -378,13 +378,13 @@ fn add_remove_multiple_targets() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             &this_host_triple(),
             clitools::CROSS_ARCH2
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
 
         expect_ok(
             config,
@@ -401,13 +401,13 @@ fn add_remove_multiple_targets() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(!config.rustupdir.has(&path));
+        assert!(!config.rustupdir.has(path));
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             &this_host_triple(),
             clitools::CROSS_ARCH2
         );
-        assert!(!config.rustupdir.has(&path));
+        assert!(!config.rustupdir.has(path));
     });
 }
 
@@ -449,7 +449,7 @@ fn add_target_explicit() {
                 clitools::CROSS_ARCH1,
             ],
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -528,7 +528,7 @@ fn fallback_cargo_calls_correct_rustc() {
         let cargo_bin_path = config.cargodir.join("bin");
         fs::create_dir_all(&cargo_bin_path).unwrap();
         let rustc_path = cargo_bin_path.join(format!("rustc{EXE_SUFFIX}"));
-        fs::hard_link(&rustup_path, &rustc_path).unwrap();
+        fs::hard_link(rustup_path, &rustc_path).unwrap();
 
         // Install a custom toolchain and a nightly toolchain for the cargo fallback
         let path = config.customdir.join("custom-1");
@@ -1309,7 +1309,7 @@ fn add_component() {
             "toolchains/stable-{}/lib/rustlib/src/rust-src/foo.rs",
             this_host_triple()
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -1527,7 +1527,7 @@ fn file_override_path_no_options() {
         let cwd = config.current_dir();
         let toolchain_path = cwd.join("ephemeral");
         let toolchain_bin = toolchain_path.join("bin");
-        fs::create_dir_all(&toolchain_bin).unwrap();
+        fs::create_dir_all(toolchain_bin).unwrap();
 
         let toolchain_file = cwd.join("rust-toolchain.toml");
         raw::write_file(
@@ -1575,7 +1575,7 @@ fn file_override_path_xor_channel() {
         let cwd = config.current_dir();
         let toolchain_path = cwd.join("ephemeral");
         let toolchain_bin = toolchain_path.join("bin");
-        fs::create_dir_all(&toolchain_bin).unwrap();
+        fs::create_dir_all(toolchain_bin).unwrap();
 
         let toolchain_file = cwd.join("rust-toolchain.toml");
         raw::write_file(

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -111,7 +111,7 @@ fn install_twice() {
         with_saved_path(&|| {
             expect_ok(config, &["rustup-init", "-y"]);
             expect_ok(config, &["rustup-init", "-y"]);
-            let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+            let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
             assert!(rustup.exists());
         })
     });
@@ -147,15 +147,13 @@ fn uninstall_deletes_bins() {
         // no-modify-path isn't needed here, as the test-dir-path isn't present
         // in the registry, so the no-change code path will be triggered.
         expect_ok(config, &["rustup", "self", "uninstall", "-y"]);
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
-        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
-        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
-        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
-        let rust_gdbgui = config
-            .cargodir
-            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
+        let rustc = config.cargodir.join(format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(format!("bin/rust-gdb{EXE_SUFFIX}"));
+        let rust_gdbgui = config.cargodir.join(format!("bin/rust-gdbgui{EXE_SUFFIX}"));
         assert!(!rustup.exists());
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
@@ -169,15 +167,13 @@ fn uninstall_deletes_bins() {
 #[test]
 fn uninstall_works_if_some_bins_dont_exist() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
-        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
-        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
-        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
-        let rust_gdbgui = config
-            .cargodir
-            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
+        let rustc = config.cargodir.join(format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(format!("bin/rust-gdb{EXE_SUFFIX}"));
+        let rust_gdbgui = config.cargodir.join(format!("bin/rust-gdbgui{EXE_SUFFIX}"));
 
         fs::remove_file(&rustc).unwrap();
         fs::remove_file(&cargo).unwrap();
@@ -221,8 +217,8 @@ fn uninstall_deletes_cargo_home() {
 #[test]
 fn uninstall_fails_if_not_installed() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
-        fs::remove_file(&rustup).unwrap();
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
+        fs::remove_file(rustup).unwrap();
         expect_err(
             config,
             &["rustup", "self", "uninstall", "-y"],
@@ -238,7 +234,7 @@ fn uninstall_fails_if_not_installed() {
 #[cfg_attr(target_os = "macos", ignore)] // FIXME #1515
 fn uninstall_self_delete_works() {
     setup_empty_installed(&|config| {
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         let mut cmd = Command::new(rustup.clone());
         cmd.args(["self", "uninstall", "-y"]);
         clitools::env(config, &mut cmd);
@@ -250,14 +246,12 @@ fn uninstall_self_delete_works() {
         assert!(!rustup.exists());
         assert!(!config.cargodir.exists());
 
-        let rustc = config.cargodir.join(&format!("bin/rustc{EXE_SUFFIX}"));
-        let rustdoc = config.cargodir.join(&format!("bin/rustdoc{EXE_SUFFIX}"));
-        let cargo = config.cargodir.join(&format!("bin/cargo{EXE_SUFFIX}"));
-        let rust_lldb = config.cargodir.join(&format!("bin/rust-lldb{EXE_SUFFIX}"));
-        let rust_gdb = config.cargodir.join(&format!("bin/rust-gdb{EXE_SUFFIX}"));
-        let rust_gdbgui = config
-            .cargodir
-            .join(&format!("bin/rust-gdbgui{EXE_SUFFIX}"));
+        let rustc = config.cargodir.join(format!("bin/rustc{EXE_SUFFIX}"));
+        let rustdoc = config.cargodir.join(format!("bin/rustdoc{EXE_SUFFIX}"));
+        let cargo = config.cargodir.join(format!("bin/cargo{EXE_SUFFIX}"));
+        let rust_lldb = config.cargodir.join(format!("bin/rust-lldb{EXE_SUFFIX}"));
+        let rust_gdb = config.cargodir.join(format!("bin/rust-gdb{EXE_SUFFIX}"));
+        let rust_gdbgui = config.cargodir.join(format!("bin/rust-gdbgui{EXE_SUFFIX}"));
         assert!(!rustc.exists());
         assert!(!rustdoc.exists());
         assert!(!cargo.exists());
@@ -329,9 +323,7 @@ fn update_but_not_installed() {
 fn update_but_delete_existing_updater_first() {
     update_setup(&|config, _| {
         // The updater is stored in a known location
-        let setup = config
-            .cargodir
-            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
+        let setup = config.cargodir.join(format!("bin/rustup-init{EXE_SUFFIX}"));
 
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
@@ -340,7 +332,7 @@ fn update_but_delete_existing_updater_first() {
         raw::write_file(&setup, "").unwrap();
         expect_ok(config, &["rustup", "self", "update"]);
 
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         assert!(rustup.exists());
     });
 }
@@ -351,8 +343,8 @@ fn update_download_404() {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
         let trip = this_host_triple();
-        let dist_dir = self_dist.join(&format!("archive/{TEST_VERSION}/{trip}"));
-        let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
+        let dist_dir = self_dist.join(format!("archive/{TEST_VERSION}/{trip}"));
+        let dist_exe = dist_dir.join(format!("rustup-init{EXE_SUFFIX}"));
 
         fs::remove_file(dist_exe).unwrap();
 
@@ -384,7 +376,7 @@ fn update_updates_rustup_bin() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let bin = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         // Running the self update command on the installed binary,
@@ -444,7 +436,7 @@ fn rustup_self_updates_trivial() {
         expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let bin = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update"]);
@@ -461,7 +453,7 @@ fn rustup_self_updates_with_specified_toolchain() {
         expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let bin = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update", "stable"]);
@@ -477,7 +469,7 @@ fn rustup_no_self_update_with_specified_toolchain() {
     update_setup(&|config, _| {
         expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
 
-        let bin = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let bin = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         let before_hash = calc_hash(&bin);
 
         expect_ok(config, &["rustup", "update", "stable"]);
@@ -524,9 +516,7 @@ fn updater_leaves_itself_for_later_deletion() {
         expect_ok(config, &["rustup", "update", "nightly"]);
         expect_ok(config, &["rustup", "self", "update"]);
 
-        let setup = config
-            .cargodir
-            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
+        let setup = config.cargodir.join(format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(setup.exists());
     });
 }
@@ -540,9 +530,7 @@ fn updater_is_deleted_after_running_rustup() {
 
         expect_ok(config, &["rustup", "update", "nightly"]);
 
-        let setup = config
-            .cargodir
-            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
+        let setup = config.cargodir.join(format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(!setup.exists());
     });
 }
@@ -556,9 +544,7 @@ fn updater_is_deleted_after_running_rustc() {
 
         expect_ok(config, &["rustc", "--version"]);
 
-        let setup = config
-            .cargodir
-            .join(&format!("bin/rustup-init{EXE_SUFFIX}"));
+        let setup = config.cargodir.join(format!("bin/rustup-init{EXE_SUFFIX}"));
         assert!(!setup.exists());
     });
 }
@@ -582,7 +568,7 @@ fn as_rustup_setup() {
     clitools::setup(Scenario::Empty, &|config| {
         let init = config.exedir.join(format!("rustup-init{EXE_SUFFIX}"));
         let setup = config.exedir.join(format!("rustup-setup{EXE_SUFFIX}"));
-        fs::copy(&init, &setup).unwrap();
+        fs::copy(init, setup).unwrap();
         expect_ok(
             config,
             &[
@@ -708,11 +694,11 @@ fn readline_no_stdin() {
 fn rustup_init_works_with_weird_names() {
     // Browsers often rename bins to e.g. rustup-init(2).exe.
     clitools::setup(Scenario::SimpleV2, &|config| {
-        let old = config.exedir.join(&format!("rustup-init{EXE_SUFFIX}"));
-        let new = config.exedir.join(&format!("rustup-init(2){EXE_SUFFIX}"));
+        let old = config.exedir.join(format!("rustup-init{EXE_SUFFIX}"));
+        let new = config.exedir.join(format!("rustup-init(2){EXE_SUFFIX}"));
         utils::rename_file("test", &old, &new, &|_: Notification<'_>| {}).unwrap();
         expect_ok(config, &["rustup-init(2)", "-y", "--no-modify-path"]);
-        let rustup = config.cargodir.join(&format!("bin/rustup{EXE_SUFFIX}"));
+        let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));
         assert!(rustup.exists());
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -662,7 +662,7 @@ fn add_target1() {
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -676,7 +676,7 @@ fn add_target2() {
             this_host_triple(),
             clitools::CROSS_ARCH2
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -690,13 +690,13 @@ fn add_all_targets() {
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
             clitools::CROSS_ARCH2
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -873,7 +873,7 @@ fn add_target_again() {
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(config.rustupdir.has(&path));
+        assert!(config.rustupdir.has(path));
     });
 }
 
@@ -900,19 +900,19 @@ fn remove_target() {
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(!config.rustupdir.has(&path));
+        assert!(!config.rustupdir.has(path));
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib",
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(!config.rustupdir.has(&path));
+        assert!(!config.rustupdir.has(path));
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}",
             this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        assert!(!config.rustupdir.has(&path));
+        assert!(!config.rustupdir.has(path));
     });
 }
 

--- a/tests/dist.rs
+++ b/tests/dist.rs
@@ -334,8 +334,8 @@ fn rename_component() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
-            assert!(!utils::path_exists(&prefix.path().join("bin/bobo")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
+            assert!(!utils::path_exists(prefix.path().join("bin/bobo")));
             change_channel_date(url, "nightly", "2016-02-02");
             update_from_dist(
                 url,
@@ -348,8 +348,8 @@ fn rename_component() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
-            assert!(!utils::path_exists(&prefix.path().join("bin/bobo")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
+            assert!(!utils::path_exists(prefix.path().join("bin/bobo")));
         },
     );
 }
@@ -400,8 +400,8 @@ fn rename_component_new() {
             )
             .unwrap();
             // Neither bonus nor bobo are installed at this point.
-            assert!(!utils::path_exists(&prefix.path().join("bin/bonus")));
-            assert!(!utils::path_exists(&prefix.path().join("bin/bobo")));
+            assert!(!utils::path_exists(prefix.path().join("bin/bonus")));
+            assert!(!utils::path_exists(prefix.path().join("bin/bobo")));
             // Now we move to day 2, where bobo is part of the set of things we want
             // to have installed
             change_channel_date(url, "nightly", "2016-02-02");
@@ -419,8 +419,8 @@ fn rename_component_new() {
             // As a result `bin/bonus` is present but not `bin/bobo` which we'd
             // expect since the bonus component installs `bin/bonus` regardless of
             // its name being `bobo`
-            assert!(!utils::path_exists(&prefix.path().join("bin/bobo")));
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
+            assert!(!utils::path_exists(prefix.path().join("bin/bobo")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
         },
     );
 }
@@ -563,7 +563,7 @@ fn setup_from_dist_server(
 
     currentprocess::with(
         Box::new(currentprocess::TestProcess::new(
-            &env::current_dir().unwrap(),
+            env::current_dir().unwrap(),
             &["rustup"],
             HashMap::default(),
             "",
@@ -590,8 +590,8 @@ fn initial_install(comps: Compressions) {
         )
         .unwrap();
 
-        assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
-        assert!(utils::path_exists(&prefix.path().join("lib/libstd.rlib")));
+        assert!(utils::path_exists(prefix.path().join("bin/rustc")));
+        assert!(utils::path_exists(prefix.path().join("lib/libstd.rlib")));
     });
 }
 
@@ -630,8 +630,8 @@ fn test_uninstall() {
         .unwrap();
         uninstall(toolchain, prefix, temp_cfg, &|_| ()).unwrap();
 
-        assert!(!utils::path_exists(&prefix.path().join("bin/rustc")));
-        assert!(!utils::path_exists(&prefix.path().join("lib/libstd.rlib")));
+        assert!(!utils::path_exists(prefix.path().join("bin/rustc")));
+        assert!(!utils::path_exists(prefix.path().join("lib/libstd.rlib")));
     });
 }
 
@@ -654,11 +654,11 @@ fn uninstall_removes_config_file() {
         )
         .unwrap();
         assert!(utils::path_exists(
-            &prefix.manifest_file("multirust-config.toml")
+            prefix.manifest_file("multirust-config.toml")
         ));
         uninstall(toolchain, prefix, temp_cfg, &|_| ()).unwrap();
         assert!(!utils::path_exists(
-            &prefix.manifest_file("multirust-config.toml")
+            prefix.manifest_file("multirust-config.toml")
         ));
     });
 }
@@ -684,7 +684,7 @@ fn upgrade() {
         .unwrap();
         assert_eq!(
             "2016-02-01",
-            fs::read_to_string(&prefix.path().join("bin/rustc")).unwrap()
+            fs::read_to_string(prefix.path().join("bin/rustc")).unwrap()
         );
         change_channel_date(url, "nightly", "2016-02-02");
         update_from_dist(
@@ -700,7 +700,7 @@ fn upgrade() {
         .unwrap();
         assert_eq!(
             "2016-02-02",
-            fs::read_to_string(&prefix.path().join("bin/rustc")).unwrap()
+            fs::read_to_string(prefix.path().join("bin/rustc")).unwrap()
         );
     });
 }
@@ -760,7 +760,7 @@ fn unavailable_component() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
             change_channel_date(url, "nightly", "2016-02-02");
 
             // Update without bonus, should fail.
@@ -821,7 +821,7 @@ fn unavailable_component_from_profile() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
+            assert!(utils::path_exists(prefix.path().join("bin/rustc")));
             change_channel_date(url, "nightly", "2016-02-02");
 
             // Update without rustc, should fail.
@@ -901,7 +901,7 @@ fn removed_component() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
 
             // Update without bonus, should fail with RequestedComponentsUnavailable
             change_channel_date(url, "nightly", "2016-02-02");
@@ -976,10 +976,10 @@ fn unavailable_components_is_target() {
             .unwrap();
 
             assert!(utils::path_exists(
-                &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+                prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
             ));
             assert!(utils::path_exists(
-                &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+                prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
             ));
 
             // Update without rust-std
@@ -1058,8 +1058,8 @@ fn unavailable_components_with_same_target() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
-            assert!(utils::path_exists(&prefix.path().join("lib/libstd.rlib")));
+            assert!(utils::path_exists(prefix.path().join("bin/rustc")));
+            assert!(utils::path_exists(prefix.path().join("lib/libstd.rlib")));
 
             // Update without rust-std and rustc
             change_channel_date(url, "nightly", "2016-02-02");
@@ -1123,10 +1123,10 @@ fn update_preserves_extensions() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
 
         change_channel_date(url, "nightly", "2016-02-02");
@@ -1143,10 +1143,10 @@ fn update_preserves_extensions() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1217,10 +1217,10 @@ fn add_extensions_for_initial_install() {
         )
         .unwrap();
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1270,10 +1270,10 @@ fn add_extensions_for_same_manifest() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1327,10 +1327,10 @@ fn add_extensions_for_upgrade() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1436,7 +1436,7 @@ fn add_extensions_does_not_remove_other_components() {
         )
         .unwrap();
 
-        assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
+        assert!(utils::path_exists(prefix.path().join("bin/rustc")));
     });
 }
 
@@ -1520,10 +1520,10 @@ fn remove_extensions_for_same_manifest() {
         .unwrap();
 
         assert!(!utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1583,10 +1583,10 @@ fn remove_extensions_for_upgrade() {
         .unwrap();
 
         assert!(!utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1677,7 +1677,7 @@ fn remove_extension_not_in_manifest_but_is_already_installed() {
                 false,
             )
             .unwrap();
-            assert!(utils::path_exists(&prefix.path().join("bin/bonus")));
+            assert!(utils::path_exists(prefix.path().join("bin/bonus")));
 
             change_channel_date(url, "nightly", "2016-02-02");
 
@@ -1828,7 +1828,7 @@ fn remove_extensions_does_not_remove_other_components() {
         )
         .unwrap();
 
-        assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
+        assert!(utils::path_exists(prefix.path().join("bin/rustc")));
     });
 }
 
@@ -1886,10 +1886,10 @@ fn add_and_remove_for_upgrade() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(!utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -1944,10 +1944,10 @@ fn add_and_remove() {
         .unwrap();
 
         assert!(utils::path_exists(
-            &prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
+            prefix.path().join("lib/i686-apple-darwin/libstd.rlib")
         ));
         assert!(!utils::path_exists(
-            &prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
+            prefix.path().join("lib/i686-unknown-linux-gnu/libstd.rlib")
         ));
     });
 }
@@ -2036,7 +2036,7 @@ fn unable_to_download_component() {
                           temp_cfg| {
         let path = url.to_file_path().unwrap();
         let path = path.join("dist/2016-02-02/rustc-nightly-x86_64-apple-darwin.tar.gz");
-        fs::remove_file(&path).unwrap();
+        fs::remove_file(path).unwrap();
 
         let err = update_from_dist(
             url,
@@ -2229,7 +2229,7 @@ fn handle_corrupt_partial_downloads() {
         )
         .unwrap();
 
-        assert!(utils::path_exists(&prefix.path().join("bin/rustc")));
-        assert!(utils::path_exists(&prefix.path().join("lib/libstd.rlib")));
+        assert!(utils::path_exists(prefix.path().join("bin/rustc")));
+        assert!(utils::path_exists(prefix.path().join("lib/libstd.rlib")));
     });
 }

--- a/tests/dist_transactions.rs
+++ b/tests/dist_transactions.rs
@@ -33,7 +33,7 @@ fn add_file() {
     drop(file);
 
     assert_eq!(
-        fs::read_to_string(&prefix.path().join("foo/bar")).unwrap(),
+        fs::read_to_string(prefix.path().join("foo/bar")).unwrap(),
         "test"
     );
 }
@@ -76,7 +76,7 @@ fn add_file_that_exists() {
     let notify = |_: Notification<'_>| ();
     let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
 
-    fs::create_dir_all(&prefixdir.path().join("foo")).unwrap();
+    fs::create_dir_all(prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
 
     let err = tx.add_file("c", PathBuf::from("foo/bar")).unwrap_err();
@@ -164,7 +164,7 @@ fn copy_file_that_exists() {
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
 
-    fs::create_dir_all(&prefixdir.path().join("foo")).unwrap();
+    fs::create_dir_all(prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
 
     let err = tx
@@ -484,7 +484,7 @@ fn write_file_then_rollback() {
         .unwrap();
     drop(tx);
 
-    assert!(!utils::is_file(&prefix.path().join("foo/bar")));
+    assert!(!utils::is_file(prefix.path().join("foo/bar")));
 }
 
 #[test]
@@ -678,7 +678,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let path5 = prefix.path().join(&relpath5);
     let path6 = prefix.path().join(&relpath6);
     let path7 = prefix.path().join(&relpath7);
-    let path8 = prefix.path().join(&relpath8);
+    let path8 = prefix.path().join(relpath8);
 
     let srcpath1 = srcdir.path().join(&relpath1);
     fs::create_dir_all(srcpath1.parent().unwrap()).unwrap();

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -160,7 +160,7 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     let rls_path = config.exedir.join(format!("rls{EXE_SUFFIX}"));
     let rust_lldb_path = config.exedir.join(format!("rust-lldb{EXE_SUFFIX}"));
 
-    copy_binary(&build_path, &rustup_path).unwrap();
+    copy_binary(build_path, &rustup_path).unwrap();
     hard_link(&rustup_path, setup_path).unwrap();
     hard_link(&rustup_path, rustc_path).unwrap();
     hard_link(&rustup_path, cargo_path).unwrap();
@@ -199,13 +199,13 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
 
 fn create_local_update_server(self_dist: &Path, config: &mut Config, version: &str) {
     let trip = this_host_triple();
-    let dist_dir = self_dist.join(&format!("archive/{version}/{trip}"));
-    let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
-    let rustup_bin = config.exedir.join(&format!("rustup-init{EXE_SUFFIX}"));
+    let dist_dir = self_dist.join(format!("archive/{version}/{trip}"));
+    let dist_exe = dist_dir.join(format!("rustup-init{EXE_SUFFIX}"));
+    let rustup_bin = config.exedir.join(format!("rustup-init{EXE_SUFFIX}"));
 
     fs::create_dir_all(dist_dir).unwrap();
     output_release_file(self_dist, "1", version);
-    fs::copy(&rustup_bin, &dist_exe).unwrap();
+    fs::copy(rustup_bin, dist_exe).unwrap();
 
     let root_url = format!("file://{}", self_dist.display());
     config.rustup_update_root = Some(root_url);
@@ -239,8 +239,8 @@ pub fn self_update_setup(f: &dyn Fn(&Config, &Path), version: &str) {
         create_local_update_server(self_dist, config, version);
 
         let trip = this_host_triple();
-        let dist_dir = self_dist.join(&format!("archive/{version}/{trip}"));
-        let dist_exe = dist_dir.join(&format!("rustup-init{EXE_SUFFIX}"));
+        let dist_dir = self_dist.join(format!("archive/{version}/{trip}"));
+        let dist_exe = dist_dir.join(format!("rustup-init{EXE_SUFFIX}"));
 
         // Modify the exe so it hashes different
         raw::append_file(&dist_exe, "").unwrap();
@@ -1317,7 +1317,7 @@ fn mock_bin(name: &str, version: &str, version_hash: &str) -> Vec<MockFile> {
             // Create a temp directory to hold the source and the output
             let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
             let source_path = tempdir.path().join("in.rs");
-            let dest_path = tempdir.path().join(&format!("out{EXE_SUFFIX}"));
+            let dest_path = tempdir.path().join(format!("out{EXE_SUFFIX}"));
 
             // Write the source
             let source = include_bytes!("mock_bin_src.rs");


### PR DESCRIPTION
`cargo clippy` suggests removal of borrows in a number of locations. Seems like the standard library has changed to allow for borrows to be omitted on the result of `format!` and in a few other cases.

https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

`CONTRIBUTING.md` suggests one runs this, before publishing a change:
```bash
cargo clippy --all --all-targets --all-features -- -D warnings`
```
But, at the moment, this command generated more than a thousand warnings for me on `master`.

This particular warning is responsible for about 50 cases.

This change is just `cargo clippy --fix`, with flags to only show `clippy::needless_borrow`, followed by `cargo fmt`.