### PR TITLE
[doc] windows.md: fix link

### DIFF
--- a/doc/user-guide/src/installation/windows.md
+++ b/doc/user-guide/src/installation/windows.md
@@ -61,6 +61,7 @@ targets with the same compiler.
 
 [ABIs]: https://en.wikipedia.org/wiki/Application_binary_interface
 [cross-compilation]: ../cross-compilation.md
+[Visual Studio]: https://visualstudio.microsoft.com/
 [GCC toolchain]: https://gcc.gnu.org/
 [MSYS2]: https://www.msys2.org/
 [msvc-toolchain]: https://www.rust-lang.org/tools/install?platform_override=win


### PR DESCRIPTION
Link `[Visual Studio]` in https://rust-lang.github.io/rustup/installation/windows.html was not rendered, since its href had been deleted.