### PR TITLE
Move test calls from fn(&config) to self.fn 

### DIFF
--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -4,8 +4,7 @@
 pub mod mock;
 
 use crate::mock::clitools::{
-    self, check_update_setup, expect_err_ex, expect_ok, expect_ok_ex, expect_stderr_ok,
-    expect_stdout_ok, self_update_setup, set_current_dist_date, Config, Scenario,
+    self, check_update_setup, self_update_setup, set_current_dist_date, Config, Scenario,
 };
 use rustup::for_host;
 use rustup::test::this_host_triple;
@@ -17,8 +16,7 @@ fn setup(f: &dyn Fn(&mut Config)) {
 #[test]
 fn update_once() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "update", "nightly"],
             for_host!(
                 r"
@@ -50,12 +48,11 @@ fn update_once_and_check_self_update() {
 
     self_update_setup(
         &|config, _| {
-            expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
-            expect_ok(config, &["rustup", "set", "auto-self-update", "check-only"]);
+            config.expect_ok(&["rustup-init", "-y", "--no-modify-path"]);
+            config.expect_ok(&["rustup", "set", "auto-self-update", "check-only"]);
             let current_version = env!("CARGO_PKG_VERSION");
 
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &["rustup", "update", "nightly"],
                 &format!(
                     r"
@@ -92,10 +89,9 @@ fn update_once_and_self_update() {
 
     self_update_setup(
         &|config, _| {
-            expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
-            expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
-            expect_ok_ex(
-                config,
+            config.expect_ok(&["rustup-init", "-y", "--no-modify-path"]);
+            config.expect_ok(&["rustup", "set", "auto-self-update", "enable"]);
+            config.expect_ok_ex(
                 &["rustup", "update", "nightly"],
                 for_host!(
                     r"
@@ -127,10 +123,9 @@ info: downloading self-update
 #[test]
 fn update_again() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "upgrade", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "upgrade", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "update", "nightly"],
             for_host!(
                 r"
@@ -143,8 +138,7 @@ fn update_again() {
 "
             ),
         );
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "upgrade", "nightly"],
             for_host!(
                 r"
@@ -164,11 +158,10 @@ fn update_again() {
 fn check_updates_none() {
     check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "check"],
             for_host!(
                 r"stable-{0} - Up to date : 1.0.0 (hash-stable-1.0.0)
@@ -184,12 +177,11 @@ nightly-{0} - Up to date : 1.2.0 (hash-nightly-1)
 fn check_updates_some() {
     check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "check"],
             for_host!(
                 r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
@@ -209,8 +201,7 @@ fn check_updates_self() {
         &|config, _| {
             let current_version = env!("CARGO_PKG_VERSION");
 
-            expect_stdout_ok(
-                config,
+            config.expect_stdout_ok(
                 &["rustup", "check"],
                 &format!(
                     r"rustup - Update available : {current_version} -> {test_version}
@@ -228,8 +219,7 @@ fn check_updates_self_no_change() {
 
     self_update_setup(
         &|config, _| {
-            expect_stdout_ok(
-                config,
+            config.expect_stdout_ok(
                 &["rustup", "check"],
                 &format!(
                     r"rustup - Up to date : {current_version}
@@ -245,11 +235,10 @@ fn check_updates_self_no_change() {
 fn check_updates_with_update() {
     check_update_setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "check"],
             for_host!(
                 r"stable-{0} - Up to date : 1.0.0 (hash-stable-1.0.0)
@@ -259,8 +248,7 @@ nightly-{0} - Up to date : 1.2.0 (hash-nightly-1)
             ),
         );
         set_current_dist_date(config, "2015-01-02");
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "check"],
             for_host!(
                 r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
@@ -269,9 +257,8 @@ nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2
 "
             ),
         );
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_stdout_ok(
             &["rustup", "check"],
             for_host!(
                 r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
@@ -286,8 +273,7 @@ nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2
 #[test]
 fn default() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "default", "nightly"],
             for_host!(
                 r"
@@ -317,9 +303,8 @@ info: default toolchain set to 'nightly-{0}'
 fn override_again() {
     setup(&|config| {
         let cwd = config.current_dir();
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "override", "add", "nightly"],
             for_host!(
                 r"
@@ -343,9 +328,8 @@ fn remove_override() {
     for keyword in &["remove", "unset"] {
         setup(&|config| {
             let cwd = config.current_dir();
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_ok_ex(
-                config,
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_ok_ex(
                 &["rustup", "override", keyword],
                 r"",
                 &format!("info: override toolchain for '{}' removed\n", cwd.display()),
@@ -359,8 +343,7 @@ fn remove_override_none() {
     for keyword in &["remove", "unset"] {
         setup(&|config| {
             let cwd = config.current_dir();
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &["rustup", "override", keyword],
                 r"",
                 &format!(
@@ -382,10 +365,9 @@ fn remove_override_with_path() {
                 .tempdir()
                 .unwrap();
             config.change_dir(dir.path(), || {
-                expect_ok(config, &["rustup", "override", "add", "nightly"]);
+                config.expect_ok(&["rustup", "override", "add", "nightly"]);
             });
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &[
                     "rustup",
                     "override",
@@ -414,12 +396,11 @@ fn remove_override_with_path_deleted() {
                     .unwrap();
                 let path = std::fs::canonicalize(dir.path()).unwrap();
                 config.change_dir(&path, || {
-                    expect_ok(config, &["rustup", "override", "add", "nightly"]);
+                    config.expect_ok(&["rustup", "override", "add", "nightly"]);
                 });
                 path
             };
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &[
                     "rustup",
                     "override",
@@ -449,15 +430,14 @@ fn remove_override_nonexistent() {
                     .unwrap();
                 let path = std::fs::canonicalize(dir.path()).unwrap();
                 config.change_dir(&path, || {
-                    expect_ok(config, &["rustup", "override", "add", "nightly"]);
+                    config.expect_ok(&["rustup", "override", "add", "nightly"]);
                 });
                 path
             };
             // FIXME TempDir seems to succumb to difficulties removing dirs on windows
             let _ = rustup::utils::raw::remove_dir(&path);
             assert!(!path.exists());
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &["rustup", "override", keyword, "--nonexistent"],
                 r"",
                 &format!(
@@ -480,9 +460,8 @@ fn list_overrides() {
         }
 
         let trip = this_host_triple();
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "override", "list"],
             &format!(
                 "{:<40}\t{:<20}\n",
@@ -505,7 +484,7 @@ fn list_overrides_with_nonexistent() {
                 .tempdir()
                 .unwrap();
             config.change_dir(dir.path(), || {
-                expect_ok(config, &["rustup", "override", "add", "nightly"]);
+                config.expect_ok(&["rustup", "override", "add", "nightly"]);
             });
             std::fs::canonicalize(dir.path()).unwrap()
         };
@@ -518,8 +497,7 @@ fn list_overrides_with_nonexistent() {
             path_formatted = path_formatted[4..].to_owned();
         }
 
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "override", "list"],
             &format!(
                 "{:<40}\t{:<20}\n\n",
@@ -535,8 +513,7 @@ fn list_overrides_with_nonexistent() {
 #[test]
 fn update_no_manifest() {
     setup(&|config| {
-        expect_err_ex(
-            config,
+        config.expect_err_ex(
             &["rustup", "update", "nightly-2016-01-01"],
             r"",
             for_host!(
@@ -552,8 +529,7 @@ error: no release found for 'nightly-2016-01-01'
 #[test]
 fn update_invalid_toolchain() {
     setup(&|config| {
-        expect_err_ex(
-            config,
+        config.expect_err_ex(
             &["rustup", "update", "nightly-2016-03-1"],
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
@@ -567,8 +543,7 @@ error: target '2016-03-1' not found in channel.  Perhaps check https://doc.rust-
 #[test]
 fn default_invalid_toolchain() {
     setup(&|config| {
-        expect_err_ex(
-            config,
+        config.expect_err_ex(
             &["rustup", "default", "nightly-2016-03-1"],
             r"",
             r"info: syncing channel updates for 'nightly-2016-03-1'
@@ -582,13 +557,11 @@ error: target '2016-03-1' not found in channel.  Perhaps check https://doc.rust-
 #[test]
 fn default_none() {
     setup(&|config| {
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "default", "none"],
             "info: default toolchain unset",
         );
-        expect_err_ex(
-            config,
+        config.expect_err_ex(
             &["rustc", "--version"],
             "",
             "error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
@@ -611,9 +584,9 @@ fn list_targets() {
 
         let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_ok_ex(config, &["rustup", "target", "list"], &expected, r"");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok_ex(&["rustup", "target", "list"], &expected, r"");
     });
 }
 
@@ -630,25 +603,19 @@ fn list_installed_targets() {
 
         let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
-        expect_ok_ex(
-            config,
-            &["rustup", "target", "list", "--installed"],
-            &expected,
-            r"",
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        config.expect_ok_ex(&["rustup", "target", "list", "--installed"], &expected, r"");
     });
 }
 
 #[test]
 fn cross_install_indicates_target() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         // TODO error 'nightly-x86_64-apple-darwin' is not installed
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "target", "add", clitools::CROSS_ARCH1],
             r"",
             &format!(
@@ -665,8 +632,7 @@ info: installing component 'rust-std' for '{0}'
 #[test]
 fn undefined_linked_toolchain() {
     setup(&|config| {
-        expect_err_ex(
-            config,
+        config.expect_err_ex(
             &["cargo", "+bogus", "test"],
             r"",
             "error: toolchain 'bogus' is not installed\n",
@@ -677,7 +643,7 @@ fn undefined_linked_toolchain() {
 #[test]
 fn install_by_version_number() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "0.100.99"]);
+        config.expect_ok(&["rustup", "default", "0.100.99"]);
     })
 }
 
@@ -687,14 +653,13 @@ fn install_unreleased_component() {
     clitools::setup(Scenario::MissingComponentMulti, &|config| {
         // Initial channel content is host + rls + multiarch-std
         set_current_dist_date(config, "2019-09-12");
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "component", "add", "rls"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::MULTI_ARCH1]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "component", "add", "rls"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::MULTI_ARCH1]);
 
         // Next channel variant should have host + rls but not multiarch-std
         set_current_dist_date(config, "2019-09-13");
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "update", "nightly"],
             for_host!(
                 r"
@@ -715,8 +680,7 @@ info: syncing channel updates for 'nightly-2019-09-12-{0}'
 
         // Next channel variant should have host + multiarch-std but have rls missing
         set_current_dist_date(config, "2019-09-14");
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "update", "nightly"],
             for_host!(
                 r"

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -11,10 +11,7 @@ use rustup::test::this_host_triple;
 use rustup::test::with_saved_path;
 use rustup::utils::raw;
 
-use crate::mock::clitools::{
-    self, expect_err, expect_ok, expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date,
-    Config, SanitizedOutput, Scenario,
-};
+use crate::mock::clitools::{self, set_current_dist_date, Config, SanitizedOutput, Scenario};
 
 fn run_input(config: &Config, args: &[&str], input: &str) -> SanitizedOutput {
     run_input_with_env(config, args, input, &[])
@@ -132,7 +129,7 @@ fn smoke_case_install_with_path_install() {
 #[test]
 fn blank_lines_around_stderr_log_output_update() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
+        config.expect_ok(&["rustup-init", "-y", "--no-modify-path"]);
         let out = run_input(
             config,
             &["rustup-init", "--no-update-default-toolchain"],
@@ -293,7 +290,7 @@ fn with_no_toolchain() {
         );
         assert!(out.ok);
 
-        expect_stdout_ok(config, &["rustup", "show"], "no active toolchain");
+        config.expect_stdout_ok(&["rustup", "show"], "no active toolchain");
     });
 }
 
@@ -311,7 +308,7 @@ fn with_non_default_toolchain_still_prompts() {
         );
         assert!(out.ok);
 
-        expect_stdout_ok(config, &["rustup", "show"], "nightly");
+        config.expect_stdout_ok(&["rustup", "show"], "nightly");
     });
 }
 
@@ -329,8 +326,8 @@ fn with_non_release_channel_non_default_toolchain() {
         );
         assert!(out.ok);
 
-        expect_stdout_ok(config, &["rustup", "show"], "nightly");
-        expect_stdout_ok(config, &["rustup", "show"], "2015-01-02");
+        config.expect_stdout_ok(&["rustup", "show"], "nightly");
+        config.expect_stdout_ok(&["rustup", "show"], "2015-01-02");
     });
 }
 
@@ -344,7 +341,7 @@ fn set_nightly_toolchain() {
         );
         assert!(out.ok);
 
-        expect_stdout_ok(config, &["rustup", "show"], "nightly");
+        config.expect_stdout_ok(&["rustup", "show"], "nightly");
     });
 }
 
@@ -376,7 +373,7 @@ fn set_nightly_toolchain_and_unset() {
         println!("{:?}", out.stdout);
         assert!(out.ok);
 
-        expect_stdout_ok(config, &["rustup", "show"], "beta");
+        config.expect_stdout_ok(&["rustup", "show"], "beta");
     });
 }
 
@@ -400,14 +397,9 @@ fn install_with_components() {
         args.extend_from_slice(comp_args);
 
         clitools::setup(Scenario::SimpleV2, &|config| {
-            expect_ok(config, &args);
-            expect_stdout_ok(
-                config,
-                &["rustup", "component", "list"],
-                "rust-src (installed)",
-            );
-            expect_stdout_ok(
-                config,
+            config.expect_ok(&args);
+            config.expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
+            config.expect_stdout_ok(
                 &["rustup", "component", "list"],
                 &format!("rust-analysis-{} (installed)", this_host_triple()),
             );
@@ -445,8 +437,7 @@ fn install_forces_and_skips_rls() {
 #[test]
 fn test_warn_if_complete_profile_is_used() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &[
                 "rustup-init",
                 "-y",
@@ -513,7 +504,7 @@ fn test_prompt_succeed_if_rustup_sh_already_installed_reply_yes() {
 #[test]
 fn installing_when_already_installed_updates_toolchain() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        expect_ok(config, &["rustup-init", "-y", "--no-modify-path"]);
+        config.expect_ok(&["rustup-init", "-y", "--no-modify-path"]);
         let out = run_input(config, &["rustup-init", "--no-modify-path"], "\n\n");
         println!("stdout:\n{}\n...\n", out.stdout);
         assert!(out
@@ -534,8 +525,7 @@ fn install_stops_if_rustc_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     clitools::setup(Scenario::SimpleV2, &|config| {
-        let out = run(
-            config,
+        let out = config.run(
             "rustup-init",
             &["--no-modify-path"],
             &[
@@ -565,8 +555,7 @@ fn install_stops_if_cargo_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     clitools::setup(Scenario::SimpleV2, &|config| {
-        let out = run(
-            config,
+        let out = config.run(
             "rustup-init",
             &["--no-modify-path"],
             &[
@@ -596,8 +585,7 @@ fn with_no_prompt_install_succeeds_if_rustc_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     clitools::setup(Scenario::SimpleV2, &|config| {
-        let out = run(
-            config,
+        let out = config.run(
             "rustup-init",
             &["-y", "--no-modify-path"],
             &[
@@ -613,8 +601,7 @@ fn with_no_prompt_install_succeeds_if_rustc_exists() {
 #[test]
 fn install_non_installable_toolchain() {
     clitools::setup(Scenario::Unavailable, &|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &[
                 "rustup-init",
                 "-y",

--- a/tests/cli-paths.rs
+++ b/tests/cli-paths.rs
@@ -354,7 +354,7 @@ mod windows {
     use rustup::test::{get_path, with_saved_path};
 
     use super::INIT_NONE;
-    use crate::mock::clitools::{self, expect_ok, Scenario};
+    use crate::mock::clitools::{self, Scenario};
 
     #[test]
     /// Smoke test for end-to-end code connectivity of the installer path mgmt on windows.

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -10,10 +10,7 @@ use rustup::for_host;
 use rustup::test::this_host_triple;
 use rustup::utils::raw;
 
-use crate::mock::clitools::{
-    self, expect_err, expect_not_stderr_ok, expect_not_stdout_ok, expect_ok, expect_ok_ex,
-    expect_stderr_ok, expect_stdout_ok, run, set_current_dist_date, Config, Scenario,
-};
+use crate::mock::clitools::{self, set_current_dist_date, Config, Scenario};
 
 macro_rules! for_host_and_home {
     ($config:ident, $s: expr) => {
@@ -31,10 +28,9 @@ pub fn setup(f: &dyn Fn(&Config)) {
 fn rustup_stable() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "stable"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "update"],
             for_host!(
                 r"
@@ -68,10 +64,9 @@ info: cleaning up downloads & tmp directories
 fn rustup_stable_quiet() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "--quiet", "update", "stable"]);
+        config.expect_ok(&["rustup", "--quiet", "update", "stable"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "--quiet", "update"],
             for_host!(
                 r"
@@ -105,9 +100,8 @@ info: cleaning up downloads & tmp directories
 fn rustup_stable_no_change() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok_ex(
             &["rustup", "update"],
             for_host!(
                 r"
@@ -128,12 +122,11 @@ info: cleaning up downloads & tmp directories
 fn rustup_all_channels() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "update"],
             for_host!(
                 r"
@@ -197,13 +190,12 @@ info: cleaning up downloads & tmp directories
 fn rustup_some_channels_up_to_date() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok_ex(
             &["rustup", "update"],
             for_host!(
                 r"
@@ -253,10 +245,9 @@ info: cleaning up downloads & tmp directories
 #[test]
 fn rustup_no_channels() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "stable"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "stable"]);
+        config.expect_ok_ex(
             &["rustup", "update"],
             r"",
             r"info: no updatable toolchains installed
@@ -269,8 +260,7 @@ info: cleaning up downloads & tmp directories
 #[test]
 fn default() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "default", "nightly"],
             for_host!(
                 r"
@@ -299,11 +289,10 @@ info: default toolchain set to 'nightly-{0}'
 #[test]
 fn default_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "override", "set", "nightly"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "override", "set", "nightly"]);
+        config.expect_stderr_ok(
             &["rustup", "default", "stable"],
             for_host!(
                 r"info: using existing install for 'stable-{0}'
@@ -318,8 +307,7 @@ info: note that the toolchain 'nightly-{0}' is currently in use (directory overr
 fn rustup_zstd() {
     setup(&|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "--verbose", "update", "nightly"],
             for_host!(r"dist/2015-01-01/rust-std-nightly-{0}.tar.zst"),
         );
@@ -334,8 +322,8 @@ fn add_target() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
         assert!(config.rustupdir.has(path));
     });
 }
@@ -348,13 +336,10 @@ fn remove_target() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
         assert!(config.rustupdir.has(&path));
-        expect_ok(
-            config,
-            &["rustup", "target", "remove", clitools::CROSS_ARCH1],
-        );
+        config.expect_ok(&["rustup", "target", "remove", clitools::CROSS_ARCH1]);
         assert!(!config.rustupdir.has(&path));
     });
 }
@@ -362,17 +347,14 @@ fn remove_target() {
 #[test]
 fn add_remove_multiple_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "target",
-                "add",
-                clitools::CROSS_ARCH1,
-                clitools::CROSS_ARCH2,
-            ],
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "target",
+            "add",
+            clitools::CROSS_ARCH1,
+            clitools::CROSS_ARCH2,
+        ]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             &this_host_triple(),
@@ -386,16 +368,13 @@ fn add_remove_multiple_targets() {
         );
         assert!(config.rustupdir.has(path));
 
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "target",
-                "remove",
-                clitools::CROSS_ARCH1,
-                clitools::CROSS_ARCH2,
-            ],
-        );
+        config.expect_ok(&[
+            "rustup",
+            "target",
+            "remove",
+            clitools::CROSS_ARCH1,
+            clitools::CROSS_ARCH2,
+        ]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             &this_host_triple(),
@@ -414,8 +393,8 @@ fn add_remove_multiple_targets() {
 #[test]
 fn list_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "target", "list"], clitools::CROSS_ARCH1);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "target", "list"], clitools::CROSS_ARCH1);
     });
 }
 
@@ -424,8 +403,8 @@ fn list_installed_targets() {
     setup(&|config| {
         let trip = this_host_triple();
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "target", "list", "--installed"], &trip);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "target", "list", "--installed"], &trip);
     });
 }
 
@@ -437,18 +416,15 @@ fn add_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "target",
-                "add",
-                "--toolchain",
-                "nightly",
-                clitools::CROSS_ARCH1,
-            ],
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "target",
+            "add",
+            "--toolchain",
+            "nightly",
+            clitools::CROSS_ARCH1,
+        ]);
         assert!(config.rustupdir.has(path));
     });
 }
@@ -461,30 +437,24 @@ fn remove_target_explicit() {
             &this_host_triple(),
             clitools::CROSS_ARCH1
         );
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "target",
-                "add",
-                "--toolchain",
-                "nightly",
-                clitools::CROSS_ARCH1,
-            ],
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "target",
+            "add",
+            "--toolchain",
+            "nightly",
+            clitools::CROSS_ARCH1,
+        ]);
         assert!(config.rustupdir.has(&path));
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "target",
-                "remove",
-                "--toolchain",
-                "nightly",
-                clitools::CROSS_ARCH1,
-            ],
-        );
+        config.expect_ok(&[
+            "rustup",
+            "target",
+            "remove",
+            "--toolchain",
+            "nightly",
+            clitools::CROSS_ARCH1,
+        ]);
         assert!(!config.rustupdir.has(&path));
     });
 }
@@ -492,9 +462,8 @@ fn remove_target_explicit() {
 #[test]
 fn list_targets_explicit() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "target", "list", "--toolchain", "nightly"],
             clitools::CROSS_ARCH1,
         );
@@ -506,13 +475,13 @@ fn link() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
-        expect_ok(config, &["rustup", "default", "custom"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
-        expect_stdout_ok(config, &["rustup", "show"], "custom (default)");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "show"], "custom");
+        config.expect_ok(&["rustup", "toolchain", "link", "custom", &path]);
+        config.expect_ok(&["rustup", "default", "custom"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-c-1");
+        config.expect_stdout_ok(&["rustup", "show"], "custom (default)");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "show"], "custom");
     });
 }
 
@@ -533,11 +502,11 @@ fn fallback_cargo_calls_correct_rustc() {
         // Install a custom toolchain and a nightly toolchain for the cargo fallback
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
-        expect_ok(config, &["rustup", "default", "custom"]);
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-c-1");
-        expect_stdout_ok(config, &["cargo", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "toolchain", "link", "custom", &path]);
+        config.expect_ok(&["rustup", "default", "custom"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-c-1");
+        config.expect_stdout_ok(&["cargo", "--version"], "hash-nightly-2");
 
         assert!(rustc_path.exists());
 
@@ -545,15 +514,14 @@ fn fallback_cargo_calls_correct_rustc() {
         // We should be ultimately calling the custom rustc, according to the
         // RUSTUP_TOOLCHAIN variable set by the original "cargo" proxy, and
         // interpreted by the nested "rustc" proxy.
-        expect_stdout_ok(config, &["cargo", "--call-rustc"], "hash-c-1");
+        config.expect_stdout_ok(&["cargo", "--call-rustc"], "hash-c-1");
     });
 }
 
 #[test]
 fn show_home() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "show", "home"],
             &format!(
                 r"{}
@@ -568,8 +536,7 @@ fn show_home() {
 #[test]
 fn show_toolchain_none() {
     setup(&|config| {
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "show"],
             for_host_and_home!(
                 config,
@@ -587,9 +554,8 @@ no active toolchain
 #[test]
 fn show_toolchain_default() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "show"],
             for_host_and_home!(
                 config,
@@ -608,10 +574,9 @@ nightly-{0} (default)
 #[test]
 fn show_multiple_toolchains() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "stable"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "update", "stable"]);
+        config.expect_ok_ex(
             &["rustup", "show"],
             for_host_and_home!(
                 config,
@@ -640,17 +605,13 @@ nightly-{0} (default)
 #[test]
 fn show_multiple_targets() {
     clitools::setup(Scenario::MultiHost, &|config| {
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "default",
-                &format!("nightly-{}", clitools::MULTI_ARCH1),
-            ],
-        );
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&[
+            "rustup",
+            "default",
+            &format!("nightly-{}", clitools::MULTI_ARCH1),
+        ]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        config.expect_ok_ex(
             &["rustup", "show"],
             &format!(
                 r"Default host: {2}
@@ -686,25 +647,18 @@ fn show_multiple_toolchains_and_targets() {
     }
 
     clitools::setup(Scenario::MultiHost, &|config| {
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "default",
-                &format!("nightly-{}", clitools::MULTI_ARCH1),
-            ],
-        );
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "update",
-                &format!("stable-{}", clitools::MULTI_ARCH1),
-            ],
-        );
-        expect_ok_ex(
-            config,
+        config.expect_ok(&[
+            "rustup",
+            "default",
+            &format!("nightly-{}", clitools::MULTI_ARCH1),
+        ]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        config.expect_ok(&[
+            "rustup",
+            "update",
+            &format!("stable-{}", clitools::MULTI_ARCH1),
+        ]);
+        config.expect_ok_ex(
             &["rustup", "show"],
             &format!(
                 r"Default host: {2}
@@ -742,9 +696,8 @@ nightly-{0} (default)
 #[test]
 fn list_default_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "toolchain", "list"],
             for_host!(
                 r"nightly-{0} (default)
@@ -758,9 +711,8 @@ fn list_default_toolchain() {
 #[test]
 fn list_override_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "set", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "override", "set", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "toolchain", "list"],
             for_host!(
                 r"nightly-{0} (override)
@@ -774,10 +726,9 @@ fn list_override_toolchain() {
 #[test]
 fn list_default_and_override_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "override", "set", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "override", "set", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "toolchain", "list"],
             for_host!(
                 r"nightly-{0} (default) (override)
@@ -791,9 +742,8 @@ fn list_default_and_override_toolchain() {
 #[test]
 fn heal_damaged_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_not_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_not_stderr_ok(
             &["rustup", "show", "active-toolchain"],
             "syncing channel updates",
         );
@@ -802,8 +752,7 @@ fn heal_damaged_toolchain() {
             this_host_triple()
         );
         fs::remove_file(config.rustupdir.join(path)).unwrap();
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "show", "active-toolchain"],
             &format!(
                 r"nightly-{0} (default)
@@ -815,9 +764,8 @@ fn heal_damaged_toolchain() {
 "
             ),
         );
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stderr_ok(
             &["rustup", "show", "active-toolchain"],
             "syncing channel updates",
         );
@@ -829,9 +777,8 @@ fn heal_damaged_toolchain() {
 fn show_toolchain_override() {
     setup(&|config| {
         let cwd = config.current_dir();
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "show"],
             &format!(
                 r"Default host: {0}
@@ -853,16 +800,15 @@ nightly-{0} (directory override for '{2}')
 #[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_toolchain_file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
 
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "show"],
             &format!(
                 r"Default host: {0}
@@ -894,8 +840,8 @@ nightly-{0} (overridden by '{2}')
 #[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_version_nested_file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -906,8 +852,7 @@ fn show_toolchain_version_nested_file_override() {
 
         fs::create_dir_all(&subdir).unwrap();
         config.change_dir(&subdir, &|| {
-            expect_ok_ex(
-                config,
+            config.expect_ok_ex(
                 &["rustup", "show"],
                 &format!(
                     r"Default host: {0}
@@ -938,7 +883,7 @@ nightly-{0} (overridden by '{1}')
 #[ignore = "FIXME: Windows shows UNC paths"]
 fn show_toolchain_toolchain_file_override_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -963,8 +908,8 @@ fn show_toolchain_toolchain_file_override_not_installed() {
 #[test]
 fn show_toolchain_override_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
         let mut cmd = clitools::cmd(config, "rustup", ["show"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -988,33 +933,24 @@ fn override_set_unset_with_path() {
         }
 
         config.change_dir(&config.emptydir, &|| {
-            expect_ok(
-                config,
-                &["rustup", "override", "set", "nightly", "--path", cwd_str],
-            );
+            config.expect_ok(&["rustup", "override", "set", "nightly", "--path", cwd_str]);
         });
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &["rustup", "override", "list"],
             &format!("{}\tnightly-{}\n", cwd_str, this_host_triple()),
             r"",
         );
         config.change_dir(&config.emptydir, &|| {
-            expect_ok(config, &["rustup", "override", "unset", "--path", cwd_str]);
+            config.expect_ok(&["rustup", "override", "unset", "--path", cwd_str]);
         });
-        expect_ok_ex(
-            config,
-            &["rustup", "override", "list"],
-            "no overrides\n",
-            r"",
-        );
+        config.expect_ok_ex(&["rustup", "override", "list"], "no overrides\n", r"");
     });
 }
 
 #[test]
 fn show_toolchain_env() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         let mut cmd = clitools::cmd(config, "rustup", ["show"]);
         clitools::env(config, &mut cmd);
         cmd.env("RUSTUP_TOOLCHAIN", "nightly");
@@ -1054,9 +990,8 @@ fn show_toolchain_env_not_installed() {
 #[test]
 fn show_active_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "show", "active-toolchain"],
             for_host!(
                 r"nightly-{0} (default)
@@ -1070,10 +1005,9 @@ fn show_active_toolchain() {
 #[test]
 fn show_with_verbose() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "nightly-2015-01-01"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "update", "nightly-2015-01-01"]);
+        config.expect_ok_ex(
             &["rustup", "show", "--verbose"],
             for_host_and_home!(
                 config,
@@ -1106,9 +1040,8 @@ nightly-{0} (default)
 #[test]
 fn show_active_toolchain_with_verbose() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok_ex(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok_ex(
             &["rustup", "show", "active-toolchain", "--verbose"],
             for_host!(
                 r"nightly-{0} (default)
@@ -1123,11 +1056,10 @@ fn show_active_toolchain_with_verbose() {
 #[test]
 fn show_active_toolchain_with_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "override", "set", "stable"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "override", "set", "stable"]);
+        config.expect_stdout_ok(
             &["rustup", "show", "active-toolchain"],
             for_host!("stable-{0} (directory override for"),
         );
@@ -1137,21 +1069,21 @@ fn show_active_toolchain_with_override() {
 #[test]
 fn show_active_toolchain_none() {
     setup(&|config| {
-        expect_ok_ex(config, &["rustup", "show", "active-toolchain"], r"", r"");
+        config.expect_ok_ex(&["rustup", "show", "active-toolchain"], r"", r"");
     });
 }
 
 #[test]
 fn show_profile() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "show", "profile"], "default");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "show", "profile"], "default");
 
         // Check we get the same thing after we add or remove a component.
-        expect_ok(config, &["rustup", "component", "add", "rust-src"]);
-        expect_stdout_ok(config, &["rustup", "show", "profile"], "default");
-        expect_ok(config, &["rustup", "component", "remove", "rustc"]);
-        expect_stdout_ok(config, &["rustup", "show", "profile"], "default");
+        config.expect_ok(&["rustup", "component", "add", "rust-src"]);
+        config.expect_stdout_ok(&["rustup", "show", "profile"], "default");
+        config.expect_ok(&["rustup", "component", "remove", "rustc"]);
+        config.expect_stdout_ok(&["rustup", "show", "profile"], "default");
     });
 }
 
@@ -1159,11 +1091,8 @@ fn show_profile() {
 #[test]
 fn set_default_host() {
     setup(&|config| {
-        expect_ok(
-            config,
-            &["rustup", "set", "default-host", &this_host_triple()],
-        );
-        expect_stdout_ok(config, &["rustup", "show"], for_host!("Default host: {0}"));
+        config.expect_ok(&["rustup", "set", "default-host", &this_host_triple()]);
+        config.expect_stdout_ok(&["rustup", "show"], for_host!("Default host: {0}"));
     });
 }
 
@@ -1171,8 +1100,7 @@ fn set_default_host() {
 #[test]
 fn set_default_host_invalid_triple() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "set", "default-host", "foo"],
             "error: Provided host 'foo' couldn't be converted to partial triple",
         );
@@ -1183,8 +1111,7 @@ fn set_default_host_invalid_triple() {
 #[test]
 fn set_default_host_invalid_triple_valid_partial() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "set", "default-host", "x86_64-msvc"],
             "error: Provided host 'x86_64-msvc' did not specify an operating system",
         );
@@ -1195,8 +1122,8 @@ fn set_default_host_invalid_triple_valid_partial() {
 #[test]
 fn update_doesnt_update_non_tracking_channels() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "update", "nightly-2015-01-01"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "update", "nightly-2015-01-01"]);
         let mut cmd = clitools::cmd(config, "rustup", ["update"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -1210,9 +1137,8 @@ fn update_doesnt_update_non_tracking_channels() {
 #[test]
 fn toolchain_install_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "run", "nightly", "rustc", "--version"],
             "hash-nightly-2",
         );
@@ -1222,12 +1148,8 @@ fn toolchain_install_is_like_update() {
 #[test]
 fn toolchain_install_is_like_update_quiet() {
     setup(&|config| {
-        expect_ok(
-            config,
-            &["rustup", "--quiet", "toolchain", "install", "nightly"],
-        );
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "--quiet", "toolchain", "install", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "run", "nightly", "rustc", "--version"],
             "hash-nightly-2",
         );
@@ -1237,8 +1159,7 @@ fn toolchain_install_is_like_update_quiet() {
 #[test]
 fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "toolchain", "install"],
             "arguments were not provided",
         );
@@ -1248,9 +1169,8 @@ fn toolchain_install_is_like_update_except_that_bare_install_is_an_error() {
 #[test]
 fn toolchain_update_is_like_update() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "update", "nightly"]);
+        config.expect_stdout_ok(
             &["rustup", "run", "nightly", "rustc", "--version"],
             "hash-nightly-2",
         );
@@ -1260,7 +1180,7 @@ fn toolchain_update_is_like_update() {
 #[test]
 fn toolchain_uninstall_is_like_uninstall() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "uninstall", "nightly"]);
+        config.expect_ok(&["rustup", "uninstall", "nightly"]);
         let mut cmd = clitools::cmd(config, "rustup", ["show"]);
         clitools::env(config, &mut cmd);
         let out = cmd.output().unwrap();
@@ -1273,8 +1193,7 @@ fn toolchain_uninstall_is_like_uninstall() {
 #[test]
 fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "toolchain", "update"],
             "arguments were not provided",
         );
@@ -1284,27 +1203,19 @@ fn toolchain_update_is_like_update_except_that_bare_install_is_an_error() {
 #[test]
 fn proxy_toolchain_shorthand() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
-        expect_stdout_ok(
-            config,
-            &["rustc", "+stable", "--version"],
-            "hash-stable-1.1.0",
-        );
-        expect_stdout_ok(
-            config,
-            &["rustc", "+nightly", "--version"],
-            "hash-nightly-2",
-        );
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "+stable", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "+nightly", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn add_component() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "component", "add", "rust-src"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "component", "add", "rust-src"]);
         let path = format!(
             "toolchains/stable-{}/lib/rustlib/src/rust-src/foo.rs",
             this_host_triple()
@@ -1316,14 +1227,14 @@ fn add_component() {
 #[test]
 fn remove_component() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "component", "add", "rust-src"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "component", "add", "rust-src"]);
         let path = PathBuf::from(format!(
             "toolchains/stable-{}/lib/rustlib/src/rust-src/foo.rs",
             this_host_triple()
         ));
         assert!(config.rustupdir.has(&path));
-        expect_ok(config, &["rustup", "component", "remove", "rust-src"]);
+        config.expect_ok(&["rustup", "component", "remove", "rust-src"]);
         assert!(!config.rustupdir.has(path.parent().unwrap()));
     });
 }
@@ -1336,19 +1247,13 @@ fn add_remove_multiple_components() {
     ];
 
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(
-            config,
-            &["rustup", "component", "add", "rust-src", "rust-analysis"],
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "component", "add", "rust-src", "rust-analysis"]);
         for file in &files {
             let path = format!("toolchains/nightly-{}/{}", this_host_triple(), file);
             assert!(config.rustupdir.has(&path));
         }
-        expect_ok(
-            config,
-            &["rustup", "component", "remove", "rust-src", "rust-analysis"],
-        );
+        config.expect_ok(&["rustup", "component", "remove", "rust-src", "rust-analysis"]);
         for file in &files {
             let path = PathBuf::from(format!(
                 "toolchains/nightly-{}/{}",
@@ -1363,24 +1268,24 @@ fn add_remove_multiple_components() {
 #[test]
 fn file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn env_override_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1401,15 +1306,14 @@ fn env_override_path() {
 #[test]
 fn plus_override_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
             .join("toolchains")
             .join(format!("nightly-{}", this_host_triple()));
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &[
                 "rustup",
                 "run",
@@ -1425,8 +1329,8 @@ fn plus_override_path() {
 #[test]
 fn file_override_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1439,11 +1343,10 @@ fn file_override_path() {
         )
         .unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
 
         // Check that the toolchain has the right name
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "show", "active-toolchain"],
             &format!("nightly-{}", this_host_triple()),
         );
@@ -1453,8 +1356,8 @@ fn file_override_path() {
 #[test]
 fn proxy_override_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1467,15 +1370,15 @@ fn proxy_override_path() {
         )
         .unwrap();
 
-        expect_stdout_ok(config, &["cargo", "--call-rustc"], "hash-nightly-2");
+        config.expect_stdout_ok(&["cargo", "--call-rustc"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn file_override_path_relative() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let toolchain_path = config
             .rustupdir
@@ -1515,7 +1418,7 @@ fn file_override_path_relative() {
         let ephemeral = config.current_dir().join("ephemeral");
         fs::create_dir_all(&ephemeral).unwrap();
         config.change_dir(&ephemeral, || {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -1536,8 +1439,7 @@ fn file_override_path_no_options() {
         )
         .unwrap();
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "toolchain options are ignored for path toolchain (ephemeral)",
         );
@@ -1548,8 +1450,7 @@ fn file_override_path_no_options() {
         )
         .unwrap();
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "toolchain options are ignored for path toolchain (ephemeral)",
         );
@@ -1560,8 +1461,7 @@ fn file_override_path_no_options() {
         )
         .unwrap();
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "toolchain options are ignored for path toolchain (ephemeral)",
         );
@@ -1584,8 +1484,7 @@ fn file_override_path_xor_channel() {
         )
         .unwrap();
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "cannot specify both channel (nightly) and path (ephemeral) simultaneously",
         );
@@ -1595,10 +1494,10 @@ fn file_override_path_xor_channel() {
 #[test]
 fn file_override_subdir() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1607,7 +1506,7 @@ fn file_override_subdir() {
         let subdir = cwd.join("subdir");
         fs::create_dir_all(&subdir).unwrap();
         config.change_dir(&subdir, &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -1615,32 +1514,26 @@ fn file_override_subdir() {
 #[test]
 fn file_override_with_archive() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "nightly-2015-01-01"],
-        );
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly-2015-01-01"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly-2015-01-01").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
     });
 }
 
 #[test]
 fn file_override_toml_format_select_installed_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "install", "nightly-2015-01-01"],
-        );
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly-2015-01-01"]);
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1653,20 +1546,16 @@ channel = "nightly-2015-01-01"
         )
         .unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
     });
 }
 
 #[test]
 fn file_override_toml_format_install_both_toolchain_and_components() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
-        expect_not_stdout_ok(
-            config,
-            &["rustup", "component", "list"],
-            "rust-src (installed)",
-        );
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_not_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1680,24 +1569,16 @@ components = [ "rust-src" ]
         )
         .unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
-        expect_stdout_ok(
-            config,
-            &["rustup", "component", "list"],
-            "rust-src (installed)",
-        );
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
+        config.expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
     });
 }
 
 #[test]
 fn file_override_toml_format_add_missing_components() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_not_stdout_ok(
-            config,
-            &["rustup", "component", "list"],
-            "rust-src (installed)",
-        );
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_not_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1710,20 +1591,15 @@ components = [ "rust-src" ]
         )
         .unwrap();
 
-        expect_stdout_ok(
-            config,
-            &["rustup", "component", "list"],
-            "rust-src (installed)",
-        );
+        config.expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
     });
 }
 
 #[test]
 fn file_override_toml_format_add_missing_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_not_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_not_stdout_ok(
             &["rustup", "component", "list"],
             "arm-linux-androideabi (installed)",
         );
@@ -1739,8 +1615,7 @@ targets = [ "arm-linux-androideabi" ]
         )
         .unwrap();
 
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "component", "list"],
             "arm-linux-androideabi (installed)",
         );
@@ -1750,7 +1625,7 @@ targets = [ "arm-linux-androideabi" ]
 #[test]
 fn file_override_toml_format_skip_invalid_component() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1763,8 +1638,7 @@ components = [ "rust-bongo" ]
         )
         .unwrap();
 
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustc", "--version"],
             "warning: Force-skipping unavailable component 'rust-bongo",
         );
@@ -1774,9 +1648,8 @@ components = [ "rust-bongo" ]
 #[test]
 fn file_override_toml_format_specify_profile() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "set", "profile", "default"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "set", "profile", "default"]);
+        config.expect_stderr_ok(
             &["rustup", "default", "stable"],
             "downloading component 'rust-docs'",
         );
@@ -1792,8 +1665,7 @@ channel = "nightly"
 "#,
         )
         .unwrap();
-        expect_not_stdout_ok(
-            config,
+        config.expect_not_stdout_ok(
             &["rustup", "component", "list"],
             for_host!("rust-docs-{} (installed)"),
         );
@@ -1803,30 +1675,30 @@ channel = "nightly"
 #[test]
 fn directory_override_beats_file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
-        expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "override", "set", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
     });
 }
 
 #[test]
 fn close_file_override_beats_far_directory_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
-        expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "override", "set", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
 
@@ -1837,7 +1709,7 @@ fn close_file_override_beats_far_directory_override() {
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
         config.change_dir(&subdir, &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -1845,27 +1717,27 @@ fn close_file_override_beats_far_directory_override() {
 #[test]
 fn directory_override_doesnt_need_to_exist_unless_it_is_selected() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "beta"]);
         // not installing nightly
 
-        expect_ok(config, &["rustup", "override", "set", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "override", "set", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
     });
 }
 
 #[test]
 fn env_override_beats_file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
@@ -1885,15 +1757,15 @@ fn env_override_beats_file_override() {
 #[test]
 fn plus_override_beats_file_override() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "+beta", "--version"], "hash-beta-1.2.0");
+        config.expect_stdout_ok(&["rustc", "+beta", "--version"], "hash-beta-1.2.0");
     });
 }
 
@@ -1904,11 +1776,7 @@ fn bad_file_override() {
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "gumbo").unwrap();
 
-        expect_err(
-            config,
-            &["rustc", "--version"],
-            "invalid toolchain name: 'gumbo'",
-        );
+        config.expect_err(&["rustc", "--version"], "invalid toolchain name: 'gumbo'");
     });
 }
 
@@ -1917,28 +1785,25 @@ fn valid_override_settings() {
     setup(&|config| {
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         raw::write_file(&toolchain_file, "nightly").unwrap();
-        expect_ok(config, &["rustc", "--version"]);
+        config.expect_ok(&["rustc", "--version"]);
         raw::write_file(&toolchain_file, for_host!("nightly-{}")).unwrap();
-        expect_ok(config, &["rustc", "--version"]);
+        config.expect_ok(&["rustc", "--version"]);
         let fullpath = config
             .rustupdir
             .clone()
             .join("toolchains")
             .join(for_host!("nightly-{}"));
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "link",
-                "system",
-                &format!("{}", fullpath.display()),
-            ],
-        );
+        config.expect_ok(&[
+            "rustup",
+            "toolchain",
+            "link",
+            "system",
+            &format!("{}", fullpath.display()),
+        ]);
         raw::write_file(&toolchain_file, "system").unwrap();
-        expect_ok(config, &["rustc", "--version"]);
+        config.expect_ok(&["rustc", "--version"]);
     })
 }
 
@@ -1949,8 +1814,7 @@ fn file_override_with_target_info() {
         let toolchain_file = cwd.join("rust-toolchain");
         raw::write_file(&toolchain_file, "nightly-x86_64-unknown-linux-gnu").unwrap();
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "target triple in channel name 'nightly-x86_64-unknown-linux-gnu'",
         );
@@ -1960,8 +1824,8 @@ fn file_override_with_target_info() {
 #[test]
 fn docs_with_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         let mut cmd = clitools::cmd(config, "rustup", ["doc", "--path"]);
         clitools::env(config, &mut cmd);
@@ -1985,8 +1849,8 @@ fn docs_with_path() {
 #[test]
 fn docs_topical_with_path() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
 
         for (topic, path) in mock::topical_doc_data::test_cases() {
             let mut cmd = clitools::cmd(config, "rustup", ["doc", "--path", topic]);
@@ -2006,10 +1870,9 @@ fn docs_topical_with_path() {
 #[test]
 fn docs_missing() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "set", "profile", "minimal"]);
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "set", "profile", "minimal"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &["rustup", "doc"],
             "error: unable to view documentation which is not installed",
         );
@@ -2021,9 +1884,9 @@ fn docs_custom() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(config, &["rustup", "toolchain", "link", "custom", &path]);
-        expect_ok(config, &["rustup", "default", "custom"]);
-        expect_stdout_ok(config, &["rustup", "doc", "--path"], "custom");
+        config.expect_ok(&["rustup", "toolchain", "link", "custom", &path]);
+        config.expect_ok(&["rustup", "default", "custom"]);
+        config.expect_stdout_ok(&["rustup", "doc", "--path"], "custom");
     });
 }
 
@@ -2034,9 +1897,8 @@ fn non_utf8_arg() {
     use std::os::unix::ffi::OsStrExt;
 
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        let out = run(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        let out = config.run(
             "rustc",
             &[
                 OsStr::new("--echo-args"),
@@ -2056,9 +1918,8 @@ fn non_utf8_arg() {
     use std::os::windows::ffi::OsStringExt;
 
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        let out = run(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        let out = self.run(
             "rustc",
             &[
                 OsString::from("--echo-args".to_string()),
@@ -2078,9 +1939,8 @@ fn non_utf8_toolchain() {
     use std::os::unix::ffi::OsStrExt;
 
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        let out = run(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        let out = config.run(
             "rustc",
             &[OsStr::from_bytes(b"+\xc3\x28")],
             &[("RUST_BACKTRACE", "1")],
@@ -2096,9 +1956,8 @@ fn non_utf8_toolchain() {
     use std::os::windows::ffi::OsStringExt;
 
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        let out = run(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        let out = self.run(
             "rustc",
             &[OsString::from_wide(&[u16::from(b'+'), 0xd801, 0xd801])],
             &[("RUST_BACKTRACE", "1")],
@@ -2111,10 +1970,9 @@ fn non_utf8_toolchain() {
 fn check_host_goes_away() {
     clitools::setup(Scenario::HostGoesMissing, &|config| {
         set_current_dist_date(config, "2019-12-09");
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         set_current_dist_date(config, "2019-12-10");
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "update", "nightly"],
             for_host!("target '{}' not found in channel"),
         );
@@ -2126,11 +1984,7 @@ fn check_host_goes_away() {
 fn check_unix_settings_fallback() {
     setup(&|config| {
         // No default toolchain specified yet
-        expect_err(
-            config,
-            &["rustup", "default"],
-            r"no default toolchain configured",
-        );
+        config.expect_err(&["rustup", "default"], r"no default toolchain configured");
 
         // Default toolchain specified in fallback settings file
         let mock_settings_file = config.current_dir().join("mock_fallback_settings.toml");
@@ -2163,8 +2017,7 @@ fn check_unix_settings_fallback() {
 fn warn_on_unmatch_build() {
     clitools::setup(Scenario::MultiHost, &|config| {
         let arch = clitools::MULTI_ARCH1;
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "toolchain", "install", &format!("nightly-{arch}")],
             &format!(
                 r"warning: toolchain 'nightly-{arch}' may not be able to run on this system.
@@ -2201,8 +2054,7 @@ fn dont_warn_on_partial_build() {
 #[test]
 fn rust_toolchain_toml() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "--version"],
             "rustup could not choose a version of rustc to run",
         );
@@ -2211,7 +2063,7 @@ fn rust_toolchain_toml() {
         let toolchain_file = cwd.join("rust-toolchain.toml");
         raw::write_file(&toolchain_file, "[toolchain]\nchannel = \"nightly\"").unwrap();
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -2223,11 +2075,7 @@ fn only_toml_in_rust_toolchain_toml() {
         let toolchain_file = cwd.join("rust-toolchain.toml");
         raw::write_file(&toolchain_file, "nightly").unwrap();
 
-        expect_err(
-            config,
-            &["rustc", "--version"],
-            "error parsing override file",
-        );
+        config.expect_err(&["rustc", "--version"], "error parsing override file");
     });
 }
 
@@ -2241,8 +2089,7 @@ fn warn_on_duplicate_rust_toolchain_file() {
         let toolchain_file_2 = cwd.join("rust-toolchain.toml");
         raw::write_file(&toolchain_file_2, "[toolchain]").unwrap();
 
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustc", "--version"],
             &format!(
                 "warning: both `{0}` and `{1}` exist. Using `{0}`",

--- a/tests/cli-rustup.rs
+++ b/tests/cli-rustup.rs
@@ -1919,7 +1919,7 @@ fn non_utf8_arg() {
 
     setup(&|config| {
         config.expect_ok(&["rustup", "default", "nightly"]);
-        let out = self.run(
+        let out = config.run(
             "rustc",
             &[
                 OsString::from("--echo-args".to_string()),
@@ -1957,7 +1957,7 @@ fn non_utf8_toolchain() {
 
     setup(&|config| {
         config.expect_ok(&["rustup", "default", "nightly"]);
-        let out = self.run(
+        let out = config.run(
             "rustc",
             &[OsString::from_wide(&[u16::from(b'+'), 0xd801, 0xd801])],
             &[("RUST_BACKTRACE", "1")],

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -7,10 +7,7 @@ use std::fs;
 
 use rustup::for_host;
 
-use crate::mock::clitools::{
-    self, expect_err, expect_ok, expect_stderr_ok, expect_stdout_ok, set_current_dist_date, Config,
-    Scenario,
-};
+use crate::mock::clitools::{self, set_current_dist_date, Config, Scenario};
 
 pub fn setup(f: &dyn Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV1, f);
@@ -19,8 +16,7 @@ pub fn setup(f: &dyn Fn(&mut Config)) {
 #[test]
 fn rustc_no_default_toolchain() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc"],
             "rustup could not choose a version of rustc to run",
         );
@@ -30,49 +26,48 @@ fn rustc_no_default_toolchain() {
 #[test]
 fn expected_bins_exist() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "1.3.0");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "1.3.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_channel() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
-        expect_ok(config, &["rustup", "default", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
-        expect_ok(config, &["rustup", "default", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
-        expect_ok(config, &["rustup", "default", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
+        config.expect_ok(&["rustup", "default", "nightly-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0");
+        config.expect_ok(&["rustup", "default", "stable-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_version() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "default", "1.1.0"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stderr_ok(
             &["rustup", "default", "nightly"],
             for_host!("using existing install for 'nightly-{0}'"),
         );
@@ -83,47 +78,39 @@ fn default_existing_toolchain() {
 fn update_channel() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list", "-v"],
-            "(default)\t",
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(default)\t");
         #[cfg(windows)]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             for_host!("\\toolchains\\nightly-{}"),
         );
         #[cfg(not(windows))]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             for_host!("/toolchains/nightly-{}"),
         );
-        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "beta-2015-01-01");
         #[cfg(windows)]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             "\\toolchains\\beta-2015-01-01",
         );
         #[cfg(not(windows))]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             "/toolchains/beta-2015-01-01",
         );
@@ -133,38 +120,26 @@ fn list_toolchains() {
 #[test]
 fn list_toolchains_with_none() {
     setup(&|config| {
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
-        );
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains");
     });
 }
 
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "list"]);
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "list"]);
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains");
     });
 }
 
 #[test]
 fn remove_default_toolchain_autoinstalls() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_stderr_ok(
-            config,
-            &["rustc", "--version"],
-            "info: installing component",
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_stderr_ok(&["rustc", "--version"], "info: installing component");
     });
 }
 
@@ -173,14 +148,10 @@ fn remove_override_toolchain_err_handling() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "default", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-            expect_stderr_ok(
-                config,
-                &["rustc", "--version"],
-                "info: installing component",
-            );
+            config.expect_ok(&["rustup", "default", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
+            config.expect_stderr_ok(&["rustc", "--version"], "info: installing component");
         });
     });
 }
@@ -194,7 +165,7 @@ fn bad_sha_on_manifest() {
         sha_bytes[..10].clone_from_slice(b"aaaaaaaaaa");
         let sha_str = String::from_utf8(sha_bytes).unwrap();
         rustup::utils::raw::write_file(&sha_file, &sha_str).unwrap();
-        expect_err(config, &["rustup", "default", "nightly"], "checksum failed");
+        config.expect_err(&["rustup", "default", "nightly"], "checksum failed");
     });
 }
 
@@ -210,39 +181,39 @@ fn bad_sha_on_installer() {
                 rustup::utils::raw::write_file(&path, "xxx").unwrap();
             }
         }
-        expect_err(config, &["rustup", "default", "nightly"], "checksum failed");
+        config.expect_err(&["rustup", "default", "nightly"], "checksum failed");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_channel() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-        expect_ok(config, &["rustup", "override", "add", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
-        expect_ok(config, &["rustup", "override", "add", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "override", "add", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "override", "add", "stable"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
-        expect_ok(config, &["rustup", "override", "add", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
-        expect_ok(config, &["rustup", "override", "add", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
-        expect_ok(config, &["rustup", "override", "add", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
+        config.expect_ok(&["rustup", "override", "add", "nightly-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "override", "add", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "stable-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_version() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "add", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "1.1.0"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -250,10 +221,10 @@ fn install_override_toolchain_from_version() {
 fn override_overrides_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -264,21 +235,21 @@ fn multiple_overrides() {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "stable"]);
+            config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
 
         config.change_dir(tempdir1.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -288,9 +259,9 @@ fn change_override() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -300,10 +271,9 @@ fn remove_override_no_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_err(
-                config,
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_err(
                 &["rustc"],
                 "rustup could not choose a version of rustc to run",
             );
@@ -316,10 +286,10 @@ fn remove_override_with_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "default", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_ok(&["rustup", "default", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -329,20 +299,20 @@ fn remove_override_with_multiple_overrides() {
     setup(&|config| {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "stable"]);
+            config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -350,8 +320,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "update", "nightly"], "unchanged");
     });
 }
 
@@ -359,21 +329,20 @@ fn no_update_on_channel_when_date_has_not_changed() {
 fn update_on_channel_when_date_has_changed() {
     clitools::setup(Scenario::ArchivesV1, &|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_stdout_ok(
             &["rustup", "run", "nightly", "rustc", "--version"],
             "hash-nightly-2",
         );
@@ -384,9 +353,9 @@ fn run_command() {
 fn remove_toolchain_then_add_again() {
     // Issue brson/multirust #53
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustc", "--version"]);
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustc", "--version"]);
     });
 }

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -10,11 +10,7 @@ use rustup::dist::dist::TargetTriple;
 use rustup::for_host;
 use rustup::test::this_host_triple;
 
-use crate::mock::clitools::{
-    self, expect_component_executable, expect_component_not_executable, expect_err,
-    expect_not_stderr_err, expect_not_stdout_ok, expect_ok, expect_ok_ex, expect_stderr_ok,
-    expect_stdout_ok, set_current_dist_date, Config, Scenario,
-};
+use crate::mock::clitools::{self, set_current_dist_date, Config, Scenario};
 
 pub fn setup(f: &dyn Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV2, f);
@@ -27,8 +23,7 @@ pub fn setup_complex(f: &dyn Fn(&mut Config)) {
 #[test]
 fn rustc_no_default_toolchain() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc"],
             "rustup could not choose a version of rustc to run",
         );
@@ -38,40 +33,40 @@ fn rustc_no_default_toolchain() {
 #[test]
 fn expected_bins_exist() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "1.3.0");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "1.3.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_channel() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
-        expect_ok(config, &["rustup", "default", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "default", "stable"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
-        expect_ok(config, &["rustup", "default", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
-        expect_ok(config, &["rustup", "default", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
-        expect_ok(config, &["rustup", "default", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
+        config.expect_ok(&["rustup", "default", "nightly-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0");
+        config.expect_ok(&["rustup", "default", "stable-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
 #[test]
 fn install_toolchain_from_version() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "default", "1.1.0"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -80,42 +75,38 @@ fn install_with_profile() {
     setup_complex(&|config| {
         // Start with a config that uses the "complete" profile
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "set", "profile", "complete"]);
+        config.expect_ok(&["rustup", "set", "profile", "complete"]);
 
         // Installing with minimal profile should only install rustc
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "--profile",
-                "minimal",
-                "nightly",
-            ],
-        );
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "toolchain",
+            "install",
+            "--profile",
+            "minimal",
+            "nightly",
+        ]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
 
-        expect_component_executable(config, "rustup");
-        expect_component_executable(config, "rustc");
-        expect_component_not_executable(config, "cargo");
+        config.expect_component_executable("rustup");
+        config.expect_component_executable("rustc");
+        config.expect_component_not_executable("cargo");
 
         // After an update, we should _still_ only have the profile-dictated components
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
 
-        expect_component_executable(config, "rustup");
-        expect_component_executable(config, "rustc");
-        expect_component_not_executable(config, "cargo");
+        config.expect_component_executable("rustup");
+        config.expect_component_executable("rustc");
+        config.expect_component_not_executable("cargo");
     });
 }
 
 #[test]
 fn default_existing_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stderr_ok(
             &["rustup", "default", "nightly"],
             for_host!("using existing install for 'nightly-{0}'"),
         );
@@ -126,47 +117,39 @@ fn default_existing_toolchain() {
 fn update_channel() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn list_toolchains() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "update", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list", "-v"],
-            "(default)\t",
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(default)\t");
         #[cfg(windows)]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             for_host!("\\toolchains\\nightly-{}"),
         );
         #[cfg(not(windows))]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             for_host!("/toolchains/nightly-{}"),
         );
-        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "beta-2015-01-01");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "beta-2015-01-01");
         #[cfg(windows)]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             "\\toolchains\\beta-2015-01-01",
         );
         #[cfg(not(windows))]
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
             "/toolchains/beta-2015-01-01",
         );
@@ -177,38 +160,30 @@ fn list_toolchains() {
 fn list_toolchains_with_bogus_file() {
     // #520
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
 
         let name = "bogus_regular_file.txt";
         let path = config.rustupdir.join("toolchains").join(name);
         rustup::utils::utils::write_file(name, &path, "").unwrap();
-        expect_stdout_ok(config, &["rustup", "toolchain", "list"], "nightly");
-        expect_not_stdout_ok(config, &["rustup", "toolchain", "list"], name);
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly");
+        config.expect_not_stdout_ok(&["rustup", "toolchain", "list"], name);
     });
 }
 
 #[test]
 fn list_toolchains_with_none() {
     setup(&|config| {
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
-        );
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains");
     });
 }
 
 #[test]
 fn remove_toolchain() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "list"]);
-        expect_stdout_ok(
-            config,
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains",
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "list"]);
+        config.expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains");
     });
 }
 
@@ -219,9 +194,8 @@ fn remove_toolchain_ignore_trailing_slash() {
         // custom toolchain name with trailing slash
         let path = config.customdir.join("custom-1");
         let path_str = path.to_string_lossy();
-        expect_ok(config, &["rustup", "toolchain", "link", "dev", &path_str]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "link", "dev", &path_str]);
+        config.expect_stderr_ok(
             &["rustup", "toolchain", "remove", "dev/"],
             "toolchain 'dev' uninstalled",
         );
@@ -229,9 +203,8 @@ fn remove_toolchain_ignore_trailing_slash() {
         let toolchain_dir_is_non_empty = fs::read_dir(&path).unwrap().next().is_some();
         assert!(toolchain_dir_is_non_empty);
         // distributable toolchain name with trailing slash
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stderr_ok(
             &["rustup", "toolchain", "remove", for_host!("nightly-{}/")],
             for_host!("toolchain 'nightly-{}' uninstalled"),
         );
@@ -245,15 +218,15 @@ fn add_remove_multiple_toolchains() {
             let tch1 = "beta";
             let tch2 = "nightly";
 
-            expect_ok(config, &["rustup", "toolchain", add, tch1, tch2]);
-            expect_ok(config, &["rustup", "toolchain", "list"]);
-            expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
-            expect_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
+            config.expect_ok(&["rustup", "toolchain", add, tch1, tch2]);
+            config.expect_ok(&["rustup", "toolchain", "list"]);
+            config.expect_stdout_ok(&["rustup", "toolchain", "list"], tch1);
+            config.expect_stdout_ok(&["rustup", "toolchain", "list"], tch2);
 
-            expect_ok(config, &["rustup", "toolchain", rm, tch1, tch2]);
-            expect_ok(config, &["rustup", "toolchain", "list"]);
-            expect_not_stdout_ok(config, &["rustup", "toolchain", "list"], tch1);
-            expect_not_stdout_ok(config, &["rustup", "toolchain", "list"], tch2);
+            config.expect_ok(&["rustup", "toolchain", rm, tch1, tch2]);
+            config.expect_ok(&["rustup", "toolchain", "list"]);
+            config.expect_not_stdout_ok(&["rustup", "toolchain", "list"], tch1);
+            config.expect_not_stdout_ok(&["rustup", "toolchain", "list"], tch2);
         });
     }
 
@@ -267,13 +240,9 @@ fn add_remove_multiple_toolchains() {
 #[test]
 fn remove_default_toolchain_autoinstalls() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
-        expect_stderr_ok(
-            config,
-            &["rustc", "--version"],
-            "info: installing component",
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_stderr_ok(&["rustc", "--version"], "info: installing component");
     });
 }
 
@@ -282,14 +251,10 @@ fn remove_override_toolchain_err_handling() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "default", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-            expect_stderr_ok(
-                config,
-                &["rustc", "--version"],
-                "info: installing component",
-            );
+            config.expect_ok(&["rustup", "default", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
+            config.expect_stderr_ok(&["rustc", "--version"], "info: installing component");
         });
     });
 }
@@ -300,19 +265,14 @@ fn file_override_toolchain_err_handling() {
         let cwd = config.current_dir();
         let toolchain_file = cwd.join("rust-toolchain");
         rustup::utils::raw::write_file(&toolchain_file, "beta").unwrap();
-        expect_stderr_ok(
-            config,
-            &["rustc", "--version"],
-            "info: installing component",
-        );
+        config.expect_stderr_ok(&["rustc", "--version"], "info: installing component");
     });
 }
 
 #[test]
 fn plus_override_toolchain_err_handling() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustc", "+beta"],
             for_host!("toolchain 'beta-{0}' is not installed"),
         );
@@ -330,8 +290,7 @@ fn bad_sha_on_manifest() {
         let sha_str = String::from_utf8(sha_bytes).unwrap();
         rustup::utils::raw::write_file(&sha_file, &sha_str).unwrap();
         // We fail because the sha is bad, but we should emit the special message to that effect.
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "default", "nightly"],
             "update not yet available",
         );
@@ -354,39 +313,39 @@ fn bad_sha_on_installer() {
                 rustup::utils::raw::write_file(&path, "xxx").unwrap();
             }
         }
-        expect_err(config, &["rustup", "default", "nightly"], "checksum failed");
+        config.expect_err(&["rustup", "default", "nightly"], "checksum failed");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_channel() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "add", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-        expect_ok(config, &["rustup", "override", "add", "beta"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
-        expect_ok(config, &["rustup", "override", "add", "stable"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "override", "add", "beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
+        config.expect_ok(&["rustup", "override", "add", "stable"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_archive() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
-        expect_ok(config, &["rustup", "override", "add", "nightly-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
-        expect_ok(config, &["rustup", "override", "add", "beta-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.1.0");
-        expect_ok(config, &["rustup", "override", "add", "stable-2015-01-01"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.0.0");
+        config.expect_ok(&["rustup", "override", "add", "nightly-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "override", "add", "beta-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "stable-2015-01-01"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0");
     });
 }
 
 #[test]
 fn install_override_toolchain_from_version() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "override", "add", "1.1.0"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+        config.expect_ok(&["rustup", "override", "add", "1.1.0"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
     });
 }
 
@@ -394,10 +353,10 @@ fn install_override_toolchain_from_version() {
 fn override_overrides_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -408,21 +367,21 @@ fn multiple_overrides() {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "stable"]);
+            config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
 
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
 
         config.change_dir(tempdir1.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -446,11 +405,11 @@ fn override_windows_root() {
         let prefix = prefix.as_os_str().to_str().unwrap();
         let prefix = format!("{}\\", prefix);
         config.change_dir(&PathBuf::from(&prefix), &|| {
-            expect_ok(config, &["rustup", "default", "stable"]);
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+            config.expect_ok(&["rustup", "default", "stable"]);
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -460,9 +419,9 @@ fn change_override() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-beta-1.2.0");
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
     });
 }
@@ -472,10 +431,9 @@ fn remove_override_no_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "nightly"]);
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_err(
-                config,
+            config.expect_ok(&["rustup", "override", "add", "nightly"]);
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_err(
                 &["rustc"],
                 "rustup could not choose a version of rustc to run",
             );
@@ -488,10 +446,10 @@ fn remove_override_with_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.change_dir(tempdir.path(), &|| {
-            expect_ok(config, &["rustup", "default", "nightly"]);
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_ok(&["rustup", "default", "nightly"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
     });
 }
@@ -501,20 +459,20 @@ fn remove_override_with_multiple_overrides() {
     setup(&|config| {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "beta"]);
+            config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_ok(config, &["rustup", "override", "add", "stable"]);
+            config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         config.change_dir(tempdir1.path(), &|| {
-            expect_ok(config, &["rustup", "override", "remove"]);
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+            config.expect_ok(&["rustup", "override", "remove"]);
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
         config.change_dir(tempdir2.path(), &|| {
-            expect_stdout_ok(config, &["rustc", "--version"], "hash-stable-1.1.0");
+            config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
 }
@@ -522,8 +480,8 @@ fn remove_override_with_multiple_overrides() {
 #[test]
 fn no_update_on_channel_when_date_has_not_changed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "update", "nightly"], "unchanged");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "update", "nightly"], "unchanged");
     });
 }
 
@@ -531,21 +489,20 @@ fn no_update_on_channel_when_date_has_not_changed() {
 fn update_on_channel_when_date_has_changed() {
     clitools::setup(Scenario::ArchivesV2, &|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
 #[test]
 fn run_command() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_stdout_ok(
             &["rustup", "run", "nightly", "rustc", "--version"],
             "hash-nightly-2",
         );
@@ -556,10 +513,10 @@ fn run_command() {
 fn remove_toolchain_then_add_again() {
     // Issue brson/multirust #53
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "beta"]);
-        expect_ok(config, &["rustup", "toolchain", "remove", "beta"]);
-        expect_ok(config, &["rustup", "update", "beta"]);
-        expect_ok(config, &["rustc", "--version"]);
+        config.expect_ok(&["rustup", "default", "beta"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
+        config.expect_ok(&["rustup", "update", "beta"]);
+        config.expect_ok(&["rustc", "--version"]);
     });
 }
 
@@ -569,11 +526,11 @@ fn upgrade_v1_to_v2() {
         set_current_dist_date(config, "2015-01-01");
         // Delete the v2 manifest so the first day we install from the v1s
         fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-1");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1");
         set_current_dist_date(config, "2015-01-02");
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
     });
 }
 
@@ -581,11 +538,10 @@ fn upgrade_v1_to_v2() {
 fn upgrade_v2_to_v1() {
     clitools::setup(Scenario::Full, &|config| {
         set_current_dist_date(config, "2015-01-01");
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         set_current_dist_date(config, "2015-01-02");
         fs::remove_file(config.distdir.join("dist/channel-rust-nightly.toml.sha256")).unwrap();
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "update", "nightly"],
             "the server unexpectedly provided an obsolete version of the distribution manifest",
         );
@@ -595,8 +551,7 @@ fn upgrade_v2_to_v1() {
 #[test]
 fn list_targets_no_toolchain() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "target", "list", "--toolchain=nightly"],
             for_host!("toolchain 'nightly-{0}' is not installed"),
         );
@@ -606,9 +561,8 @@ fn list_targets_no_toolchain() {
 #[test]
 fn list_targets_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_err(
             &["rustup", "target", "list", "--toolchain=nightly"],
             for_host!("toolchain 'nightly-{0}' does not support components"),
         );
@@ -620,13 +574,9 @@ fn list_targets_custom_toolchain() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "link", "default-from-path", &path],
-        );
-        expect_ok(config, &["rustup", "default", "default-from-path"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "link", "default-from-path", &path]);
+        config.expect_ok(&["rustup", "default", "default-from-path"]);
+        config.expect_err(
             &["rustup", "target", "list"],
             "toolchain 'default-from-path' does not support components",
         );
@@ -636,9 +586,9 @@ fn list_targets_custom_toolchain() {
 #[test]
 fn list_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "target", "list"], clitools::CROSS_ARCH1);
-        expect_stdout_ok(config, &["rustup", "target", "list"], clitools::CROSS_ARCH2);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "target", "list"], clitools::CROSS_ARCH1);
+        config.expect_stdout_ok(&["rustup", "target", "list"], clitools::CROSS_ARCH2);
     });
 }
 
@@ -647,16 +597,16 @@ fn list_installed_targets() {
     setup(&|config| {
         let trip = this_host_triple();
 
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustup", "target", "list", "--installed"], &trip);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustup", "target", "list", "--installed"], &trip);
     });
 }
 
 #[test]
 fn add_target1() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
@@ -669,8 +619,8 @@ fn add_target1() {
 #[test]
 fn add_target2() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH2]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH2]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
@@ -683,8 +633,8 @@ fn add_target2() {
 #[test]
 fn add_all_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", "all"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", "all"]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
@@ -703,9 +653,8 @@ fn add_all_targets() {
 #[test]
 fn add_all_targets_fail() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -726,23 +675,18 @@ fn add_all_targets_fail() {
 #[test]
 fn add_target_by_component_add() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_not_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_not_stdout_ok(
             &["rustup", "target", "list"],
             &format!("{} (installed)", clitools::CROSS_ARCH1),
         );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "component",
-                "add",
-                &format!("rust-std-{}", clitools::CROSS_ARCH1),
-            ],
-        );
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&[
+            "rustup",
+            "component",
+            "add",
+            &format!("rust-std-{}", clitools::CROSS_ARCH1),
+        ]);
+        config.expect_stdout_ok(
             &["rustup", "target", "list"],
             &format!("{} (installed)", clitools::CROSS_ARCH1),
         );
@@ -752,24 +696,19 @@ fn add_target_by_component_add() {
 #[test]
 fn remove_target_by_component_remove() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_stdout_ok(
             &["rustup", "target", "list"],
             &format!("{} (installed)", clitools::CROSS_ARCH1),
         );
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "component",
-                "remove",
-                &format!("rust-std-{}", clitools::CROSS_ARCH1),
-            ],
-        );
-        expect_not_stdout_ok(
-            config,
+        config.expect_ok(&[
+            "rustup",
+            "component",
+            "remove",
+            &format!("rust-std-{}", clitools::CROSS_ARCH1),
+        ]);
+        config.expect_not_stdout_ok(
             &["rustup", "target", "list"],
             &format!("{} (installed)", clitools::CROSS_ARCH1),
         );
@@ -779,8 +718,7 @@ fn remove_target_by_component_remove() {
 #[test]
 fn add_target_no_toolchain() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -795,9 +733,8 @@ fn add_target_no_toolchain() {
 #[test]
 fn add_target_bogus() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &["rustup", "target", "add", "bogus"],
             "does not contain component 'rust-std' for target 'bogus'\n\
                 note: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html\n\
@@ -809,9 +746,8 @@ fn add_target_bogus() {
 #[test]
 fn add_target_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -829,13 +765,9 @@ fn add_target_custom_toolchain() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "link", "default-from-path", &path],
-        );
-        expect_ok(config, &["rustup", "default", "default-from-path"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "link", "default-from-path", &path]);
+        config.expect_ok(&["rustup", "default", "default-from-path"]);
+        config.expect_err(
             &["rustup", "target", "add", clitools::CROSS_ARCH1],
             "toolchain 'default-from-path' does not support components",
         );
@@ -847,8 +779,7 @@ fn cannot_add_empty_named_custom_toolchain() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "toolchain", "link", "", &path],
             "toolchain names must not be empty",
         );
@@ -858,10 +789,9 @@ fn cannot_add_empty_named_custom_toolchain() {
 #[test]
 fn add_target_again() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_stderr_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_stderr_ok(
             &["rustup", "target", "add", clitools::CROSS_ARCH1],
             &format!(
                 "component 'rust-std' for target '{}' is up to date",
@@ -881,20 +811,17 @@ fn add_target_again() {
 fn add_target_host() {
     setup(&|config| {
         let trip = this_host_triple();
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", &trip]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", &trip]);
     });
 }
 
 #[test]
 fn remove_target() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_ok(
-            config,
-            &["rustup", "target", "remove", clitools::CROSS_ARCH1],
-        );
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "target", "remove", clitools::CROSS_ARCH1]);
         let path = format!(
             "toolchains/nightly-{}/lib/rustlib/{}/lib/libstd.rlib",
             this_host_triple(),
@@ -919,9 +846,8 @@ fn remove_target() {
 #[test]
 fn remove_target_not_installed() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &["rustup", "target", "remove", clitools::CROSS_ARCH1],
             &format!(
                 "toolchain 'nightly-{}' does not contain component 'rust-std' for target '{}'",
@@ -935,8 +861,7 @@ fn remove_target_not_installed() {
 #[test]
 fn remove_target_no_toolchain() {
     setup(&|config| {
-        expect_err(
-            config,
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -952,9 +877,8 @@ fn remove_target_no_toolchain() {
 #[test]
 fn remove_target_bogus() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &["rustup", "target", "remove", "bogus"],
             "does not contain component 'rust-std' for target 'bogus'",
         );
@@ -964,9 +888,8 @@ fn remove_target_bogus() {
 #[test]
 fn remove_target_v1_toolchain() {
     clitools::setup(Scenario::SimpleV1, &|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -984,13 +907,9 @@ fn remove_target_custom_toolchain() {
     setup(&|config| {
         let path = config.customdir.join("custom-1");
         let path = path.to_string_lossy();
-        expect_ok(
-            config,
-            &["rustup", "toolchain", "link", "default-from-path", &path],
-        );
-        expect_ok(config, &["rustup", "default", "default-from-path"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "toolchain", "link", "default-from-path", &path]);
+        config.expect_ok(&["rustup", "default", "default-from-path"]);
+        config.expect_err(
             &["rustup", "target", "remove", clitools::CROSS_ARCH1],
             "toolchain 'default-from-path' does not support components",
         );
@@ -1000,14 +919,10 @@ fn remove_target_custom_toolchain() {
 #[test]
 fn remove_target_again() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_ok(
-            config,
-            &["rustup", "target", "remove", clitools::CROSS_ARCH1],
-        );
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_ok(&["rustup", "target", "remove", clitools::CROSS_ARCH1]);
+        config.expect_err(
             &["rustup", "target", "remove", clitools::CROSS_ARCH1],
             &format!(
                 "toolchain 'nightly-{}' does not contain component 'rust-std' for target '{}'",
@@ -1022,8 +937,8 @@ fn remove_target_again() {
 fn remove_target_host() {
     setup(&|config| {
         let trip = this_host_triple();
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(config, &["rustup", "target", "remove", &trip]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "target", "remove", &trip]);
     });
 }
 
@@ -1031,12 +946,12 @@ fn remove_target_host() {
 // Issue #304
 fn remove_target_missing_update_hash() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "update", "nightly"]);
+        config.expect_ok(&["rustup", "update", "nightly"]);
 
         let file_name = format!("nightly-{}", this_host_triple());
         fs::remove_file(config.rustupdir.join("update-hashes").join(file_name)).unwrap();
 
-        expect_ok(config, &["rustup", "toolchain", "remove", "nightly"]);
+        config.expect_ok(&["rustup", "toolchain", "remove", "nightly"]);
     });
 }
 
@@ -1054,16 +969,15 @@ fn warn_about_and_remove_stray_hash() {
             .expect("Unable to write update-hash");
         drop(file);
 
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "toolchain", "install", "nightly"],
             &format!(
                 "removing stray hash found at '{}' in order to continue",
                 hash_path.display()
             ),
         );
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "1.3.0");
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "1.3.0");
     });
 }
 
@@ -1099,8 +1013,7 @@ fn make_component_unavailable(config: &Config, name: &str, target: &str) {
 fn update_unavailable_std() {
     setup(&|config| {
         make_component_unavailable(config, "rust-std", &this_host_triple());
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "update", "nightly", ],
             for_host!(
                 "component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'"
@@ -1113,8 +1026,7 @@ fn update_unavailable_std() {
 fn add_missing_component_toolchain() {
     setup(&|config| {
         make_component_unavailable(config, "rust-std", &this_host_triple());
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "toolchain", "add", "nightly"],
             for_host!(
                 r"component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'
@@ -1130,80 +1042,65 @@ Sometimes not all components are available in any given nightly. If you don't ne
 fn update_unavailable_force() {
     setup(&|config| {
         let trip = this_host_triple();
-        expect_ok(config, &["rustup", "update", "nightly"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "component",
-                "add",
-                "rls",
-                "--toolchain",
-                "nightly",
-            ],
-        );
+        config.expect_ok(&["rustup", "update", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "component",
+            "add",
+            "rls",
+            "--toolchain",
+            "nightly",
+        ]);
         make_component_unavailable(config, "rls-preview", &trip);
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "update", "nightly"],
             for_host!(
                 "component 'rls' for target '{0}' is unavailable for download for channel 'nightly'"
             ),
         );
-        expect_ok(config, &["rustup", "update", "nightly", "--force"]);
+        config.expect_ok(&["rustup", "update", "nightly", "--force"]);
     });
 }
 
 #[test]
 fn add_component_suggest_best_match() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &["rustup", "component", "add", "rsl"],
             "did you mean 'rls'?",
         );
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "component", "add", "rsl-preview"],
             "did you mean 'rls-preview'?",
         );
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "component", "add", "rustd"],
             "did you mean 'rustc'?",
         );
-        expect_not_stderr_err(
-            config,
-            &["rustup", "component", "add", "potato"],
-            "did you mean",
-        );
+        config.expect_not_stderr_err(&["rustup", "component", "add", "potato"], "did you mean");
     });
 }
 
 #[test]
 fn remove_component_suggest_best_match() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_not_stderr_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_not_stderr_err(
             &["rustup", "component", "remove", "rsl"],
             "did you mean 'rls'?",
         );
-        expect_ok(config, &["rustup", "component", "add", "rls"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "component", "add", "rls"]);
+        config.expect_err(
             &["rustup", "component", "remove", "rsl"],
             "did you mean 'rls'?",
         );
-        expect_ok(config, &["rustup", "component", "add", "rls-preview"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "component", "add", "rls-preview"]);
+        config.expect_err(
             &["rustup", "component", "add", "rsl-preview"],
             "did you mean 'rls-preview'?",
         );
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "component", "remove", "rustd"],
             "did you mean 'rustc'?",
         );
@@ -1213,9 +1110,8 @@ fn remove_component_suggest_best_match() {
 #[test]
 fn add_target_suggest_best_match() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -1224,20 +1120,15 @@ fn add_target_suggest_best_match() {
             ],
             &format!("did you mean '{}'", clitools::CROSS_ARCH1),
         );
-        expect_not_stderr_err(
-            config,
-            &["rustup", "target", "add", "potato"],
-            "did you mean",
-        );
+        config.expect_not_stderr_err(&["rustup", "target", "add", "potato"], "did you mean");
     });
 }
 
 #[test]
 fn remove_target_suggest_best_match() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_not_stderr_err(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_not_stderr_err(
             &[
                 "rustup",
                 "target",
@@ -1246,9 +1137,8 @@ fn remove_target_suggest_best_match() {
             ],
             &format!("did you mean '{}'", clitools::CROSS_ARCH1),
         );
-        expect_ok(config, &["rustup", "target", "add", clitools::CROSS_ARCH1]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1]);
+        config.expect_err(
             &[
                 "rustup",
                 "target",
@@ -1263,12 +1153,12 @@ fn remove_target_suggest_best_match() {
 #[test]
 fn target_list_ignores_unavailable_targets() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
+        config.expect_ok(&["rustup", "default", "nightly"]);
         let target_list = &["rustup", "target", "list"];
-        expect_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
+        config.expect_stdout_ok(target_list, clitools::CROSS_ARCH1);
         make_component_unavailable(config, "rust-std", clitools::CROSS_ARCH1);
-        expect_ok(config, &["rustup", "update", "nightly", "--force"]);
-        expect_not_stdout_ok(config, target_list, clitools::CROSS_ARCH1);
+        config.expect_ok(&["rustup", "update", "nightly", "--force"]);
+        config.expect_not_stdout_ok(target_list, clitools::CROSS_ARCH1);
     })
 }
 
@@ -1279,14 +1169,9 @@ fn install_with_components() {
         args.extend_from_slice(comp_args);
 
         setup(&|config| {
-            expect_ok(config, &args);
-            expect_stdout_ok(
-                config,
-                &["rustup", "component", "list"],
-                "rust-src (installed)",
-            );
-            expect_stdout_ok(
-                config,
+            config.expect_ok(&args);
+            config.expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)");
+            config.expect_stdout_ok(
                 &["rustup", "component", "list"],
                 &format!("rust-analysis-{} (installed)", this_host_triple()),
             );
@@ -1304,14 +1189,12 @@ fn install_with_targets() {
         args.extend_from_slice(comp_args);
 
         setup(&|config| {
-            expect_ok(config, &args);
-            expect_stdout_ok(
-                config,
+            config.expect_ok(&args);
+            config.expect_stdout_ok(
                 &["rustup", "target", "list"],
                 &format!("{} (installed)", clitools::CROSS_ARCH1),
             );
-            expect_stdout_ok(
-                config,
+            config.expect_stdout_ok(
                 &["rustup", "target", "list"],
                 &format!("{} (installed)", clitools::CROSS_ARCH2),
             );
@@ -1328,27 +1211,22 @@ fn install_with_targets() {
 #[test]
 fn install_with_component_and_target() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "default", "nightly"]);
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "-c",
-                "rls",
-                "-t",
-                clitools::CROSS_ARCH1,
-            ],
-        );
-        expect_stdout_ok(
-            config,
+        config.expect_ok(&["rustup", "default", "nightly"]);
+        config.expect_ok(&[
+            "rustup",
+            "toolchain",
+            "install",
+            "nightly",
+            "-c",
+            "rls",
+            "-t",
+            clitools::CROSS_ARCH1,
+        ]);
+        config.expect_stdout_ok(
             &["rustup", "component", "list"],
             &format!("rls-{} (installed)", this_host_triple()),
         );
-        expect_stdout_ok(
-            config,
+        config.expect_stdout_ok(
             &["rustup", "target", "list"],
             &format!("{} (installed)", clitools::CROSS_ARCH1),
         );
@@ -1358,9 +1236,8 @@ fn install_with_component_and_target() {
 #[test]
 fn test_warn_if_complete_profile_is_used() {
     setup(&|config| {
-        expect_ok(config, &["rustup", "set", "auto-self-update", "enable"]);
-        expect_err(
-            config,
+        config.expect_ok(&["rustup", "set", "auto-self-update", "enable"]);
+        config.expect_err(
             &[
                 "rustup",
                 "toolchain",
@@ -1379,10 +1256,9 @@ fn test_complete_profile_skips_missing_when_forced() {
     setup_complex(&|config| {
         set_current_dist_date(config, "2015-01-01");
 
-        expect_ok(config, &["rustup", "set", "profile", "complete"]);
+        config.expect_ok(&["rustup", "set", "profile", "complete"]);
         // First try and install without force
-        expect_err(
-            config,
+        config.expect_err(
             &[
                 "rustup",
                 "toolchain",
@@ -1392,15 +1268,13 @@ fn test_complete_profile_skips_missing_when_forced() {
             for_host!("error: component 'rls' for target '{}' is unavailable for download for channel 'nightly'")
         );
         // Now try and force
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "toolchain", "install", "--force", "nightly"],
             for_host!("warning: Force-skipping unavailable component 'rls-{}'"),
         );
 
         // Ensure that the skipped component (rls) is not installed
-        expect_not_stdout_ok(
-            config,
+        config.expect_not_stdout_ok(
             &["rustup", "component", "list"],
             for_host!("rls-{} (installed)"),
         );
@@ -1412,8 +1286,7 @@ fn run_with_install_flag_against_unavailable_component() {
     setup(&|config| {
         let trip = this_host_triple();
         make_component_unavailable(config, "rust-std", &trip);
-        expect_ok_ex(
-            config,
+        config.expect_ok_ex(
             &[
                 "rustup",
                 "run",
@@ -1456,8 +1329,7 @@ fn warn_on_invalid_signature() {
     setup(&|config| {
         make_signature_invalid(config);
 
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "update", "nightly", ],
             &format!(
                 "warning: Signature verification failed for 'file://{}/dist/channel-rust-nightly.toml'",
@@ -1470,13 +1342,11 @@ fn warn_on_invalid_signature() {
 #[test]
 fn check_pgp_keys() {
     setup(&|config| {
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "show", "keys"],
             "Fingerprint: 108F 6620 5EAE B0AA A8DD 5E1C 85AB 96E6 FA1B E5FE",
         );
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "show", "keys"],
             "Fingerprint: B695 EF92 BE5C D24E D391 24DD 1F62 3994 2A48 2D51",
         );
@@ -1490,34 +1360,30 @@ fn install_allow_downgrade() {
 
         // this dist has no rls and there is no newer one
         set_current_dist_date(config, "2019-09-14");
-        expect_ok(config, &["rustup", "toolchain", "install", "nightly"]);
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-3");
-        expect_component_not_executable(config, "rls");
+        config.expect_ok(&["rustup", "toolchain", "install", "nightly"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-3");
+        config.expect_component_not_executable("rls");
 
-        expect_err(
-            config,
+        config.expect_err(
             &["rustup", "toolchain", "install", "nightly", "-c", "rls"],
             &format!(
                 "component 'rls' for target '{trip}' is unavailable for download for channel 'nightly'",
             ),
         );
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-3");
-        expect_component_not_executable(config, "rls");
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-3");
+        config.expect_component_not_executable("rls");
 
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "nightly",
-                "-c",
-                "rls",
-                "--allow-downgrade",
-            ],
-        );
-        expect_stdout_ok(config, &["rustc", "--version"], "hash-nightly-2");
-        expect_component_executable(config, "rls");
+        config.expect_ok(&[
+            "rustup",
+            "toolchain",
+            "install",
+            "nightly",
+            "-c",
+            "rls",
+            "--allow-downgrade",
+        ]);
+        config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
+        config.expect_component_executable("rls");
     });
 }
 
@@ -1525,24 +1391,20 @@ fn install_allow_downgrade() {
 fn regression_2601() {
     // We're checking that we don't regress per #2601
     setup(&|config| {
-        expect_ok(
-            config,
-            &[
-                "rustup",
-                "toolchain",
-                "install",
-                "--profile",
-                "minimal",
-                "nightly",
-                "--component",
-                "rust-src",
-            ],
-        );
+        config.expect_ok(&[
+            "rustup",
+            "toolchain",
+            "install",
+            "--profile",
+            "minimal",
+            "nightly",
+            "--component",
+            "rust-src",
+        ]);
         // The bug exposed in #2601 was that the above would end up installing
         // rust-src-$ARCH which would then have to be healed on the following
         // command, resulting in a reinstallation.
-        expect_stderr_ok(
-            config,
+        config.expect_stderr_ok(
             &["rustup", "component", "add", "rust-src"],
             "info: component 'rust-src' is up to date",
         );

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -171,16 +171,14 @@ pub fn setup(s: Scenario, f: &dyn Fn(&mut Config)) {
     // Make sure the host triple matches the build triple. Otherwise testing a 32-bit build of
     // rustup on a 64-bit machine will fail, because the tests do not have the host detection
     // functionality built in.
-    run(
-        &config,
+    config.run(
         "rustup",
         &["set", "default-host", &this_host_triple()],
         &[],
     );
 
     // Set the auto update mode to disable, as most tests do not want to update rustup itself during the test.
-    run(
-        &config,
+    config.run(
         "rustup",
         &["set", "auto-self-update", "disable"],
         &[],
@@ -285,6 +283,321 @@ impl Config {
         let version_file = rustup_dir.join("rustup-version");
         raw::write_file(&version_file, "").unwrap();
     }
+
+pub fn cmd<I, A>(&self, name: &str, args: I) -> Command
+where
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    let exe_path = self.exedir.join(format!("{name}{EXE_SUFFIX}"));
+    let mut cmd = Command::new(exe_path);
+    cmd.args(args);
+    cmd.current_dir(&*self.workdir.borrow());
+    self.env( &mut cmd);
+    cmd
+}
+
+pub fn env<E: rustup_test::Env>(&self, cmd: &mut E) {
+    // Ensure PATH is prefixed with the rustup-exe directory
+    let prev_path = env::var_os("PATH");
+    let mut new_path = self.exedir.clone().into_os_string();
+    if let Some(ref p) = prev_path {
+        new_path.push(if cfg!(windows) { ";" } else { ":" });
+        new_path.push(p);
+    }
+    cmd.env("PATH", new_path);
+    self.rustupdir.apply(cmd);
+    cmd.env(
+        "RUSTUP_DIST_SERVER",
+        format!("file://{}", self.distdir.to_string_lossy()),
+    );
+    cmd.env("CARGO_HOME", self.cargodir.to_string_lossy().to_string());
+    cmd.env("RUSTUP_OVERRIDE_HOST_TRIPLE", this_host_triple());
+
+    // These are used in some installation tests that unset RUSTUP_HOME/CARGO_HOME
+    cmd.env("HOME", self.homedir.to_string_lossy().to_string());
+    cmd.env("USERPROFILE", self.homedir.to_string_lossy().to_string());
+
+    // Setting HOME will confuse the sudo check for rustup-init. Override it
+    cmd.env("RUSTUP_INIT_SKIP_SUDO_CHECK", "yes");
+
+    // Skip the MSVC warning check since it's environment dependent
+    cmd.env("RUSTUP_INIT_SKIP_MSVC_CHECK", "yes");
+
+    // The test environment may interfere with checking the PATH for the existence of rustc or
+    // cargo, so we disable that check globally
+    cmd.env("RUSTUP_INIT_SKIP_PATH_CHECK", "yes");
+
+    // Setup pgp test key
+    cmd.env(
+        "RUSTUP_PGP_KEY",
+        std::env::current_dir()
+            .unwrap()
+            .join("tests/mock/signing-key.pub.asc"),
+    );
+
+    // The unix fallback settings file may be present in the test environment, so override
+    // the path to the settings file with a non-existing path to avoid interference
+    cmd.env(
+        "RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS",
+        "/bogus-config-file.toml",
+    );
+
+    if let Some(root) = self.rustup_update_root.as_ref() {
+        cmd.env("RUSTUP_UPDATE_ROOT", root);
+    }
+}
+
+    pub fn expect_ok(&self, args: &[&str]) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            panic!();
+        }
+    }
+
+    pub fn expect_err(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if out.ok || !out.stderr.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: false");
+            print_indented("expected.stderr.contains", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_stdout_ok(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || !out.stdout.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            print_indented("expected.stdout.contains", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_not_stdout_ok(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || out.stdout.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            print_indented("expected.stdout.does_not_contain", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_not_stderr_ok(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || out.stderr.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: false");
+            print_indented("expected.stderr.does_not_contain", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_not_stderr_err(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if out.ok || out.stderr.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: false");
+            print_indented("expected.stderr.does_not_contain", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_stderr_ok(&self, args: &[&str], expected: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || !out.stderr.contains(expected) {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            print_indented("expected.stderr.contains", expected);
+            panic!();
+        }
+    }
+
+    pub fn expect_ok_ex(&self, args: &[&str], stdout: &str, stderr: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || out.stdout != stdout || out.stderr != stderr {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            print_indented("expected.stdout", stdout);
+            print_indented("expected.stderr", stderr);
+            dbg!(out.stdout == stdout);
+            dbg!(out.stderr == stderr);
+            panic!();
+        }
+    }
+
+    pub fn expect_err_ex(&self, args: &[&str], stdout: &str, stderr: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if out.ok || out.stdout != stdout || out.stderr != stderr {
+            print_command(args, &out);
+            println!("expected.ok: false");
+            print_indented("expected.stdout", stdout);
+            print_indented("expected.stderr", stderr);
+            if out.ok {
+                panic!("expected command to fail");
+            } else if out.stdout != stdout {
+                panic!("expected stdout to match");
+            } else if out.stderr != stderr {
+                panic!("expected stderr to match");
+            } else {
+                unreachable!()
+            }
+        }
+    }
+
+    pub fn expect_ok_contains(&self, args: &[&str], stdout: &str, stderr: &str) {
+        let out = self.run(args[0], &args[1..], &[]);
+        if !out.ok || !out.stdout.contains(stdout) || !out.stderr.contains(stderr) {
+            print_command(args, &out);
+            println!("expected.ok: true");
+            print_indented("expected.stdout.contains", stdout);
+            print_indented("expected.stderr.contains", stderr);
+            panic!();
+        }
+    }
+
+    pub fn expect_ok_eq(&self, args1: &[&str], args2: &[&str]) {
+        let out1 = self.run(args1[0], &args1[1..], &[]);
+        let out2 = self.run(args2[0], &args2[1..], &[]);
+        if !out1.ok || !out2.ok || out1.stdout != out2.stdout || out1.stderr != out2.stderr {
+            print_command(args1, &out1);
+            println!("expected.ok: true");
+            print_command(args2, &out2);
+            println!("expected.ok: true");
+            panic!();
+        }
+    }
+
+    pub fn expect_component_executable(&self, cmd: &str) {
+        let out1 = self.run(cmd, &["--version"], &[]);
+        if !out1.ok {
+            print_command(&[cmd, "--version"], &out1);
+            println!("expected.ok: true");
+            panic!()
+        }
+    }
+
+    pub fn expect_component_not_executable(&self, cmd: &str) {
+        let out1 = self.run(cmd, &["--version"], &[]);
+        if out1.ok {
+            print_command(&[cmd, "--version"], &out1);
+            println!("expected.ok: false");
+            panic!()
+        }
+    }
+
+    pub fn run<I, A>(&self, name: &str, args: I, env: &[(&str, &str)]) -> SanitizedOutput
+    where
+        I: IntoIterator<Item = A> + Clone,
+        A: AsRef<OsStr>,
+    {
+        let inprocess = allow_inprocess(name, args.clone());
+        let start = Instant::now();
+        let out = if inprocess {
+            self.run_inprocess( name, args, env)
+        } else {
+            self.run_subprocess( name, args, env)
+        };
+        let duration = Instant::now() - start;
+        let output = SanitizedOutput {
+            ok: matches!(out.status, Some(0)),
+            stdout: String::from_utf8(out.stdout).unwrap(),
+            stderr: String::from_utf8(out.stderr).unwrap(),
+        };
+
+        println!("inprocess: {inprocess}");
+        println!("status: {:?}", out.status);
+        println!("duration: {:.3}s", duration.as_secs_f32());
+        println!("stdout:\n====\n{}\n====\n", output.stdout);
+        println!("stderr:\n====\n{}\n====\n", output.stderr);
+
+        output
+    }
+
+    pub(crate) fn run_inprocess<I, A>(&self, name: &str, args: I, env: &[(&str, &str)]) -> Output
+    where
+        I: IntoIterator<Item = A>,
+        A: AsRef<OsStr>,
+    {
+        // should we use vars_os, or skip over non-stringable vars? This is test
+        // code after all...
+        let mut vars: HashMap<String, String> = HashMap::default();
+        self::env(self, &mut vars);
+        vars.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
+        let mut arg_strings: Vec<Box<str>> = Vec::new();
+        arg_strings.push(name.to_owned().into_boxed_str());
+        for arg in args {
+            arg_strings.push(
+                arg.as_ref()
+                    .to_os_string()
+                    .into_string()
+                    .unwrap()
+                    .into_boxed_str(),
+            );
+        }
+        let tp = Box::new(currentprocess::TestProcess::new(
+            &*self.workdir.borrow(),
+            &arg_strings,
+            vars,
+            "",
+        ));
+        let process_res = currentprocess::with(tp.clone(), rustup_mode::main);
+        // convert Err's into an ec
+        let ec = match process_res {
+            Ok(process_res) => process_res,
+            Err(e) => {
+                currentprocess::with(tp.clone(), || rustup::cli::common::report_error(&e));
+                utils::ExitCode(1)
+            }
+        };
+        Output {
+            status: Some(ec.0),
+            stderr: (*tp).get_stderr(),
+            stdout: (*tp).get_stdout(),
+        }
+    }
+
+    pub fn run_subprocess<I, A>(&self, name: &str, args: I, env: &[(&str, &str)]) -> Output
+where
+    I: IntoIterator<Item = A>,
+    A: AsRef<OsStr>,
+{
+    let mut cmd = self.cmd(name, args);
+    for env in env {
+        cmd.env(env.0, env.1);
+    }
+
+    let mut retries = 8;
+    let out = loop {
+        let lock = cmd_lock().read().unwrap();
+        let out = cmd.output();
+        drop(lock);
+        match out {
+            Ok(out) => break out,
+            Err(e) => {
+                retries -= 1;
+                if retries > 0
+                    && e.kind() == std::io::ErrorKind::Other
+                    && e.raw_os_error() == Some(26)
+                {
+                    // This is an ETXTBSY situation
+                    std::thread::sleep(std::time::Duration::from_millis(250));
+                } else {
+                    panic!("Unable to run test command: {e:?}");
+                }
+            }
+        }
+    };
+    Output {
+        status: out.status.code(),
+        stdout: out.stdout,
+        stderr: out.stderr,
+    }
+}
 }
 
 /// Change the current distribution manifest to a particular date
@@ -295,146 +608,69 @@ pub fn set_current_dist_date(config: &Config, date: &str) {
     }
 }
 
+#[deprecated]
 pub fn expect_ok(config: &Config, args: &[&str]) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        panic!();
-    }
+    config.expect_ok(args)
 }
 
+#[deprecated]
 pub fn expect_err(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if out.ok || !out.stderr.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: false");
-        print_indented("expected.stderr.contains", expected);
-        panic!();
-    }
+    config.expect_err(args, expected)
 }
 
+#[deprecated]
 pub fn expect_stdout_ok(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || !out.stdout.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        print_indented("expected.stdout.contains", expected);
-        panic!();
-    }
+    config.expect_stdout_ok(args, expected)
 }
 
+#[deprecated]
 pub fn expect_not_stdout_ok(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || out.stdout.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        print_indented("expected.stdout.does_not_contain", expected);
-        panic!();
-    }
+    config.expect_not_stdout_ok(args, expected)
 }
 
+#[deprecated]
 pub fn expect_not_stderr_ok(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || out.stderr.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: false");
-        print_indented("expected.stderr.does_not_contain", expected);
-        panic!();
-    }
+    config.expect_not_stderr_ok(args, expected)
 }
 
+#[deprecated]
 pub fn expect_not_stderr_err(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if out.ok || out.stderr.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: false");
-        print_indented("expected.stderr.does_not_contain", expected);
-        panic!();
-    }
+    config.expect_not_stderr_err(args, expected)
 }
 
+#[deprecated]
 pub fn expect_stderr_ok(config: &Config, args: &[&str], expected: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || !out.stderr.contains(expected) {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        print_indented("expected.stderr.contains", expected);
-        panic!();
-    }
+    config.expect_stderr_ok(args, expected)
 }
 
+#[deprecated]
 pub fn expect_ok_ex(config: &Config, args: &[&str], stdout: &str, stderr: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || out.stdout != stdout || out.stderr != stderr {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        print_indented("expected.stdout", stdout);
-        print_indented("expected.stderr", stderr);
-        dbg!(out.stdout == stdout);
-        dbg!(out.stderr == stderr);
-        panic!();
-    }
+    config.expect_ok_ex(args, stdout, stderr)
 }
 
+#[deprecated]
 pub fn expect_err_ex(config: &Config, args: &[&str], stdout: &str, stderr: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if out.ok || out.stdout != stdout || out.stderr != stderr {
-        print_command(args, &out);
-        println!("expected.ok: false");
-        print_indented("expected.stdout", stdout);
-        print_indented("expected.stderr", stderr);
-        if out.ok {
-            panic!("expected command to fail");
-        } else if out.stdout != stdout {
-            panic!("expected stdout to match");
-        } else if out.stderr != stderr {
-            panic!("expected stderr to match");
-        } else {
-            unreachable!()
-        }
-    }
+    config.expect_err_ex(args, stdout, stderr)
 }
 
+#[deprecated]
 pub fn expect_ok_contains(config: &Config, args: &[&str], stdout: &str, stderr: &str) {
-    let out = run(config, args[0], &args[1..], &[]);
-    if !out.ok || !out.stdout.contains(stdout) || !out.stderr.contains(stderr) {
-        print_command(args, &out);
-        println!("expected.ok: true");
-        print_indented("expected.stdout.contains", stdout);
-        print_indented("expected.stderr.contains", stderr);
-        panic!();
-    }
+    config.expect_ok_contains(args, stdout, stderr)
 }
 
+#[deprecated]
 pub fn expect_ok_eq(config: &Config, args1: &[&str], args2: &[&str]) {
-    let out1 = run(config, args1[0], &args1[1..], &[]);
-    let out2 = run(config, args2[0], &args2[1..], &[]);
-    if !out1.ok || !out2.ok || out1.stdout != out2.stdout || out1.stderr != out2.stderr {
-        print_command(args1, &out1);
-        println!("expected.ok: true");
-        print_command(args2, &out2);
-        println!("expected.ok: true");
-        panic!();
-    }
+    config.expect_ok_eq(args1, args2)
 }
 
+#[deprecated]
 pub fn expect_component_executable(config: &Config, cmd: &str) {
-    let out1 = run(config, cmd, &["--version"], &[]);
-    if !out1.ok {
-        print_command(&[cmd, "--version"], &out1);
-        println!("expected.ok: true");
-        panic!()
-    }
+    config.expect_component_executable(cmd)
 }
 
+#[deprecated]
 pub fn expect_component_not_executable(config: &Config, cmd: &str) {
-    let out1 = run(config, cmd, &["--version"], &[]);
-    if out1.ok {
-        print_command(&[cmd, "--version"], &out1);
-        println!("expected.ok: false");
-        panic!()
-    }
+    config.expect_component_not_executable(cmd)
 }
 
 pub(crate) fn print_command(args: &[&str], out: &SanitizedOutput) {
@@ -485,63 +721,11 @@ where
     I: IntoIterator<Item = A>,
     A: AsRef<OsStr>,
 {
-    let exe_path = config.exedir.join(format!("{name}{EXE_SUFFIX}"));
-    let mut cmd = Command::new(exe_path);
-    cmd.args(args);
-    cmd.current_dir(&*config.workdir.borrow());
-    env(config, &mut cmd);
-    cmd
+    config.cmd(name, args)
 }
 
 pub fn env<E: rustup_test::Env>(config: &Config, cmd: &mut E) {
-    // Ensure PATH is prefixed with the rustup-exe directory
-    let prev_path = env::var_os("PATH");
-    let mut new_path = config.exedir.clone().into_os_string();
-    if let Some(ref p) = prev_path {
-        new_path.push(if cfg!(windows) { ";" } else { ":" });
-        new_path.push(p);
-    }
-    cmd.env("PATH", new_path);
-    config.rustupdir.apply(cmd);
-    cmd.env(
-        "RUSTUP_DIST_SERVER",
-        format!("file://{}", config.distdir.to_string_lossy()),
-    );
-    cmd.env("CARGO_HOME", config.cargodir.to_string_lossy().to_string());
-    cmd.env("RUSTUP_OVERRIDE_HOST_TRIPLE", this_host_triple());
-
-    // These are used in some installation tests that unset RUSTUP_HOME/CARGO_HOME
-    cmd.env("HOME", config.homedir.to_string_lossy().to_string());
-    cmd.env("USERPROFILE", config.homedir.to_string_lossy().to_string());
-
-    // Setting HOME will confuse the sudo check for rustup-init. Override it
-    cmd.env("RUSTUP_INIT_SKIP_SUDO_CHECK", "yes");
-
-    // Skip the MSVC warning check since it's environment dependent
-    cmd.env("RUSTUP_INIT_SKIP_MSVC_CHECK", "yes");
-
-    // The test environment may interfere with checking the PATH for the existence of rustc or
-    // cargo, so we disable that check globally
-    cmd.env("RUSTUP_INIT_SKIP_PATH_CHECK", "yes");
-
-    // Setup pgp test key
-    cmd.env(
-        "RUSTUP_PGP_KEY",
-        std::env::current_dir()
-            .unwrap()
-            .join("tests/mock/signing-key.pub.asc"),
-    );
-
-    // The unix fallback settings file may be present in the test environment, so override
-    // the path to the settings file with a non-existing path to avoid interference
-    cmd.env(
-        "RUSTUP_OVERRIDE_UNIX_FALLBACK_SETTINGS",
-        "/bogus-config-file.toml",
-    );
-
-    if let Some(root) = config.rustup_update_root.as_ref() {
-        cmd.env("RUSTUP_UPDATE_ROOT", root);
-    }
+    config.env(cmd)
 }
 
 use std::sync::RwLock;
@@ -597,118 +781,22 @@ where
     !(run || self_cmd || version || (is_update && !no_self_update))
 }
 
+#[deprecated]
 pub fn run<I, A>(config: &Config, name: &str, args: I, env: &[(&str, &str)]) -> SanitizedOutput
 where
     I: IntoIterator<Item = A> + Clone,
     A: AsRef<OsStr>,
 {
-    let inprocess = allow_inprocess(name, args.clone());
-    let start = Instant::now();
-    let out = if inprocess {
-        run_inprocess(config, name, args, env)
-    } else {
-        run_subprocess(config, name, args, env)
-    };
-    let duration = Instant::now() - start;
-    let output = SanitizedOutput {
-        ok: matches!(out.status, Some(0)),
-        stdout: String::from_utf8(out.stdout).unwrap(),
-        stderr: String::from_utf8(out.stderr).unwrap(),
-    };
-
-    println!("inprocess: {inprocess}");
-    println!("status: {:?}", out.status);
-    println!("duration: {:.3}s", duration.as_secs_f32());
-    println!("stdout:\n====\n{}\n====\n", output.stdout);
-    println!("stderr:\n====\n{}\n====\n", output.stderr);
-
-    output
+    config.run(name, args, env)
 }
 
-pub(crate) fn run_inprocess<I, A>(
-    config: &Config,
-    name: &str,
-    args: I,
-    env: &[(&str, &str)],
-) -> Output
-where
-    I: IntoIterator<Item = A>,
-    A: AsRef<OsStr>,
-{
-    // should we use vars_os, or skip over non-stringable vars? This is test
-    // code after all...
-    let mut vars: HashMap<String, String> = HashMap::default();
-    self::env(config, &mut vars);
-    vars.extend(env.iter().map(|(k, v)| (k.to_string(), v.to_string())));
-    let mut arg_strings: Vec<Box<str>> = Vec::new();
-    arg_strings.push(name.to_owned().into_boxed_str());
-    for arg in args {
-        arg_strings.push(
-            arg.as_ref()
-                .to_os_string()
-                .into_string()
-                .unwrap()
-                .into_boxed_str(),
-        );
-    }
-    let tp = Box::new(currentprocess::TestProcess::new(
-        &*config.workdir.borrow(),
-        &arg_strings,
-        vars,
-        "",
-    ));
-    let process_res = currentprocess::with(tp.clone(), rustup_mode::main);
-    // convert Err's into an ec
-    let ec = match process_res {
-        Ok(process_res) => process_res,
-        Err(e) => {
-            currentprocess::with(tp.clone(), || rustup::cli::common::report_error(&e));
-            utils::ExitCode(1)
-        }
-    };
-    Output {
-        status: Some(ec.0),
-        stderr: (*tp).get_stderr(),
-        stdout: (*tp).get_stdout(),
-    }
-}
-
+#[deprecated]
 pub fn run_subprocess<I, A>(config: &Config, name: &str, args: I, env: &[(&str, &str)]) -> Output
 where
     I: IntoIterator<Item = A>,
     A: AsRef<OsStr>,
 {
-    let mut cmd = cmd(config, name, args);
-    for env in env {
-        cmd.env(env.0, env.1);
-    }
-
-    let mut retries = 8;
-    let out = loop {
-        let lock = cmd_lock().read().unwrap();
-        let out = cmd.output();
-        drop(lock);
-        match out {
-            Ok(out) => break out,
-            Err(e) => {
-                retries -= 1;
-                if retries > 0
-                    && e.kind() == std::io::ErrorKind::Other
-                    && e.raw_os_error() == Some(26)
-                {
-                    // This is an ETXTBSY situation
-                    std::thread::sleep(std::time::Duration::from_millis(250));
-                } else {
-                    panic!("Unable to run test command: {e:?}");
-                }
-            }
-        }
-    };
-    Output {
-        status: out.status.code(),
-        stdout: out.stdout,
-        stderr: out.stderr,
-    }
+    config.run_subprocess(name, args, env)
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]


### PR DESCRIPTION
This will permit some future refactorings, but also is somewhat more idiomatic given that the functions aren't generic