### PR TITLE
Fix the test toolchain_broken_symlink on Windows

### DIFF
--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -131,7 +131,7 @@ pub fn append_file(dest: &Path, line: &str) -> io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
+pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     #[cfg(windows)]
     fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {
         // std's symlink uses Windows's symlink function, which requires


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rustup/issues/3516

`rustup` on Windows uses "directory junctions" instead of symbolic links for `rustup toolchain link`. These are somewhere between a symbolic and a hard link, and require fewer permissions. However, the test in question was trying to use symbolic links. It now uses the same codepath to create the link as `toolchain link` itself.