### PR TITLE
Rewrite `toolchain_sort` to prevent panics

### DIFF
--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -313,8 +313,6 @@ impl Display for ToolchainName {
 /// 2. `X.Y.Z-suffix` names, sorted by semver rules on `X.Y.Z`, then by `suffix`.
 /// 3. Other names, sorted alphanumerically.
 pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
-    use semver::Version;
-
     v.sort_by_key(|name| {
         let s = name.to_string();
         if s.starts_with("stable") {
@@ -327,7 +325,7 @@ pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
             return (2, None, s);
         }
         if let Some((ver_str, suffix)) = s.split_once('-') {
-            if let Ok(ver) = Version::parse(ver_str) {
+            if let Ok(ver) = semver::Version::parse(ver_str) {
                 return (3, Some(ver), suffix.to_owned());
             }
         }

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -321,7 +321,8 @@ pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
         }
     }
 
-    fn toolchain_sort_key(s: &str) -> Version {
+    v.sort_by_key(|name| {
+        let s: &str = &format!("{name}");
         if s.starts_with("stable") {
             special_version(0, s)
         } else if s.starts_with("beta") {
@@ -331,9 +332,7 @@ pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
         } else {
             Version::parse(&s.replace('_', "-")).unwrap_or_else(|_| special_version(3, s))
         }
-    }
-
-    v.sort_by_key(|name| toolchain_sort_key(&format!("{name}")));
+    });
 }
 
 /// ResolvableLocalToolchainName is used to process values set in

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -675,6 +675,9 @@ mod tests {
             "1.2.0-x86_64-unknown-linux-gnu",
             "1.8.0-x86_64-unknown-linux-gnu",
             "1.10.0-x86_64-unknown-linux-gnu",
+            "bar(baz)",
+            "foo#bar",
+            "this.is.not-a+semver",
         ]
         .into_iter()
         .map(|s| ToolchainName::try_from(s).unwrap())
@@ -688,6 +691,10 @@ mod tests {
             "1.10.0-x86_64-unknown-linux-gnu",
             "beta-x86_64-unknown-linux-gnu",
             "1.2.0-x86_64-unknown-linux-gnu",
+            // https://github.com/rust-lang/rustup/issues/3517
+            "foo#bar",
+            "bar(baz)",
+            "this.is.not-a+semver",
         ]
         .into_iter()
         .map(|s| ToolchainName::try_from(s).unwrap())

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -333,13 +333,7 @@ pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
         }
     }
 
-    v.sort_by(|a, b| {
-        let a_str = &format!("{a}");
-        let b_str = &format!("{b}");
-        let a_key = toolchain_sort_key(a_str);
-        let b_key = toolchain_sort_key(b_str);
-        a_key.cmp(&b_key)
-    });
+    v.sort_by_key(|name| toolchain_sort_key(&format!("{name}")));
 }
 
 /// ResolvableLocalToolchainName is used to process values set in

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -308,6 +308,10 @@ impl Display for ToolchainName {
     }
 }
 
+/// Sorts [`ToolchainName`]s in the following order:
+/// 1. `stable`/`beta`/`nightly`-prefixed names, in this exact order.
+/// 2. `X.Y.Z-suffix` names, sorted by semver rules on `X.Y.Z`, then by `suffix`.
+/// 3. Other names, sorted alphanumerically.
 pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
     use semver::Version;
 

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -309,36 +309,26 @@ impl Display for ToolchainName {
 }
 
 pub(crate) fn toolchain_sort(v: &mut [ToolchainName]) {
-    use semver::{BuildMetadata, Prerelease, Version};
+    use semver::Version;
 
     v.sort_by_key(|name| {
-        let s: &str = &format!("{name}");
-        let default_ver = Version {
-            major: 0,
-            minor: 0,
-            patch: 0,
-            pre: Prerelease::EMPTY,
-            build: BuildMetadata::EMPTY,
-        };
-
+        let s = name.to_string();
         if s.starts_with("stable") {
-            let pre = Prerelease::new(&format!("pre.{}.{}", 0, s.replace('_', "-"))).unwrap();
-            return Version { pre, ..default_ver };
+            return (0, None, s);
         }
         if s.starts_with("beta") {
-            let pre = Prerelease::new(&format!("pre.{}.{}", 1, s.replace('_', "-"))).unwrap();
-            return Version { pre, ..default_ver };
+            return (1, None, s);
         }
         if s.starts_with("nightly") {
-            let pre = Prerelease::new(&format!("pre.{}.{}", 2, s.replace('_', "-"))).unwrap();
-            return Version { pre, ..default_ver };
+            return (2, None, s);
         }
-        if let Ok(v) = Version::parse(&s.replace('_', "-")) {
-            return v;
+        if let Some((ver_str, suffix)) = s.split_once('-') {
+            if let Ok(ver) = Version::parse(ver_str) {
+                return (3, Some(ver), suffix.to_owned());
+            }
         }
-        let pre = Prerelease::new(&format!("pre.{}.{}", 3, s.replace('_', "-"))).unwrap();
-        Version { pre, ..default_ver }
-    });
+        (4, None, s)
+    })
 }
 
 /// ResolvableLocalToolchainName is used to process values set in


### PR DESCRIPTION
Fixes #3517 by completely rewriting the `toolchain_sort` function.

The original code uses the hack of putting everything in `semver::Version::pre` which can easily fail.