### PR TITLE
Work improving check_updates_none test performance

### DIFF
--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -167,12 +167,6 @@ fn check_updates_none() {
         expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["rustup", "update", "beta"]);
         expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "upgrade", "stable"]);
-        expect_ok(config, &["rustup", "upgrade", "beta"]);
-        expect_ok(config, &["rustup", "upgrade", "nightly"]);
-        expect_ok(config, &["rustup", "up", "stable"]);
-        expect_ok(config, &["rustup", "up", "beta"]);
-        expect_ok(config, &["rustup", "up", "nightly"]);
         expect_stdout_ok(
             config,
             &["rustup", "check"],
@@ -193,9 +187,6 @@ fn check_updates_some() {
         expect_ok(config, &["rustup", "update", "stable"]);
         expect_ok(config, &["rustup", "update", "beta"]);
         expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "upgrade", "stable"]);
-        expect_ok(config, &["rustup", "upgrade", "beta"]);
-        expect_ok(config, &["rustup", "upgrade", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
         expect_stdout_ok(
             config,

--- a/tests/cli-ui.rs
+++ b/tests/cli-ui.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 #[test]
-fn ui_tests() {
+fn ui_doc_text_tests() {
     let t = trycmd::TestCases::new();
     let rustup_init = trycmd::cargo::cargo_bin("rustup-init");
     let rustup = trycmd::cargo::cargo_bin("rustup");

--- a/tests/cli-ui/rustup_up_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_up_cmd_help_flag_stdout.toml
@@ -1,0 +1,29 @@
+bin.name = "rustup"
+args = ["up","--help"]
+stdout = """
+...
+Update Rust toolchains and rustup
+
+USAGE:
+    rustup[EXE] update [FLAGS] [toolchain]...
+
+FLAGS:
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
+                            lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Prints help information
+        --no-self-update    Don't perform self update when running the `rustup update` command
+
+ARGS:
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                      toolchain`
+
+DISCUSSION:
+    With no toolchain specified, the `update` command updates each of
+    the installed toolchains from the official release channels, then
+    updates rustup itself.
+
+    If given a toolchain argument then `update` updates that
+    toolchain, the same as `rustup toolchain install`.
+"""
+stderr = ""

--- a/tests/cli-ui/rustup_upgrade_cmd_help_flag_stdout.toml
+++ b/tests/cli-ui/rustup_upgrade_cmd_help_flag_stdout.toml
@@ -1,0 +1,29 @@
+bin.name = "rustup"
+args = ["upgrade","--help"]
+stdout = """
+...
+Update Rust toolchains and rustup
+
+USAGE:
+    rustup[EXE] update [FLAGS] [toolchain]...
+
+FLAGS:
+        --force             Force an update, even if some components are missing
+        --force-non-host    Install toolchains that require an emulator. See https://github.com/rust-
+                            lang/rustup/wiki/Non-host-toolchains
+    -h, --help              Prints help information
+        --no-self-update    Don't perform self update when running the `rustup update` command
+
+ARGS:
+    <toolchain>...    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see `rustup help
+                      toolchain`
+
+DISCUSSION:
+    With no toolchain specified, the `update` command updates each of
+    the installed toolchains from the official release channels, then
+    updates rustup itself.
+
+    If given a toolchain argument then `update` updates that
+    toolchain, the same as `rustup toolchain install`.
+"""
+stderr = ""

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -10,6 +10,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
+use std::time::Instant;
 
 use lazy_static::lazy_static;
 use url::Url;
@@ -602,19 +603,23 @@ where
     A: AsRef<OsStr>,
 {
     let inprocess = allow_inprocess(name, args.clone());
+    let start = Instant::now();
     let out = if inprocess {
         run_inprocess(config, name, args, env)
     } else {
         run_subprocess(config, name, args, env)
     };
+    let duration = Instant::now() - start;
     let output = SanitizedOutput {
         ok: matches!(out.status, Some(0)),
         stdout: String::from_utf8(out.stdout).unwrap(),
         stderr: String::from_utf8(out.stderr).unwrap(),
     };
 
+
     println!("inprocess: {inprocess}");
     println!("status: {:?}", out.status);
+    println!("duration: {:.3}s", duration.as_secs_f32());
     println!("stdout:\n====\n{}\n====\n", output.stdout);
     println!("stderr:\n====\n{}\n====\n", output.stderr);
 

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -616,7 +616,6 @@ where
         stderr: String::from_utf8(out.stderr).unwrap(),
     };
 
-
     println!("inprocess: {inprocess}");
     println!("status: {:?}", out.status);
     println!("duration: {:.3}s", duration.as_secs_f32());

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -615,8 +615,8 @@ where
 
     println!("inprocess: {inprocess}");
     println!("status: {:?}", out.status);
-    println!("----- stdout\n{}", output.stdout);
-    println!("----- stderr\n{}", output.stderr);
+    println!("stdout:\n====\n{}\n====\n", output.stdout);
+    println!("stderr:\n====\n{}\n====\n", output.stderr);
 
     output
 }


### PR DESCRIPTION
- Move tests of aliases out of the test - they are unrelated
- rename the trycmd test for better precision
- clarify test command output
- measure the time test commands take to run