### PR TITLE
'llvm-tools-preview' component is now named 'llvm-tools'

### DIFF
--- a/doc/user-guide/src/concepts/components.md
+++ b/doc/user-guide/src/concepts/components.md
@@ -57,8 +57,7 @@ toolchains. The following is an overview of the different components:
   [RLS].
 * `rust-mingw` — This contains a linker and platform libraries for building on
   the `x86_64-pc-windows-gnu` platform.
-* `llvm-tools-preview` — This is an experimental component which contains a
-  collection of [LLVM] tools.
+* `llvm-tools` — This component contains a collection of [LLVM] tools.
 * `rustc-dev` — This component contains the compiler as a library. Most users
   will not need this; it is only needed for development *of* tools that link
   to the compiler, such as making modifications to [Clippy].


### PR DESCRIPTION
The `llvm-tools-preview` component is now name `llvm-tools`. It seems this change happened in version 1.67 since `rustup +1.67 component add llvm-tools` succeeds but `rustup +1.66 component add llvm-tools` fails.


