### PR TITLE
Bump some deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1345,9 +1345,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1386,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1584,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/rustup-macros/Cargo.toml
+++ b/rustup-macros/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.51"
+proc-macro2 = "1.0.63"
 quote = "1.0.23"
 regex = "1.7.1"
 sha2 = "0.10.6"


### PR DESCRIPTION
1. Bump the openssl v0.10.52 -> v0.10.55 to address the security alert. https://github.com/rust-lang/rustup/security/dependabot
2. Bump proc-macro2 v1.0.51 -> v1.0.63 to make rustup complile. See https://github.com/dtolnay/proc-macro2/pull/391.