### PR TITLE
Add browser detection for RISC-V 64 platform

### DIFF
--- a/www/rustup.js
+++ b/www/rustup.js
@@ -23,6 +23,7 @@ function detect_platform() {
     if (navigator.platform == "Linux ppc64") {os = "unix";}
     if (navigator.platform == "Linux mips") {os = "unix";}
     if (navigator.platform == "Linux mips64") {os = "unix";}
+    if (navigator.platform == "Linux riscv64") {os = "unix";}
     if (navigator.platform == "Mac") {os = "unix";}
     if (navigator.platform == "Win32") {os = "win32";}
     if (navigator.platform == "Win64" ||


### PR DESCRIPTION
I have a RISC-V 64 device, and the website failed to recognize it.

```
I don't recognize your platform.

rustup runs on Windows, Linux, macOS, FreeBSD, NetBSD, and illumos. If you are on one of these platforms and are seeing this then please report an issue (https://github.com/rust-lang/rustup/issues/new), along with the following values:

navigator.platform:
Linux riscv64
navigator.appVersion:
5.0 (X11; Linux riscv64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36
```

I've added detection for ```riscv64```and successfully installed ```rustup``` on my device following the instructions.