### PR TITLE
CI: Enable openssl and rustls on loongarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1344,9 +1344,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.0+3.2.0"
+version = "300.2.1+3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1ebed1d188c4cd64c2bcd73d6c1fe1092f3d98c111831923cc1b706c3859fca"
+checksum = "3fe476c29791a5ca0d1273c697e96085bbabbbea2ef7afd5617e78a4b40332d3"
 dependencies = [
  "cc",
 ]

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -8,22 +8,10 @@ rustc -vV
 cargo -vV
 
 
-FEATURES=('--no-default-features' '--features' 'reqwest-backend')
+FEATURES=('--no-default-features' '--features' 'curl-backend,reqwest-backend,reqwest-default-tls')
 case "$(uname -s)" in
   *NT* ) ;; # Windows NT
-  * )
-    case "$TARGET" in
-      loongarch* ) ;;
-      *) FEATURES+=('--features' 'vendored-openssl') ;;
-    esac
-    ;;
-esac
-
-case "$TARGET" in
-  # these platforms aren't supported by openssl:
-  loongarch* ) ;;
-  # default case, build with openssl enabled
-  * ) FEATURES+=('--features' 'curl-backend,reqwest-default-tls') ;;
+  * ) FEATURES+=('--features' 'vendored-openssl') ;;
 esac
 
 case "$TARGET" in
@@ -32,6 +20,7 @@ case "$TARGET" in
   mips* ) ;;
   riscv* ) ;;
   s390x* ) ;;
+  loongarch* ) ;;
   aarch64-pc-windows-msvc ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
@@ -51,21 +40,14 @@ target_cargo() {
 target_cargo build
 
 download_pkg_test() {
-  features=('--no-default-features' '--features' 'reqwest-backend')
-
-  case "$TARGET" in
-    # these platforms aren't supported by openssl:
-    loongarch* ) ;;
-    # default case, build with openssl enabled
-    * ) features+=('--features' 'curl-backend,reqwest-default-tls') ;;
-  esac
-
+  features=('--no-default-features' '--features' 'curl-backend,reqwest-backend,reqwest-default-tls')
   case "$TARGET" in
     # these platforms aren't supported by ring:
     powerpc* ) ;;
     mips* ) ;;
     riscv* ) ;;
     s390x* ) ;;
+    loongarch* ) ;;
     aarch64-pc-windows-msvc ) ;;
     # default case, build with rustls enabled
     * ) features+=('--features' 'reqwest-rustls-tls') ;;

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -20,7 +20,6 @@ case "$TARGET" in
   mips* ) ;;
   riscv* ) ;;
   s390x* ) ;;
-  loongarch* ) ;;
   aarch64-pc-windows-msvc ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
@@ -47,7 +46,6 @@ download_pkg_test() {
     mips* ) ;;
     riscv* ) ;;
     s390x* ) ;;
-    loongarch* ) ;;
     aarch64-pc-windows-msvc ) ;;
     # default case, build with rustls enabled
     * ) features+=('--features' 'reqwest-rustls-tls') ;;


### PR DESCRIPTION
This PR updates `openssl-src` to `v300.2.1+3.2.0`, reverts the disabling of `openssl` and enabling `rustls` on loongarch64.