### PR TITLE
Add target env for windows

### DIFF
--- a/.github/workflows/windows-builds-on-master.yaml
+++ b/.github/workflows/windows-builds-on-master.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Skip tests
         if: matrix.run_tests == '' || matrix.mode == 'release'
         run: |

--- a/.github/workflows/windows-builds-on-pr.yaml
+++ b/.github/workflows/windows-builds-on-pr.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Skip tests
         if: matrix.run_tests == '' || matrix.mode == 'release'
         run: |

--- a/.github/workflows/windows-builds-on-stable.yaml
+++ b/.github/workflows/windows-builds-on-stable.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Skip tests
         if: matrix.run_tests == '' || matrix.mode == 'release'
         run: |

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -76,6 +76,7 @@ jobs:
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          echo "TARGET=${{ matrix.target }}" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
       - name: Skip tests
         if: matrix.run_tests == '' || matrix.mode == 'release'
         run: |


### PR DESCRIPTION
Add it back. We removed it in https://github.com/rust-lang/rustup/commit/6dc031d8439874af74014e0ba2627fff842d5678#diff-7092fe111c1a4ffef6c91c938ee0c3c177ba6c9fa515af8a3aaa8506171ffba4.

I suppose it should fix this broken CI. https://github.com/rust-lang/rustup/actions/runs/4398020551/jobs/7701558190