### PR TITLE
Support `RUSTUP_TERM_COLOR` as an override environment variable

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -29,6 +29,10 @@
   determines the directory that traces will be written too. Traces are of the
   form PID.trace. Traces can be read by the Catapult project [tracing viewer].
 
+- `RUSTUP_TERM_COLOR` (default: `auto`) Controls whether colored output is used in the terminal.
+  Set to `auto` to use colors only in tty streams, to `always` to always enable colors,
+  or to `never` to disable colors.
+
 - `RUSTUP_UNPACK_RAM` *unstable* (default free memory or 500MiB if unable to tell, min 210MiB) Caps the amount of
   RAM `rustup` will use for IO tasks while unpacking.
 

--- a/src/currentprocess/filesource.rs
+++ b/src/currentprocess/filesource.rs
@@ -198,7 +198,7 @@ impl Write for TestWriterLock<'_> {
 #[cfg(feature = "test")]
 pub(super) type TestWriterInner = Arc<Mutex<Vec<u8>>>;
 /// A thread-safe test file handle that pretends to be e.g. stdout.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[cfg(feature = "test")]
 pub(super) struct TestWriter(TestWriterInner);
 

--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -83,7 +83,9 @@ impl ColorableTerminal {
     /// then color commands will be sent to the stream.
     /// Otherwise color commands are discarded.
     pub(super) fn new(stream: StreamSelector) -> Self {
-        let env_override = process().var("RUSTUP_TERM_COLOR");
+        let env_override = process()
+            .var("RUSTUP_TERM_COLOR")
+            .map(|it| it.to_lowercase());
         let choice = match env_override.as_deref() {
             Ok("always") => ColorChoice::Always,
             Ok("never") => ColorChoice::Never,
@@ -260,24 +262,24 @@ mod tests {
         }
 
         assert_color_choice(
-            "always",
+            "aLWayS",
             StreamSelector::TestWriter(Default::default()),
             ColorChoice::Always,
         );
         assert_color_choice(
-            "never",
+            "neVer",
             StreamSelector::TestWriter(Default::default()),
             ColorChoice::Never,
         );
         // tty + `auto` enables the colors.
         assert_color_choice(
-            "auto",
+            "AutO",
             StreamSelector::TestTtyWriter(Default::default()),
             ColorChoice::Auto,
         );
         // non-tty + `auto` does not enable the colors.
         assert_color_choice(
-            "auto",
+            "aUTo",
             StreamSelector::TestWriter(Default::default()),
             ColorChoice::Never,
         );


### PR DESCRIPTION
Closes #3433, getting my feet wet at the same time.

The variable name and the description are directly copied from the [Cargo Book](https://doc.rust-lang.org/cargo/reference/config.html#termcolor).

### Concerns

- [x] Is the naming of the variable ideal?
- [ ] Are there any test cases to be added for this change?
- [ ] ~~Should we add a CLI flag (e.g. `--color`) for this as well?~~
  - [ ] ~~If so, should we use Clap's `env` feature?~~