### PR TITLE
Refactor: Use download_cfg.notify_handler in update()

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -927,7 +927,6 @@ fn try_update_from_dist_(
                 changes,
                 force_update,
                 &download,
-                &download.notify_handler,
                 &toolchain.manifest_name(),
                 true,
             ) {

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -466,7 +466,6 @@ fn update_from_dist(
         changes,
         force,
         download_cfg,
-        download_cfg.notify_handler,
         &toolchain.manifest_name(),
         true,
     )

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -108,7 +108,6 @@ impl<'a> DistributableToolchain<'a> {
             changes,
             false,
             &download_cfg,
-            &download_cfg.notify_handler,
             &self.desc.manifest_name(),
             false,
         )?;
@@ -500,7 +499,6 @@ impl<'a> DistributableToolchain<'a> {
             changes,
             false,
             &download_cfg,
-            &download_cfg.notify_handler,
             &self.desc.manifest_name(),
             false,
         )?;


### PR DESCRIPTION
All calls to update() were just passing it in already.