### PR TITLE
Improvements and clean-up for docs and help messages

### DIFF
--- a/doc/user-guide/src/concepts/profiles.md
+++ b/doc/user-guide/src/concepts/profiles.md
@@ -20,15 +20,22 @@ available at this time are `minimal`, `default`, and `complete`:
   install the needed additional components manually, either by using `rustup
   component add` or by using `-c` when installing the toolchain.
 
-To change the `rustup` profile you can use the `rustup set profile` command.
+To change the profile `rustup install` uses by default, you can use the
+`rustup set profile` command.
 For example, to select the minimal profile you can use:
 
 ```console
 rustup set profile minimal
 ```
 
-It's also possible to choose the profile when installing `rustup` for the
-first time, either interactively by choosing the "Customize installation"
+You can also directly select the profile used when installing a toolchain with:
+
+```console
+rustup install --profile <name>
+```
+
+It's also possible to choose the default profile when installing `rustup` for
+the first time, either interactively by choosing the "Customize installation"
 option or programmatically by passing the `--profile=<name>` flag. Profiles
 will only affect newly installed toolchains: as usual it will be possible to
 install individual components later with: `rustup component add`.

--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -137,9 +137,8 @@ host-specific toolchains.
 
 #### path
 
-The `path` setting allows a custom toolchain to be used. The value is a
-path string. A relative path is resolved relative to the location of the
-`rust-toolchain.toml` file.
+The `path` setting allows a custom toolchain to be used. The value is an
+absolute path string.
 
 Since a `path` directive directly names a local toolchain, other options
 like `components`, `targets`, and `profile` have no effect.

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -304,7 +304,7 @@ pub(crate) fn cli() -> Command {
                     Command::new("home")
                         .about("Display the computed value of RUSTUP_HOME"),
                 )
-                .subcommand(Command::new("profile").about("Show the current profile"))
+                .subcommand(Command::new("profile").about("Show the default profile used for the `rustup install` command"))
         )
         .subcommand(
             Command::new("install")
@@ -625,7 +625,7 @@ pub(crate) fn cli() -> Command {
         )
         .subcommand(
             Command::new("override")
-                .about("Modify directory toolchain overrides")
+                .about("Modify toolchain overrides for directories")
                 .after_help(OVERRIDE_HELP)
                 .subcommand_required(true)
                 .arg_required_else_help(true)
@@ -784,7 +784,7 @@ pub(crate) fn cli() -> Command {
                 )
                 .subcommand(
                     Command::new("profile")
-                        .about("The default components installed")
+                        .about("The default components installed with a toolchain")
                         .arg(
                             Arg::new("profile-name")
                                 .required(true)

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -16,7 +16,7 @@ Commands:
   toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
-  override     Modify directory toolchain overrides
+  override     Modify toolchain overrides for directories
   run          Run a command with an environment configured for a given toolchain
   which        Display which binary will be run for a given command
   doc          Open the documentation for the current toolchain

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -16,7 +16,7 @@ Commands:
   toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
-  override     Modify directory toolchain overrides
+  override     Modify toolchain overrides for directories
   run          Run a command with an environment configured for a given toolchain
   which        Display which binary will be run for a given command
   doc          Open the documentation for the current toolchain

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -16,7 +16,7 @@ Commands:
   toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
-  override     Modify directory toolchain overrides
+  override     Modify toolchain overrides for directories
   run          Run a command with an environment configured for a given toolchain
   which        Display which binary will be run for a given command
   doc          Open the documentation for the current toolchain

--- a/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_override_cmd_help_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "rustup"
 args = ["override","--help"]
 stdout = """
 ...
-Modify directory toolchain overrides
+Modify toolchain overrides for directories
 
 Usage: rustup[EXE] override <COMMAND>
 

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
@@ -8,7 +8,7 @@ Usage: rustup[EXE] set <COMMAND>
 
 Commands:
   default-host      The triple used to identify toolchains when not specified
-  profile           The default components installed
+  profile           The default components installed with a toolchain
   auto-self-update  The rustup auto self update mode
   help              Print this message or the help of the given subcommand(s)
 

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_profile_cmd_help_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "rustup"
 args = ["set","profile","--help"]
 stdout = """
 ...
-The default components installed
+The default components installed with a toolchain
 
 Usage: rustup[EXE] set profile <profile-name>
 

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_help_flag_stdout.toml
@@ -9,7 +9,7 @@ Usage: rustup[EXE] show [OPTIONS] [COMMAND]
 Commands:
   active-toolchain  Show the active toolchain
   home              Display the computed value of RUSTUP_HOME
-  profile           Show the current profile
+  profile           Show the default profile used for the `rustup install` command
   help              Print this message or the help of the given subcommand(s)
 
 Options:

--- a/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_show_cmd_profile_cmd_help_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "rustup"
 args = ["show","profile","--help"]
 stdout = """
 ...
-Show the current profile
+Show the default profile used for the `rustup install` command
 
 Usage: rustup[EXE] show profile
 


### PR DESCRIPTION
I've removed a reference to relative paths in `rust-toolchain.toml` files, as they're no longer supported for security reasons.
I've also tried to improve the clarity and intuitiveness of several help messages, especially around profiles.

It got me thinking: could we rename the profile named "default" to "regular"? It's pretty confusing that there's a default profile and a "default" profile and your default profile doesn't have to be the "default" profile.