### PR TITLE
Fix compile on rust nightly

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -269,7 +269,7 @@ pub mod reqwest_be {
     use std::time::Duration;
 
     use anyhow::{anyhow, Context, Result};
-    #[cfg(feature = "reqwest-rustls-tls")]
+    #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-default-tls"))]
     use lazy_static::lazy_static;
     use reqwest::blocking::{Client, ClientBuilder, Response};
     use reqwest::{header, Proxy};


### PR DESCRIPTION
This PR fixes compile on rust nightly (1.71.0-nightly) with non-default features:

```
--no-default-features --features curl-backend,reqwest-backend,reqwest-default-tls --features vendored-openssl
```

### Compile errors

```
error: cannot find macro `lazy_static` in this scope
   --> download/src/lib.rs:345:5
    |
345 |     lazy_static! {
    |     ^^^^^^^^^^^
    |
    = help: consider importing this macro:
            lazy_static::lazy_static
    = note: `lazy_static` is in scope, but it is a crate, not a macro

error[E0425]: cannot find value `CLIENT_DEFAULT_TLS` in this scope
   --> download/src/lib.rs:379:37
    |
379 |             TlsBackend::Default => &CLIENT_DEFAULT_TLS,
    |                                     ^^^^^^^^^^^^^^^^^^ not found in this scope

For more information about this error, try `rustc --explain E0425`.
```