### PR TITLE
CI support for loongarch64-unknown-linux-gnu

### DIFF
--- a/ci/actions-templates/README.md
+++ b/ci/actions-templates/README.md
@@ -62,6 +62,7 @@ system.
 | i686-linux-android            | Yes        | Two   | No     | No         |
 | x86_64-linux-android          | Yes        | Two   | No     | No         |
 | riscv64gc-unknown-linux-gnu   | Yes        | ---   | No     | No         |
+| loongarch64-unknown-linux-gnu | Yes        | Two   | No     | No         |
 | ----------------------------- | ---------- | ----- | ------ | ---------- |
 | aarch64-apple-darwin          | Yes        | Two   | Yes    | Yes        |
 | x86_64-apple-darwin           | No         | One   | Yes    | Yes        |

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -53,6 +53,7 @@ jobs:
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
           - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
+          - loongarch64-unknown-linux-gnu # skip-pr skip-master skip-stable
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,0 +1,4 @@
+FROM rust-loongarch64-unknown-linux-gnu
+
+ENV CC_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-gcc \
+    CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-unknown-linux-gnu-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -36,6 +36,7 @@ case "$TARGET" in
   x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;
   x86_64-unknown-netbsd)           image=dist-x86_64-netbsd ;;
   riscv64gc-unknown-linux-gnu)     image=dist-riscv64-linux ;;
+  loongarch64-unknown-linux-gnu)   image=dist-loongarch64-linux ;;
   *) exit ;;
 esac
 

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -20,6 +20,7 @@ case "$TARGET" in
   mips* ) ;;
   riscv* ) ;;
   s390x* ) ;;
+  loongarch* ) ;;
   aarch64-pc-windows-msvc ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
@@ -46,6 +47,7 @@ download_pkg_test() {
     mips* ) ;;
     riscv* ) ;;
     s390x* ) ;;
+    loongarch* ) ;;
     aarch64-pc-windows-msvc ) ;;
     # default case, build with rustls enabled
     * ) features+=('--features' 'reqwest-rustls-tls') ;;


### PR DESCRIPTION
This PR adds CI support for `loongarch64-unknown-linux-gnu` target and skip stable until rust 1.71 is released.