### PR TITLE
Add RUSTUP_TOOLCHAIN_DIR

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -401,6 +401,7 @@ impl<'a> InstalledCommonToolchain<'a> {
 
         cmd.env("RUSTUP_TOOLCHAIN", &self.0.name);
         cmd.env("RUSTUP_HOME", &self.0.cfg.rustup_dir);
+        cmd.env("RUSTUP_TOOLCHAIN_DIR", &self.0.path);
     }
 
     fn set_ldpath(&self, cmd: &mut Command) {

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -4,7 +4,7 @@ pub mod mock;
 
 use std::env::consts::EXE_SUFFIX;
 use std::fs;
-use std::path::{PathBuf, MAIN_SEPARATOR};
+use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 
 use rustup::for_host;
 use rustup::test::this_host_triple;
@@ -2249,6 +2249,22 @@ fn warn_on_duplicate_rust_toolchain_file() {
                 toolchain_file_1.canonicalize().unwrap().display(),
                 toolchain_file_2.canonicalize().unwrap().display(),
             ),
+        );
+    });
+}
+
+/// Checks that the RUSTUP_TOOLCHAIN_DIR is set.
+#[test]
+fn toolchain_dir_env() {
+    setup(&|config| {
+        expect_ok(config, &["rustup", "default", "nightly"]);
+        let output = clitools::run(config, "rustup", &["which", "rustc"], &[]);
+        let real_mock_rustc = Path::new(output.stdout.trim());
+        let toolchain_dir = real_mock_rustc.parent().unwrap().parent().unwrap();
+        expect_stderr_ok(
+            config,
+            &["rustc", "--echo-env", "RUSTUP_TOOLCHAIN_DIR"],
+            toolchain_dir.to_str().unwrap(),
         );
     });
 }

--- a/tests/mock/mock_bin_src.rs
+++ b/tests/mock/mock_bin_src.rs
@@ -71,6 +71,11 @@ fn main() {
             let mut out = io::stderr();
             writeln!(out, "{}", std::env::var("PATH").unwrap()).unwrap();
         }
+        Some("--echo-env") => {
+            let mut out = io::stderr();
+            let var = args.next().unwrap();
+            writeln!(out, "{}", std::env::var(var).unwrap_or_default()).unwrap();
+        }
         _ => panic!("bad mock proxy commandline"),
     }
 }


### PR DESCRIPTION
This adds an environment variable `RUSTUP_TOOLCHAIN_DIR` that is set when running a toolchain command. This is intended to be used by Cargo to execute rustc and rustdoc directly without going through the rustup wrappers. This should help improve performance on non-Windows platforms, and to avoid the performance loss on Windows in #3178.

Modifying PATH isn't an option because it prevents recursive commands from being able to run via the proxies (#812).
Setting RUSTC isn't an option because it breaks recursive invocations (#3029 and #3031).
This option *should* be safe, since cargo will only invoke the toolchain binary if no other setting is specified. Recursive invocations should continue to be able to run the rustup wrappers.

https://github.com/ehuss/cargo/commit/f6d949b80fb385d331c73ff82a43a1eb2e04a764 is a prototype of what the cargo side looks like.

I have done performance testing on a variety of machines running macOS and Linux across 10 different projects. Typical improvement for a clean cargo check is about 1.07 to 1.16 times faster (with a peak of 1.25).

Closes #3035
