### PR TITLE
chore(deps): update `renovate.json` to remove version bumps covered by lockfile maintenance PRs, take 2

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,21 @@
     },
     "packageRules": [
         {
+            "matchManagers": ["cargo"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["cargo"],
+            "matchUpdateTypes": ["major"],
+            "enabled": true
+        },
+        {
+            "matchManagers": ["cargo"],
+            "matchUpdateTypes": ["minor"],
+            "matchCurrentVersion": "/^0\\./",
+            "enabled": true
+        },
+        {
             "matchPackagePatterns": [
                 "opentelemetry"
             ],


### PR DESCRIPTION
Closes #3623.

Since #3626 didn't work, this PR tries another approach to solve this problem. It first disables all cargo version bumps, then add only two cases to the whitelist:
- All major updates;
- All minor updates for v0.

cc https://github.com/renovatebot/renovate/discussions/22694