### PR TITLE
refactor(cli): clean up `rustup-init` implementation

### DIFF
--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -15,6 +15,8 @@ use crate::{
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
 pub fn main() -> Result<utils::ExitCode> {
+    use clap::error::ErrorKind;
+
     let args: Vec<_> = process().args().collect();
     let arg1 = args.get(1).map(|a| &**a);
 
@@ -107,10 +109,7 @@ pub fn main() -> Result<utils::ExitCode> {
 
     let matches = match cli.try_get_matches_from(process().args_os()) {
         Ok(matches) => matches,
-        Err(e)
-            if e.kind() == clap::error::ErrorKind::DisplayHelp
-                || e.kind() == clap::error::ErrorKind::DisplayVersion =>
-        {
+        Err(e) if [ErrorKind::DisplayHelp, ErrorKind::DisplayVersion].contains(&e.kind()) => {
             write!(process().stdout().lock(), "{e}")?;
             return Ok(utils::ExitCode(0));
         }

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::{builder::PossibleValuesParser, Arg, ArgAction, Command};
+use clap::{builder::PossibleValuesParser, value_parser, Arg, ArgAction, Command};
 
 use crate::{
     cli::{
@@ -9,7 +9,7 @@ use crate::{
     currentprocess::{argsource::ArgSource, filesource::StdoutSource},
     dist::dist::Profile,
     process,
-    toolchain::names::{maybe_official_toolchainame_parser, MaybeOfficialToolchainName},
+    toolchain::names::MaybeOfficialToolchainName,
     utils::utils,
 };
 
@@ -66,7 +66,7 @@ pub fn main() -> Result<utils::ExitCode> {
                 .long("default-toolchain")
                 .num_args(1)
                 .help("Choose a default toolchain to install. Use 'none' to not install any toolchains at all")
-                .value_parser(maybe_official_toolchainame_parser)
+                .value_parser(value_parser!(MaybeOfficialToolchainName))
         )
         .arg(
             Arg::new("profile")

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -95,6 +95,14 @@ macro_rules! try_from_str {
                 $to::validate(&value)
             }
         }
+
+        impl FromStr for $to {
+            type Err = InvalidName;
+
+            fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+                $to::validate(value)
+            }
+        }
     };
     ($from:ty, $to:ident) => {
         impl TryFrom<$from> for $to {
@@ -262,15 +270,6 @@ impl Display for MaybeOfficialToolchainName {
             MaybeOfficialToolchainName::Some(t) => write!(f, "{t}"),
         }
     }
-}
-
-/// Thunk to avoid errors like
-///  = note: `fn(&'2 str) -> Result<CustomToolchainName, <CustomToolchainName as TryFrom<&'2 str>>::Error> {<CustomToolchainName as TryFrom<&'2 str>>::try_from}` must implement `FnOnce<(&'1 str,)>`, for any lifetime `'1`...
-/// = note: ...but it actually implements `FnOnce<(&'2 str,)>`, for some specific lifetime `'2`
-pub(crate) fn maybe_official_toolchainame_parser(
-    value: &str,
-) -> Result<MaybeOfficialToolchainName, InvalidName> {
-    MaybeOfficialToolchainName::try_from(value)
 }
 
 /// ToolchainName can be used in calls to Cfg that alter configuration,


### PR DESCRIPTION
Cherry-picked from #3596.