### PR TITLE
Windows library loading

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -27,4 +27,44 @@ fn main() {
     }
     let target = env::var("TARGET").unwrap();
     println!("cargo:rustc-env=TARGET={target}");
+
+    // Set linker options specific to Windows MSVC.
+    let target_os = env::var("CARGO_CFG_TARGET_OS");
+    let target_env = env::var("CARGO_CFG_TARGET_ENV");
+    if !(target_os.as_deref() == Ok("windows") && target_env.as_deref() == Ok("msvc")) {
+        return;
+    }
+
+    // # Only search system32 for DLLs
+    //
+    // This applies to DLLs loaded at load time. However, this setting is ignored
+    // before Windows 10 RS1 (aka 1601).
+    // https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170
+    println!("cargo:cargo:rustc-link-arg-bin=rustup-init=/DEPENDENTLOADFLAG:0x800");
+
+    // # Delay load
+    //
+    // Delay load dlls that are not "known DLLs"[1].
+    // Known DLLs are always loaded from the system directory whereas other DLLs
+    // are loaded from the application directory. By delay loading the latter
+    // we can ensure they are instead loaded from the system directory.
+    // [1]: https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#factors-that-affect-searching
+    //
+    // This will work on all supported Windows versions but it relies on
+    // us using `SetDefaultDllDirectories` before any libraries are loaded.
+    // See also: src/bin/rustup-init.rs
+    let delay_load_dlls = ["bcrypt", "powrprof", "secur32"];
+    for dll in delay_load_dlls {
+        println!("cargo:rustc-link-arg-bin=rustup-init=/delayload:{dll}.dll");
+    }
+    // When using delayload, it's necessary to also link delayimp.lib
+    // https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170
+    println!("cargo:rustc-link-arg-bin=rustup-init=delayimp.lib");
+
+    // # Turn linker warnings into errors
+    //
+    // Rust hides linker warnings meaning mistakes may go unnoticed.
+    // Turning them into errors forces them to be displayed (and the build to fail).
+    // If we do want to ignore specific warnings then `/IGNORE:` should be used.
+    println!("cargo:cargo:rustc-link-arg-bin=rustup-init=/WX");
 }


### PR DESCRIPTION
When loading DLLs, the loader uses a [standard search order](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-search-order#standard-search-order-for-unpackaged-apps) that may include the application directory. To ensure the right DLLs get loaded, this PR makes sure to force DLLs to be loaded from system32. This is done using [`/DEPENDENTLOADFLAG`](https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170) msvc linker option. However this only works for Windows 10 RS1 and higher (which admittedly is almost all Windows 10 users) and will have no effect on earlier OSes. So as a fallback we use the [delay load](https://learn.microsoft.com/en-us/cpp/build/reference/delayload-delay-load-import?view=msvc-170) mechanism to get the DLLs loaded at runtime so that we can use [SetDefaultDllDirectories](https://learn.microsoft.com/en-us/windows/win32/api/LibLoaderAPI/nf-libloaderapi-setdefaultdlldirectories) to affect DLL loading.  Note that DLLs on the system's list of "Known DLLs" are always loaded from system32 so don't need to be delay loaded this way.