### PR TITLE
Group updates to opentelemetry together

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,5 +16,15 @@
         "fileMatch": [
             "^ci\\/.*/[^/]+\\.ya?ml$"
         ]
+    },
+    {
+        "packageRules": [
+            {
+                "matchPackagePatterns": [
+                    "opentelemetry"
+                ],
+                "groupName": "opentelemetry"
+            }
+        ]
     }
 }


### PR DESCRIPTION
This might not be the exact pattern we need - we can iterate on it
easily.

The Rust opentelemetry ecosystem has tight coupling across versions
between releases, so it is unlikely for single-dependency upgrades to
work.