### PR TITLE
Update Rust crate toml to 0.7.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,11 +2124,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+checksum = "b403acf6f2bb0859c93c7f0d967cb4a75a7ac552100f9322faf64dc047669b21"
 dependencies = [
  "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ tempfile.workspace = true
 term = "=0.5.1"
 thiserror.workspace = true
 threadpool = "1"
-toml = "0.5"
+toml = "0.7"
 url.workspace = true
 wait-timeout = "0.2"
 xz2 = "0.1.3"

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -48,7 +48,7 @@ impl Config {
     }
 
     pub(crate) fn stringify(self) -> String {
-        toml::Value::Table(self.into_toml()).to_string()
+        self.into_toml().to_string()
     }
 
     fn toml_to_components(arr: toml::value::Array, path: &str) -> Result<Vec<Component>> {

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -117,7 +117,7 @@ impl Manifest {
         Ok(manifest)
     }
     pub fn stringify(self) -> String {
-        toml::Value::Table(self.into_toml()).to_string()
+        self.into_toml().to_string()
     }
 
     pub(crate) fn from_toml(mut table: toml::value::Table, path: &str) -> Result<Self> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -143,7 +143,7 @@ impl Settings {
     }
 
     pub(crate) fn stringify(self) -> String {
-        toml::Value::Table(self.into_toml()).to_string()
+        self.into_toml().to_string()
     }
 
     pub(crate) fn from_toml(mut table: toml::value::Table, path: &str) -> Result<Self> {


### PR DESCRIPTION
Fixes #3241.
close https://github.com/rust-lang/rustup/pull/3202
~~Theoretically this may be a breaking change, as Rustup will no longer parse incorrectly formatted TOML files anymore (storing inline values directly, which is [not permitted by specification](https://toml.io/en/)). However, official manifest server encodes TOML files correctly, and I was unable to find incorrectly formatted `rust-toolchain.toml` files on GitHub.~~ (verified that it isn't actually a breaking change)

`toml::Value::Table(self.into_toml()).to_string()` was replaced with `self.into_toml().to_string()` as now `toml` crates formats `Value`s into inline tables, and this can be avoided by not wrapping the table within `toml::Value::Table` unnecessarily.