### PR TITLE
Fix component remove error by component name with explicit target triple

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1364,8 +1364,7 @@ fn component_add(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
     let target = get_target(m, &distributable);
 
     for component in m.get_many::<String>("component").unwrap() {
-        let new_component = Component::new_with_target(component, false)
-            .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
+        let new_component = Component::try_new(component, &distributable, target.as_ref())?;
         distributable.add_component(new_component)?;
     }
 
@@ -1385,8 +1384,7 @@ fn component_remove(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
     let target = get_target(m, &distributable);
 
     for component in m.get_many::<String>("component").unwrap() {
-        let new_component = Component::new_with_target(component, false)
-            .unwrap_or_else(|| Component::new(component.to_string(), target.clone(), true));
+        let new_component = Component::try_new(component, &distributable, target.as_ref())?;
         distributable.remove_component(new_component)?;
     }
 

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -468,22 +468,6 @@ impl TargetTriple {
     }
 }
 
-impl std::convert::TryFrom<PartialTargetTriple> for TargetTriple {
-    type Error = &'static str;
-    fn try_from(value: PartialTargetTriple) -> std::result::Result<Self, Self::Error> {
-        if value.arch.is_some() && value.os.is_some() && value.env.is_some() {
-            Ok(Self(format!(
-                "{}-{}-{}",
-                value.arch.unwrap(),
-                value.os.unwrap(),
-                value.env.unwrap()
-            )))
-        } else {
-            Err("Incomplete / bad target triple")
-        }
-    }
-}
-
 impl FromStr for PartialToolchainDesc {
     type Err = anyhow::Error;
     fn from_str(name: &str) -> Result<Self> {

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1367,6 +1367,63 @@ fn add_component() {
 }
 
 #[test]
+fn add_component_by_target_triple() {
+    test(&|config| {
+        config.with_scenario(Scenario::SimpleV2, &|config| {
+            config.expect_ok(&["rustup", "default", "stable"]);
+            config.expect_ok(&[
+                "rustup",
+                "component",
+                "add",
+                &format!("rust-std-{}", clitools::CROSS_ARCH1),
+            ]);
+            let path = format!(
+                "toolchains/stable-{}/lib/rustlib/{}/lib/libstd.rlib",
+                this_host_triple(),
+                clitools::CROSS_ARCH1
+            );
+            assert!(config.rustupdir.has(path));
+        })
+    });
+}
+
+#[test]
+fn fail_invalid_component_name() {
+    test(&|config| {
+        config.with_scenario(Scenario::SimpleV2, &|config| {
+            config.expect_ok(&["rustup", "default", "stable"]);
+            config.expect_err(
+                &[
+                    "rustup",
+                    "component",
+                    "add",
+                    &format!("dummy-{}", clitools::CROSS_ARCH1),
+                ],
+                &format!("error: toolchain 'stable-{}' does not contain component 'dummy-{}' for target '{}'",this_host_triple(), clitools::CROSS_ARCH1, this_host_triple()),
+            );
+        })
+    });
+}
+
+#[test]
+fn fail_invalid_component_target() {
+    test(&|config| {
+        config.with_scenario(Scenario::SimpleV2, &|config| {
+            config.expect_ok(&["rustup", "default", "stable"]);
+            config.expect_err(
+                &[
+                    "rustup",
+                    "component",
+                    "add",
+                    "rust-std-invalid-target",
+                ],
+                &format!("error: toolchain 'stable-{}' does not contain component 'rust-std-invalid-target' for target '{}'",this_host_triple(),  this_host_triple()),
+            );
+        })
+    });
+}
+
+#[test]
 fn remove_component() {
     test(&|config| {
         config.with_scenario(Scenario::SimpleV2, &|config| {
@@ -1384,21 +1441,60 @@ fn remove_component() {
 }
 
 #[test]
+fn remove_component_by_target_triple() {
+    let component_with_triple = format!("rust-std-{}", clitools::CROSS_ARCH1);
+    test(&|config| {
+        config.with_scenario(Scenario::SimpleV2, &|config| {
+            config.expect_ok(&["rustup", "default", "stable"]);
+            config.expect_ok(&["rustup", "component", "add", &component_with_triple]);
+            let path = PathBuf::from(format!(
+                "toolchains/stable-{}/lib/rustlib/{}/lib/libstd.rlib",
+                this_host_triple(),
+                clitools::CROSS_ARCH1
+            ));
+            assert!(config.rustupdir.has(&path));
+            config.expect_ok(&["rustup", "component", "remove", &component_with_triple]);
+            assert!(!config.rustupdir.has(path.parent().unwrap()));
+        })
+    });
+}
+
+#[test]
 fn add_remove_multiple_components() {
     let files = [
         "lib/rustlib/src/rust-src/foo.rs".to_owned(),
         format!("lib/rustlib/{}/analysis/libfoo.json", this_host_triple()),
+        format!("lib/rustlib/{}/lib/libstd.rlib", clitools::CROSS_ARCH1),
+        format!("lib/rustlib/{}/lib/libstd.rlib", clitools::CROSS_ARCH2),
     ];
+    let component_with_triple1 = format!("rust-std-{}", clitools::CROSS_ARCH1);
+    let component_with_triple2 = format!("rust-std-{}", clitools::CROSS_ARCH2);
 
     test(&|config| {
         config.with_scenario(Scenario::SimpleV2, &|config| {
             config.expect_ok(&["rustup", "default", "nightly"]);
-            config.expect_ok(&["rustup", "component", "add", "rust-src", "rust-analysis"]);
+            config.expect_ok(&[
+                "rustup",
+                "component",
+                "add",
+                "rust-src",
+                "rust-analysis",
+                &component_with_triple1,
+                &component_with_triple2,
+            ]);
             for file in &files {
                 let path = format!("toolchains/nightly-{}/{}", this_host_triple(), file);
                 assert!(config.rustupdir.has(&path));
             }
-            config.expect_ok(&["rustup", "component", "remove", "rust-src", "rust-analysis"]);
+            config.expect_ok(&[
+                "rustup",
+                "component",
+                "remove",
+                "rust-src",
+                "rust-analysis",
+                &component_with_triple1,
+                &component_with_triple2,
+            ]);
             for file in &files {
                 let path = PathBuf::from(format!(
                     "toolchains/nightly-{}/{}",


### PR DESCRIPTION
Fix #3166

Follow by #3467, another approach to fix the error.

## Rationale

 The basic point of this PR is to improve the error message when Rustup somehow cannot recognize a component's full name by extracting the component name first from the manifest when parsing `rust-std-x-y-z`, so that at least `x-y-z` is intended to be a target triple. This prevents Rustup from falling back on the default target triple, producing an error message that is not very helpful (see the quote below).

The direct cause of #3166 is that `wasm32-unknown-unknown` hasn't been hardcoded into our codebase:

https://github.com/rust-lang/rustup/blob/a6c9fae915f41d611ab88ddd2228e19ea978ecaa/src/dist/triple.rs#L7-L37

... but that's another issue (later split into #3783), i.e. we really should not hardcode target triples in our artifact, as the complete list changes quite regularly.

The old `component_(add|remove)()` functions rely on the `new_with_target()` function; on the other hand, the new implementation of those two functions in this PR is based on `distributable` and `fallback_target`, which relies on detecting the component names (fetched from the distributable manifest) first, so will be more robust implementation-wise.

> For the case in #3166:
> 
> > rustup component remove rust-std-wasm32-unknown-unknown
> 
> Because of rustup cannot parse `wasm32-unknown-unknown` as a valid target, the `rust-std-wasm32-unknown-unknown` here is treated as a component name, and the target inferred to be `x86_64-apple-darwin` for this case. The error message as following:
> 
> > error: toolchain 'nightly-x86_64-apple-darwin' does not contain component 'rust-std-wasm32-unknown-unknown' for target 'x86_64-apple-darwin'
> > note: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html
> 
> The actual component and target should be `rust-std` and `wasm32-unknown-unknown` in this error message respectively.
> This is subtle because component name may also contains a '-' character (`rust-std` in this case), the component name is determined by user input subtract from possible target suffix currently (`TryFrom<PartialTargetTriple>`).

_https://github.com/rust-lang/rustup/pull/3467#issuecomment-1714078977_