### PR TITLE
Run the tests on x86_64-pc-windows-msvc

### DIFF
--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -26,12 +26,12 @@ jobs:
         mode:
           - dev
           - release         
-        include: # skip-pr
+        include:
+          - target: x86_64-pc-windows-msvc
+            run_tests: YES
           - target: x86_64-pc-windows-gnu  # skip-pr
             mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z  # skip-pr
             mingwdir: mingw64  # skip-pr
-          - target: aarch64-pc-windows-msvc # skip-pr skip-stable
-            skip_tests: yes # skip-pr skip-stable
     steps:
       - uses: actions/checkout@v3
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -23,6 +23,9 @@ jobs:
         mode:
           - dev
           - release         
+        include:
+          - target: x86_64-pc-windows-msvc
+            run_tests: YES
     steps:
       - uses: actions/checkout@v3
         # v2 defaults to a shallow checkout, but we need at least to the previous tag

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -26,7 +26,9 @@ jobs:
         mode:
           - dev
           - release         
-        include: # skip-pr
+        include:
+          - target: x86_64-pc-windows-msvc
+            run_tests: YES
           - target: x86_64-pc-windows-gnu  # skip-pr
             mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z  # skip-pr
             mingwdir: mingw64  # skip-pr

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -35,15 +35,15 @@ jobs:
         mode:
           - dev
           - release         
-        include: # skip-pr
+        include:
+          - target: x86_64-pc-windows-msvc
+            run_tests: YES
           - target: x86_64-pc-windows-gnu  # skip-pr
             mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z  # skip-pr
             mingwdir: mingw64  # skip-pr
           - target: i686-pc-windows-gnu  # skip-pr skip-master
             mingwdir: mingw32  # skip-pr skip-master
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z  # skip-pr skip-master
-          - target: aarch64-pc-windows-msvc # skip-pr skip-stable
-            skip_tests: yes # skip-pr skip-stable
     steps:
       - uses: actions/checkout@v3
         # v2 defaults to a shallow checkout, but we need at least to the previous tag


### PR DESCRIPTION
I think we turned off the tests on windows by accident in this PR. https://github.com/rust-lang/rustup/pull/3247