### PR TITLE
Return the right lifetime from DistributableToolchain::install

### DIFF
--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -320,7 +320,7 @@ impl<'a> DistributableToolchain<'a> {
         targets: &[&str],
         profile: Profile,
         force: bool,
-    ) -> anyhow::Result<(UpdateStatus, Self)> {
+    ) -> anyhow::Result<(UpdateStatus, DistributableToolchain<'a>)> {
         let hash_path = cfg.get_hash_file(desc, true)?;
         let update_hash = Some(&hash_path as &Path);
 


### PR DESCRIPTION
With Self this infers an lifetime of '_ rather than 'a, which leads to a
compile error when the function is made async.