### PR TITLE
Adjust instructions for manual installation

### DIFF
--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -55,8 +55,11 @@ which is a `brew`-managed `rust` toolchain installation.
 
 ## Manual installation
 
-If you prefer you can directly download `rustup-init` for the platform of your
-choice:
+You can manually download `rustup-init` for a given target from
+`https://static.rust-lang.org/rustup/dist/{target-triple}/rustup-init[.exe]`[^msvc].
+
+<details>
+<summary>Direct links</summary>
 
 - [aarch64-apple-darwin](https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init.sha256)
@@ -121,6 +124,13 @@ choice:
 - [x86_64-unknown-netbsd](https://static.rust-lang.org/rustup/dist/x86_64-unknown-netbsd/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/x86_64-unknown-netbsd/rustup-init.sha256)
 
+</details>
+
+To get a previous version, use
+`https://static.rust-lang.org/rustup/archive/{rustup-version}/{target-triple}/rustup-init[.exe]`.
+
+SHA-256 checksums are also available by appending `.sha256` to the link.
+
 [^msvc]: MSVC builds of `rustup` additionally require an [installation of
     Visual Studio 2019 or the Visual C++ Build Tools 2019][vs]. For Visual
     Studio, make sure to check the "C++ tools" and "Windows 10 SDK" option. No
@@ -128,9 +138,6 @@ choice:
     build.
 
 [vs]: https://visualstudio.microsoft.com/downloads/
-
-You can fetch an older version from
-`https://static.rust-lang.org/rustup/archive/{rustup-version}/{target-triple}/rustup-init[.exe]`
 
 ## Self-compiled installation
 


### PR DESCRIPTION
Closes #3484.

This PR makes direct links in the Manual Installation section foldable so that one might be able to find the link format for previous versions and SHA-256 checksums even easier:

<img width="767" alt="image" src="https://github.com/rust-lang/rustup/assets/33851577/05015599-00a2-4698-b195-d419076070d0">

