### PR TITLE
Fix broken CI for `rust-x86_64-unknown-illumos`

### DIFF
--- a/ci/docker/x86_64-unknown-illumos/Dockerfile
+++ b/ci/docker/x86_64-unknown-illumos/Dockerfile
@@ -1,7 +1,8 @@
 FROM rust-x86_64-unknown-illumos
 
 ENV \
-    AR_x86_64_unknown_illumos=x86_64-illumos-ar \
-    CC_x86_64_unknown_illumos=x86_64-illumos-gcc \
-    CXX_x86_64_unknown_illumos=x86_64-illumos-g++ \
-    CARGO_TARGET_X86_64_UNKNOWN_ILLUMOS_LINKER=x86_64-illumos-gcc
+  AR_x86_64_unknown_illumos="x86_64-illumos-ar" \
+  RANLIB_x86_64_unknown_illumos="x86_64-illumos-ranlib" \
+  CC_x86_64_unknown_illumos=x86_64-illumos-gcc \
+  CXX_x86_64_unknown_illumos=x86_64-illumos-g++ \
+  CARGO_TARGET_X86_64_UNKNOWN_ILLUMOS_LINKER=x86_64-illumos-gcc


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/issues/3263
See more at: https://github.com/sfackler/rust-openssl/issues/1839#issuecomment-1469192775

You can see the test result at: https://github.com/hi-rustin/rustup/actions/runs/4422102163/jobs/7753569729