### PR TITLE
macOS `uname -m` can lie due to Rosetta shenanigans

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -255,10 +255,19 @@ get_architecture() {
         fi
     fi
 
-    if [ "$_ostype" = Darwin ] && [ "$_cputype" = i386 ]; then
-        # Darwin `uname -m` lies
-        if sysctl hw.optional.x86_64 | grep -q ': 1'; then
-            _cputype=x86_64
+    if [ "$_ostype" = Darwin ]; then
+        # Darwin `uname -m` can lie due to Rosetta shenanigans. If you manage to
+        # invoke a native shell binary and then a native uname binary, you can
+        # get the real answer, but that's hard to ensure, so instead we use
+        # `sysctl` (which doesn't lie) to check for the actual architecture.
+        if [ "$_cputype" = i386 ]; then
+            if sysctl hw.optional.x86_64 | grep -q ': 1'; then
+                _cputype=x86_64
+            fi
+        elif [ "$_cputype" = x86_64 ]; then
+            if sysctl hw.optional.arm64 | grep -q ': 1'; then
+                _cputype=arm64
+            fi
         fi
     fi
 


### PR DESCRIPTION
Closes #3419.

Originally provided in https://github.com/JuliaLang/juliaup/pull/701, this shell script fix uses `sysctl` to prevent Rosetta 2 from lying about the system's actual CPU architecture.

---

Possibly related: #3068