### PR TITLE
Bump fs_at from v0.1.1 to v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,9 +964,9 @@ dependencies = [
 
 [[package]]
 name = "fs_at"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab60b097d8208fe02d24ae954c3248a9436f96edefa8f4b9fcb0f26d60d003a9"
+checksum = "e3dfc546714a30e1e1f2eb5e1d233a6c1254c4a3d25ac35c09743e824a39d35e"
 dependencies = [
  "aligned",
  "cfg-if 1.0.0",


### PR DESCRIPTION
Fix broken CI. See https://github.com/rust-lang/rustup/actions/runs/4397256299/jobs/7700257188#logs