### PR TITLE
`rustup show` shouldn't install things

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1069,8 +1069,8 @@ fn show(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
 
     let cwd = utils::current_dir()?;
     let installed_toolchains = cfg.list_toolchains()?;
-    // XXX: we may want a find_without_install capability for show.
-    let active_toolchain = cfg.find_or_install_override_toolchain_or_default(&cwd);
+    // Retrieve the active toolchain but do not install it
+    let active_toolchain = cfg.find_override_toolchain_or_default(&cwd);
 
     // active_toolchain will carry the reason we don't have one in its detail.
     let active_targets = if let Ok(ref at) = active_toolchain {


### PR DESCRIPTION
Fixes #1397

Currently `rustup show` will install missing components or missing toolchains when ran. This has a couple of issues:
* It's unintuitive - I don't think anyone expects a `show` command to install things
* It causes lots of programs to accidentally cause installations
  * Lots of shell prompts use `rustup show` to show current toolchain and similar. This means `cd`'ing into a rust project with an uninstalled toolchain can cause the shell to freeze while it installs the entire toolchain