### PR TITLE
Fix some more clippy-related issues.

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -634,7 +634,7 @@ pub(crate) fn delete_rustup_and_cargo_home() -> Result<()> {
     // CARGO_HOME, hopefully empty except for bin/rustup.exe
     let cargo_home = utils::cargo_home()?;
     // The rustup.exe bin
-    let rustup_path = cargo_home.join(&format!("bin/rustup{}", EXE_SUFFIX));
+    let rustup_path = cargo_home.join(format!("bin/rustup{EXE_SUFFIX}"));
 
     // The directory containing CARGO_HOME
     let work_path = cargo_home
@@ -644,7 +644,7 @@ pub(crate) fn delete_rustup_and_cargo_home() -> Result<()> {
     // Generate a unique name for the files we're about to move out
     // of CARGO_HOME.
     let numbah: u32 = rand::random();
-    let gc_exe = work_path.join(&format!("rustup-gc-{:x}.exe", numbah));
+    let gc_exe = work_path.join(format!("rustup-gc-{numbah:x}.exe"));
     // Copy rustup (probably this process's exe) to the gc exe
     utils::copy_file(&rustup_path, &gc_exe)?;
     let gc_exe_win: Vec<_> = gc_exe.as_os_str().encode_wide().chain(Some(0)).collect();
@@ -800,7 +800,7 @@ mod tests {
                 match reg_value {
                     Ok(_) => panic!("key not deleted"),
                     Err(ref e) if e.kind() == io::ErrorKind::NotFound => {}
-                    Err(ref e) => panic!("error {}", e),
+                    Err(ref e) => panic!("error {e}"),
                 }
             })
         });

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -300,7 +300,7 @@ impl TargetTriple {
 
             // Default to msvc
             let arch = arch_primary().or_else(arch_fallback)?;
-            let msvc_triple = format!("{}-pc-windows-msvc", arch);
+            let msvc_triple = format!("{arch}-pc-windows-msvc");
             Some(TargetTriple(msvc_triple))
         }
 

--- a/tests/cli-ui.rs
+++ b/tests/cli-ui.rs
@@ -6,7 +6,7 @@ fn rustup_ui_doc_text_tests() {
     let rustup_init = trycmd::cargo::cargo_bin("rustup-init");
     let rustup = trycmd::cargo::cargo_bin("rustup");
     // Copy rustup-init to rustup so that the tests can run it.
-    fs::copy(&rustup_init, &rustup).unwrap();
+    fs::copy(rustup_init, &rustup).unwrap();
     t.register_bin("rustup", &rustup);
     t.case("tests/cli-ui/rustup/*.toml");
     #[cfg(target_os = "windows")]

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -403,7 +403,7 @@ fn override_windows_root() {
         // This value is probably "C:"
         // Really sketchy to be messing with C:\ in a test...
         let prefix = prefix.as_os_str().to_str().unwrap();
-        let prefix = format!("{}\\", prefix);
+        let prefix = format!("{prefix}\\");
         config.change_dir(&PathBuf::from(&prefix), &|| {
             config.expect_ok(&["rustup", "default", "stable"]);
             config.expect_ok(&["rustup", "override", "add", "nightly"]);


### PR DESCRIPTION
Format strings with embedded variables, and passing in structs by value
when they implement the requested trait directly. Neither seem to affect
readability so shouldn't be contentious.