### PR TITLE
Improve CurrentProcess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -649,6 +649,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum_dispatch"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f36e95862220b211a6e2aa5eca09b4fa391b13cd52ceb8035a24bf65a79de2"
+dependencies = [
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "env_proxy"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2059,6 +2071,7 @@ dependencies = [
  "download",
  "effective-limits",
  "enum-map",
+ "enum_dispatch",
  "flate2",
  "fs_at",
  "git-testament",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ derivative.workspace = true
 download = { path = "download", default-features = false }
 effective-limits = "0.5.5"
 enum-map = "2.5.0"
+enum_dispatch.workspace = true
 flate2 = "1"
 fs_at.workspace = true
 git-testament = "0.2"
@@ -174,6 +175,7 @@ members = ["download", "rustup-macros"]
 [workspace.dependencies]
 anyhow = "1.0.69"
 derivative = "2.2.0"
+enum_dispatch = "0.3.11"
 fs_at = "0.1.6"
 lazy_static = "1"
 once_cell = "1.17.1"

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -23,14 +23,14 @@ use rustup::cli::rustup_mode;
 #[cfg(windows)]
 use rustup::cli::self_update;
 use rustup::cli::setup_mode;
-use rustup::currentprocess::{process, with, OSProcess};
+use rustup::currentprocess::{process, varsource::VarSource, with, OSProcess};
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
 use rustup::is_proxyable_tools;
 use rustup::utils::utils;
 
 fn main() {
     let process = OSProcess::default();
-    with(Box::new(process), || match maybe_trace_rustup() {
+    with(process.into(), || match maybe_trace_rustup() {
         Err(e) => {
             common::report_error(&e);
             std::process::exit(1);

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -14,6 +14,11 @@ use term2::Terminal;
 
 use super::self_update;
 use super::term2;
+use crate::currentprocess::argsource::ArgSource;
+use crate::currentprocess::{
+    filesource::{StdinSource, StdoutSource},
+    varsource::VarSource,
+};
 use crate::utils::notifications as util_notifications;
 use crate::utils::notify::NotificationLevel;
 use crate::utils::utils;

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use term2::Terminal;
 
 use super::term2;
+use crate::currentprocess::varsource::VarSource;
 use crate::process;
 
 macro_rules! warn {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use crate::{
     cli::{common::set_globals, job, self_update},
     command::run_command_for_dir,
+    currentprocess::argsource::ArgSource,
     toolchain::names::{LocalToolchainName, ResolvableLocalToolchainName},
     utils::utils::{self, ExitCode},
     Cfg,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -21,6 +21,11 @@ use crate::{
         topical_doc,
     },
     command,
+    currentprocess::{
+        argsource::ArgSource,
+        filesource::{StderrSource, StdoutSource},
+        varsource::VarSource,
+    },
     dist::{
         dist::{PartialToolchainDesc, Profile, TargetTriple},
         manifest::{Component, ComponentStatus},

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -65,6 +65,7 @@ use crate::{
         markdown::md,
         term2::{self, Terminal},
     },
+    currentprocess::{filesource::StdoutSource, varsource::VarSource},
     dist::dist::{self, PartialToolchainDesc, Profile, TargetTriple, ToolchainDesc},
     install::UpdateStatus,
     process,
@@ -1296,11 +1297,11 @@ mod tests {
         with_rustup_home(|home| {
             let mut vars = HashMap::new();
             home.apply(&mut vars);
-            let tp = Box::new(currentprocess::TestProcess {
+            let tp = currentprocess::TestProcess {
                 vars,
                 ..Default::default()
-            });
-            currentprocess::with(tp.clone(), || -> Result<()> {
+            };
+            currentprocess::with(tp.clone().into(), || -> Result<()> {
                 // TODO: we could pass in a custom cfg to get notification
                 // callbacks rather than output to the tp sink.
                 let mut cfg = common::set_globals(false, false).unwrap();
@@ -1343,11 +1344,11 @@ info: default host triple is {0}
         let cargo_home = root_dir.path().join("cargo");
         let mut vars = HashMap::new();
         vars.env("CARGO_HOME", cargo_home.to_string_lossy().to_string());
-        let tp = Box::new(currentprocess::TestProcess {
+        let tp = currentprocess::TestProcess {
             vars,
             ..Default::default()
-        });
-        currentprocess::with(tp, || -> Result<()> {
+        };
+        currentprocess::with(tp.into(), || -> Result<()> {
             super::install_bins().unwrap();
             Ok(())
         })

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 
 use super::utils;
-use crate::process;
+use crate::{currentprocess::varsource::VarSource, process};
 
 pub(crate) type Shell = Box<dyn UnixShell>;
 

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -5,6 +5,7 @@ use anyhow::{bail, Context, Result};
 
 use super::install_bins;
 use super::shell;
+use crate::currentprocess::varsource::VarSource;
 use crate::process;
 use crate::utils::utils;
 use crate::utils::Notification;

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -13,6 +13,7 @@ use super::super::errors::*;
 use super::common;
 use super::{install_bins, InstallOpts};
 use crate::cli::download_tracker::DownloadTracker;
+use crate::currentprocess::{filesource::StdoutSource, varsource::VarSource};
 use crate::dist::dist::TargetTriple;
 use crate::process;
 use crate::utils::utils;
@@ -747,9 +748,9 @@ mod tests {
     #[test]
     fn windows_path_regkey_type() {
         // per issue #261, setting PATH should use REG_EXPAND_SZ.
-        let tp = Box::new(currentprocess::TestProcess::default());
+        let tp = currentprocess::TestProcess::default();
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone(), || {
+            currentprocess::with(tp.clone().into(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
                     .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
@@ -777,9 +778,9 @@ mod tests {
         use std::io;
         // during uninstall the PATH key may end up empty; if so we should
         // delete it.
-        let tp = Box::new(currentprocess::TestProcess::default());
+        let tp = currentprocess::TestProcess::default();
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone(), || {
+            currentprocess::with(tp.clone().into(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
                     .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
@@ -812,15 +813,15 @@ mod tests {
     #[test]
     fn windows_doesnt_mess_with_a_non_string_path() {
         // This writes an error, so we want a sink for it.
-        let tp = Box::new(currentprocess::TestProcess {
+        let tp = currentprocess::TestProcess {
             vars: [("HOME".to_string(), "/unused".to_string())]
                 .iter()
                 .cloned()
                 .collect(),
             ..Default::default()
-        });
+        };
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone(), || {
+            currentprocess::with(tp.clone().into(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
                     .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
@@ -847,9 +848,9 @@ mod tests {
     #[test]
     fn windows_treat_missing_path_as_empty() {
         // during install the PATH key may be missing; treat it as empty
-        let tp = Box::new(currentprocess::TestProcess::default());
+        let tp = currentprocess::TestProcess::default();
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone(), || {
+            currentprocess::with(tp.clone().into(), || {
                 let root = RegKey::predef(HKEY_CURRENT_USER);
                 let environment = root
                     .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -6,6 +6,7 @@ use crate::{
         common,
         self_update::{self, InstallOpts},
     },
+    currentprocess::{argsource::ArgSource, filesource::StdoutSource},
     dist::dist::Profile,
     process,
     toolchain::names::{maybe_official_toolchainame_parser, MaybeOfficialToolchainName},

--- a/src/cli/term2.rs
+++ b/src/cli/term2.rs
@@ -11,7 +11,7 @@ pub(crate) use term::color;
 pub(crate) use term::Attr;
 pub(crate) use term::Terminal;
 
-use crate::currentprocess::filesource::{Isatty, Writer};
+use crate::currentprocess::filesource::{Isatty, StderrSource, StdoutSource, Writer};
 use crate::process;
 
 mod termhack {

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,7 @@ use thiserror::Error as ThisError;
 
 use crate::{
     cli::self_update::SelfUpdateMode,
+    currentprocess::varsource::VarSource,
     dist::{
         dist::{self, PartialToolchainDesc, Profile, ToolchainDesc},
         download::DownloadCfg,

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -32,7 +32,11 @@ use cwdsource::*;
 use filesource::*;
 use varsource::*;
 
-/// An abstraction for the current process
+/// An abstraction for the current process.
+///
+/// This acts as a clonable proxy to the global state provided by some key OS
+/// interfaces - it is a zero cost abstraction. For the test variant it manages
+/// a mutex and takes out locks to ensure consistency.
 ///
 /// This provides replacements env::arg*, env::var*, and the standard files
 /// io::std* with traits that are customisable for tests. As a result any macros

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -1,7 +1,10 @@
 use std::boxed::Box;
 use std::cell::RefCell;
 use std::default::Default;
+use std::env;
+use std::ffi::OsString;
 use std::fmt::Debug;
+use std::io;
 use std::panic;
 use std::path::PathBuf;
 use std::sync::Once;
@@ -13,15 +16,16 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use enum_dispatch::enum_dispatch;
 use home::env as home;
 #[cfg(feature = "test")]
 use rand::{thread_rng, Rng};
 
-pub(crate) mod argsource;
-pub(crate) mod cwdsource;
-pub(crate) mod filesource;
+pub mod argsource;
+pub mod cwdsource;
+pub mod filesource;
 mod homethunk;
-pub(crate) mod varsource;
+pub mod varsource;
 
 use argsource::*;
 use cwdsource::*;
@@ -58,32 +62,10 @@ use varsource::*;
 /// needing to thread trait parameters across the entire code base: none of the
 /// methods are in performance critical loops (except perhaps progress bars -
 /// and even there we should be doing debouncing and managing update rates).
-/// The real trait is CurrentProcess; HomeProcess is a single trait because
-/// Box<T> only allows autotraits to be added to it; so we use a subtrait to add
-/// home::Env in.
-pub trait HomeProcess: CurrentProcess + home::Env {
-    fn clone_boxed(&self) -> Box<dyn HomeProcess>;
-}
-
-// Machinery for Cloning boxes
-
-impl<T> HomeProcess for T
-where
-    T: 'static + CurrentProcess + home::Env + Clone,
-{
-    fn clone_boxed(&self) -> Box<dyn HomeProcess + 'static> {
-        Box::new(T::clone(self))
-    }
-}
-
-impl Clone for Box<dyn HomeProcess + 'static> {
-    fn clone(&self) -> Self {
-        HomeProcess::clone_boxed(self.as_ref())
-    }
-}
-
+#[enum_dispatch]
 pub trait CurrentProcess:
-    ArgSource
+    home::Env
+    + ArgSource
     + CurrentDirSource
     + VarSource
     + StdoutSource
@@ -92,31 +74,28 @@ pub trait CurrentProcess:
     + ProcessSource
     + Debug
 {
-    fn clone_boxed(&self) -> Box<dyn CurrentProcess>;
-
-    fn name(&self) -> Option<String>;
 }
 
-// Machinery for Cloning boxes
+/// Allows concrete types for the currentprocess abstraction.
+#[derive(Clone, Debug)]
+#[enum_dispatch(
+    CurrentProcess,
+    ArgSource,
+    CurrentDirSource,
+    VarSource,
+    StdoutSource,
+    StderrSource,
+    StdinSource,
+    ProcessSource
+)]
+pub enum Process {
+    OSProcess(OSProcess),
+    #[cfg(feature = "test")]
+    TestProcess(TestProcess),
+}
 
-impl<T> CurrentProcess for T
-where
-    T: 'static
-        + Clone
-        + Debug
-        + ArgSource
-        + CurrentDirSource
-        + VarSource
-        + StdoutSource
-        + StderrSource
-        + StdinSource
-        + ProcessSource,
-{
-    fn clone_boxed(&self) -> Box<dyn CurrentProcess + 'static> {
-        Box::new(T::clone(self))
-    }
-
-    fn name(&self) -> Option<String> {
+impl Process {
+    pub fn name(&self) -> Option<String> {
         let arg0 = match self.var("RUSTUP_FORCE_ARG0") {
             Ok(v) => Some(v),
             Err(_) => self.args().next(),
@@ -130,19 +109,13 @@ where
     }
 }
 
-impl Clone for Box<dyn CurrentProcess + 'static> {
-    fn clone(&self) -> Self {
-        self.as_ref().clone_boxed()
-    }
-}
-
 /// Obtain the current instance of CurrentProcess
-pub fn process() -> Box<dyn CurrentProcess> {
-    CurrentProcess::clone_boxed(&*home_process())
+pub fn process() -> Process {
+    home_process()
 }
 
 /// Obtain the current instance of HomeProcess
-pub(crate) fn home_process() -> Box<dyn HomeProcess> {
+pub(crate) fn home_process() -> Process {
     match PROCESS.with(|p| p.borrow().clone()) {
         None => panic!("No process instance"),
         Some(p) => p,
@@ -155,7 +128,7 @@ static HOOK_INSTALLED: Once = Once::new();
 ///
 /// If the function panics, the process definition *in that thread* is cleared
 /// by an implicitly installed global panic hook.
-pub fn with<F, R>(process: Box<dyn HomeProcess>, f: F) -> R
+pub fn with<F, R>(process: Process, f: F) -> R
 where
     F: FnOnce() -> R,
 {
@@ -184,11 +157,11 @@ fn clear_process() {
 }
 
 thread_local! {
-    pub(crate) static PROCESS:RefCell<Option<Box<dyn HomeProcess>>> = RefCell::new(None);
+    pub(crate) static PROCESS:RefCell<Option<Process>> = RefCell::new(None);
 }
 
 // PID related things
-
+#[enum_dispatch]
 pub trait ProcessSource {
     /// Returns a unique id for the process.
     ///
@@ -287,7 +260,7 @@ mod tests {
             HashMap::default(),
             "",
         );
-        with(Box::new(proc.clone()), || {
+        with(proc.clone().into(), || {
             assert_eq!(proc.id(), process().id(), "{:?} != {:?}", proc, process())
         });
     }

--- a/src/currentprocess/argsource.rs
+++ b/src/currentprocess/argsource.rs
@@ -4,6 +4,9 @@ use std::env;
 use std::ffi::OsString;
 use std::marker::PhantomData;
 
+use enum_dispatch::enum_dispatch;
+
+#[enum_dispatch]
 pub trait ArgSource {
     fn args(&self) -> Box<dyn Iterator<Item = String>>;
     fn args_os(&self) -> Box<dyn Iterator<Item = OsString>>;

--- a/src/currentprocess/cwdsource.rs
+++ b/src/currentprocess/cwdsource.rs
@@ -4,6 +4,9 @@ use std::env;
 use std::io;
 use std::path::PathBuf;
 
+use enum_dispatch::enum_dispatch;
+
+#[enum_dispatch]
 pub trait CurrentDirSource {
     fn current_dir(&self) -> io::Result<PathBuf>;
 }

--- a/src/currentprocess/filesource.rs
+++ b/src/currentprocess/filesource.rs
@@ -1,6 +1,8 @@
 use std::io::{self, BufRead, Cursor, Read, Result, Write};
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use enum_dispatch::enum_dispatch;
+
 use crate::utils::tty;
 
 /// Stand-in for std::io::Stdin
@@ -13,6 +15,7 @@ pub trait Stdin {
 pub trait StdinLock: Read + BufRead {}
 
 /// Stand-in for std::io::stdin
+#[enum_dispatch]
 pub trait StdinSource {
     fn stdin(&self) -> Box<dyn Stdin>;
 }
@@ -95,6 +98,7 @@ pub trait Writer: Write + Isatty + Send {
 }
 
 /// Stand-in for std::io::stdout
+#[enum_dispatch]
 pub trait StdoutSource {
     fn stdout(&self) -> Box<dyn Writer>;
 }
@@ -102,6 +106,7 @@ pub trait StdoutSource {
 // -------------- stderr -------------------------------
 
 /// Stand-in for std::io::stderr
+#[enum_dispatch]
 pub trait StderrSource {
     fn stderr(&self) -> Box<dyn Writer>;
 }

--- a/src/currentprocess/homethunk.rs
+++ b/src/currentprocess/homethunk.rs
@@ -7,20 +7,32 @@ use std::path::PathBuf;
 
 use home::env as home;
 
-use super::HomeProcess;
 use super::OSProcess;
+use super::Process;
 #[cfg(feature = "test")]
 use super::{CurrentDirSource, TestProcess, VarSource};
 
-impl home::Env for Box<dyn HomeProcess + 'static> {
+impl home::Env for Process {
     fn home_dir(&self) -> Option<PathBuf> {
-        (**self).home_dir()
+        match self {
+            Process::OSProcess(p) => p.home_dir(),
+            #[cfg(feature = "test")]
+            Process::TestProcess(p) => p.home_dir(),
+        }
     }
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
-        home::Env::current_dir(&(**self))
+        match self {
+            Process::OSProcess(p) => home::Env::current_dir(p),
+            #[cfg(feature = "test")]
+            Process::TestProcess(p) => home::Env::current_dir(p),
+        }
     }
     fn var_os(&self, key: &str) -> Option<OsString> {
-        home::Env::var_os(&(**self), key)
+        match self {
+            Process::OSProcess(p) => home::Env::var_os(p, key),
+            #[cfg(feature = "test")]
+            Process::TestProcess(p) => home::Env::var_os(p, key),
+        }
     }
 }
 

--- a/src/currentprocess/varsource.rs
+++ b/src/currentprocess/varsource.rs
@@ -3,6 +3,9 @@
 use std::env;
 use std::ffi::OsString;
 
+use enum_dispatch::enum_dispatch;
+
+#[enum_dispatch]
 pub trait VarSource {
     // In order to support dyn dispatch we use concrete types rather than the
     // stdlib signature.

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -65,6 +65,7 @@ use std::{fmt::Debug, fs::OpenOptions};
 
 use anyhow::{Context, Result};
 
+use crate::currentprocess::varsource::VarSource;
 use crate::process;
 use crate::utils::notifications::Notification;
 use threaded::PoolReference;

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -23,11 +23,11 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
-    let tp = Box::new(currentprocess::TestProcess {
+    let tp = currentprocess::TestProcess {
         vars,
         ..Default::default()
-    });
-    currentprocess::with(tp, || -> Result<()> {
+    };
+    currentprocess::with(tp.into(), || -> Result<()> {
         let mut written = 0;
         let mut file_finished = false;
         let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024)?;
@@ -97,11 +97,11 @@ fn test_complete_file(io_threads: &str) -> Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
-    let tp = Box::new(currentprocess::TestProcess {
+    let tp = currentprocess::TestProcess {
         vars,
         ..Default::default()
-    });
-    currentprocess::with(tp, || -> Result<()> {
+    };
+    currentprocess::with(tp.into(), || -> Result<()> {
         let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024)?;
         let mut chunk = io_executor.get_buffer(10);
         chunk.extend(b"0123456789");

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -14,6 +14,7 @@ use enum_map::{enum_map, Enum, EnumMap};
 use sharded_slab::pool::{OwnedRef, OwnedRefMut};
 
 use super::{perform, CompletedIo, Executor, Item};
+use crate::currentprocess::varsource::VarSource;
 use crate::utils::notifications::Notification;
 use crate::utils::units::Unit;
 

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -11,6 +11,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{anyhow, bail, Context, Result};
 use tar::EntryType;
 
+use crate::currentprocess::{filesource::StderrSource, varsource::VarSource};
 use crate::diskio::{get_executor, CompletedIo, Executor, FileBuffer, Item, Kind, IO_CHUNK_SIZE};
 use crate::dist::component::components::*;
 use crate::dist::component::transaction::*;

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -14,6 +14,7 @@ use thiserror::Error as ThisError;
 
 pub(crate) use crate::dist::triple::*;
 use crate::{
+    currentprocess::varsource::VarSource,
     dist::{
         download::DownloadCfg,
         manifest::{Component, Manifest as ManifestV2},
@@ -27,7 +28,6 @@ use crate::{
     toolchain::names::ToolchainName,
     utils::utils,
 };
-
 pub static DEFAULT_DIST_SERVER: &str = "https://static.rust-lang.org";
 
 // Deprecated

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -10,6 +10,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use retry::delay::NoDelay;
 use retry::{retry, OperationResult};
 
+use crate::currentprocess::varsource::VarSource;
 use crate::dist::component::{
     Components, Package, TarGzPackage, TarXzPackage, TarZStdPackage, Transaction,
 };

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -558,12 +558,13 @@ fn setup_from_dist_server(
     };
 
     currentprocess::with(
-        Box::new(currentprocess::TestProcess::new(
+        currentprocess::TestProcess::new(
             env::current_dir().unwrap(),
             &["rustup"],
             HashMap::default(),
             "",
-        )),
+        )
+        .into(),
         || f(url, &toolchain, &prefix, &download_cfg, &temp_cfg),
     );
 }

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::process;
+use crate::{currentprocess::varsource::VarSource, process};
 
 pub const RUST_RECURSION_COUNT_MAX: u32 = 20;
 
@@ -54,12 +54,12 @@ mod tests {
             "PATH",
             env::join_paths(vec!["/home/a/.cargo/bin", "/home/b/.cargo/bin"].iter()).unwrap(),
         );
-        let tp = Box::new(currentprocess::TestProcess {
+        let tp = currentprocess::TestProcess {
             vars,
             ..Default::default()
-        });
+        };
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone(), || {
+            currentprocess::with(tp.clone().into(), || {
                 let mut path_entries = vec![];
                 let mut cmd = Command::new("test");
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -124,8 +124,8 @@ pub fn this_host_triple() -> String {
         // For windows, this host may be different to the target: we may be
         // building with i686 toolchain, but on an x86_64 host, so run the
         // actual detection logic and trust it.
-        let tp = Box::new(currentprocess::TestProcess::default());
-        return currentprocess::with(tp, || TargetTriple::from_host().unwrap().to_string());
+        let tp = currentprocess::TestProcess::default();
+        return currentprocess::with(tp.into(), || TargetTriple::from_host().unwrap().to_string());
     }
     let arch = if cfg!(target_arch = "x86") {
         "i686"

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -724,25 +724,20 @@ impl Config {
                     .into_boxed_str(),
             );
         }
-        let tp = Box::new(currentprocess::TestProcess::new(
-            &*self.workdir.borrow(),
-            &arg_strings,
-            vars,
-            "",
-        ));
-        let process_res = currentprocess::with(tp.clone(), rustup_mode::main);
+        let tp = currentprocess::TestProcess::new(&*self.workdir.borrow(), &arg_strings, vars, "");
+        let process_res = currentprocess::with(tp.clone().into(), rustup_mode::main);
         // convert Err's into an ec
         let ec = match process_res {
             Ok(process_res) => process_res,
             Err(e) => {
-                currentprocess::with(tp.clone(), || crate::cli::common::report_error(&e));
+                currentprocess::with(tp.clone().into(), || crate::cli::common::report_error(&e));
                 utils::ExitCode(1)
             }
         };
         Output {
             status: Some(ec.0),
-            stderr: (*tp).get_stderr(),
-            stdout: (*tp).get_stdout(),
+            stderr: tp.get_stderr(),
+            stdout: tp.get_stdout(),
         }
     }
 

--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -16,7 +16,7 @@ use wait_timeout::ChildExt;
 
 use crate::{
     config::Cfg,
-    currentprocess::process,
+    currentprocess::{process, varsource::VarSource},
     env_var, install,
     notifications::Notification,
     utils::{raw::open_dir, utils},

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -11,7 +11,7 @@ use std::str;
 use libc;
 
 #[cfg(not(windows))]
-use crate::process;
+use crate::{currentprocess::varsource::VarSource, process};
 
 pub(crate) fn ensure_dir_exists<P: AsRef<Path>, F: FnOnce(&Path)>(
     path: P,

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -10,7 +10,7 @@ use retry::{retry, OperationResult};
 use sha2::Sha256;
 use url::Url;
 
-// use crate::currentprocess::cwdsource::CurrentDirSource;
+use crate::currentprocess::{cwdsource::CurrentDirSource, varsource::VarSource};
 use crate::errors::*;
 use crate::utils::notifications::Notification;
 use crate::utils::raw;


### PR DESCRIPTION
To bring in tokio runtime pervasively we need to evolve CurrentProcess
to be a bit more friendly with Send/Sync. Getting at the concrete types
is actually clearer than what we had I think, and should ease that
process.