### PR TITLE
Add preload directive to HSTS header

### DIFF
--- a/www/website_config.json
+++ b/www/website_config.json
@@ -1,6 +1,6 @@
 {
     "headers": {
-        "Strict-Transport-Security": "max-age=63072000; includeSubDomains",
+        "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "DENY",
         "X-XSS-Protection": "1; mode=block",


### PR DESCRIPTION
The preload directive has been added to the Strict-Transport-Security header to enable HSTS preloading.