### PR TITLE
Fix RUSTUP_PERMIT_COPY_RENAME condition so it is actually used

### DIFF
--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -622,9 +622,8 @@ where
                     OperationResult::Retry(e)
                 }
                 #[cfg(target_os = "linux")]
-                io::ErrorKind::Other
-                    if process().var_os("RUSTUP_PERMIT_COPY_RENAME").is_some()
-                        && Some(EXDEV) == e.raw_os_error() =>
+                _ if process().var_os("RUSTUP_PERMIT_COPY_RENAME").is_some()
+                    && Some(EXDEV) == e.raw_os_error() =>
                 {
                     match copy_and_delete(name, src, dest, notify_handler) {
                         Ok(()) => OperationResult::Ok(()),


### PR DESCRIPTION
cc @mckaymatt

## Problem

It looks like https://github.com/rust-lang/rustup/pull/2410 stopped working because it has a match on the io::ErrorKind::Other, but the [experimental io::ErrorKind::CrossesDevices variant](https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.CrossesDevices) was later added, which prevented it from every matching the match arm for the RUSTUP_PERMIT_COPY_RENAME condition.  As such, it would never fallback to copying and deleting and just continue failing with the "Invalid cross-device link" error.

## Solution

An explicit match on io::ErrorKind::Other wasn't necessary (it already is conditional on the raw_os_error) and this bug showed how matching on it makes the code fragile to the addition to new variants, so I just replaced it with a `_` catch all match with the same condition.

## Testing

I've managed to manual test this in isolation, although the use of `sudo` to mount an overlayfs seems like it would be a problem with testing this through `cargo test`.

```bash
# dev setup as suggested in CONTRIBUTING.md
mkdir home
export RUSTUP_HOME=home CARGO_HOME=home
target/debug/rustup-init --no-modify-path --default-toolchain=none -y

# force download of an older version to test upgrading
home/bin/rustup toolchain install 1.68.1
mv home/toolchains/{1.68.1-x86_64-unknown-linux-gnu,stable-x86_64-unknown-linux-gnu}

# turn rustup home into an overlay over the initial rustup installation
mv home homelower
mkdir homeupper homework home
sudo mount -t overlay overlay -o lowerdir=homelower,upperdir=homeupper,workdir=homework home

RUSTUP_PERMIT_COPY_RENAME=1 home/bin/rustup update

# cleanup
sudo umount home
rm -r homework home homelower homeupper
```

On master, I get the "could not rename component file" error, but it works when retrying the above steps on this branch.