### PR TITLE
Set SubcommandRequiredElseHelp correctly

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -226,7 +226,7 @@ pub(crate) fn cli() -> Command<'static> {
         .about("The Rust toolchain installer")
         .after_help(RUSTUP_HELP)
         .global_setting(AppSettings::DeriveDisplayOrder)
-        .arg_required_else_help(true)
+        .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(
             verbose_arg("Enable verbose output"),
         )
@@ -369,8 +369,7 @@ pub(crate) fn cli() -> Command<'static> {
             Command::new("toolchain")
                 .about("Modify or query the installed toolchains")
                 .after_help(TOOLCHAIN_HELP)
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     Command::new("list")
                         .about("List installed toolchains")
@@ -475,8 +474,7 @@ pub(crate) fn cli() -> Command<'static> {
         .subcommand(
             Command::new("target")
                 .about("Modify a toolchain's supported targets")
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     Command::new("list")
                         .about("List installed and available targets")
@@ -536,8 +534,7 @@ pub(crate) fn cli() -> Command<'static> {
         .subcommand(
             Command::new("component")
                 .about("Modify a toolchain's installed components")
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     Command::new("list")
                         .about("List installed and available components")
@@ -593,8 +590,7 @@ pub(crate) fn cli() -> Command<'static> {
             Command::new("override")
                 .about("Modify directory toolchain overrides")
                 .after_help(OVERRIDE_HELP)
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     Command::new("list").about("List directory toolchain overrides"),
                 )
@@ -722,8 +718,7 @@ pub(crate) fn cli() -> Command<'static> {
         .subcommand(
             Command::new("self")
                 .about("Modify the rustup installation")
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(Command::new("update").about("Download and install updates to rustup"))
                 .subcommand(
                     Command::new("uninstall")
@@ -737,8 +732,7 @@ pub(crate) fn cli() -> Command<'static> {
         .subcommand(
             Command::new("set")
                 .about("Alter rustup settings")
-                .subcommand_required(true)
-                .arg_required_else_help(true)
+                .setting(AppSettings::SubcommandRequiredElseHelp)
                 .subcommand(
                     Command::new("default-host")
                         .about("The triple used to identify toolchains when not specified")

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -6,7 +6,7 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup[EXE] [OPTIONS] [+toolchain] [SUBCOMMAND]
+    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
 
 ARGS:
     <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -6,7 +6,7 @@ rustup [..]
 The Rust toolchain installer
 
 USAGE:
-    rustup[EXE] [OPTIONS] [+toolchain] [SUBCOMMAND]
+    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
 
 ARGS:
     <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -1,0 +1,48 @@
+bin.name = "rustup"
+args = ["-v"]
+status.code = 1
+stdout = """
+rustup [..]
+The Rust toolchain installer
+
+USAGE:
+    rustup[EXE] [OPTIONS] [+toolchain] <SUBCOMMAND>
+
+ARGS:
+    <+toolchain>    release channel (e.g. +stable) or custom toolchain to set override
+
+OPTIONS:
+    -v, --verbose    Enable verbose output
+    -q, --quiet      Disable progress output
+    -h, --help       Print help information
+    -V, --version    Print version information
+
+SUBCOMMANDS:
+    show           Show the active and installed toolchains or profiles
+    update         Update Rust toolchains and rustup
+    check          Check for updates to Rust toolchains and rustup
+    default        Set the default toolchain
+    toolchain      Modify or query the installed toolchains
+    target         Modify a toolchain's supported targets
+    component      Modify a toolchain's installed components
+    override       Modify directory toolchain overrides
+    run            Run a command with an environment configured for a given toolchain
+    which          Display which binary will be run for a given command
+    doc            Open the documentation for the current toolchain
+...
+    self           Modify the rustup installation
+    set            Alter rustup settings
+    completions    Generate tab-completion scripts for your shell
+    help           Print this message or the help of the given subcommand(s)
+
+DISCUSSION:
+    Rustup installs The Rust Programming Language from the official
+    release channels, enabling you to easily switch between stable,
+    beta, and nightly compilers and keep them updated. It makes
+    cross-compiling simpler with binary builds of the standard library
+    for common platforms.
+
+    If you are new to Rust consider running `rustup doc --book` to
+    learn Rust.
+"""
+stderr = ""


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/issues/3290

Set `SubcommandRequiredElseHelp` correctly and remove useless and wrong `arg_required_else_help`.