### PR TITLE
Config mutable

### DIFF
--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -36,7 +36,7 @@ fn restore_path(p: Option<RegValue>) {
 }
 
 /// Support testing of code that mutates global path state
-pub fn with_saved_path(f: &dyn Fn()) {
+pub fn with_saved_path(f: &mut dyn FnMut()) {
     // Lock protects concurrent mutation of registry
     lazy_static! {
         static ref LOCK: Mutex<()> = Mutex::new(());

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -745,7 +745,7 @@ mod tests {
     fn windows_path_regkey_type() {
         // per issue #261, setting PATH should use REG_EXPAND_SZ.
         let tp = Box::new(currentprocess::TestProcess::default());
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             currentprocess::with(tp.clone(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
@@ -775,7 +775,7 @@ mod tests {
         // during uninstall the PATH key may end up empty; if so we should
         // delete it.
         let tp = Box::new(currentprocess::TestProcess::default());
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             currentprocess::with(tp.clone(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
@@ -816,7 +816,7 @@ mod tests {
                 .collect(),
             ..Default::default()
         });
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             currentprocess::with(tp.clone(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
@@ -845,7 +845,7 @@ mod tests {
     fn windows_treat_missing_path_as_empty() {
         // during install the PATH key may be missing; treat it as empty
         let tp = Box::new(currentprocess::TestProcess::default());
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             currentprocess::with(tp.clone(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -56,7 +56,7 @@ mod tests {
             vars,
             ..Default::default()
         });
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             currentprocess::with(tp.clone(), || {
                 let mut path_entries = vec![];
                 let mut cmd = Command::new("test");

--- a/tests/cli-exact.rs
+++ b/tests/cli-exact.rs
@@ -364,7 +364,7 @@ fn remove_override_with_path() {
                 .prefix("rustup-test")
                 .tempdir()
                 .unwrap();
-            config.change_dir(dir.path(), || {
+            config.change_dir(dir.path(), &|config| {
                 config.expect_ok(&["rustup", "override", "add", "nightly"]);
             });
             config.expect_ok_ex(
@@ -395,7 +395,7 @@ fn remove_override_with_path_deleted() {
                     .tempdir()
                     .unwrap();
                 let path = std::fs::canonicalize(dir.path()).unwrap();
-                config.change_dir(&path, || {
+                config.change_dir(&path, &|config| {
                     config.expect_ok(&["rustup", "override", "add", "nightly"]);
                 });
                 path
@@ -429,7 +429,7 @@ fn remove_override_nonexistent() {
                     .tempdir()
                     .unwrap();
                 let path = std::fs::canonicalize(dir.path()).unwrap();
-                config.change_dir(&path, || {
+                config.change_dir(&path, &|config| {
                     config.expect_ok(&["rustup", "override", "add", "nightly"]);
                 });
                 path
@@ -483,7 +483,7 @@ fn list_overrides_with_nonexistent() {
                 .prefix("rustup-test")
                 .tempdir()
                 .unwrap();
-            config.change_dir(dir.path(), || {
+            config.change_dir(dir.path(), &|config| {
                 config.expect_ok(&["rustup", "override", "add", "nightly"]);
             });
             std::fs::canonicalize(dir.path()).unwrap()

--- a/tests/cli-inst-interactive.rs
+++ b/tests/cli-inst-interactive.rs
@@ -53,7 +53,7 @@ fn run_input_with_env(
 #[test]
 fn update() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             run_input(config, &["rustup-init"], "\n\n");
             let out = run_input(config, &["rustup-init"], "\n\n");
             assert!(out.ok, "stdout:\n{}\nstderr:\n{}", out.stdout, out.stderr);
@@ -116,7 +116,7 @@ Rust is installed now. Great!
 #[test]
 fn smoke_case_install_with_path_install() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             let out = run_input(config, &["rustup-init"], "\n\n");
             assert!(out.ok);
             assert!(!out

--- a/tests/cli-paths.rs
+++ b/tests/cli-paths.rs
@@ -360,7 +360,7 @@ mod windows {
     /// Smoke test for end-to-end code connectivity of the installer path mgmt on windows.
     fn install_uninstall_affect_path() {
         clitools::setup(Scenario::Empty, &|config| {
-            with_saved_path(&|| {
+            with_saved_path(&mut || {
                 let path = format!("{:?}", config.cargodir.join("bin").to_string_lossy());
 
                 config.expect_ok(&INIT_NONE);
@@ -390,7 +390,7 @@ mod windows {
         use winreg::{RegKey, RegValue};
 
         clitools::setup(Scenario::Empty, &|config| {
-            with_saved_path(&|| {
+            with_saved_path(&mut || {
                 // Set up a non unicode PATH
                 let reg_value = RegValue {
                     bytes: vec![

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -20,7 +20,7 @@ use crate::mock::dist::calc_hash;
 
 const TEST_VERSION: &str = "1.1.1";
 
-pub fn update_setup(f: &dyn Fn(&Config, &Path)) {
+pub fn update_setup(f: &dyn Fn(&mut Config, &Path)) {
     self_update_setup(f, TEST_VERSION)
 }
 

--- a/tests/cli-self-upd.rs
+++ b/tests/cli-self-upd.rs
@@ -25,7 +25,7 @@ pub fn update_setup(f: &dyn Fn(&mut Config, &Path)) {
 }
 
 /// Empty dist server, rustup installed with no toolchain
-fn setup_empty_installed(f: &dyn Fn(&Config)) {
+fn setup_empty_installed(f: &dyn Fn(&mut Config)) {
     clitools::setup(Scenario::Empty, &|config| {
         config.expect_ok(&[
             "rustup-init",
@@ -39,7 +39,7 @@ fn setup_empty_installed(f: &dyn Fn(&Config)) {
 }
 
 /// SimpleV3 dist server, rustup installed with default toolchain
-fn setup_installed(f: &dyn Fn(&Config)) {
+fn setup_installed(f: &dyn Fn(&mut Config)) {
     clitools::setup(Scenario::SimpleV2, &|config| {
         config.expect_ok(&["rustup-init", "-y", "--no-modify-path"]);
         f(config);
@@ -52,7 +52,7 @@ fn setup_installed(f: &dyn Fn(&Config)) {
 /// status of the proxies.
 fn install_bins_to_cargo_home() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             config.expect_ok_contains(
                 &["rustup-init", "-y"],
                 for_host!(
@@ -101,7 +101,7 @@ info: default toolchain set to 'stable-{0}'
 #[test]
 fn install_twice() {
     clitools::setup(Scenario::SimpleV2, &|config| {
-        with_saved_path(&|| {
+        with_saved_path(&mut || {
             config.expect_ok(&["rustup-init", "-y"]);
             config.expect_ok(&["rustup-init", "-y"]);
             let rustup = config.cargodir.join(format!("bin/rustup{EXE_SUFFIX}"));

--- a/tests/cli-v1.rs
+++ b/tests/cli-v1.rs
@@ -147,7 +147,7 @@ fn remove_default_toolchain_autoinstalls() {
 fn remove_override_toolchain_err_handling() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "default", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
@@ -222,7 +222,7 @@ fn override_overrides_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
@@ -236,19 +236,19 @@ fn multiple_overrides() {
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
 
         config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
 
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
@@ -258,7 +258,7 @@ fn multiple_overrides() {
 fn change_override() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
@@ -270,7 +270,7 @@ fn change_override() {
 fn remove_override_no_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "nightly"]);
             config.expect_ok(&["rustup", "override", "remove"]);
             config.expect_err(
@@ -285,7 +285,7 @@ fn remove_override_no_default() {
 fn remove_override_with_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "default", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_ok(&["rustup", "override", "remove"]);
@@ -300,18 +300,18 @@ fn remove_override_with_multiple_overrides() {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
         config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "remove"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });

--- a/tests/cli-v2.rs
+++ b/tests/cli-v2.rs
@@ -250,7 +250,7 @@ fn remove_default_toolchain_autoinstalls() {
 fn remove_override_toolchain_err_handling() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "default", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_ok(&["rustup", "toolchain", "remove", "beta"]);
@@ -354,7 +354,7 @@ fn override_overrides_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
@@ -368,19 +368,19 @@ fn multiple_overrides() {
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
 
         config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
 
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });
@@ -404,7 +404,7 @@ fn override_windows_root() {
         // Really sketchy to be messing with C:\ in a test...
         let prefix = prefix.as_os_str().to_str().unwrap();
         let prefix = format!("{prefix}\\");
-        config.change_dir(&PathBuf::from(&prefix), &|| {
+        config.change_dir(&PathBuf::from(&prefix), &|config| {
             config.expect_ok(&["rustup", "default", "stable"]);
             config.expect_ok(&["rustup", "override", "add", "nightly"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
@@ -418,7 +418,7 @@ fn override_windows_root() {
 fn change_override() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0");
@@ -430,7 +430,7 @@ fn change_override() {
 fn remove_override_no_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "nightly"]);
             config.expect_ok(&["rustup", "override", "remove"]);
             config.expect_err(
@@ -445,7 +445,7 @@ fn remove_override_no_default() {
 fn remove_override_with_default() {
     setup(&|config| {
         let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-        config.change_dir(tempdir.path(), &|| {
+        config.change_dir(tempdir.path(), &|config| {
             config.expect_ok(&["rustup", "default", "nightly"]);
             config.expect_ok(&["rustup", "override", "add", "beta"]);
             config.expect_ok(&["rustup", "override", "remove"]);
@@ -460,18 +460,18 @@ fn remove_override_with_multiple_overrides() {
         let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
         config.expect_ok(&["rustup", "default", "nightly"]);
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "beta"]);
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_ok(&["rustup", "override", "add", "stable"]);
         });
         config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
-        config.change_dir(tempdir1.path(), &|| {
+        config.change_dir(tempdir1.path(), &|config| {
             config.expect_ok(&["rustup", "override", "remove"]);
             config.expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2");
         });
-        config.change_dir(tempdir2.path(), &|| {
+        config.change_dir(tempdir2.path(), &|config| {
             config.expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0");
         });
     });

--- a/tests/mock/clitools.rs
+++ b/tests/mock/clitools.rs
@@ -329,7 +329,7 @@ impl Config {
         }
     }
 
-    pub fn expect_ok(&self, args: &[&str]) {
+    pub fn expect_ok(&mut self, args: &[&str]) {
         let out = self.run(args[0], &args[1..], &[]);
         if !out.ok {
             print_command(args, &out);


### PR DESCRIPTION
Change enough of the Config methods to be mutable to permit the following style of code:
```
test(&|config| {
        config.with_scenario(Scenario::ArchivesV2, &|config| {
            config.expect_ok_ex(....
```

This requires that expect_ok_ex takes a mut reference to self, and everything it calls into.

Without this such a `with_scenario` function would require internal mutability, which would be effectively preventing the borrow checker doing its job.

Alternatively it could make a new Config object with only the distdir field changed, but then we have a sort of anti-aliasing occuring where folk could be confused about what config instance is being referred to.

Another alternative is to not wrap the code under test, but then its possible for the state to be changed and not popped back... possibly that would be better; so this is genuinely asking for thoughts around it