### PR TITLE
Use available_parallelism to replace the `num_cpus`crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1973,7 +1973,6 @@ dependencies = [
  "home",
  "lazy_static",
  "libc",
- "num_cpus",
  "once_cell",
  "opener",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ git-testament = "0.2"
 home = "0.5.4"
 lazy_static.workspace = true
 libc = "0.2"
-num_cpus = "1.15"
 once_cell = { workspace = true, optional = true }
 opener = "0.6.0"
 opentelemetry = { workspace = true, optional = true }

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -60,6 +60,7 @@ use std::io::{self, Write};
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::Receiver;
+use std::thread::available_parallelism;
 use std::time::{Duration, Instant};
 use std::{fmt::Debug, fs::OpenOptions};
 
@@ -452,7 +453,7 @@ pub(crate) fn get_executor<'a>(
 ) -> Result<Box<dyn Executor + 'a>> {
     // If this gets lots of use, consider exposing via the config file.
     let thread_count = match process().var("RUSTUP_IO_THREADS") {
-        Err(_) => num_cpus::get(),
+        Err(_) => available_parallelism().map(|p| p.get()).unwrap_or(1),
         Ok(n) => n
             .parse::<usize>()
             .context("invalid value in RUSTUP_IO_THREADS. Must be a natural number")?,


### PR DESCRIPTION
close https://github.com/rust-lang/rustup/pull/3393

Use available_parallelism to replace the `num_cpus`crate. It has already been stable for a while. So I think we can replace it safely.