### PR TITLE
doc: add links for the aarch64-apple-darwin files

### DIFF
--- a/doc/src/installation/other.md
+++ b/doc/src/installation/other.md
@@ -32,6 +32,8 @@ $ curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchai
 If you prefer you can directly download `rustup-init` for the platform of your
 choice:
 
+- [aarch64-apple-darwin](https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init.sha256)
 - [aarch64-linux-android](https://static.rust-lang.org/rustup/dist/aarch64-linux-android/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-linux-android/rustup-init.sha256)
 - [aarch64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init)


### PR DESCRIPTION
The links on the [Other installation methods](https://rust-lang.github.io/rustup/installation/other.html) page don't mention the `aarch64-apple-darwin` builds, this PR adds them.