### PR TITLE
Do not fallback to "arm" in rustup-init.sh on aarch64 with 32-bit userland

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -517,8 +517,8 @@ get_architecture() {
     # and fall back to arm.
     # See https://github.com/rust-lang/rustup.rs/issues/587.
     if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
-        if ensure grep '^Features' /proc/cpuinfo | grep -q -v neon; then
-            # At least one processor does not have NEON.
+        if ensure grep '^Features' /proc/cpuinfo | grep -E -q -v 'neon|simd'; then
+            # At least one processor does not have NEON (which is asimd on armv8+).
             _cputype=arm
         fi
     fi


### PR DESCRIPTION
On aarch64, neon will not be present in /proc/cpuinfo, instead asimd is there. Previously, we'd fall back to arm when running with a 32-bit userland, even though armv7 is perfectly appropriate in this case.

This would then run into the issue described in https://github.com/rust-lang/rust/issues/58414 with "CP15 barrier emulation".

This PR fixes that.