### PR TITLE
Enable loongarch64-linux-gnu builds on stable

### DIFF
--- a/.github/workflows/linux-builds-on-stable.yaml
+++ b/.github/workflows/linux-builds-on-stable.yaml
@@ -44,6 +44,7 @@ jobs:
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
           - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
+          - loongarch64-unknown-linux-gnu # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -53,7 +53,7 @@ jobs:
           - i686-linux-android            # skip-pr skip-master
           - x86_64-linux-android          # skip-pr skip-master
           - riscv64gc-unknown-linux-gnu   # skip-pr skip-master
-          - loongarch64-unknown-linux-gnu # skip-pr skip-master skip-stable
+          - loongarch64-unknown-linux-gnu # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES


### PR DESCRIPTION
Enable loongarch64-linux-gnu builds on stable and request a new release.