### PR TITLE
chore(deps): update `renovate.json` to remove version bumps covered by lockfile maintenance PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,21 +24,6 @@
                 "opentelemetry"
             ],
             "groupName": "opentelemetry"
-        },
-        {
-            "matchUpdateTypes": [
-                "minor",
-                "patch"
-            ],
-            "matchCurrentVersion": "!/^0/",
-            "automerge": true
-        },
-        {
-            "matchUpdateTypes": [
-                "patch"
-            ],
-            "matchCurrentVersion": "/^0\\./",
-            "automerge": true
         }
     ]
 }


### PR DESCRIPTION
Closes #3623.

The `config:base` a.k.a. `config:recommended` preset should work out of the box, so patch bump PRs for v0 and patch/minor bump PRs for v1+ should no longer be needed.