### PR TITLE
Add support for listing components with target omitted

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -384,12 +384,17 @@ pub(crate) fn list_installed_targets(toolchain: &Toolchain<'_>) -> Result<utils:
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_components(toolchain: &Toolchain<'_>, short: bool) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(toolchain)?;
     let components = distributable.list_components()?;
     for component in components {
-        let name = component.name;
+        let name = if short {
+            component.component.short_name_in_manifest()
+        } else {
+            &component.name
+        };
+
         if component.installed {
             t.attr(term2::Attr::Bold)?;
             writeln!(t, "{name} (installed)")?;
@@ -402,13 +407,22 @@ pub(crate) fn list_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCo
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn list_installed_components(toolchain: &Toolchain<'_>) -> Result<utils::ExitCode> {
+pub(crate) fn list_installed_components(
+    toolchain: &Toolchain<'_>,
+    short: bool,
+) -> Result<utils::ExitCode> {
     let mut t = term2::stdout();
     let distributable = DistributableToolchain::new_for_components(toolchain)?;
     let components = distributable.list_components()?;
     for component in components {
+        let name = if short {
+            component.component.short_name_in_manifest()
+        } else {
+            &component.name
+        };
+
         if component.installed {
-            writeln!(t, "{}", component.name)?;
+            writeln!(t, "{}", name)?;
         }
     }
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -549,6 +549,12 @@ pub(crate) fn cli() -> Command<'static> {
                                 .long("installed")
                                 .help("List only installed components")
                                 .action(ArgAction::SetTrue)
+                        )
+                        .arg(
+                            Arg::new("no-target")
+                                .long("no-target")
+                                .help("Omit target from component name")
+                                .action(ArgAction::SetTrue)
                         ),
                 )
                 .subcommand(
@@ -1369,9 +1375,9 @@ fn component_list(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
     let toolchain = explicit_or_dir_toolchain(cfg, m)?;
 
     if m.get_flag("installed") {
-        common::list_installed_components(&toolchain)
+        common::list_installed_components(&toolchain, m.get_flag("no-target"))
     } else {
-        common::list_components(&toolchain)?;
+        common::list_components(&toolchain, m.get_flag("no-target"))?;
         Ok(utils::ExitCode(0))
     }
 }

--- a/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_component_cmd_list_cmd_help_flag_stdout.toml
@@ -11,6 +11,7 @@ OPTIONS:
         --toolchain <toolchain>    Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more
                                    information see `rustup help toolchain`
         --installed                List only installed components
+        --no-target                Omit target from component name
     -h, --help                     Print help information
 """
 stderr = ""

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1189,6 +1189,10 @@ fn install_with_components() {
                 &["rustup", "component", "list"],
                 &format!("rust-analysis-{} (installed)", this_host_triple()),
             );
+            config.expect_stdout_ok(
+                &["rustup", "component", "list", "--no-target"],
+                "rust-analysis (installed)",
+            );
         })
     }
 


### PR DESCRIPTION
Configuration management like Chef or Ansible commonly checks this list to know whether a component is present, with a view to installing it if it is not.

This is slightly unwieldy at present because while installing can use an implicit target (e.g., `rustup component add foo`), target-specific components always show their target when listing (e.g., `foo-x86_64-unknown-linux-gnu`). The naive way to tackle this is to just strip after the first dash, but of course this doesn't work well with things like rust-analyzer.

There are other ways to achieve this (e.g., split from the end, since the target is always a triple, although that can also get tricky when the component is target agnostic), but it would be nice to just have a --no-target flag which permits just showing the component short name for tools which just want to simply check if the component is installed or not, and don't really care about anything other than the implied target.