### PR TITLE
Use workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ no-self-update = []
 
 # Sorted by alphabetic order
 [dependencies]
-anyhow = "1.0.69"
+anyhow.workspace = true
 cfg-if = "1.0"
 chrono = "0.4"
 clap = {version = "2", features = ["wrap_help"]}
@@ -36,12 +36,13 @@ enum-map = "2.4.2"
 flate2 = "1"
 git-testament = "0.2"
 home = "0.5.4"
-lazy_static = "1"
+lazy_static.workspace = true
 libc = "0.2"
 num_cpus = "1.15"
 opener = "0.5.2"
-# Used by `curl` or `reqwest` backend although it isn't imported
-# by our rustup.
+# Used by `curl` or `reqwest` backend although it isn't imported by our rustup :
+# this allows controlling the vendoring status without exposing the presence of
+# the download crate.
 openssl = {version = "0.10", optional = true}
 pulldown-cmark = {version = "0.9", default-features = false}
 rand = "0.8"
@@ -56,13 +57,13 @@ sha2 = "0.10"
 sharded-slab = "0.1.1"
 strsim = "0.10"
 tar = "0.4.26"
-tempfile = "3.1"
+tempfile.workspace = true
 # FIXME(issue #1818, #1826, and friends)
 term = "=0.7.0"
-thiserror = "1.0"
+thiserror.workspace = true
 threadpool = "1"
 toml = "0.5"
-url = "2.3"
+url.workspace = true
 wait-timeout = "0.2"
 xz2 = "0.1.3"
 zstd = "0.12"
@@ -118,6 +119,13 @@ regex = "1"
 
 [workspace]
 members = ["download"]
+
+[workspace.dependencies]
+anyhow = "1.0.69"
+lazy_static = "1"
+tempfile = "3.1"
+thiserror = "1.0"
+url = "2.3"
 
 [lib]
 name = "rustup"

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -16,15 +16,15 @@ reqwest-default-tls = ["reqwest/default-tls"]
 reqwest-rustls-tls = ["reqwest/rustls-tls-native-roots"]
 
 [dependencies]
-anyhow = "1.0.69"
+anyhow.workspace = true
 curl = {version = "0.4.11", optional = true}
 env_proxy = {version = "0.4.1", optional = true}
-lazy_static = {version = "1.0", optional = true}
+lazy_static = {workspace=true, optional = true}
 reqwest = {version = "0.11", default-features = false, features = ["blocking", "gzip", "socks"], optional = true}
-thiserror = "1.0"
-url = "2.3"
+thiserror.workspace = true
+url.workspace = true
 
 [dev-dependencies]
 hyper = {version = "0.14", default-features = false, features = ["tcp", "server"]}
-tempfile = "3"
+tempfile.workspace = true
 tokio = {version = "1", default-features = false, features = ["sync"]}


### PR DESCRIPTION
This should reduce rebuilds of packages during testing as they will be
identical.