### PR TITLE
Avoid warning for unused variant

### DIFF
--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -19,7 +19,7 @@ pub(super) enum StreamSelector {
     Stderr,
     #[cfg(feature = "test")]
     TestWriter(TestWriter),
-    #[cfg(feature = "test")]
+    #[cfg(all(test, feature = "test"))]
     TestTtyWriter(TestWriter),
 }
 
@@ -38,7 +38,7 @@ impl StreamSelector {
             },
             #[cfg(feature = "test")]
             StreamSelector::TestWriter(_) => false,
-            #[cfg(feature = "test")]
+            #[cfg(all(test, feature = "test"))]
             StreamSelector::TestTtyWriter(_) => true,
         }
     }
@@ -100,9 +100,9 @@ impl ColorableTerminal {
                 TerminalInner::StandardStream(StandardStream::stderr(choice), ColorSpec::new())
             }
             #[cfg(feature = "test")]
-            StreamSelector::TestWriter(w) | StreamSelector::TestTtyWriter(w) => {
-                TerminalInner::TestWriter(w, choice)
-            }
+            StreamSelector::TestWriter(w) => TerminalInner::TestWriter(w, choice),
+            #[cfg(all(test, feature = "test"))]
+            StreamSelector::TestTtyWriter(w) => TerminalInner::TestWriter(w, choice),
         };
         ColorableTerminal {
             inner: Arc::new(Mutex::new(inner)),


### PR DESCRIPTION
The `StreamSelector::TestTtyWriter` variant was previously guarded with `feature = test` but not `test`. Because it's only used in unit tests in the same module that means rustc would yield a warning for an unused variable if the crate is compiled with `--features test` but without actually running the tests.