### PR TITLE
Fix typo: prerequistes -> prerequisites

### DIFF
--- a/doc/src/installation/windows-msvc.md
+++ b/doc/src/installation/windows-msvc.md
@@ -1,4 +1,4 @@
-# MSVC prerequistes
+# MSVC prerequisites
 
 To compile programs into an exe file, Rust requires a linker, libraries and Windows API import libraries.
 For `msvc` targets these can be acquired through Visual Studio.

--- a/www/index.html
+++ b/www/index.html
@@ -47,7 +47,7 @@
     <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequistes</a>.</p>
+  <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequisites</a>.</p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
     <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
@@ -69,7 +69,7 @@
     <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
     then follow the onscreen instructions.
   </p>
-  <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequistes</a>.</p>
+  <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequisites</a>.</p>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
     <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>


### PR DESCRIPTION
Hi, I noticed a small spelling mistake on the homepage and in the documentation.