### PR TITLE
Configure automerge in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,8 @@
         "dependencies"
     ],
     "lockFileMaintenance": {
-        "enabled": true
+        "enabled": true,
+        "automerge": true
     },
     "prCreation": "not-pending",
     "rangeStrategy": "replace",
@@ -23,6 +24,21 @@
                 "opentelemetry"
             ],
             "groupName": "opentelemetry"
+        },
+        {
+            "matchUpdateTypes": [
+                "minor",
+                "patch"
+            ],
+            "matchCurrentVersion": "!/^0/",
+            "automerge": true
+        },
+        {
+            "matchUpdateTypes": [
+                "patch"
+            ],
+            "matchCurrentVersion": "/^0\\./",
+            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
This should merge test-passing branches with the following policy:
- Anything that is just a lockfile update
- Minor version bumps of direct dependencies that are > version 1.0.0
- Patch version bumps of direct dependencies that are < version 1.0.0