### PR TITLE
Switch from sync to a tokio runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "thiserror",
  "threadpool",
  "tokio",
+ "tokio-retry",
  "toml",
  "tracing",
  "tracing-opentelemetry",
@@ -2450,6 +2451,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "url",
 ]
 
@@ -1827,6 +1828,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "winreg",
 ]
@@ -2875,6 +2877,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ otel = [
     "dep:tracing-subscriber",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
-    "dep:tokio",
-    "dep:tracing",
 ]
 
 # Exports code dependent on private interfaces for the integration test suite
@@ -85,11 +83,11 @@ tempfile.workspace = true
 termcolor.workspace = true
 thiserror.workspace = true
 threadpool = "1"
-tokio = { workspace = true, optional = true }
+tokio.workspace = true
 toml = "0.8"
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
-tracing = { workspace = true, optional = true }
+tracing.workspace = true
 url.workspace = true
 wait-timeout = "0.2"
 walkdir = { workspace = true, optional = true }
@@ -145,7 +143,8 @@ rustup-macros = { path = "rustup-macros" }
 tempfile = "3.8"
 termcolor = "1.2"
 thiserror = "1.0"
-tokio = { version = "1.26.0", default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.14" }
 tracing = "0.1"
 tracing-opentelemetry = "0.24"
 tracing-subscriber = "0.3.16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ tempfile.workspace = true
 termcolor.workspace = true
 thiserror.workspace = true
 threadpool = "1"
+tokio-retry.workspace = true
 tokio.workspace = true
 toml = "0.8"
 tracing-opentelemetry = { workspace = true, optional = true }
@@ -144,6 +145,7 @@ tempfile = "3.8"
 termcolor = "1.2"
 thiserror = "1.0"
 tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio-retry = { version = "0.3.0" }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1"
 tracing-opentelemetry = "0.24"

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -18,8 +18,10 @@ anyhow.workspace = true
 curl = { version = "0.4.44", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 once_cell = { workspace = true, optional = true }
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "socks"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "socks", "stream"], optional = true }
 thiserror.workspace = true
+tokio = { workspace = true, default-features = false, features = ["sync"] }
+tokio-stream.workspace = true
 url.workspace = true
 
 [dev-dependencies]
@@ -27,4 +29,3 @@ http-body-util = "0.1.0"
 hyper = { version = "1.0", default-features = false, features = ["server", "http1"] }
 hyper-util = { version = "0.1.1", features = ["tokio"] }
 tempfile.workspace = true
-tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -123,6 +123,8 @@ pub async fn download_to_path_with_backend_(
         } else {
             0
         };
+
+        // TODO: blocking call
         let mut possible_partial = OpenOptions::new()
             .write(true)
             .create(true)

--- a/download/tests/download-curl-resume.rs
+++ b/download/tests/download-curl-resume.rs
@@ -10,8 +10,8 @@ use download::*;
 mod support;
 use crate::support::{serve_file, tmp_dir, write_file};
 
-#[test]
-fn partially_downloaded_file_gets_resumed_from_byte_offset() {
+#[tokio::test]
+async fn partially_downloaded_file_gets_resumed_from_byte_offset() {
     let tmpdir = tmp_dir();
     let from_path = tmpdir.path().join("download-source");
     write_file(&from_path, "xxx45");
@@ -21,13 +21,14 @@ fn partially_downloaded_file_gets_resumed_from_byte_offset() {
 
     let from_url = Url::from_file_path(&from_path).unwrap();
     download_to_path_with_backend(Backend::Curl, &from_url, &target_path, true, None)
+        .await
         .expect("Test download failed");
 
     assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }
 
-#[test]
-fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
+#[tokio::test]
+async fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
     let tmpdir = tmp_dir();
     let target_path = tmpdir.path().join("downloaded");
     write_file(&target_path, "123");
@@ -66,6 +67,7 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
             Ok(())
         }),
     )
+    .await
     .expect("Test download failed");
 
     assert!(callback_partial.into_inner());

--- a/download/tests/download-reqwest-resume.rs
+++ b/download/tests/download-reqwest-resume.rs
@@ -10,8 +10,8 @@ use download::*;
 mod support;
 use crate::support::{serve_file, tmp_dir, write_file};
 
-#[test]
-fn resume_partial_from_file_url() {
+#[tokio::test]
+async fn resume_partial_from_file_url() {
     let tmpdir = tmp_dir();
     let from_path = tmpdir.path().join("download-source");
     write_file(&from_path, "xxx45");
@@ -27,13 +27,14 @@ fn resume_partial_from_file_url() {
         true,
         None,
     )
+    .await
     .expect("Test download failed");
 
     assert_eq!(std::fs::read_to_string(&target_path).unwrap(), "12345");
 }
 
-#[test]
-fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
+#[tokio::test]
+async fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
     let tmpdir = tmp_dir();
     let target_path = tmpdir.path().join("downloaded");
     write_file(&target_path, "123");
@@ -72,6 +73,7 @@ fn callback_gets_all_data_as_if_the_download_happened_all_at_once() {
             Ok(())
         }),
     )
+    .await
     .expect("Test download failed");
 
     assert!(callback_partial.into_inner());

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -9,7 +9,7 @@ use std::thread;
 use std::time::Duration;
 
 use env_proxy::for_url;
-use reqwest::{blocking::Client, Proxy};
+use reqwest::{Client, Proxy};
 use url::Url;
 
 static SERIALISE_TESTS: Mutex<()> = Mutex::new(());
@@ -27,8 +27,8 @@ fn scrub_env() {
 }
 
 // Tests for correctly retrieving the proxy (host, port) tuple from $https_proxy
-#[test]
-fn read_basic_proxy_params() {
+#[tokio::test]
+async fn read_basic_proxy_params() {
     let _guard = SERIALISE_TESTS
         .lock()
         .expect("Unable to lock the test guard");
@@ -42,8 +42,8 @@ fn read_basic_proxy_params() {
 }
 
 // Tests to verify if socks feature is available and being used
-#[test]
-fn socks_proxy_request() {
+#[tokio::test]
+async fn socks_proxy_request() {
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
     let _guard = SERIALISE_TESTS
         .lock()
@@ -68,7 +68,7 @@ fn socks_proxy_request() {
         .timeout(Duration::from_secs(1))
         .build()
         .unwrap();
-    let res = client.get(url.as_str()).send();
+    let res = client.get(url.as_str()).send().await;
 
     if let Err(e) = res {
         let s = e.source().unwrap();

--- a/rustup-macros/src/lib.rs
+++ b/rustup-macros/src/lib.rs
@@ -77,6 +77,8 @@ pub fn unit_test(
     .into()
 }
 
+// False positive from clippy :/
+#[allow(clippy::redundant_clone)]
 fn test_inner(mod_path: String, mut input: ItemFn) -> syn::Result<TokenStream> {
     if input.sig.asyncness.is_some() {
         let before_ident = format!("{}::before_test_async", mod_path);

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -119,7 +119,7 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
     utils::current_exe()?;
 
     match process().name().as_deref() {
-        Some("rustup") => rustup_mode::main(),
+        Some("rustup") => rustup_mode::main().await,
         Some(n) if n.starts_with("rustup-setup") || n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -125,7 +125,7 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
             // name. Browsers rename duplicates to
             // e.g. rustup-setup(2), and this allows all variations
             // to work.
-            setup_mode::main()
+            setup_mode::main().await
         }
         Some(n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -100,7 +100,7 @@ async fn run_rustup() -> Result<utils::ExitCode> {
     if let Ok(dir) = process().var("RUSTUP_TRACE_DIR") {
         open_trace_file!(dir)?;
     }
-    let result = run_rustup_inner();
+    let result = run_rustup_inner().await;
     if process().var("RUSTUP_TRACE_DIR").is_ok() {
         close_trace_file!();
     }
@@ -108,7 +108,7 @@ async fn run_rustup() -> Result<utils::ExitCode> {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument(err))]
-fn run_rustup_inner() -> Result<utils::ExitCode> {
+async fn run_rustup_inner() -> Result<utils::ExitCode> {
     // Guard against infinite proxy recursion. This mostly happens due to
     // bugs in rustup.
     do_recursion_guard()?;

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -41,7 +41,7 @@ fn main() {
     builder.enable_all();
     with_runtime(process.into(), builder, {
         async {
-            match maybe_trace_rustup() {
+            match maybe_trace_rustup().await {
                 Err(e) => {
                     common::report_error(&e);
                     std::process::exit(1);
@@ -52,7 +52,7 @@ fn main() {
     });
 }
 
-fn maybe_trace_rustup() -> Result<utils::ExitCode> {
+async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
     #[cfg(not(feature = "otel"))]
     {
         run_rustup()

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -55,7 +55,7 @@ fn main() {
 async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
     #[cfg(not(feature = "otel"))]
     {
-        run_rustup()
+        run_rustup().await
     }
     #[cfg(feature = "otel")]
     {
@@ -88,7 +88,7 @@ async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
         let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
         let subscriber = Registry::default().with(env_filter).with(telemetry);
         tracing::subscriber::set_global_default(subscriber)?;
-        let result = run_rustup();
+        let result = run_rustup().await;
         // We're tracing, so block until all spans are exported.
         opentelemetry::global::shutdown_tracer_provider();
         result
@@ -96,7 +96,7 @@ async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-fn run_rustup() -> Result<utils::ExitCode> {
+async fn run_rustup() -> Result<utils::ExitCode> {
     if let Ok(dir) = process().var("RUSTUP_TRACE_DIR") {
         open_trace_file!(dir)?;
     }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -285,7 +285,7 @@ fn show_channel_updates(
     Ok(())
 }
 
-pub(crate) fn update_all_channels(
+pub(crate) async fn update_all_channels(
     cfg: &Cfg,
     do_self_update: bool,
     force_update: bool,
@@ -310,7 +310,7 @@ pub(crate) fn update_all_channels(
     };
 
     if do_self_update {
-        utils::run_future(self_update(show_channel_updates))
+        self_update(show_channel_updates).await
     } else {
         show_channel_updates()
     }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -363,7 +363,7 @@ where
         SelfUpdatePermission::Permit => {}
     }
 
-    let setup_path = self_update::prepare_update()?;
+    let setup_path = utils::run_future(self_update::prepare_update())?;
 
     before_restart()?;
 

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -310,7 +310,7 @@ pub(crate) fn update_all_channels(
     };
 
     if do_self_update {
-        self_update(show_channel_updates)
+        utils::run_future(self_update(show_channel_updates))
     } else {
         show_channel_updates()
     }
@@ -350,7 +350,8 @@ pub(crate) fn self_update_permitted(explicit: bool) -> Result<SelfUpdatePermissi
     }
 }
 
-pub(crate) fn self_update<F>(before_restart: F) -> Result<utils::ExitCode>
+/// Performs all of a self-update: check policy, download, apply and exit.
+pub(crate) async fn self_update<F>(before_restart: F) -> Result<utils::ExitCode>
 where
     F: FnOnce() -> Result<utils::ExitCode>,
 {
@@ -363,7 +364,7 @@ where
         SelfUpdatePermission::Permit => {}
     }
 
-    let setup_path = utils::run_future(self_update::prepare_update())?;
+    let setup_path = self_update::prepare_update().await?;
 
     before_restart()?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -712,7 +712,9 @@ fn default_(cfg: &Cfg, toolchain: Option<MaybeResolvableToolchainName>) -> Resul
             }
             MaybeResolvableToolchainName::Some(ResolvableToolchainName::Official(toolchain)) => {
                 let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
-                let status = DistributableToolchain::install_if_not_installed(cfg, &desc)?;
+                let status = utils::run_future(DistributableToolchain::install_if_not_installed(
+                    cfg, &desc,
+                ))?;
 
                 cfg.set_default(Some(&(&desc).into()))?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -779,7 +779,7 @@ fn check_updates(cfg: &Cfg) -> Result<utils::ExitCode> {
         }
     }
 
-    check_rustup_update()?;
+    utils::run_future(check_rustup_update())?;
 
     Ok(utils::ExitCode(0))
 }
@@ -870,7 +870,7 @@ fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
     }
 
     if !self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::CheckOnly {
-        check_rustup_update()?;
+        utils::run_future(check_rustup_update())?;
     }
 
     if self_update::NEVER_SELF_UPDATE {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -639,7 +639,9 @@ pub async fn main() -> Result<utils::ExitCode> {
                 installed,
             } => handle_epipe(target_list(cfg, toolchain, installed)),
             TargetSubcmd::Add { target, toolchain } => target_add(cfg, target, toolchain),
-            TargetSubcmd::Remove { target, toolchain } => target_remove(cfg, target, toolchain),
+            TargetSubcmd::Remove { target, toolchain } => {
+                target_remove(cfg, target, toolchain).await
+            }
         },
         RustupSubcmd::Component { subcmd } => match subcmd {
             ComponentSubcmd::List {
@@ -1159,7 +1161,7 @@ fn target_add(
     Ok(utils::ExitCode(0))
 }
 
-fn target_remove(
+async fn target_remove(
     cfg: &Cfg,
     targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
@@ -1187,7 +1189,7 @@ fn target_remove(
             warn!("after removing the last target, no build targets will be available");
         }
         let new_component = Component::new("rust-std".to_string(), Some(target), false);
-        utils::run_future(distributable.remove_component(new_component))?;
+        distributable.remove_component(new_component).await?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -750,7 +750,7 @@ fn check_updates(cfg: &Cfg) -> Result<utils::ExitCode> {
     for channel in channels {
         let (name, distributable) = channel;
         let current_version = distributable.show_version()?;
-        let dist_version = distributable.show_dist_version()?;
+        let dist_version = utils::run_future(distributable.show_dist_version())?;
         let _ = t.attr(terminalsource::Attr::Bold);
         write!(t.lock(), "{name} - ")?;
         match (current_version, dist_version) {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -832,9 +832,13 @@ fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
                 cfg,
                 desc.clone(),
             ) {
-                Ok(mut d) => {
-                    d.update_extra(&components, &targets, profile, force, allow_downgrade)?
-                }
+                Ok(mut d) => utils::run_future(d.update_extra(
+                    &components,
+                    &targets,
+                    profile,
+                    force,
+                    allow_downgrade,
+                ))?,
                 Err(RustupError::ToolchainNotInstalled(_)) => {
                     crate::toolchain::distributable::DistributableToolchain::install(
                         cfg,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -873,7 +873,7 @@ fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
             utils::run_future(common::self_update(|| Ok(utils::ExitCode(0))))?;
         }
     } else {
-        common::update_all_channels(cfg, self_update, opts.force)?;
+        utils::run_future(common::update_all_channels(cfg, self_update, opts.force))?;
         info!("cleaning up downloads & tmp directories");
         utils::delete_dir_contents_following_links(&cfg.download_dir);
         cfg.tmp_cx.clean();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1250,14 +1250,16 @@ fn toolchain_link(cfg: &Cfg, dest: &CustomToolchainName, src: &Path) -> Result<u
     utils::assert_is_file(&pathbuf)?;
 
     if true {
-        InstallMethod::Link {
-            src: &utils::to_absolute(src)?,
-            dest,
-            cfg,
-        }
-        .install()?;
+        utils::run_future(
+            InstallMethod::Link {
+                src: &utils::to_absolute(src)?,
+                dest,
+                cfg,
+            }
+            .install(),
+        )?;
     } else {
-        InstallMethod::Copy { src, dest, cfg }.install()?;
+        utils::run_future(InstallMethod::Copy { src, dest, cfg }.install())?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -655,7 +655,7 @@ pub async fn main() -> Result<utils::ExitCode> {
                 component,
                 toolchain,
                 target,
-            } => component_remove(cfg, component, toolchain, target),
+            } => component_remove(cfg, component, toolchain, target).await,
         },
         RustupSubcmd::Override { subcmd } => match subcmd {
             OverrideSubcmd::List => handle_epipe(common::list_overrides(cfg)),
@@ -1230,7 +1230,7 @@ fn get_target(
         .or_else(|| Some(distributable.desc().target.clone()))
 }
 
-fn component_remove(
+async fn component_remove(
     cfg: &Cfg,
     components: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
@@ -1241,7 +1241,7 @@ fn component_remove(
 
     for component in &components {
         let new_component = Component::try_new(component, &distributable, target.as_ref())?;
-        utils::run_future(distributable.remove_component(new_component))?;
+        distributable.remove_component(new_component).await?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -679,7 +679,7 @@ pub async fn main() -> Result<utils::ExitCode> {
         #[cfg(not(windows))]
         RustupSubcmd::Man { command, toolchain } => man(cfg, &command, toolchain),
         RustupSubcmd::Self_ { subcmd } => match subcmd {
-            SelfSubcmd::Update => self_update::update(cfg),
+            SelfSubcmd::Update => self_update::update(cfg).await,
             SelfSubcmd::Uninstall { no_prompt } => self_update::uninstall(no_prompt),
             SelfSubcmd::UpgradeData => cfg.upgrade_data().map(|_| ExitCode(0)),
         },

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -860,7 +860,7 @@ fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
             }
         }
         if self_update {
-            common::self_update(|| Ok(utils::ExitCode(0)))?;
+            utils::run_future(common::self_update(|| Ok(utils::ExitCode(0))))?;
         }
     } else {
         common::update_all_channels(cfg, self_update, opts.force)?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -840,13 +840,15 @@ fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
                     allow_downgrade,
                 ))?,
                 Err(RustupError::ToolchainNotInstalled(_)) => {
-                    crate::toolchain::distributable::DistributableToolchain::install(
-                        cfg,
-                        &desc,
-                        &components,
-                        &targets,
-                        profile,
-                        force,
+                    utils::run_future(
+                        crate::toolchain::distributable::DistributableToolchain::install(
+                            cfg,
+                            &desc,
+                            &components,
+                            &targets,
+                            profile,
+                            force,
+                        ),
                     )?
                     .0
                 }
@@ -1295,14 +1297,14 @@ fn override_add(
         Err(e @ RustupError::ToolchainNotInstalled(_)) => match &toolchain_name {
             ToolchainName::Custom(_) => Err(e)?,
             ToolchainName::Official(desc) => {
-                let status = DistributableToolchain::install(
+                let status = utils::run_future(DistributableToolchain::install(
                     cfg,
                     desc,
                     &[],
                     &[],
                     cfg.get_profile()?,
                     false,
-                )?
+                ))?
                 .0;
                 writeln!(process().stdout().lock())?;
                 common::show_channel_update(

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -526,7 +526,7 @@ enum SetSubcmd {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument(fields(args = format!("{:?}", process().args_os().collect::<Vec<_>>()))))]
-pub fn main() -> Result<utils::ExitCode> {
+pub async fn main() -> Result<utils::ExitCode> {
     self_update::cleanup_self_updater()?;
 
     use clap::error::ErrorKind::*;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1185,7 +1185,7 @@ fn target_remove(
             warn!("after removing the last target, no build targets will be available");
         }
         let new_component = Component::new("rust-std".to_string(), Some(target), false);
-        distributable.remove_component(new_component)?;
+        utils::run_future(distributable.remove_component(new_component))?;
     }
 
     Ok(utils::ExitCode(0))
@@ -1239,7 +1239,7 @@ fn component_remove(
 
     for component in &components {
         let new_component = Component::try_new(component, &distributable, target.as_ref())?;
-        distributable.remove_component(new_component)?;
+        utils::run_future(distributable.remove_component(new_component))?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -650,7 +650,7 @@ pub async fn main() -> Result<utils::ExitCode> {
                 component,
                 toolchain,
                 target,
-            } => component_add(cfg, component, toolchain, target),
+            } => component_add(cfg, component, toolchain, target).await,
             ComponentSubcmd::Remove {
                 component,
                 toolchain,
@@ -1204,7 +1204,7 @@ fn component_list(
     Ok(utils::ExitCode(0))
 }
 
-fn component_add(
+async fn component_add(
     cfg: &Cfg,
     components: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
@@ -1215,7 +1215,7 @@ fn component_add(
 
     for component in &components {
         let new_component = Component::try_new(component, &distributable, target.as_ref())?;
-        utils::run_future(distributable.add_component(new_component))?;
+        distributable.add_component(new_component).await?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -638,7 +638,7 @@ pub async fn main() -> Result<utils::ExitCode> {
                 toolchain,
                 installed,
             } => handle_epipe(target_list(cfg, toolchain, installed)),
-            TargetSubcmd::Add { target, toolchain } => target_add(cfg, target, toolchain),
+            TargetSubcmd::Add { target, toolchain } => target_add(cfg, target, toolchain).await,
             TargetSubcmd::Remove { target, toolchain } => {
                 target_remove(cfg, target, toolchain).await
             }
@@ -1112,7 +1112,7 @@ fn target_list(
     )
 }
 
-fn target_add(
+async fn target_add(
     cfg: &Cfg,
     mut targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
@@ -1155,7 +1155,7 @@ fn target_add(
             Some(TargetTriple::new(target)),
             false,
         );
-        utils::run_future(distributable.add_component(new_component))?;
+        distributable.add_component(new_component).await?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1151,7 +1151,7 @@ fn target_add(
             Some(TargetTriple::new(target)),
             false,
         );
-        distributable.add_component(new_component)?;
+        utils::run_future(distributable.add_component(new_component))?;
     }
 
     Ok(utils::ExitCode(0))
@@ -1213,7 +1213,7 @@ fn component_add(
 
     for component in &components {
         let new_component = Component::try_new(component, &distributable, target.as_ref())?;
-        distributable.add_component(new_component)?;
+        utils::run_future(distributable.add_component(new_component))?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -399,7 +399,7 @@ pub(crate) fn install(
             md(&mut term, MSVC_AUTO_INSTALL_MESSAGE);
             match windows::choose_vs_install()? {
                 Some(VsInstallPlan::Automatic) => {
-                    match try_install_msvc(&opts) {
+                    match utils::run_future(try_install_msvc(&opts)) {
                         Err(e) => {
                             // Make sure the console doesn't exit before the user can
                             // see the error and give the option to continue anyway.

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -871,14 +871,14 @@ fn maybe_install_rust(
             let mut toolchain = DistributableToolchain::new(&cfg, desc.clone())?;
             utils::run_future(toolchain.update(components, targets, cfg.get_profile()?))?
         } else {
-            DistributableToolchain::install(
+            utils::run_future(DistributableToolchain::install(
                 &cfg,
                 desc,
                 components,
                 targets,
                 cfg.get_profile()?,
                 true,
-            )?
+            ))?
             .0
         };
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -869,7 +869,7 @@ fn maybe_install_rust(
             // - delete the partial install and start over
             // For now, we error.
             let mut toolchain = DistributableToolchain::new(&cfg, desc.clone())?;
-            toolchain.update(components, targets, cfg.get_profile()?)?
+            utils::run_future(toolchain.update(components, targets, cfg.get_profile()?))?
         } else {
             DistributableToolchain::install(
                 &cfg,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1208,7 +1208,12 @@ pub(crate) fn prepare_update() -> Result<Option<PathBuf>> {
 
     // Download new version
     info!("downloading self-update");
-    utils::download_file(&download_url, &setup_path, None, &|_| ())?;
+    utils::run_future(utils::download_file(
+        &download_url,
+        &setup_path,
+        None,
+        &|_| (),
+    ))?;
 
     // Mark as executable
     utils::make_executable(&setup_path)?;
@@ -1227,7 +1232,12 @@ pub(crate) fn get_available_rustup_version() -> Result<String> {
     let release_file_url = format!("{update_root}/release-stable.toml");
     let release_file_url = utils::parse_url(&release_file_url)?;
     let release_file = tempdir.path().join("release-stable.toml");
-    utils::download_file(&release_file_url, &release_file, None, &|_| ())?;
+    utils::run_future(utils::download_file(
+        &release_file_url,
+        &release_file,
+        None,
+        &|_| (),
+    ))?;
     let release_toml_str = utils::read_file("rustup release", &release_file)?;
     let release_toml: toml::Value =
         toml::from_str(&release_toml_str).context("unable to parse rustup release file")?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1254,13 +1254,13 @@ async fn get_available_rustup_version() -> Result<String> {
     Ok(String::from(available_version))
 }
 
-pub(crate) fn check_rustup_update() -> Result<()> {
+pub(crate) async fn check_rustup_update() -> Result<()> {
     let mut t = process().stdout().terminal();
     // Get current rustup version
     let current_version = env!("CARGO_PKG_VERSION");
 
     // Get available rustup version
-    let available_version = utils::run_future(get_available_rustup_version())?;
+    let available_version = get_available_rustup_version().await?;
 
     let _ = t.attr(terminalsource::Attr::Bold);
     write!(t.lock(), "rustup - ")?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -364,7 +364,7 @@ fn canonical_cargo_home() -> Result<Cow<'static, str>> {
 /// Installing is a simple matter of copying the running binary to
 /// `CARGO_HOME`/bin, hard-linking the various Rust tools to it,
 /// and adding `CARGO_HOME`/bin to PATH.
-pub(crate) fn install(
+pub(crate) async fn install(
     no_prompt: bool,
     verbose: bool,
     quiet: bool,
@@ -399,7 +399,7 @@ pub(crate) fn install(
             md(&mut term, MSVC_AUTO_INSTALL_MESSAGE);
             match windows::choose_vs_install()? {
                 Some(VsInstallPlan::Automatic) => {
-                    match utils::run_future(try_install_msvc(&opts)) {
+                    match try_install_msvc(&opts).await {
                         Err(e) => {
                             // Make sure the console doesn't exit before the user can
                             // see the error and give the option to continue anyway.

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1081,7 +1081,7 @@ pub(crate) fn uninstall(no_prompt: bool) -> Result<utils::ExitCode> {
 /// (and on windows this process will not be running to do it),
 /// rustup-init is stored in `CARGO_HOME`/bin, and then deleted next
 /// time rustup runs.
-pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
+pub(crate) async fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
     common::warn_if_host_is_emulated();
 
     use common::SelfUpdatePermission::*;
@@ -1104,7 +1104,7 @@ pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
         Permit => {}
     }
 
-    match utils::run_future(prepare_update())? {
+    match prepare_update().await? {
         Some(setup_path) => {
             let Some(version) = get_and_parse_new_rustup_version(&setup_path) else {
                 err!("failed to get rustup version");

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -183,11 +183,16 @@ pub(crate) fn try_install_msvc(opts: &InstallOpts<'_>) -> Result<ContinueInstall
     download_tracker.lock().unwrap().download_finished();
 
     info!("downloading Visual Studio installer");
-    utils::download_file(&visual_studio_url, &visual_studio, None, &move |n| {
-        download_tracker.lock().unwrap().handle_notification(
-            &crate::notifications::Notification::Install(crate::dist::Notification::Utils(n)),
-        );
-    })?;
+    utils::run_future(utils::download_file(
+        &visual_studio_url,
+        &visual_studio,
+        None,
+        &move |n| {
+            download_tracker.lock().unwrap().handle_notification(
+                &crate::notifications::Notification::Install(crate::dist::Notification::Utils(n)),
+            );
+        },
+    ))?;
 
     // Run the installer. Arguments are documented at:
     // https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -122,5 +122,5 @@ pub fn main() -> Result<utils::ExitCode> {
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    self_update::install(no_prompt, verbose, quiet, opts)
+    utils::run_future(self_update::install(no_prompt, verbose, quiet, opts))
 }

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -74,7 +74,7 @@ struct RustupInit {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-pub fn main() -> Result<utils::ExitCode> {
+pub async fn main() -> Result<utils::ExitCode> {
     use clap::error::ErrorKind;
 
     let RustupInit {
@@ -122,5 +122,5 @@ pub fn main() -> Result<utils::ExitCode> {
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    utils::run_future(self_update::install(no_prompt, verbose, quiet, opts))
+    self_update::install(no_prompt, verbose, quiet, opts).await
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -798,11 +798,11 @@ impl Cfg {
             }
             Ok(mut distributable) => {
                 if !distributable.components_exist(&components, &targets)? {
-                    distributable.update(
+                    utils::run_future(distributable.update(
                         &components,
                         &targets,
                         profile.unwrap_or(Profile::Default),
-                    )?;
+                    ))?;
                 }
                 distributable
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -786,14 +786,14 @@ impl Cfg {
         let targets: Vec<_> = targets.iter().map(AsRef::as_ref).collect();
         let toolchain = match DistributableToolchain::new(self, toolchain.clone()) {
             Err(RustupError::ToolchainNotInstalled(_)) => {
-                DistributableToolchain::install(
+                utils::run_future(DistributableToolchain::install(
                     self,
                     &toolchain,
                     &components,
                     &targets,
                     profile.unwrap_or(Profile::Default),
                     false,
-                )?
+                ))?
                 .1
             }
             Ok(mut distributable) => {
@@ -944,14 +944,14 @@ impl Cfg {
                 match DistributableToolchain::new(self, desc.clone()) {
                     Err(RustupError::ToolchainNotInstalled(_)) => {
                         if install_if_missing {
-                            DistributableToolchain::install(
+                            utils::run_future(DistributableToolchain::install(
                                 self,
                                 desc,
                                 &[],
                                 &[],
                                 self.get_profile()?,
                                 true,
-                            )?;
+                            ))?;
                         }
                     }
                     o => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -895,7 +895,13 @@ impl Cfg {
 
         // Update toolchains and collect the results
         let channels = channels.map(|(desc, mut distributable)| {
-            let st = distributable.update_extra(&[], &[], profile, force_update, false);
+            let st = utils::run_future(distributable.update_extra(
+                &[],
+                &[],
+                profile,
+                force_update,
+                false,
+            ));
 
             if let Err(ref e) = st {
                 (self.notify_handler)(Notification::NonFatalError(e));

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -1043,12 +1043,12 @@ fn try_update_from_dist_(
             }
         }
     };
-    let result = manifestation.update_v1(
+    let result = utils::run_future(manifestation.update_v1(
         &manifest,
         update_hash,
         download.tmp_cx,
         &download.notify_handler,
-    );
+    ));
     // inspect, determine what context to add, then process afterwards.
     let mut download_not_exists = false;
     match &result {

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -1074,7 +1074,7 @@ pub(crate) fn dl_v2_manifest(
     toolchain: &ToolchainDesc,
 ) -> Result<Option<(ManifestV2, String)>> {
     let manifest_url = toolchain.manifest_v2_url(download.dist_root);
-    match download.download_and_check(&manifest_url, update_hash, ".toml") {
+    match utils::run_future(download.download_and_check(&manifest_url, update_hash, ".toml")) {
         Ok(manifest_dl) => {
             // Downloaded ok!
             let (manifest_file, manifest_hash) = if let Some(m) = manifest_dl {
@@ -1111,7 +1111,7 @@ fn dl_v1_manifest(download: DownloadCfg<'_>, toolchain: &ToolchainDesc) -> Resul
     }
 
     let manifest_url = toolchain.manifest_v1_url(download.dist_root);
-    let manifest_dl = download.download_and_check(&manifest_url, None, "")?;
+    let manifest_dl = utils::run_future(download.download_and_check(&manifest_url, None, ""))?;
     let (manifest_file, _) = manifest_dl.unwrap();
     let manifest_str = utils::read_file("manifest", &manifest_file)?;
     let urls = manifest_str

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -703,7 +703,7 @@ pub(crate) fn valid_profile_names() -> String {
 //
 // Returns the manifest's hash if anything changed.
 #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all, fields(profile=format!("{profile:?}"), prefix=prefix.path().to_string_lossy().to_string())))]
-pub(crate) fn update_from_dist(
+pub(crate) async fn update_from_dist(
     download: DownloadCfg<'_>,
     update_hash: Option<&Path>,
     toolchain: &ToolchainDesc,
@@ -724,7 +724,7 @@ pub(crate) fn update_from_dist(
         std::fs::remove_file(update_hash.unwrap())?;
     }
 
-    let res = utils::run_future(update_from_dist_(
+    let res = update_from_dist_(
         download,
         update_hash,
         toolchain,
@@ -735,7 +735,8 @@ pub(crate) fn update_from_dist(
         old_date,
         components,
         targets,
-    ));
+    )
+    .await;
 
     // Don't leave behind an empty / broken installation directory
     if res.is_err() && fresh_install {

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -962,14 +962,14 @@ fn try_update_from_dist_(
 
             fetched.clone_from(&m.date);
 
-            return match manifestation.update(
+            return match utils::run_future(manifestation.update(
                 &m,
                 changes,
                 force_update,
                 &download,
                 &toolchain.manifest_name(),
                 true,
-            ) {
+            )) {
                 Ok(status) => match status {
                     UpdateStatus::Unchanged => Ok(None),
                     UpdateStatus::Changed => Ok(Some(hash)),

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -130,9 +130,9 @@ impl<'a> DownloadCfg<'a> {
         let hash_url = utils::parse_url(&(url.to_owned() + ".sha256"))?;
         let hash_file = self.tmp_cx.new_file()?;
 
-        utils::download_file(&hash_url, &hash_file, None, &|n| {
+        utils::run_future(utils::download_file(&hash_url, &hash_file, None, &|n| {
             (self.notify_handler)(n.into())
-        })?;
+        }))?;
 
         utils::read_file("hash", &hash_file).map(|s| s[0..64].to_owned())
     }
@@ -170,9 +170,9 @@ impl<'a> DownloadCfg<'a> {
         let file = self.tmp_cx.new_file_with_ext("", ext)?;
 
         let mut hasher = Sha256::new();
-        utils::download_file(&url, &file, Some(&mut hasher), &|n| {
+        utils::run_future(utils::download_file(&url, &file, Some(&mut hasher), &|n| {
             (self.notify_handler)(n.into())
-        })?;
+        }))?;
         let actual_hash = format!("{:x}", hasher.finalize());
 
         if hash != actual_hash {

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -71,13 +71,13 @@ impl<'a> DownloadCfg<'a> {
 
         let mut hasher = Sha256::new();
 
-        if let Err(e) = utils::download_file_with_resume(
+        if let Err(e) = utils::run_future(utils::download_file_with_resume(
             url,
             &partial_file_path,
             Some(&mut hasher),
             true,
             &|n| (self.notify_handler)(n.into()),
-        ) {
+        )) {
             let err = Err(e);
             if partial_file_existed {
                 return err.context(RustupError::BrokenPartialFile);

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -378,7 +378,7 @@ impl Manifestation {
     }
 
     /// Installation using the legacy v1 manifest format
-    pub(crate) fn update_v1(
+    pub(crate) async fn update_v1(
         &self,
         new_manifest: &[String],
         update_hash: Option<&Path>,
@@ -421,7 +421,9 @@ impl Manifestation {
             notify_handler,
         };
 
-        let dl = utils::run_future(dlcfg.download_and_check(&url, update_hash, ".tar.gz"))?;
+        let dl = dlcfg
+            .download_and_check(&url, update_hash, ".tar.gz")
+            .await?;
         if dl.is_none() {
             return Ok(None);
         };

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -432,7 +432,7 @@ impl Manifestation {
             notify_handler,
         };
 
-        let dl = dlcfg.download_and_check(&url, update_hash, ".tar.gz")?;
+        let dl = utils::run_future(dlcfg.download_and_check(&url, update_hash, ".tar.gz"))?;
         if dl.is_none() {
             return Ok(None);
         };

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -466,14 +466,14 @@ fn update_from_dist(
         remove_components: remove.to_owned(),
     };
 
-    manifestation.update(
+    utils::run_future(manifestation.update(
         &manifest,
         changes,
         force,
         download_cfg,
         &toolchain.manifest_name(),
         true,
-    )
+    ))
 }
 
 fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> Result<Url> {

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -443,7 +443,12 @@ fn update_from_dist(
     // Download the dist manifest and place it into the installation prefix
     let manifest_url = make_manifest_url(dist_server, toolchain)?;
     let manifest_file = tmp_cx.new_file()?;
-    utils::download_file(&manifest_url, &manifest_file, None, &|_| {})?;
+    utils::run_future(utils::download_file(
+        &manifest_url,
+        &manifest_file,
+        None,
+        &|_| {},
+    ))?;
     let manifest_str = utils::read_file("manifest", &manifest_file)?;
     let manifest = Manifest::parse(&manifest_str)?;
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -136,7 +136,7 @@ impl<'a> InstallMethod<'a> {
                 ..
             } => {
                 let prefix = &InstallPrefix::from(path.to_owned());
-                let maybe_new_hash = dist::update_from_dist(
+                let maybe_new_hash = utils::run_future(dist::update_from_dist(
                     *dl_cfg,
                     update_hash.as_deref(),
                     desc,
@@ -147,7 +147,7 @@ impl<'a> InstallMethod<'a> {
                     old_date_version.as_ref().map(|dv| dv.0.as_str()),
                     components,
                     targets,
-                )?;
+                ))?;
 
                 if let Some(hash) = maybe_new_hash {
                     if let Some(hash_file) = update_hash {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     install::{InstallMethod, UpdateStatus},
     notifications::Notification,
+    utils::utils,
     RustupError,
 };
 
@@ -110,14 +111,14 @@ impl<'a> DistributableToolchain<'a> {
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        manifestation.update(
+        utils::run_future(manifestation.update(
             &manifest,
             changes,
             false,
             &download_cfg,
             &self.desc.manifest_name(),
             false,
-        )?;
+        ))?;
 
         Ok(())
     }
@@ -508,14 +509,14 @@ impl<'a> DistributableToolchain<'a> {
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        manifestation.update(
+        utils::run_future(manifestation.update(
             &manifest,
             changes,
             false,
             &download_cfg,
             &self.desc.manifest_name(),
             false,
-        )?;
+        ))?;
 
         Ok(())
     }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -372,13 +372,14 @@ impl<'a> DistributableToolchain<'a> {
     }
 
     #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
-    pub(crate) fn update(
+    pub(crate) async fn update(
         &mut self,
         components: &[&str],
         targets: &[&str],
         profile: Profile,
     ) -> anyhow::Result<UpdateStatus> {
-        utils::run_future(self.update_extra(components, targets, profile, true, false))
+        self.update_extra(components, targets, profile, true, false)
+            .await
     }
 
     /// Update a toolchain with control over the channel behaviour

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -53,7 +53,7 @@ impl<'a> DistributableToolchain<'a> {
         &self.desc
     }
 
-    pub(crate) fn add_component(&self, mut component: Component) -> anyhow::Result<()> {
+    pub(crate) async fn add_component(&self, mut component: Component) -> anyhow::Result<()> {
         // TODO: take multiple components?
         let manifestation = self.get_manifestation()?;
         let manifest = self.get_manifest()?;
@@ -111,14 +111,16 @@ impl<'a> DistributableToolchain<'a> {
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        utils::run_future(manifestation.update(
-            &manifest,
-            changes,
-            false,
-            &download_cfg,
-            &self.desc.manifest_name(),
-            false,
-        ))?;
+        manifestation
+            .update(
+                &manifest,
+                changes,
+                false,
+                &download_cfg,
+                &self.desc.manifest_name(),
+                false,
+            )
+            .await?;
 
         Ok(())
     }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -525,17 +525,15 @@ impl<'a> DistributableToolchain<'a> {
         Ok(())
     }
 
-    pub fn show_dist_version(&self) -> anyhow::Result<Option<String>> {
+    pub async fn show_dist_version(&self) -> anyhow::Result<Option<String>> {
         let update_hash = self.cfg.get_hash_file(&self.desc, false)?;
         let notify_handler =
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        match utils::run_future(crate::dist::dist::dl_v2_manifest(
-            download_cfg,
-            Some(&update_hash),
-            &self.desc,
-        ))? {
+        match crate::dist::dist::dl_v2_manifest(download_cfg, Some(&update_hash), &self.desc)
+            .await?
+        {
             Some((manifest, _)) => Ok(Some(manifest.get_rust_version()?.to_string())),
             None => Ok(None),
         }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -338,20 +338,22 @@ impl<'a> DistributableToolchain<'a> {
         let hash_path = cfg.get_hash_file(desc, true)?;
         let update_hash = Some(&hash_path as &Path);
 
-        let status = InstallMethod::Dist {
-            cfg,
-            desc,
-            profile,
-            update_hash,
-            dl_cfg: cfg.download_cfg(&|n| (cfg.notify_handler)(n.into())),
-            force,
-            allow_downgrade: false,
-            exists: false,
-            old_date_version: None,
-            components,
-            targets,
-        }
-        .install()?;
+        let status = utils::run_future(
+            InstallMethod::Dist {
+                cfg,
+                desc,
+                profile,
+                update_hash,
+                dl_cfg: cfg.download_cfg(&|n| (cfg.notify_handler)(n.into())),
+                force,
+                allow_downgrade: false,
+                exists: false,
+                old_date_version: None,
+                components,
+                targets,
+            }
+            .install(),
+        )?;
         Ok((status, Self::new(cfg, desc.clone())?))
     }
 
@@ -407,22 +409,24 @@ impl<'a> DistributableToolchain<'a> {
         let hash_path = self.cfg.get_hash_file(&self.desc, true)?;
         let update_hash = Some(&hash_path as &Path);
 
-        InstallMethod::Dist {
-            cfg: self.cfg,
-            desc: &self.desc,
-            profile,
-            update_hash,
-            dl_cfg: self
-                .cfg
-                .download_cfg(&|n| (self.cfg.notify_handler)(n.into())),
-            force,
-            allow_downgrade,
-            exists: true,
-            old_date_version,
-            components,
-            targets,
-        }
-        .install()
+        utils::run_future(
+            InstallMethod::Dist {
+                cfg: self.cfg,
+                desc: &self.desc,
+                profile,
+                update_hash,
+                dl_cfg: self
+                    .cfg
+                    .download_cfg(&|n| (self.cfg.notify_handler)(n.into())),
+                force,
+                allow_downgrade,
+                exists: true,
+                old_date_version,
+                components,
+                targets,
+            }
+            .install(),
+        )
     }
 
     pub fn recursion_error(&self, binary_lossy: String) -> Result<Infallible, anyhow::Error> {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -16,7 +16,6 @@ use crate::{
     },
     install::{InstallMethod, UpdateStatus},
     notifications::Notification,
-    utils::utils,
     RustupError,
 };
 
@@ -469,7 +468,7 @@ impl<'a> DistributableToolchain<'a> {
         }
     }
 
-    pub(crate) fn remove_component(&self, mut component: Component) -> anyhow::Result<()> {
+    pub(crate) async fn remove_component(&self, mut component: Component) -> anyhow::Result<()> {
         // TODO: take multiple components?
         let manifestation = self.get_manifestation()?;
         let config = manifestation.read_config()?.unwrap_or_default();
@@ -518,14 +517,16 @@ impl<'a> DistributableToolchain<'a> {
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        utils::run_future(manifestation.update(
-            &manifest,
-            changes,
-            false,
-            &download_cfg,
-            &self.desc.manifest_name(),
-            false,
-        ))?;
+        manifestation
+            .update(
+                &manifest,
+                changes,
+                false,
+                &download_cfg,
+                &self.desc.manifest_name(),
+                false,
+            )
+            .await?;
 
         Ok(())
     }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -527,7 +527,11 @@ impl<'a> DistributableToolchain<'a> {
             &|n: crate::dist::Notification<'_>| (self.cfg.notify_handler)(n.into());
         let download_cfg = self.cfg.download_cfg(&notify_handler);
 
-        match crate::dist::dist::dl_v2_manifest(download_cfg, Some(&update_hash), &self.desc)? {
+        match utils::run_future(crate::dist::dist::dl_v2_manifest(
+            download_cfg,
+            Some(&update_hash),
+            &self.desc,
+        ))? {
             Some((manifest, _)) => Ok(Some(manifest.get_rust_version()?.to_string())),
             None => Ok(None),
         }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -357,7 +357,7 @@ impl<'a> DistributableToolchain<'a> {
     }
 
     #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
-    pub fn install_if_not_installed(
+    pub async fn install_if_not_installed(
         cfg: &'a Cfg,
         desc: &'a ToolchainDesc,
     ) -> anyhow::Result<UpdateStatus> {
@@ -366,15 +366,11 @@ impl<'a> DistributableToolchain<'a> {
             (cfg.notify_handler)(Notification::UsingExistingToolchain(desc));
             Ok(UpdateStatus::Unchanged)
         } else {
-            Ok(utils::run_future(Self::install(
-                cfg,
-                desc,
-                &[],
-                &[],
-                cfg.get_profile()?,
-                false,
-            ))?
-            .0)
+            Ok(
+                Self::install(cfg, desc, &[], &[], cfg.get_profile()?, false)
+                    .await?
+                    .0,
+            )
         }
     }
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -151,10 +151,16 @@ pub fn download_file(
     hasher: Option<&mut Sha256>,
     notify_handler: &dyn Fn(Notification<'_>),
 ) -> Result<()> {
-    download_file_with_resume(url, path, hasher, false, &notify_handler)
+    run_future(download_file_with_resume(
+        url,
+        path,
+        hasher,
+        false,
+        &notify_handler,
+    ))
 }
 
-pub(crate) fn download_file_with_resume(
+pub(crate) async fn download_file_with_resume(
     url: &Url,
     path: &Path,
     hasher: Option<&mut Sha256>,
@@ -162,13 +168,7 @@ pub(crate) fn download_file_with_resume(
     notify_handler: &dyn Fn(Notification<'_>),
 ) -> Result<()> {
     use download::DownloadError as DEK;
-    match run_future(download_file_(
-        url,
-        path,
-        hasher,
-        resume_from_partial,
-        notify_handler,
-    )) {
+    match download_file_(url, path, hasher, resume_from_partial, notify_handler).await {
         Ok(_) => Ok(()),
         Err(e) => {
             if e.downcast_ref::<std::io::Error>().is_some() {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -145,19 +145,13 @@ where
     })
 }
 
-pub fn download_file(
+pub async fn download_file(
     url: &Url,
     path: &Path,
     hasher: Option<&mut Sha256>,
     notify_handler: &dyn Fn(Notification<'_>),
 ) -> Result<()> {
-    run_future(download_file_with_resume(
-        url,
-        path,
-        hasher,
-        false,
-        &notify_handler,
-    ))
+    download_file_with_resume(url, path, hasher, false, &notify_handler).await
 }
 
 pub(crate) async fn download_file_with_resume(


### PR DESCRIPTION
Being able to use async where relevant across the codebase makes it possible to use async constructs where relevant. rustup has many places where that can be useful: downloading channel metadata, distribution content, unpacking that content to disk, are work that could usefully proceed in parallel - and async provides a good abstraction for that.

We already have a sophisticated disk IO layer that accomodates various OS latency-inducing behaviours, and adapting that to async without any regressions could be very interesting too - but for now, it co-exists nicely with an async core.

One not necessarily obvious caveat - we can't use tokio::main because it doesn't provide the per-worker-thread injection that we use to facilitate isolated tests. (tl;dr std::env::var/args being global reflect reality well, but not writing tests that interact with those layers).
