### PR TITLE
Make the toolchain overriding config hierarchical

### DIFF
--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -12,14 +12,18 @@ and override which toolchain is used:
 5. The [default toolchain].
 
 The toolchain is chosen in the order listed above, using the first one that is
-specified. There is one exception though: directory overrides and the
-`rust-toolchain.toml` file are also preferred by their proximity to the current
-directory. That is, these two override methods are discovered by walking up
-the directory tree toward the filesystem root, and a `rust-toolchain.toml` file
-that is closer to the current directory will be preferred over a directory
-override that is further away.
+specified. There are a number of caveats though:
 
-To verify which toolchain is active, you can use `rustup show`, 
+- Directory overrides and `rust-toolchain.toml` overrides are determined together.
+  Since each of them is bounded to the directory it was set in, to find out
+  which of them to use, `rustup` walks up the directory tree towards the
+  filesystem root, and whichever has its bounded directory closest to the
+  current directory wins. If that same closest directory has both overrides,
+  then `rust-toolchain.toml` is overridden by the directory override.
+- When overriding a `rust-toolchain.toml`, its `components` and `targets`
+  will be carried over to the new toolchain.
+
+To verify which toolchain is active, you can use `rustup show`,
 which will also try to install the corresponding
 toolchain if the current one has not been installed according to the above rules.
 (Please note that this behavior is subject to change, as detailed in issue [#1397].)

--- a/src/config.rs
+++ b/src/config.rs
@@ -581,9 +581,8 @@ impl Cfg {
         settings: &Settings,
     ) -> Result<Option<(OverrideFile, OverrideReason)>> {
         let notify = self.notify_handler.as_ref();
-        let mut dir = Some(dir);
 
-        while let Some(d) = dir {
+        for d in iter::successors(Some(dir), |d| d.parent()) {
             // First check the override database
             if let Some(name) = settings.dir_override(d, notify) {
                 let reason = OverrideReason::OverrideDB(d.to_owned());
@@ -664,8 +663,6 @@ impl Cfg {
                 let reason = OverrideReason::ToolchainFile(toolchain_file);
                 return Ok(Some((override_file, reason)));
             }
-
-            dir = d.parent();
         }
 
         Ok(None)

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2027,6 +2027,49 @@ fn plus_override_beats_file_override() {
     });
 }
 
+// Ensures that the specified toolchain components and targets still work even if the toolchain is already installed.
+// See: <https://github.com/rust-lang/rustup/pull/3492#issuecomment-1793382483>
+#[test]
+fn file_override_beats_existing_toolchain() {
+    use clitools::MULTI_ARCH1;
+
+    test(&|config| {
+        config.with_scenario(Scenario::MultiHost, &|config| {
+            let beta = "hash-beta-1.2.0";
+            config.expect_ok(&[
+                "rustup",
+                "toolchain",
+                "install",
+                "beta",
+                "--profile=minimal",
+            ]);
+            config.expect_ok(&["rustup", "override", "set", "beta"]);
+
+            let cwd = config.current_dir();
+            let toolchain_file = cwd.join("rust-toolchain.toml");
+            raw::write_file(
+                &toolchain_file,
+                &format!(
+                    r#"
+                        [toolchain]
+                        channel = "beta"
+                        components = [ "rls" ]
+                        targets = [ "{MULTI_ARCH1}" ]
+                    "#,
+                ),
+            )
+            .unwrap();
+
+            // Implicitly install the missing components and targets.
+            config.expect_stdout_ok(&["rustc", "--version"], beta);
+
+            let list_installed = &["rustup", "component", "list", "--installed"];
+            config.expect_stdout_ok(list_installed, "rls-");
+            config.expect_stdout_ok(list_installed, &format!("rust-std-{MULTI_ARCH1}"));
+        })
+    });
+}
+
 #[test]
 fn file_override_not_installed_custom() {
     test(&|config| {


### PR DESCRIPTION
Fixes #3483.

Quoting https://rust-lang.github.io/rustup/overrides.html:

> `rustup` automatically determines which [toolchain] to use when one of the
> installed commands like `rustc` is executed. There are several ways to control
> and override which toolchain is used:
> 
> 1. A [toolchain override shorthand] used on the command-line, such as `cargo +beta`.
> 2. The `RUSTUP_TOOLCHAIN` environment variable.
> 3. A [directory override], set with the `rustup override` command.
> 4. The [`rust-toolchain.toml`] file.
> 5. The [default toolchain].

Please note that the "hierarchical config" we are talking about here is different from what `cargo` does right now:
`rustup` won't do file system-based config hierarchy, which means 3. and 4. will be merged if and only if they are from the same directory, otherwise only the one that comes first in terms of proximity from the current working directory will be merged.

## Concerns

- [ ] Figure out the interactions with https://github.com/rust-lang/rfcs/pull/3279.
    * This PR has been blocked on its implementation. 
- [x] Clarify the way in which`rustup override` should interact with `rust-toolchain.toml`.
   * Currently, in `find_override_from_dir_walk`, we find the first directory that has either one of those, and return immediately. There is no merging even at the same level.
     - Solution: We do the merging at the same level and keep the early return.
   * ~~To be consistent with `cargo` we need to check what we have from both sides at each level (`rustup override` first), and `dir_walk` all the way up, merging all the `rustup override` + `rust-toolchain.toml` overrides in the process. However, will this cause significant performance penalties?~~
     - We won't support that kind of file system-based config hierarchy.
- [x] Add some new test cases to the test suite.
- [x] ~~Provide an escape hatch, for the case where someone has configured defaults that are incompatible with the channel they are overriding.~~
  * ~~One possible escape hatch is just to document that installation defaults are ignored if the toolchain is already installed.~~
- [x] Adjust the current docs accordingly.
