### PR TITLE
Support `stable-DELTA` as a version descriptor

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -53,17 +53,21 @@ pub(crate) static TOOLCHAIN_HELP: &str = r"Discussion:
 
     Standard release channel toolchain names have the following form:
 
-        <channel>[-<date>][-<host>]
+        <channel>[-<date-or-delta>][-<host>]
 
-        <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
-        <date>          = YYYY-MM-DD
-        <host>          = <target-triple>
+        <channel>        = stable|beta|nightly|<major.minor>|<major.minor.patch>
+        <date-or-delta>  = <date>|<delta>
+        <date>           = YYYY-MM-DD
+        <delta>          = <minor>
+        <host>           = <target-triple>
 
     'channel' is a named release channel, a major and minor version
     number such as `1.42`, or a fully specified version number, such
     as `1.42.0`. Channel names can be optionally appended with an
     archive date, as in `nightly-2014-12-18`, in which case the
     toolchain is downloaded from the archive for that date.
+
+    TODO Talk about 'delta'
 
     The host may be specified as a target triple. This is most useful
     for installing a 32-bit compiler on a 64-bit platform, or for

--- a/src/config.rs
+++ b/src/config.rs
@@ -659,10 +659,10 @@ impl Cfg {
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
     pub(crate) fn find_or_install_override_toolchain_or_default(
         &self,
-        path: &Path,
+        override_config_path: &Path,
     ) -> Result<(Toolchain<'_>, Option<OverrideReason>)> {
         let (toolchain, components, targets, reason, profile) =
-            match self.find_override_config(path)? {
+            match self.find_override_config(override_config_path)? {
                 Some((
                     OverrideCfg {
                         toolchain,

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -159,6 +159,24 @@ static TRIPLE_MIPS64_UNKNOWN_LINUX_GNUABI64: &str = "mips64-unknown-linux-gnuabi
 #[cfg(all(not(windows), target_endian = "little"))]
 static TRIPLE_MIPS64_UNKNOWN_LINUX_GNUABI64: &str = "mips64el-unknown-linux-gnuabi64";
 
+/// Some old Rust versions don't have v2 manifests, but they don't have point releases either,
+/// so to make the two-part version numbers work for these versions, specially turn
+/// them into their corresponding ".0" version.
+fn convert_old_two_part_version(version: &str) -> &str {
+    match version {
+        "1.0" => "1.0.0",
+        "1.1" => "1.1.0",
+        "1.2" => "1.2.0",
+        "1.3" => "1.3.0",
+        "1.4" => "1.4.0",
+        "1.5" => "1.5.0",
+        "1.6" => "1.6.0",
+        "1.7" => "1.7.0",
+        "1.8" => "1.8.0",
+        other => other,
+    }
+}
+
 impl FromStr for ParsedToolchainDesc {
     type Err = anyhow::Error;
     fn from_str(desc: &str) -> Result<Self> {
@@ -181,21 +199,7 @@ impl FromStr for ParsedToolchainDesc {
                 }
             }
 
-            // These versions don't have v2 manifests, but they don't have point releases either,
-            // so to make the two-part version numbers work for these versions, specially turn
-            // them into their corresponding ".0" version.
-            let channel = match c.get(1).unwrap().as_str() {
-                "1.0" => "1.0.0",
-                "1.1" => "1.1.0",
-                "1.2" => "1.2.0",
-                "1.3" => "1.3.0",
-                "1.4" => "1.4.0",
-                "1.5" => "1.5.0",
-                "1.6" => "1.6.0",
-                "1.7" => "1.7.0",
-                "1.8" => "1.8.0",
-                other => other,
-            };
+            let channel = convert_old_two_part_version(c.get(1).unwrap().as_str());
 
             Self {
                 channel: channel.to_owned(),

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -191,20 +191,21 @@ impl FromStr for ParsedToolchainDesc {
         }
 
         let d = TOOLCHAIN_CHANNEL_RE.captures(desc).map(|c| {
-            fn fn_map(s: &str) -> Option<String> {
-                if s.is_empty() {
-                    None
-                } else {
-                    Some(s.to_owned())
-                }
-            }
-
             let channel = convert_old_two_part_version(c.get(1).unwrap().as_str());
+
+            let non_empty_component = |idx: usize| {
+                c.get(idx)
+                    .filter(|s| !s.is_empty())
+                    .map(|s| s.as_str().to_owned())
+            };
+
+            let date = non_empty_component(2);
+            let target = non_empty_component(3);
 
             Self {
                 channel: channel.to_owned(),
-                date: c.get(2).map(|s| s.as_str()).and_then(fn_map),
-                target: c.get(3).map(|s| s.as_str()).and_then(fn_map),
+                date,
+                target,
             }
         });
 

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -190,30 +190,27 @@ impl FromStr for ParsedToolchainDesc {
             static ref TOOLCHAIN_CHANNEL_RE: Regex = Regex::new(&TOOLCHAIN_CHANNEL_PATTERN).unwrap();
         }
 
-        let d = TOOLCHAIN_CHANNEL_RE.captures(desc).map(|c| {
-            let channel = convert_old_two_part_version(c.get(1).unwrap().as_str());
+        TOOLCHAIN_CHANNEL_RE
+            .captures(desc)
+            .map(|c| {
+                let channel = convert_old_two_part_version(c.get(1).unwrap().as_str());
 
-            let non_empty_component = |idx: usize| {
-                c.get(idx)
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.as_str().to_owned())
-            };
+                let non_empty_component = |idx: usize| {
+                    c.get(idx)
+                        .filter(|s| !s.is_empty())
+                        .map(|s| s.as_str().to_owned())
+                };
 
-            let date = non_empty_component(2);
-            let target = non_empty_component(3);
+                let date = non_empty_component(2);
+                let target = non_empty_component(3);
 
-            Self {
-                channel: channel.to_owned(),
-                date,
-                target,
-            }
-        });
-
-        if let Some(d) = d {
-            Ok(d)
-        } else {
-            Err(RustupError::InvalidToolchainName(desc.to_string()).into())
-        }
+                Self {
+                    channel: channel.to_owned(),
+                    date,
+                    target,
+                }
+            })
+            .ok_or_else(|| RustupError::InvalidToolchainName(desc.to_owned()).into())
     }
 }
 


### PR DESCRIPTION
Closes #2291.

The current implementation proposal is posted in https://github.com/rust-lang/rustup/issues/2291#issuecomment-1689220651.