### PR TITLE
Compile static Mutex where possible

### DIFF
--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -9,13 +9,10 @@ use std::thread;
 use std::time::Duration;
 
 use env_proxy::for_url;
-use lazy_static::lazy_static;
 use reqwest::{blocking::Client, Proxy};
 use url::Url;
 
-lazy_static! {
-    static ref SERIALISE_TESTS: Mutex<()> = Mutex::new(());
-}
+static SERIALISE_TESTS: Mutex<()> = Mutex::new(());
 
 fn scrub_env() {
     remove_var("http_proxy");

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
 #[cfg(not(unix))]
 use winreg::{
     enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
@@ -38,9 +37,7 @@ fn restore_path(p: Option<RegValue>) {
 /// Support testing of code that mutates global path state
 pub fn with_saved_path(f: &mut dyn FnMut()) {
     // Lock protects concurrent mutation of registry
-    lazy_static! {
-        static ref LOCK: Mutex<()> = Mutex::new(());
-    }
+    static LOCK: Mutex<()> = Mutex::new(());
     let _g = LOCK.lock();
 
     // On windows these tests mess with the user's PATH. Save


### PR DESCRIPTION
A few of Rustup's `lazy_static!` instances are for simple locks. These are easy to evaluate at compile time, and doing so is stable, so reduce usage of the more heavyweight dependency.

I intend to follow up with more ambitious refactorings to slim down this kind of initializer code (more of it actually in the CLI, thus more of it likely to affect startup time), but these two were so trivial it seemed obvious enough to submit this first.