### PR TITLE
Temporarily disable the android tests

### DIFF
--- a/.github/workflows/linux-builds-on-master.yaml
+++ b/.github/workflows/linux-builds-on-master.yaml
@@ -20,10 +20,12 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
-          - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
           - powerpc64-unknown-linux-gnu   # skip-pr
           - x86_64-unknown-linux-musl     # skip-pr
+# Temporarily disabled due to https://github.com/rust-lang/rust/issues/103673.
+# FIXME(hi-rustin): Re-enable them after the issue is fixed.
+#          - aarch64-linux-android
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/.github/workflows/linux-builds-on-pr.yaml
+++ b/.github/workflows/linux-builds-on-pr.yaml
@@ -19,7 +19,9 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
-          - aarch64-linux-android
+# Temporarily disabled due to https://github.com/rust-lang/rust/issues/103673.
+# FIXME(hi-rustin): Re-enable them after the issue is fixed.
+#          - aarch64-linux-android
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -18,7 +18,6 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
-          - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
           - aarch64-unknown-linux-musl    # skip-pr skip-master
           - powerpc64-unknown-linux-gnu   # skip-pr
@@ -36,10 +35,13 @@ jobs:
           - mipsel-unknown-linux-gnu      # skip-pr skip-master
           - mips64el-unknown-linux-gnuabi64 # skip-pr skip-master
           - s390x-unknown-linux-gnu       # skip-pr skip-master
-          - arm-linux-androideabi         # skip-pr skip-master
-          - armv7-linux-androideabi       # skip-pr skip-master
-          - i686-linux-android            # skip-pr skip-master
-          - x86_64-linux-android          # skip-pr skip-master
+# Temporarily disabled due to https://github.com/rust-lang/rust/issues/103673.
+# FIXME(hi-rustin): Re-enable them after the issue is fixed.
+#          - arm-linux-androideabi         skip-pr skip-master
+#          - armv7-linux-androideabi       skip-pr skip-master
+#          - i686-linux-android            skip-pr skip-master
+#          - x86_64-linux-android          skip-pr skip-master
+#          - aarch64-linux-android
           - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -27,7 +27,6 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
-          - aarch64-linux-android
           - aarch64-unknown-linux-gnu     # skip-pr
           - aarch64-unknown-linux-musl    # skip-pr skip-master
           - powerpc64-unknown-linux-gnu   # skip-pr
@@ -45,10 +44,13 @@ jobs:
           - mipsel-unknown-linux-gnu      # skip-pr skip-master
           - mips64el-unknown-linux-gnuabi64 # skip-pr skip-master
           - s390x-unknown-linux-gnu       # skip-pr skip-master
-          - arm-linux-androideabi         # skip-pr skip-master
-          - armv7-linux-androideabi       # skip-pr skip-master
-          - i686-linux-android            # skip-pr skip-master
-          - x86_64-linux-android          # skip-pr skip-master
+# Temporarily disabled due to https://github.com/rust-lang/rust/issues/103673.
+# FIXME(hi-rustin): Re-enable them after the issue is fixed.
+#          - arm-linux-androideabi         skip-pr skip-master
+#          - armv7-linux-androideabi       skip-pr skip-master
+#          - i686-linux-android            skip-pr skip-master
+#          - x86_64-linux-android          skip-pr skip-master
+#          - aarch64-linux-android
           - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu


### PR DESCRIPTION
We need to wait for [this issue](https://github.com/rust-lang/rust/issues/103673) to be fixed. So temporarily disable the android tests.