### PR TITLE
buf writes to components to prevent small writes

### DIFF
--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -2,6 +2,7 @@
 //! `Components` and `DirectoryPackage` are the two sides of the
 //! installation / uninstallation process.
 
+use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
@@ -122,7 +123,7 @@ impl<'a> ComponentBuilder<'a> {
         // Write component manifest
         let path = self.components.rel_component_manifest(&self.name);
         let abs_path = self.components.prefix.abs_path(&path);
-        let mut file = self.tx.add_file(&self.name, path)?;
+        let mut file = BufWriter::new(self.tx.add_file(&self.name, path)?);
         for part in self.parts {
             // FIXME: This writes relative paths to the component manifest,
             // but rust-installer writes absolute paths.

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -64,7 +64,7 @@ pub(crate) fn append_file(name: &'static str, path: &Path, line: &str) -> Result
 
 pub(crate) fn write_line(
     name: &'static str,
-    file: &mut File,
+    mut file: impl Write,
     path: &Path,
     line: &str,
 ) -> Result<()> {


### PR DESCRIPTION
Buf writes to components.

Without this fix, 100kb file `manifest-rust-src` written line by line, consisting of about 3k writes; with this pr ~ 20 writes.