### PR TITLE
Restrict zsh `shwordsplit` to `downloader()`

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -19,10 +19,9 @@ has_local() {
 
 has_local 2>/dev/null || alias local=typeset
 
-# zsh does not split words by default, Required for curl retry arguments below.
-if [ -n "$ZSH_VERSION" ]; then
-    setopt shwordsplit
-fi
+is_zsh() {
+    [ -n "${ZSH_VERSION-}" ]
+}
 
 set -u
 
@@ -575,6 +574,9 @@ ignore() {
 # This wraps curl or wget. Try curl first, if not installed,
 # use wget instead.
 downloader() {
+    # zsh does not split words by default, Required for curl retry arguments below.
+    is_zsh && setopt local_options shwordsplit
+
     local _dld
     local _ciphersuites
     local _err


### PR DESCRIPTION
Tiny style nitting of the #3475 patch, see https://github.com/rust-lang/rustup/pull/3475#discussion_r1352179564 for the context.

Adapted from [`nvm.sh`](https://github.com/nvm-sh/nvm/blob/8a83b36688e270e460803ab842e3333393b523c7/nvm.sh#L16-L18), tested on `zsh 5.9-r2` and `ash` (from `busybox-1.36.1-r4`) using Alpine Linux 3.18.

cc @alexhudspith 