### PR TITLE
Remove redundant message if an error occurs during package extraction

### DIFF
--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -151,7 +151,7 @@ impl<'a> TarPackage<'a> {
         // $pkgname-$version-$target. Skip that directory when
         // unpacking.
         unpack_without_first_dir(&mut archive, &temp_dir, notify_handler)
-            .context("failed to extract package (perhaps you ran out of disk space?)")?;
+            .context("failed to extract package")?;
 
         Ok(TarPackage(
             DirectoryPackage::new(temp_dir.to_owned(), false)?,


### PR DESCRIPTION
This is the message when there is an error on extracting, it does contain the source of the cause. For example, when out of space on extraction:
> error: failed to extract package (perhaps you ran out of disk space?): No space left on device (os error 28)

This PR remove the message in parentheses like this:
> error: failed to extract package: No space left on device (os error 28)

Note: the error message already contains the source of cause by the selector "{:#}" in `cli::common::report_error`.
See also: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations