### PR TITLE
CI: Disable openssl for loongarch64-unknown-linux-gnu

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -8,10 +8,22 @@ rustc -vV
 cargo -vV
 
 
-FEATURES=('--no-default-features' '--features' 'curl-backend,reqwest-backend,reqwest-default-tls')
+FEATURES=('--no-default-features' '--features' 'reqwest-backend')
 case "$(uname -s)" in
   *NT* ) ;; # Windows NT
-  * ) FEATURES+=('--features' 'vendored-openssl') ;;
+  * )
+    case "$TARGET" in
+      loongarch* ) ;;
+      *) FEATURES+=('--features' 'vendored-openssl') ;;
+    esac
+    ;;
+esac
+
+case "$TARGET" in
+  # these platforms aren't supported by openssl:
+  loongarch* ) ;;
+  # default case, build with openssl enabled
+  * ) FEATURES+=('--features' 'curl-backend,reqwest-default-tls') ;;
 esac
 
 case "$TARGET" in
@@ -20,7 +32,6 @@ case "$TARGET" in
   mips* ) ;;
   riscv* ) ;;
   s390x* ) ;;
-  loongarch* ) ;;
   aarch64-pc-windows-msvc ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
@@ -40,14 +51,21 @@ target_cargo() {
 target_cargo build
 
 download_pkg_test() {
-  features=('--no-default-features' '--features' 'curl-backend,reqwest-backend,reqwest-default-tls')
+  features=('--no-default-features' '--features' 'reqwest-backend')
+
+  case "$TARGET" in
+    # these platforms aren't supported by openssl:
+    loongarch* ) ;;
+    # default case, build with openssl enabled
+    * ) features+=('--features' 'curl-backend,reqwest-default-tls') ;;
+  esac
+
   case "$TARGET" in
     # these platforms aren't supported by ring:
     powerpc* ) ;;
     mips* ) ;;
     riscv* ) ;;
     s390x* ) ;;
-    loongarch* ) ;;
     aarch64-pc-windows-msvc ) ;;
     # default case, build with rustls enabled
     * ) features+=('--features' 'reqwest-rustls-tls') ;;


### PR DESCRIPTION
This [pull request](https://github.com/openssl/openssl/pull/19364) adds vectorized AES, and no vector instructions support detecting. After rustup's openssl-src was updated to include the patch, the build failed:

```
crypto/aes/vpaes-loongarch64.S: Assembler messages:
crypto/aes/vpaes-loongarch64.S:24: Error: no match insn: vori.b	$vr1,$vr9,0
```

The good new is that openssl next bump will [fix the issue](https://github.com/openssl/openssl/pull/21510). For the release of `1.27.0`, this patch temporarily disables the openssl features for `loongarch64-unknown-linux-gnu` target. This change will be reverted after the new openssl is released.