### PR TITLE
Add test for cli ui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,10 +351,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "concolor"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "318d6c16e73b3a900eb212ad6a82fc7d298c5ab8184c7a9998646455bc474a16"
+dependencies = [
+ "bitflags",
+ "concolor-query",
+ "is-terminal",
+]
+
+[[package]]
+name = "concolor-query"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
+
+[[package]]
 name = "const-oid"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "279bc8fc53f788a75c7804af68237d1fce02cde1e275a886a4b320604dc2aeda"
+
+[[package]]
+name = "content_inspector"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7bda66e858c683005a53a9a60c69a4aca7eeaa45d124526e389f7aec8e62f38"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -659,6 +685,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,6 +827,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,7 +876,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -986,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "group"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hmac"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1156,22 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
+dependencies = [
+ "humantime",
+ "serde",
+]
 
 [[package]]
 name = "hyper"
@@ -1206,10 +1287,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "itertools"
@@ -1315,6 +1418,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,7 +1509,7 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1432,6 +1541,21 @@ name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
+name = "nom8"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-bigint"
@@ -1581,6 +1705,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_pipe"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a53dbb20faf34b16087a931834cba2d7a73cc74af2b7ef345a4c8324e2409a12"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "p256"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,7 +1745,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1996,6 +2130,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2216,7 @@ dependencies = [
  "thiserror",
  "threadpool",
  "toml",
+ "trycmd",
  "url",
  "wait-timeout",
  "walkdir",
@@ -2104,7 +2253,7 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2240,6 +2389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2466,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+
+[[package]]
 name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,6 +2480,12 @@ dependencies = [
  "digest 0.9.0",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "simple_asn1"
@@ -2348,6 +2518,34 @@ name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "snapbox"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34eced5a65e76d5a00047986a83c65f80dc666faa27b5138f331659e2ca6bcf5"
+dependencies = [
+ "concolor",
+ "content_inspector",
+ "dunce",
+ "filetime",
+ "libc",
+ "normalize-line-endings",
+ "os_pipe",
+ "similar",
+ "snapbox-macros",
+ "tempfile",
+ "wait-timeout",
+ "walkdir",
+ "windows-sys 0.42.0",
+ "yansi",
+]
+
+[[package]]
+name = "snapbox-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "485e65c1203eb37244465e857d15a26d3a85a5410648ccb53b18bd44cb3a7336"
 
 [[package]]
 name = "socket2"
@@ -2624,7 +2822,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2684,6 +2882,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6a7712b49e1775fb9a7b998de6635b299237f48b404dde71704f2e0e7f37e5"
+dependencies = [
+ "indexmap",
+ "nom8",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,6 +2934,22 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "trycmd"
+version = "0.14.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "522dcafb4bf113bcf83e4f47a0499ea1f6798877439e6a0e96cf087a2abe97dc"
+dependencies = [
+ "glob",
+ "humantime",
+ "humantime-serde",
+ "rayon",
+ "serde",
+ "shlex",
+ "snapbox",
+ "toml_edit",
+]
 
 [[package]]
 name = "twofish"
@@ -2990,6 +3226,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
 name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3349,12 @@ checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ url = "2.1"
 wait-timeout = "0.2"
 xz2 = "0.1.3"
 zstd = "0.11"
+trycmd = "0.14.11"
 
 [dependencies.retry]
 default-features = false

--- a/tests/cli-ui.rs
+++ b/tests/cli-ui.rs
@@ -1,0 +1,13 @@
+use std::fs;
+
+#[test]
+fn ui_tests() {
+    let t = trycmd::TestCases::new();
+    let rustup_init = trycmd::cargo::cargo_bin("rustup-init");
+    let rustup = trycmd::cargo::cargo_bin("rustup");
+    t.register_bin("rustup-init", &rustup_init);
+    // Copy rustup-init to rustup so that the tests can run it.
+    fs::copy(&rustup_init, &rustup).unwrap();
+    t.register_bin("rustup", &rustup);
+    t.case("tests/cli-ui/*.toml");
+}

--- a/tests/cli-ui.rs
+++ b/tests/cli-ui.rs
@@ -10,4 +10,9 @@ fn ui_tests() {
     fs::copy(&rustup_init, &rustup).unwrap();
     t.register_bin("rustup", &rustup);
     t.case("tests/cli-ui/*.toml");
+    #[cfg(target_os = "windows")]
+    {
+        // On windows, we don't have man command, so skip the tests.
+        t.skip("tests/cli-ui/rustup_man_cmd_help_flag_stdout.toml");
+    }
 }

--- a/tests/cli-ui/rustup-init_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup-init_help_flag_stdout.toml
@@ -1,0 +1,27 @@
+bin.name = "rustup-init"
+args = ["--help"]
+status.code = 0
+stdout = """
+rustup-init [..]
+The installer for rustup
+
+USAGE:
+    rustup-init [FLAGS] [OPTIONS]
+
+FLAGS:
+    -v, --verbose                        Enable verbose output
+    -q, --quiet                          Disable progress output
+    -y                                   Disable confirmation prompt.
+        --no-update-default-toolchain    Don't update any existing default toolchain after install
+        --no-modify-path                 Don't configure the PATH environment variable
+    -h, --help                           Prints help information
+    -V, --version                        Prints version information
+
+OPTIONS:
+        --default-host <default-host>              Choose a default host triple
+        --default-toolchain <default-toolchain>    Choose a default toolchain to install
+        --profile <profile>                         [default: default]  [possible values: minimal, default, complete]
+    -c, --component <components>...                Component name to also install
+    -t, --target <targets>...                      Target name to also install
+"""
+stderr = ""

--- a/tests/cli-ui/rustup-init_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup-init_help_flag_stdout.toml
@@ -6,7 +6,7 @@ rustup-init [..]
 The installer for rustup
 
 USAGE:
-    rustup-init [FLAGS] [OPTIONS]
+    rustup-init[EXE] [FLAGS] [OPTIONS]
 
 FLAGS:
     -v, --verbose                        Enable verbose output

--- a/tests/cli-ui/rustup_check_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_check_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["check","--help"]
 stdout = """
-rustup-check 
+...
 Check for updates to Rust toolchains and rustup
 
 USAGE:
-    rustup check
+    rustup[EXE] check
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_check_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_check_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["check","--help"]
+stdout = """
+rustup-check 
+Check for updates to Rust toolchains and rustup
+
+USAGE:
+    rustup check
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_completions_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["completions","--help"]
 stdout = """
-rustup-completions 
+...
 Generate tab-completion scripts for your shell
 
 USAGE:
-    rustup completions [ARGS]
+    rustup[EXE] completions [ARGS]
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_completions_cmd_help_flag_stdout.toml
@@ -1,0 +1,138 @@
+bin.name = "rustup"
+args = ["completions","--help"]
+stdout = """
+rustup-completions 
+Generate tab-completion scripts for your shell
+
+USAGE:
+    rustup completions [ARGS]
+
+FLAGS:
+    -h, --help    Prints help information
+
+ARGS:
+    <shell>       [possible values: zsh, bash, fish, powershell, elvish]
+    <command>     [possible values: rustup, cargo]
+
+DISCUSSION:
+    Enable tab completion for Bash, Fish, Zsh, or PowerShell
+    The script is output on `stdout`, allowing one to re-direct the
+    output to the file of their choosing. Where you place the file
+    will depend on which shell, and which operating system you are
+    using. Your particular configuration may also determine where
+    these scripts need to be placed.
+
+    Here are some common set ups for the three supported shells under
+    Unix and similar operating systems (such as GNU/Linux).
+
+    BASH:
+
+    Completion files are commonly stored in `/etc/bash_completion.d/` for
+    system-wide commands, but can be stored in
+    `~/.local/share/bash-completion/completions` for user-specific commands.
+    Run the command:
+
+        $ mkdir -p ~/.local/share/bash-completion/completions
+        $ rustup completions bash >> ~/.local/share/bash-completion/completions/rustup
+
+    This installs the completion script. You may have to log out and
+    log back in to your shell session for the changes to take effect.
+
+    BASH (macOS/Homebrew):
+
+    Homebrew stores bash completion files within the Homebrew directory.
+    With the `bash-completion` brew formula installed, run the command:
+
+        $ mkdir -p $(brew --prefix)/etc/bash_completion.d
+        $ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion
+
+    FISH:
+
+    Fish completion files are commonly stored in
+    `$HOME/.config/fish/completions`. Run the command:
+
+        $ mkdir -p ~/.config/fish/completions
+        $ rustup completions fish > ~/.config/fish/completions/rustup.fish
+
+    This installs the completion script. You may have to log out and
+    log back in to your shell session for the changes to take effect.
+
+    ZSH:
+
+    ZSH completions are commonly stored in any directory listed in
+    your `$fpath` variable. To use these completions, you must either
+    add the generated script to one of those directories, or add your
+    own to this list.
+
+    Adding a custom directory is often the safest bet if you are
+    unsure of which directory to use. First create the directory; for
+    this example we'll create a hidden directory inside our `$HOME`
+    directory:
+
+        $ mkdir ~/.zfunc
+
+    Then add the following lines to your `.zshrc` just before
+    `compinit`:
+
+        fpath+=~/.zfunc
+
+    Now you can install the completions script using the following
+    command:
+
+        $ rustup completions zsh > ~/.zfunc/_rustup
+
+    You must then either log out and log back in, or simply run
+
+        $ exec zsh
+
+    for the new completions to take effect.
+
+    CUSTOM LOCATIONS:
+
+    Alternatively, you could save these files to the place of your
+    choosing, such as a custom directory inside your $HOME. Doing so
+    will require you to add the proper directives, such as `source`ing
+    inside your login script. Consult your shells documentation for
+    how to add such directives.
+
+    POWERSHELL:
+
+    The powershell completion scripts require PowerShell v5.0+ (which
+    comes with Windows 10, but can be downloaded separately for windows 7
+    or 8.1).
+
+    First, check if a profile has already been set
+
+        PS C:/> Test-Path $profile
+
+    If the above command returns `False` run the following
+
+        PS C:/> New-Item -path $profile -type file -force
+
+    Now open the file provided by `$profile` (if you used the
+    `New-Item` command it will be
+    `${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1`
+
+    Next, we either save the completions file into our profile, or
+    into a separate file and source it inside our profile. To save the
+    completions into our profile simply use
+
+        PS C:/> rustup completions powershell >>
+${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1
+
+    CARGO:
+
+    Rustup can also generate a completion script for `cargo`. The script output
+    by `rustup` will source the completion script distributed with your default
+    toolchain. Not all shells are currently supported. Here are examples for
+    the currently supported shells.
+
+    BASH:
+
+        $ rustup completions bash cargo >> ~/.local/share/bash-completion/completions/cargo
+
+    ZSH:
+
+        $ rustup completions zsh cargo > ~/.zfunc/_cargo
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_component_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_add_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["component","add","--help"]
 stdout = """
-rustup-component-add 
+...
 Add a component to a Rust toolchain
 
 USAGE:
-    rustup component add [OPTIONS] <component>...
+    rustup[EXE] component add [OPTIONS] <component>...
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_component_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_add_cmd_help_flag_stdout.toml
@@ -1,0 +1,21 @@
+bin.name = "rustup"
+args = ["component","add","--help"]
+stdout = """
+rustup-component-add 
+Add a component to a Rust toolchain
+
+USAGE:
+    rustup component add [OPTIONS] <component>...
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --target <target>          
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <component>...    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["component","list","--help"]
 stdout = """
-rustup-component-list 
+...
 List installed and available components
 
 USAGE:
-    rustup component list [FLAGS] [OPTIONS]
+    rustup[EXE] component list [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help         Prints help information

--- a/tests/cli-ui/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -1,0 +1,18 @@
+bin.name = "rustup"
+args = ["component","list","--help"]
+stdout = """
+rustup-component-list 
+List installed and available components
+
+USAGE:
+    rustup component list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help         Prints help information
+        --installed    List only installed components
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["component","remove","--help"]
 stdout = """
-rustup-component-remove 
+...
 Remove a component from a Rust toolchain
 
 USAGE:
-    rustup component remove [OPTIONS] <component>...
+    rustup[EXE] component remove [OPTIONS] <component>...
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_component_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,0 +1,21 @@
+bin.name = "rustup"
+args = ["component","remove","--help"]
+stdout = """
+rustup-component-remove 
+Remove a component from a Rust toolchain
+
+USAGE:
+    rustup component remove [OPTIONS] <component>...
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --target <target>          
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <component>...    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_default_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["default","--help"]
 stdout = """
-rustup-default 
+...
 Set the default toolchain
 
 USAGE:
-    rustup default [toolchain]
+    rustup[EXE] default [toolchain]
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_default_cmd_help_flag_stdout.toml
@@ -1,0 +1,21 @@
+bin.name = "rustup"
+args = ["default","--help"]
+stdout = """
+rustup-default 
+Set the default toolchain
+
+USAGE:
+    rustup default [toolchain]
+
+FLAGS:
+    -h, --help    Prints help information
+
+ARGS:
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                   toolchain`
+
+DISCUSSION:
+    Sets the default toolchain to the one specified. If the toolchain
+    is not already installed then it is installed first.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_doc_cmd_help_flag_stdout.toml
@@ -1,0 +1,45 @@
+bin.name = "rustup"
+args = ["doc","--help"]
+stdout = """
+rustup-doc 
+Open the documentation for the current toolchain
+
+USAGE:
+    rustup doc [FLAGS] [OPTIONS] [topic]
+
+FLAGS:
+        --alloc              The Rust core allocation and collections library
+        --book               The Rust Programming Language book
+        --cargo              The Cargo Book
+        --core               The Rust Core Library
+        --edition-guide      The Rust Edition Guide
+        --embedded-book      The Embedded Rust Book
+    -h, --help               Prints help information
+        --nomicon            The Dark Arts of Advanced and Unsafe Rust Programming
+        --path               Only print the path to the documentation
+        --proc_macro         A support library for macro authors when defining new macros
+        --reference          The Rust Reference
+        --rust-by-example    A collection of runnable examples that illustrate various Rust concepts and standard
+                             libraries
+        --rustc              The compiler for the Rust programming language
+        --rustdoc            Documentation generator for Rust projects
+        --std                Standard library API documentation
+        --test               Support code for rustc's built in unit-test and micro-benchmarking framework
+        --unstable-book      The Unstable Book
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <topic>    Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!', 'std::fs',
+               'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum', 'std::io::error::Result' etc...
+
+DISCUSSION:
+    Opens the documentation for the currently active toolchain with
+    the default browser.
+
+    By default, it opens the documentation index. Use the various
+    flags to open specific pieces of documentation.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_doc_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["doc","--help"]
 stdout = """
-rustup-doc 
+...
 Open the documentation for the current toolchain
 
 USAGE:
-    rustup doc [FLAGS] [OPTIONS] [topic]
+    rustup[EXE] doc [FLAGS] [OPTIONS] [topic]
 
 FLAGS:
         --alloc              The Rust core allocation and collections library

--- a/tests/cli-ui/rustup_help_cmd_stdout.toml
+++ b/tests/cli-ui/rustup_help_cmd_stdout.toml
@@ -1,0 +1,48 @@
+bin.name = "rustup"
+args = ["help"]
+status.code = 0
+stdout = """
+rustup [..]
+The Rust toolchain installer
+
+USAGE:
+    rustup [FLAGS] [+toolchain] <SUBCOMMAND>
+
+FLAGS:
+    -v, --verbose    Enable verbose output
+    -q, --quiet      Disable progress output
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+
+SUBCOMMANDS:
+    show           Show the active and installed toolchains or profiles
+    update         Update Rust toolchains and rustup
+    check          Check for updates to Rust toolchains and rustup
+    default        Set the default toolchain
+    toolchain      Modify or query the installed toolchains
+    target         Modify a toolchain's supported targets
+    component      Modify a toolchain's installed components
+    override       Modify directory toolchain overrides
+    run            Run a command with an environment configured for a given toolchain
+    which          Display which binary will be run for a given command
+    doc            Open the documentation for the current toolchain
+    man            View the man page for a given command
+    self           Modify the rustup installation
+    set            Alter rustup settings
+    completions    Generate tab-completion scripts for your shell
+    help           Prints this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Rustup installs The Rust Programming Language from the official
+    release channels, enabling you to easily switch between stable,
+    beta, and nightly compilers and keep them updated. It makes
+    cross-compiling simpler with binary builds of the standard library
+    for common platforms.
+
+    If you are new to Rust consider running `rustup doc --book` to
+    learn Rust.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_help_cmd_stdout.toml
+++ b/tests/cli-ui/rustup_help_cmd_stdout.toml
@@ -6,7 +6,7 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup [FLAGS] [+toolchain] <SUBCOMMAND>
+    rustup[EXE] [FLAGS] [+toolchain] <SUBCOMMAND>
 
 FLAGS:
     -v, --verbose    Enable verbose output
@@ -29,7 +29,7 @@ SUBCOMMANDS:
     run            Run a command with an environment configured for a given toolchain
     which          Display which binary will be run for a given command
     doc            Open the documentation for the current toolchain
-    man            View the man page for a given command
+...
     self           Modify the rustup installation
     set            Alter rustup settings
     completions    Generate tab-completion scripts for your shell

--- a/tests/cli-ui/rustup_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_help_flag_stdout.toml
@@ -1,0 +1,48 @@
+bin.name = "rustup"
+args = ["--help"]
+status.code = 0
+stdout = """
+rustup [..]
+The Rust toolchain installer
+
+USAGE:
+    rustup [FLAGS] [+toolchain] <SUBCOMMAND>
+
+FLAGS:
+    -v, --verbose    Enable verbose output
+    -q, --quiet      Disable progress output
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+
+SUBCOMMANDS:
+    show           Show the active and installed toolchains or profiles
+    update         Update Rust toolchains and rustup
+    check          Check for updates to Rust toolchains and rustup
+    default        Set the default toolchain
+    toolchain      Modify or query the installed toolchains
+    target         Modify a toolchain's supported targets
+    component      Modify a toolchain's installed components
+    override       Modify directory toolchain overrides
+    run            Run a command with an environment configured for a given toolchain
+    which          Display which binary will be run for a given command
+    doc            Open the documentation for the current toolchain
+    man            View the man page for a given command
+    self           Modify the rustup installation
+    set            Alter rustup settings
+    completions    Generate tab-completion scripts for your shell
+    help           Prints this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Rustup installs The Rust Programming Language from the official
+    release channels, enabling you to easily switch between stable,
+    beta, and nightly compilers and keep them updated. It makes
+    cross-compiling simpler with binary builds of the standard library
+    for common platforms.
+
+    If you are new to Rust consider running `rustup doc --book` to
+    learn Rust.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_help_flag_stdout.toml
@@ -6,7 +6,7 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup [FLAGS] [+toolchain] <SUBCOMMAND>
+    rustup[EXE] [FLAGS] [+toolchain] <SUBCOMMAND>
 
 FLAGS:
     -v, --verbose    Enable verbose output
@@ -29,7 +29,7 @@ SUBCOMMANDS:
     run            Run a command with an environment configured for a given toolchain
     which          Display which binary will be run for a given command
     doc            Open the documentation for the current toolchain
-    man            View the man page for a given command
+...
     self           Modify the rustup installation
     set            Alter rustup settings
     completions    Generate tab-completion scripts for your shell

--- a/tests/cli-ui/rustup_man_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_man_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["man","--help"]
+stdout = """
+rustup-man 
+View the man page for a given command
+
+USAGE:
+    rustup man [OPTIONS] <command>
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <command>    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_man_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_man_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["man","--help"]
 stdout = """
-rustup-man 
+...
 View the man page for a given command
 
 USAGE:
-    rustup man [OPTIONS] <command>
+    rustup[EXE] man [OPTIONS] <command>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_override_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_add_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["override","add","--help"]
+stdout = """
+rustup-override-set 
+Set the override toolchain for a directory
+
+USAGE:
+    rustup override set [OPTIONS] <toolchain>
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --path <path>    Path to the directory
+
+ARGS:
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                   toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_add_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","add","--help"]
 stdout = """
-rustup-override-set 
+...
 Set the override toolchain for a directory
 
 USAGE:
-    rustup override set [OPTIONS] <toolchain>
+    rustup[EXE] override set [OPTIONS] <toolchain>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_help_flag_stdout.toml
@@ -1,0 +1,40 @@
+bin.name = "rustup"
+args = ["override","--help"]
+stdout = """
+rustup-override 
+Modify directory toolchain overrides
+
+USAGE:
+    rustup override <SUBCOMMAND>
+
+FLAGS:
+    -h, --help    Prints help information
+
+SUBCOMMANDS:
+    list     List directory toolchain overrides
+    set      Set the override toolchain for a directory
+    unset    Remove the override toolchain for a directory
+    help     Prints this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Overrides configure Rustup to use a specific toolchain when
+    running in a specific directory.
+
+    Directories can be assigned their own Rust toolchain with `rustup
+    override`. When a directory has an override then any time `rustc`
+    or `cargo` is run inside that directory, or one of its child
+    directories, the override toolchain will be invoked.
+
+    To pin to a specific nightly:
+
+        $ rustup override set nightly-2014-12-18
+
+    Or a specific stable release:
+
+        $ rustup override set 1.0.0
+
+    To see the active toolchain use `rustup show`. To remove the
+    override and use the default toolchain again, `rustup override
+    unset`.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","--help"]
 stdout = """
-rustup-override 
+...
 Modify directory toolchain overrides
 
 USAGE:
-    rustup override <SUBCOMMAND>
+    rustup[EXE] override <SUBCOMMAND>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_override_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_list_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["override","list","--help"]
+stdout = """
+rustup-override-list 
+List directory toolchain overrides
+
+USAGE:
+    rustup override list
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_list_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","list","--help"]
 stdout = """
-rustup-override-list 
+...
 List directory toolchain overrides
 
 USAGE:
-    rustup override list
+    rustup[EXE] override list
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,0 +1,24 @@
+bin.name = "rustup"
+args = ["override","unset","--help"]
+stdout = """
+rustup-override-unset 
+Remove the override toolchain for a directory
+
+USAGE:
+    rustup override unset [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help           Prints help information
+        --nonexistent    Remove override toolchain for all nonexistent directories
+
+OPTIONS:
+        --path <path>    Path to the directory
+
+DISCUSSION:
+    If `--path` argument is present, removes the override toolchain
+    for the specified directory. If `--nonexistent` argument is
+    present, removes the override toolchain for all nonexistent
+    directories. Otherwise, removes the override toolchain for the
+    current directory.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","unset","--help"]
 stdout = """
-rustup-override-unset 
+...
 Remove the override toolchain for a directory
 
 USAGE:
-    rustup override unset [FLAGS] [OPTIONS]
+    rustup[EXE] override unset [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help           Prints help information

--- a/tests/cli-ui/rustup_override_cmd_set_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_set_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","set","--help"]
 stdout = """
-rustup-override-set 
+...
 Set the override toolchain for a directory
 
 USAGE:
-    rustup override set [OPTIONS] <toolchain>
+    rustup[EXE] override set [OPTIONS] <toolchain>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_override_cmd_set_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_set_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["override","set","--help"]
+stdout = """
+rustup-override-set 
+Set the override toolchain for a directory
+
+USAGE:
+    rustup override set [OPTIONS] <toolchain>
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --path <path>    Path to the directory
+
+ARGS:
+    <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                   toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
@@ -1,0 +1,24 @@
+bin.name = "rustup"
+args = ["override","unset","--help"]
+stdout = """
+rustup-override-unset 
+Remove the override toolchain for a directory
+
+USAGE:
+    rustup override unset [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help           Prints help information
+        --nonexistent    Remove override toolchain for all nonexistent directories
+
+OPTIONS:
+        --path <path>    Path to the directory
+
+DISCUSSION:
+    If `--path` argument is present, removes the override toolchain
+    for the specified directory. If `--nonexistent` argument is
+    present, removes the override toolchain for all nonexistent
+    directories. Otherwise, removes the override toolchain for the
+    current directory.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_override_cmd_unset_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["override","unset","--help"]
 stdout = """
-rustup-override-unset 
+...
 Remove the override toolchain for a directory
 
 USAGE:
-    rustup override unset [FLAGS] [OPTIONS]
+    rustup[EXE] override unset [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help           Prints help information

--- a/tests/cli-ui/rustup_run_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_run_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["run","--help"]
 stdout = """
-rustup-run 
+...
 Run a command with an environment configured for a given toolchain
 
 USAGE:
-    rustup run [FLAGS] <toolchain> <command>...
+    rustup[EXE] run [FLAGS] <toolchain> <command>...
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_run_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_run_cmd_help_flag_stdout.toml
@@ -1,0 +1,34 @@
+bin.name = "rustup"
+args = ["run","--help"]
+stdout = """
+rustup-run 
+Run a command with an environment configured for a given toolchain
+
+USAGE:
+    rustup run [FLAGS] <toolchain> <command>...
+
+FLAGS:
+    -h, --help       Prints help information
+        --install    Install the requested toolchain if needed
+
+ARGS:
+    <toolchain>     Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                    toolchain`
+    <command>...    
+
+DISCUSSION:
+    Configures an environment to use the given toolchain and then runs
+    the specified program. The command may be any program, not just
+    rustc or cargo. This can be used for testing arbitrary toolchains
+    without setting an override.
+
+    Commands explicitly proxied by `rustup` (such as `rustc` and
+    `cargo`) also have a shorthand for this available. The toolchain
+    can be set by using `+toolchain` as the first argument. These are
+    equivalent:
+
+        $ cargo +nightly build
+
+        $ rustup run nightly cargo build
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_self_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["self","--help"]
 stdout = """
-rustup-self 
+...
 Modify the rustup installation
 
 USAGE:
-    rustup self <SUBCOMMAND>
+    rustup[EXE] self <SUBCOMMAND>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_self_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_help_flag_stdout.toml
@@ -1,0 +1,19 @@
+bin.name = "rustup"
+args = ["self","--help"]
+stdout = """
+rustup-self 
+Modify the rustup installation
+
+USAGE:
+    rustup self <SUBCOMMAND>
+
+FLAGS:
+    -h, --help    Prints help information
+
+SUBCOMMANDS:
+    update          Download and install updates to rustup
+    uninstall       Uninstall rustup.
+    upgrade-data    Upgrade the internal data format.
+    help            Prints this message or the help of the given subcommand(s)
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["self","uninstall","--help"]
 stdout = """
-rustup-self-uninstall 
+...
 Uninstall rustup.
 
 USAGE:
-    rustup self uninstall [FLAGS]
+    rustup[EXE] self uninstall [FLAGS]
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,0 +1,14 @@
+bin.name = "rustup"
+args = ["self","uninstall","--help"]
+stdout = """
+rustup-self-uninstall 
+Uninstall rustup.
+
+USAGE:
+    rustup self uninstall [FLAGS]
+
+FLAGS:
+    -h, --help    Prints help information
+    -y            
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_self_cmd_update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_update_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["self","update","--help"]
 stdout = """
-rustup-self-update 
+...
 Download and install updates to rustup
 
 USAGE:
-    rustup self update
+    rustup[EXE] self update
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_self_cmd_update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_update_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["self","update","--help"]
+stdout = """
+rustup-self-update 
+Download and install updates to rustup
+
+USAGE:
+    rustup self update
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["self","upgrade-data","--help"]
 stdout = """
-rustup-self-upgrade-data 
+...
 Upgrade the internal data format.
 
 USAGE:
-    rustup self upgrade-data
+    rustup[EXE] self upgrade-data
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_self_cmd_upgrade-data _cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["self","upgrade-data","--help"]
+stdout = """
+rustup-self-upgrade-data 
+Upgrade the internal data format.
+
+USAGE:
+    rustup self upgrade-data
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["set","auto-self-update","--help"]
 stdout = """
-rustup-set-auto-self-update 
+...
 The rustup auto self update mode
 
 USAGE:
-    rustup set auto-self-update <auto-self-update-mode>
+    rustup[EXE] set auto-self-update <auto-self-update-mode>
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_auto-self-update_cmd_help_flag_stdout.toml
@@ -1,0 +1,17 @@
+bin.name = "rustup"
+args = ["set","auto-self-update","--help"]
+stdout = """
+rustup-set-auto-self-update 
+The rustup auto self update mode
+
+USAGE:
+    rustup set auto-self-update <auto-self-update-mode>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <auto-self-update-mode>     [default: enable]  [possible values: enable, disable, check-only]
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["set","default-host","--help"]
 stdout = """
-rustup-set-default-host 
+...
 The triple used to identify toolchains when not specified
 
 USAGE:
-    rustup set default-host <host_triple>
+    rustup[EXE] set default-host <host_triple>
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_default-host_cmd_help_flag_stdout.toml
@@ -1,0 +1,17 @@
+bin.name = "rustup"
+args = ["set","default-host","--help"]
+stdout = """
+rustup-set-default-host 
+The triple used to identify toolchains when not specified
+
+USAGE:
+    rustup set default-host <host_triple>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <host_triple>    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_help_flag_stdout.toml
@@ -1,0 +1,19 @@
+bin.name = "rustup"
+args = ["set","--help"]
+stdout = """
+rustup-set 
+Alter rustup settings
+
+USAGE:
+    rustup set <SUBCOMMAND>
+
+FLAGS:
+    -h, --help    Prints help information
+
+SUBCOMMANDS:
+    auto-self-update    The rustup auto self update mode
+    default-host        The triple used to identify toolchains when not specified
+    help                Prints this message or the help of the given subcommand(s)
+    profile             The default components installed
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["set","--help"]
 stdout = """
-rustup-set 
+...
 Alter rustup settings
 
 USAGE:
-    rustup set <SUBCOMMAND>
+    rustup[EXE] set <SUBCOMMAND>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,0 +1,17 @@
+bin.name = "rustup"
+args = ["set","profile","--help"]
+stdout = """
+rustup-set-profile 
+The default components installed
+
+USAGE:
+    rustup set profile <profile-name>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <profile-name>     [default: default]  [possible values: minimal, default, complete]
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["set","profile","--help"]
 stdout = """
-rustup-set-profile 
+...
 The default components installed
 
 USAGE:
-    rustup set profile <profile-name>
+    rustup[EXE] set profile <profile-name>
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
@@ -1,0 +1,23 @@
+bin.name = "rustup"
+args = ["show","active-toolchain","--help"]
+stdout = """
+rustup-show-active-toolchain 
+Show the active toolchain
+
+USAGE:
+    rustup show active-toolchain [FLAGS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --verbose    Enable verbose output with rustc information
+
+DISCUSSION:
+    Shows the name of the active toolchain.
+
+    This is useful for figuring out the active tool chain from
+    scripts.
+
+    You should use `rustc --print sysroot` to get the sysroot, or
+    `rustc --version` to get the toolchain version.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_active-toolchain_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["show","active-toolchain","--help"]
 stdout = """
-rustup-show-active-toolchain 
+...
 Show the active toolchain
 
 USAGE:
-    rustup show active-toolchain [FLAGS]
+    rustup[EXE] show active-toolchain [FLAGS]
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["show","--help"]
 stdout = """
-rustup-show 
+...
 Show the active and installed toolchains or profiles
 
 USAGE:
-    rustup show [FLAGS] [SUBCOMMAND]
+    rustup[EXE] show [FLAGS] [SUBCOMMAND]
 
 FLAGS:
     -v, --verbose    Enable verbose output with rustc information for all installed toolchains

--- a/tests/cli-ui/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_help_flag_stdout.toml
@@ -1,0 +1,30 @@
+bin.name = "rustup"
+args = ["show","--help"]
+stdout = """
+rustup-show 
+Show the active and installed toolchains or profiles
+
+USAGE:
+    rustup show [FLAGS] [SUBCOMMAND]
+
+FLAGS:
+    -v, --verbose    Enable verbose output with rustc information for all installed toolchains
+    -h, --help       Prints help information
+
+SUBCOMMANDS:
+    active-toolchain    Show the active toolchain
+    home                Display the computed value of RUSTUP_HOME
+    profile             Show the current profile
+    keys                Display the known PGP keys
+    help                Prints this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Shows the name of the active toolchain and the version of `rustc`.
+
+    If the active toolchain has installed support for additional
+    compilation targets, then they are listed as well.
+
+    If there are multiple toolchains installed then all installed
+    toolchains are listed as well.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_show_cmd_home_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_home_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["show","home","--help"]
+stdout = """
+rustup-show-home 
+Display the computed value of RUSTUP_HOME
+
+USAGE:
+    rustup show home
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_show_cmd_home_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_home_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["show","home","--help"]
 stdout = """
-rustup-show-home 
+...
 Display the computed value of RUSTUP_HOME
 
 USAGE:
-    rustup show home
+    rustup[EXE] show home
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["show","keys","--help"]
 stdout = """
-rustup-show-keys 
+...
 Display the known PGP keys
 
 USAGE:
-    rustup show keys
+    rustup[EXE] show keys
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_keys_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["show","keys","--help"]
+stdout = """
+rustup-show-keys 
+Display the known PGP keys
+
+USAGE:
+    rustup show keys
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,0 +1,13 @@
+bin.name = "rustup"
+args = ["show","profile","--help"]
+stdout = """
+rustup-show-profile 
+Show the current profile
+
+USAGE:
+    rustup show profile
+
+FLAGS:
+    -h, --help    Prints help information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["show","profile","--help"]
 stdout = """
-rustup-show-profile 
+...
 Show the current profile
 
 USAGE:
-    rustup show profile
+    rustup[EXE] show profile
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_target_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_add_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["target","add","--help"]
 stdout = """
-rustup-target-add 
+...
 Add a target to a Rust toolchain
 
 USAGE:
-    rustup target add [OPTIONS] <target>...
+    rustup[EXE] target add [OPTIONS] <target>...
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_target_cmd_add_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_add_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["target","add","--help"]
+stdout = """
+rustup-target-add 
+Add a target to a Rust toolchain
+
+USAGE:
+    rustup target add [OPTIONS] <target>...
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <target>...    List of targets to install; \"all\" installs all available targets
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_target_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_help_flag_stdout.toml
@@ -1,0 +1,19 @@
+bin.name = "rustup"
+args = ["target","--help"]
+stdout = """
+rustup-target 
+Modify a toolchain's supported targets
+
+USAGE:
+    rustup target <SUBCOMMAND>
+
+FLAGS:
+    -h, --help    Prints help information
+
+SUBCOMMANDS:
+    list      List installed and available targets
+    add       Add a target to a Rust toolchain
+    remove    Remove a target from a Rust toolchain
+    help      Prints this message or the help of the given subcommand(s)
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_target_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["target","--help"]
 stdout = """
-rustup-target 
+...
 Modify a toolchain's supported targets
 
 USAGE:
-    rustup target <SUBCOMMAND>
+    rustup[EXE] target <SUBCOMMAND>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_target_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_list_cmd_help_flag_stdout.toml
@@ -1,0 +1,18 @@
+bin.name = "rustup"
+args = ["target","list","--help"]
+stdout = """
+rustup-target-list 
+List installed and available targets
+
+USAGE:
+    rustup target list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help         Prints help information
+        --installed    List only installed targets
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_target_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_list_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["target","list","--help"]
 stdout = """
-rustup-target-list 
+...
 List installed and available targets
 
 USAGE:
-    rustup target list [FLAGS] [OPTIONS]
+    rustup[EXE] target list [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help         Prints help information

--- a/tests/cli-ui/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["target","remove","--help"]
+stdout = """
+rustup-target-remove 
+Remove a target from a Rust toolchain
+
+USAGE:
+    rustup target remove [OPTIONS] <target>...
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <target>...    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_target_cmd_remove_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["target","remove","--help"]
 stdout = """
-rustup-target-remove 
+...
 Remove a target from a Rust toolchain
 
 USAGE:
-    rustup target remove [OPTIONS] <target>...
+    rustup[EXE] target remove [OPTIONS] <target>...
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -1,0 +1,62 @@
+bin.name = "rustup"
+args = ["toolchain","--help"]
+stdout = """
+rustup-toolchain 
+Modify or query the installed toolchains
+
+USAGE:
+    rustup toolchain <SUBCOMMAND>
+
+FLAGS:
+    -h, --help    Prints help information
+
+SUBCOMMANDS:
+    list         List installed toolchains
+    install      Install or update a given toolchain
+    uninstall    Uninstall a toolchain
+    link         Create a custom toolchain by symlinking to a directory
+    help         Prints this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Many `rustup` commands deal with *toolchains*, a single
+    installation of the Rust compiler. `rustup` supports multiple
+    types of toolchains. The most basic track the official release
+    channels: 'stable', 'beta' and 'nightly'; but `rustup` can also
+    install toolchains from the official archives, for alternate host
+    platforms, and from local builds.
+
+    Standard release channel toolchain names have the following form:
+
+        <channel>[-<date>][-<host>]
+
+        <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
+        <date>          = YYYY-MM-DD
+        <host>          = <target-triple>
+
+    'channel' is a named release channel, a major and minor version
+    number such as `1.42`, or a fully specified version number, such
+    as `1.42.0`. Channel names can be optionally appended with an
+    archive date, as in `nightly-2014-12-18`, in which case the
+    toolchain is downloaded from the archive for that date.
+
+    The host may be specified as a target triple. This is most useful
+    for installing a 32-bit compiler on a 64-bit platform, or for
+    installing the [MSVC-based toolchain] on Windows. For example:
+
+        $ rustup toolchain install stable-x86_64-pc-windows-msvc
+
+    For convenience, omitted elements of the target triple will be
+    inferred, so the above could be written:
+
+        $ rustup toolchain install stable-msvc
+
+    The `rustup default` command may be used to both install and set
+    the desired toolchain as default in a single command:
+
+        $ rustup default stable-msvc
+
+    rustup can also manage symlinked local toolchain builds, which are
+    often used for developing Rust itself. For more information see
+    `rustup toolchain help link`.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["toolchain","--help"]
 stdout = """
-rustup-toolchain 
+...
 Modify or query the installed toolchains
 
 USAGE:
-    rustup toolchain <SUBCOMMAND>
+    rustup[EXE] toolchain <SUBCOMMAND>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -1,0 +1,27 @@
+bin.name = "rustup"
+args = ["toolchain","install","--help"]
+stdout = """
+rustup-toolchain-install 
+Install or update a given toolchain
+
+USAGE:
+    rustup toolchain install [FLAGS] [OPTIONS] <toolchain>...
+
+FLAGS:
+        --allow-downgrade    Allow rustup to downgrade the toolchain to satisfy your component choice
+        --force              Force an update, even if some components are missing
+        --force-non-host     Install toolchains that require an emulator. See https://github.com/rust-
+                             lang/rustup/wiki/Non-host-toolchains
+    -h, --help               Prints help information
+        --no-self-update     Don't perform self update when running the`rustup toolchain install` command
+
+OPTIONS:
+    -c, --component <components>...    Add specific components on installation
+        --profile <profile>             [possible values: minimal, default, complete]
+    -t, --target <targets>...          Add specific targets on installation
+
+ARGS:
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                      toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["toolchain","install","--help"]
 stdout = """
-rustup-toolchain-install 
+...
 Install or update a given toolchain
 
 USAGE:
-    rustup toolchain install [FLAGS] [OPTIONS] <toolchain>...
+    rustup[EXE] toolchain install [FLAGS] [OPTIONS] <toolchain>...
 
 FLAGS:
         --allow-downgrade    Allow rustup to downgrade the toolchain to satisfy your component choice

--- a/tests/cli-ui/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
@@ -1,0 +1,36 @@
+bin.name = "rustup"
+args = ["toolchain","link","--help"]
+stdout = """
+rustup-toolchain-link 
+Create a custom toolchain by symlinking to a directory
+
+USAGE:
+    rustup toolchain link <toolchain> <path>
+
+FLAGS:
+    -h, --help    Prints help information
+
+ARGS:
+    <toolchain>    Custom toolchain name
+    <path>         Path to the directory
+
+DISCUSSION:
+    'toolchain' is the custom name to be assigned to the new toolchain.
+    Any name is permitted as long as it does not fully match an initial
+    substring of a standard release channel. For example, you can use
+    the names 'latest' or '2017-04-01' but you cannot use 'stable' or
+    'beta-i686' or 'nightly-x86_64-unknown-linux-gnu'.
+
+    'path' specifies the directory where the binaries and libraries for
+    the custom toolchain can be found. For example, when used for
+    development of Rust itself, toolchains can be linked directly out of
+    the build directory. After building, you can test out different
+    compiler versions as follows:
+
+        $ rustup toolchain link latest-stage1 build/x86_64-unknown-linux-gnu/stage1
+        $ rustup override set latest-stage1
+
+    If you now compile a crate in the current directory, the custom
+    toolchain 'latest-stage1' will be used.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_link_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["toolchain","link","--help"]
 stdout = """
-rustup-toolchain-link 
+...
 Create a custom toolchain by symlinking to a directory
 
 USAGE:
-    rustup toolchain link <toolchain> <path>
+    rustup[EXE] toolchain link <toolchain> <path>
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
@@ -1,0 +1,14 @@
+bin.name = "rustup"
+args = ["toolchain","list","--help"]
+stdout = """
+rustup-toolchain-list 
+List installed toolchains
+
+USAGE:
+    rustup toolchain list [FLAGS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --verbose    Enable verbose output with toolchain information
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_list_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["toolchain","list","--help"]
 stdout = """
-rustup-toolchain-list 
+...
 List installed toolchains
 
 USAGE:
-    rustup toolchain list [FLAGS]
+    rustup[EXE] toolchain list [FLAGS]
 
 FLAGS:
     -h, --help       Prints help information

--- a/tests/cli-ui/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,0 +1,17 @@
+bin.name = "rustup"
+args = ["toolchain","uninstall","--help"]
+stdout = """
+rustup-toolchain-uninstall 
+Uninstall a toolchain
+
+USAGE:
+    rustup toolchain uninstall <toolchain>...
+
+FLAGS:
+    -h, --help    Prints help information
+
+ARGS:
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                      toolchain`
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["toolchain","uninstall","--help"]
 stdout = """
-rustup-toolchain-uninstall 
+...
 Uninstall a toolchain
 
 USAGE:
-    rustup toolchain uninstall <toolchain>...
+    rustup[EXE] toolchain uninstall <toolchain>...
 
 FLAGS:
     -h, --help    Prints help information

--- a/tests/cli-ui/rustup_update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_update_cmd_help_flag_stdout.toml
@@ -1,0 +1,29 @@
+bin.name = "rustup"
+args = ["update","--help"]
+stdout = """
+rustup-update 
+Update Rust toolchains and rustup
+
+USAGE:
+    rustup update [FLAGS] [toolchain]...
+
+FLAGS:
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
+                            lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Prints help information
+        --no-self-update    Don't perform self update when running the `rustup update` command
+
+ARGS:
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                      toolchain`
+
+DISCUSSION:
+    With no toolchain specified, the `update` command updates each of
+    the installed toolchains from the official release channels, then
+    updates rustup itself.
+
+    If given a toolchain argument then `update` updates that
+    toolchain, the same as `rustup toolchain install`.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_update_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_update_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["update","--help"]
 stdout = """
-rustup-update 
+...
 Update Rust toolchains and rustup
 
 USAGE:
-    rustup update [FLAGS] [toolchain]...
+    rustup[EXE] update [FLAGS] [toolchain]...
 
 FLAGS:
         --force             Force an update, even if some components are missing

--- a/tests/cli-ui/rustup_which_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_which_cmd_help_flag_stdout.toml
@@ -1,0 +1,20 @@
+bin.name = "rustup"
+args = ["which","--help"]
+stdout = """
+rustup-which 
+Display which binary will be run for a given command
+
+USAGE:
+    rustup which [OPTIONS] <command>
+
+FLAGS:
+    -h, --help    Prints help information
+
+OPTIONS:
+        --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+                                   `rustup help toolchain`
+
+ARGS:
+    <command>    
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_which_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_which_cmd_help_flag_stdout.toml
@@ -1,11 +1,11 @@
 bin.name = "rustup"
 args = ["which","--help"]
 stdout = """
-rustup-which 
+...
 Display which binary will be run for a given command
 
 USAGE:
-    rustup which [OPTIONS] <command>
+    rustup[EXE] which [OPTIONS] <command>
 
 FLAGS:
     -h, --help    Prints help information


### PR DESCRIPTION
ref https://github.com/rust-lang/rustup/pull/3064#issuecomment-1414789331

Add ui tests for cli. Then we can try to bump clap's version.

Some notes:
1. Because of [this bug](https://github.com/assert-rs/trycmd/issues/197), so we need to use `...` to ignore the first line of the subcommand bin name.
2. Because we don't have the `man` command on windows, we need to skip the man's test on windows.