### PR TITLE
Make `rustup show` output info in a more logical order

### DIFF
--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -120,15 +120,11 @@ The `channel` setting specifies which [toolchain] to use. The value is a
 string in the following form:
 
 ```
-<channel>[-<date>]
+(<channel>[-<date>])|<custom toolchain name>
 
 <channel>       = stable|beta|nightly|<major.minor.patch>
 <date>          = YYYY-MM-DD
 ```
-
-Note that this is a more restricted form than `rustup` toolchains
-generally, and cannot be used to specify custom toolchains or
-host-specific toolchains.
 
 [toolchain]: concepts/toolchains.md
 

--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -19,10 +19,7 @@ the directory tree toward the filesystem root, and a `rust-toolchain.toml` file
 that is closer to the current directory will be preferred over a directory
 override that is further away.
 
-To verify which toolchain is active, you can use `rustup show`, 
-which will also try to install the corresponding
-toolchain if the current one has not been installed according to the above rules.
-(Please note that this behavior is subject to change, as detailed in issue [#1397].)
+To verify which toolchain is active, you can use `rustup show`.
 
 [toolchain]: concepts/toolchains.md
 [toolchain override shorthand]: #toolchain-override-shorthand

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -20,6 +20,7 @@ use crate::{
         topical_doc,
     },
     command,
+    config::ActiveReason,
     currentprocess::{
         argsource::ArgSource,
         filesource::{StderrSource, StdoutSource},
@@ -864,8 +865,10 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
         };
 
         let cwd = utils::current_dir()?;
-        if let Some((toolchain, reason)) = cfg.find_override(&cwd)? {
-            info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
+        if let Some((toolchain, reason)) = cfg.find_active_toolchain(&cwd)? {
+            if !matches!(reason, ActiveReason::Default) {
+                info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
+            }
         }
     } else {
         let default_toolchain = cfg

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -872,10 +872,15 @@ fn default_(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
             }
         }
     } else {
-        let default_toolchain = cfg
-            .get_default()?
-            .ok_or_else(|| anyhow!("no default toolchain configured"))?;
-        writeln!(process().stdout().lock(), "{default_toolchain} (default)")?;
+        match cfg.get_default()? {
+            Some(default_toolchain) => {
+                writeln!(process().stdout().lock(), "{default_toolchain} (default)")?;
+            }
+            None => writeln!(
+                process().stdout().lock(),
+                "no default toolchain is configured"
+            )?,
+        }
     }
 
     Ok(utils::ExitCode(0))

--- a/src/config.rs
+++ b/src/config.rs
@@ -108,8 +108,8 @@ pub(crate) enum ActiveReason {
 impl Display for ActiveReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         match self {
-            Self::Default => write!(f, "default"),
-            Self::Environment => write!(f, "environment override by RUSTUP_TOOLCHAIN"),
+            Self::Default => write!(f, "it's the default toolchain"),
+            Self::Environment => write!(f, "overriden by environment variable RUSTUP_TOOLCHAIN"),
             Self::CommandLine => write!(f, "overridden by +toolchain on the command line"),
             Self::OverrideDB(path) => write!(f, "directory override for '{}'", path.display()),
             Self::ToolchainFile(path) => write!(f, "overridden by '{}'", path.display()),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -38,9 +38,10 @@ impl SettingsFile {
     fn read_settings(&self) -> Result<()> {
         let mut needs_save = false;
         {
-            let mut b = self.cache.borrow_mut();
+            let b = self.cache.borrow();
             if b.is_none() {
-                *b = Some(if utils::is_file(&self.path) {
+                drop(b);
+                *self.cache.borrow_mut() = Some(if utils::is_file(&self.path) {
                     let content = utils::read_file("settings", &self.path)?;
                     Settings::parse(&content)?
                 } else {

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -577,6 +577,13 @@ fn default_none() {
             &["rustup", "default", "none"],
             "info: default toolchain unset",
         );
+
+        config.expect_ok_ex(
+            &["rustup", "default"],
+            "no default toolchain is configured\n",
+            "",
+        );
+
         config.expect_err_ex(
             &["rustc", "--version"],
             "",

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1002,7 +1002,7 @@ fn override_by_toolchain_on_the_command_line() {
         config.expect_stdout_ok(&["rustup", "+nightly", "which", "rustc"], "/bin/rustc");
         config.expect_stdout_ok(
             &["rustup", "+nightly", "show"],
-            "(overridden by +toolchain on the command line)",
+            "active because: overridden by +toolchain on the command line",
         );
         config.expect_err(
             &["rustup", "+foo", "which", "rustc"],

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -477,13 +477,6 @@ fn toolchains_are_resolved_early() {
     });
 }
 
-#[test]
-fn no_panic_on_default_toolchain_missing() {
-    setup(&|config| {
-        config.expect_err(&["rustup", "default"], "no default toolchain configured");
-    });
-}
-
 // #190
 #[test]
 fn proxies_pass_empty_args() {

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2482,7 +2482,7 @@ fn check_unix_settings_fallback() {
     test(&|config| {
         config.with_scenario(Scenario::SimpleV2, &|config| {
             // No default toolchain specified yet
-            config.expect_err(&["rustup", "default"], r"no default toolchain configured");
+            config.expect_stdout_ok(&["rustup", "default"], "no default toolchain is configured");
 
             // Default toolchain specified in fallback settings file
             let mock_settings_file = config.current_dir().join("mock_fallback_settings.toml");

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -834,10 +834,7 @@ fn list_default_toolchain() {
             config.expect_ok(&["rustup", "default", "nightly"]);
             config.expect_ok_ex(
                 &["rustup", "toolchain", "list"],
-                for_host!(
-                    r"nightly-{0} (default)
-"
-                ),
+                for_host!("nightly-{0} (active, default)\n"),
                 r"",
             );
         })
@@ -845,16 +842,28 @@ fn list_default_toolchain() {
 }
 
 #[test]
-fn list_override_toolchain() {
+fn list_no_default_toolchain() {
+    test(&|config| {
+        config.with_scenario(Scenario::SimpleV2, &|config| {
+            config.expect_ok(&["rustup", "install", "nightly"]);
+            config.expect_ok(&["rustup", "default", "none"]);
+            config.expect_ok_ex(
+                &["rustup", "toolchain", "list"],
+                for_host!("nightly-{0}\n"),
+                r"",
+            );
+        })
+    });
+}
+
+#[test]
+fn list_no_default_override_toolchain() {
     test(&|config| {
         config.with_scenario(Scenario::SimpleV2, &|config| {
             config.expect_ok(&["rustup", "override", "set", "nightly"]);
             config.expect_ok_ex(
                 &["rustup", "toolchain", "list"],
-                for_host!(
-                    r"nightly-{0} (override)
-"
-                ),
+                for_host!("nightly-{0} (active)\n"),
                 r"",
             );
         })
@@ -869,10 +878,7 @@ fn list_default_and_override_toolchain() {
             config.expect_ok(&["rustup", "override", "set", "nightly"]);
             config.expect_ok_ex(
                 &["rustup", "toolchain", "list"],
-                for_host!(
-                    r"nightly-{0} (default) (override)
-"
-                ),
+                for_host!("nightly-{0} (active, default)\n"),
                 r"",
             );
         })

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -91,11 +91,11 @@ fn list_toolchains() {
         config.expect_ok(&["rustup", "update", "nightly"]);
         config.expect_ok(&["rustup", "update", "beta-2015-01-01"]);
         config.expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly");
-        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(default)\t");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(active, default) ");
         #[cfg(windows)]
         config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
-            for_host!("\\toolchains\\nightly-{}"),
+            for_host!(r"\toolchains\nightly-{}"),
         );
         #[cfg(not(windows))]
         config.expect_stdout_ok(
@@ -106,7 +106,7 @@ fn list_toolchains() {
         #[cfg(windows)]
         config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
-            "\\toolchains\\beta-2015-01-01",
+            r"\toolchains\beta-2015-01-01",
         );
         #[cfg(not(windows))]
         config.expect_stdout_ok(

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -129,11 +129,11 @@ fn list_toolchains() {
         config.expect_ok(&["rustup", "update", "nightly"]);
         config.expect_ok(&["rustup", "update", "beta-2015-01-01"]);
         config.expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly");
-        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(default)\t");
+        config.expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(active, default) ");
         #[cfg(windows)]
         config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
-            for_host!("\\toolchains\\nightly-{}"),
+            for_host!(r"\toolchains\nightly-{}"),
         );
         #[cfg(not(windows))]
         config.expect_stdout_ok(
@@ -144,7 +144,7 @@ fn list_toolchains() {
         #[cfg(windows)]
         config.expect_stdout_ok(
             &["rustup", "toolchain", "list", "-v"],
-            "\\toolchains\\beta-2015-01-01",
+            r"\toolchains\beta-2015-01-01",
         );
         #[cfg(not(windows))]
         config.expect_stdout_ok(


### PR DESCRIPTION
I ran `rustup show` and noticed that its output is in the order:
installed toolchains -> installed targets for active toolchain -> active toolchain
I thought it would make sense to put "active toolchain" before " installed targets for active toolchain" so that they in order of decreasing scope:
installed toolchains -> active toolchain -> installed targets for active toolchain
 so that is what this patch does 🙂
Thoughts?

*Before:*
```
Matt@Matts-PC /c/d/p/r/rustup (show-order)> rustup show
Default host: x86_64-pc-windows-msvc
rustup home:  C:\Users\Matt\.rustup

installed toolchains
--------------------

stable-x86_64-pc-windows-msvc (default)
nightly-x86_64-pc-windows-msvc

installed targets for active toolchain
--------------------------------------

wasm32-unknown-unknown
x86_64-pc-windows-msvc

active toolchain
----------------

stable-x86_64-pc-windows-msvc (default)
rustc 1.67.1 (d5a82bbd2 2023-02-07)

Matt@Matts-PC /c/d/p/r/rustup (show-order)>
```
*After:*
```
Matt@Matts-PC /c/d/p/r/rustup (show-order)> RUSTUP_HOME=home CARGO_HOME=home home/bin/rustup show
Default host: x86_64-pc-windows-msvc
rustup home:  D:\programming\repos\rustup\home

installed toolchains
--------------------

stable-x86_64-pc-windows-msvc (default)
nightly-x86_64-pc-windows-msvc

active toolchain
----------------

stable-x86_64-pc-windows-msvc (default)
rustc 1.67.1 (d5a82bbd2 2023-02-07)

installed targets for active toolchain
--------------------------------------

wasm32-unknown-unknown
x86_64-pc-windows-msvc

Matt@Matts-PC /c/d/p/r/rustup (show-order)>
```

Fixes https://github.com/rust-lang/rustup/issues/1397