### PR TITLE
chore(deps): update `renovate.json` to remove version bumps covered by lockfile maintenance PRs, take 3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -21,18 +21,14 @@
     "packageRules": [
         {
             "matchManagers": ["cargo"],
+            "matchUpdateTypes": ["patch"],
             "enabled": false
         },
         {
             "matchManagers": ["cargo"],
-            "matchUpdateTypes": ["major"],
-            "enabled": true
-        },
-        {
-            "matchManagers": ["cargo"],
             "matchUpdateTypes": ["minor"],
-            "matchCurrentVersion": "/^0\\./",
-            "enabled": true
+            "matchCurrentVersion": "!/^0/",
+            "enabled": false
         },
         {
             "matchPackagePatterns": [


### PR DESCRIPTION
Closes #3623.

#3632 did remove unnecessary version bumps, but the lockfile maintenance PRs have also been accidentally stopped since earlier this month (Jan 2024).

This PR returns to the original approach by adding two cases to the blacklist:

- All patch updates;
- All minor updates for v1+.

(Sorry for all the trouble, @djc!)