### PR TITLE
rustup-init.sh ksh and zsh compatibility fixes

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -19,6 +19,10 @@ has_local() {
 
 has_local 2>/dev/null || alias local=typeset
 
+# zsh does not split words by default, Required for curl retry arguments below.
+if [ -n "$ZSH_VERSION" ]; then
+    setopt shwordsplit
+fi
 
 set -u
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 # shellcheck shell=dash
+# shellcheck disable=SC2039  # local is non-POSIX
 
 # This is just a little script that can be downloaded from the internet to
 # install rustup. It just does platform detection, downloads the installer
@@ -8,13 +9,15 @@
 # It runs on Unix shells like {a,ba,da,k,z}sh. It uses the common `local`
 # extension. Note: Most shells limit `local` to 1 var per line, contra bash.
 
-if [ "$KSH_VERSION" = 'Version JM 93t+ 2010-03-05' ]; then
-    # The version of ksh93 that ships with many illumos systems does not
-    # support the "local" extension.  Print a message rather than fail in
-    # subtle ways later on:
-    echo 'rustup does not work with this ksh93 version; please try bash!' >&2
-    exit 1
-fi
+# Some versions of ksh have no `local` keyword. Alias it to `typeset`, but
+# beware this makes variables global with f()-style function syntax in ksh93.
+# mksh has this alias by default.
+has_local() {
+    # shellcheck disable=SC2034  # deliberately unused
+    local _has_local
+}
+
+has_local 2>/dev/null || alias local=typeset
 
 
 set -u


### PR DESCRIPTION
Fixes #3388
Fixes #3474

Tested with:
|Shell|Versions|
|-|-|
|bash|(ubuntu) 5.1.16(1)-release|
|dash|(ubuntu) 0.5.11+git20210903+057cd650a4ed-3build1<br>(debian) 0.5.12-2|
|ksh93|(illumos) Version jM 93u+ 2012-08-01<br>(ubuntu) Version AJM 93u+m/1.0.0-beta.2 2021-12-17|
|mksh|(ubuntu) @(#)MIRBSD KSH R59 2022/01/31 +Debian|
|zsh|(ubuntu) 5.8.1|
