### PR TITLE
TestProcess and friends should be test only

### DIFF
--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -1,15 +1,20 @@
 use std::boxed::Box;
 use std::cell::RefCell;
-use std::collections::HashMap;
 use std::default::Default;
 use std::fmt::Debug;
-use std::io::Cursor;
 use std::panic;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Once;
-use std::sync::{Arc, Mutex};
+#[cfg(feature = "test")]
+use std::{
+    collections::HashMap,
+    io::Cursor,
+    path::Path,
+    sync::{Arc, Mutex},
+};
 
 use home::env as home;
+#[cfg(feature = "test")]
 use rand::{thread_rng, Rng};
 
 pub(crate) mod argsource;
@@ -204,7 +209,7 @@ impl ProcessSource for OSProcess {
 }
 
 // ------------ test process ----------------
-
+#[cfg(feature = "test")]
 #[derive(Clone, Debug, Default)]
 pub struct TestProcess {
     pub cwd: PathBuf,
@@ -216,6 +221,7 @@ pub struct TestProcess {
     pub stderr: TestWriterInner,
 }
 
+#[cfg(feature = "test")]
 impl TestProcess {
     pub fn new<P: AsRef<Path>, A: AsRef<str>>(
         cwd: P,
@@ -257,6 +263,7 @@ impl TestProcess {
     }
 }
 
+#[cfg(feature = "test")]
 impl ProcessSource for TestProcess {
     fn id(&self) -> u64 {
         self.id

--- a/src/currentprocess/argsource.rs
+++ b/src/currentprocess/argsource.rs
@@ -52,6 +52,7 @@ impl<T: From<String>> Iterator for VecArgs<T> {
     }
 }
 
+#[cfg(feature = "test")]
 impl ArgSource for super::TestProcess {
     fn args(&self) -> Box<dyn Iterator<Item = String>> {
         Box::new(VecArgs::<String>::from(&self.args))

--- a/src/currentprocess/cwdsource.rs
+++ b/src/currentprocess/cwdsource.rs
@@ -15,6 +15,7 @@ impl CurrentDirSource for super::OSProcess {
     }
 }
 
+#[cfg(feature = "test")]
 impl CurrentDirSource for super::TestProcess {
     fn current_dir(&self) -> io::Result<PathBuf> {
         Ok(self.cwd.clone())

--- a/src/currentprocess/filesource.rs
+++ b/src/currentprocess/filesource.rs
@@ -73,6 +73,7 @@ impl Stdin for TestStdin {
     }
 }
 
+#[cfg(feature = "test")]
 impl StdinSource for super::TestProcess {
     fn stdin(&self) -> Box<dyn Stdin> {
         Box::new(TestStdin(self.stdin.clone()))
@@ -193,12 +194,14 @@ impl Isatty for TestWriter {
     }
 }
 
+#[cfg(feature = "test")]
 impl StdoutSource for super::TestProcess {
     fn stdout(&self) -> Box<dyn Writer> {
         Box::new(TestWriter(self.stdout.clone()))
     }
 }
 
+#[cfg(feature = "test")]
 impl StderrSource for super::TestProcess {
     fn stderr(&self) -> Box<dyn Writer> {
         Box::new(TestWriter(self.stderr.clone()))

--- a/src/currentprocess/homethunk.rs
+++ b/src/currentprocess/homethunk.rs
@@ -1,16 +1,16 @@
 /// Adapts currentprocess to the trait home::Env
 use std::ffi::OsString;
 use std::io;
+#[cfg(feature = "test")]
 use std::ops::Deref;
 use std::path::PathBuf;
 
 use home::env as home;
 
-use super::CurrentDirSource;
 use super::HomeProcess;
 use super::OSProcess;
-use super::TestProcess;
-use super::VarSource;
+#[cfg(feature = "test")]
+use super::{CurrentDirSource, TestProcess, VarSource};
 
 impl home::Env for Box<dyn HomeProcess + 'static> {
     fn home_dir(&self) -> Option<PathBuf> {
@@ -24,6 +24,7 @@ impl home::Env for Box<dyn HomeProcess + 'static> {
     }
 }
 
+#[cfg(feature = "test")]
 impl home::Env for TestProcess {
     fn home_dir(&self) -> Option<PathBuf> {
         self.var("HOME").ok().map(|v| v.into())

--- a/src/currentprocess/varsource.rs
+++ b/src/currentprocess/varsource.rs
@@ -20,6 +20,7 @@ impl VarSource for super::OSProcess {
     }
 }
 
+#[cfg(feature = "test")]
 impl VarSource for super::TestProcess {
     fn var(&self, key: &str) -> std::result::Result<String, env::VarError> {
         match self.var_os(key) {


### PR DESCRIPTION
Before we had the test feature we had to rely on link time optimisation
to remove this code, but there is no need to compile it at all for
non-test builds.