### PR TITLE
dist: bump `rustup` version to `1.27.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,76 @@
 # Changelog
 
+## [1.27.0] - 2024-01-29
+
+This long-awaited Rustup release has gathered all the new features and fixes since April 2023.
+These changes include improvements in Rustup's maintainability, user experience, compatibility and documentation quality.
+
+The headlines of this release are:
+- Basic support for `fish` shell has been added.
+- Support for the `loongarch64-unknown-linux-gnu` host platform has been added.
+
+Also, it's worth mentioning that Dirkjan Ochtman and rami3l have joined the team and are coordinating this new release.
+
+Finally, the project seems to have attracted a total of 21 new contributors within this release cycle. Looking forward to seeing you again in the future!
+
+### Added
+
+- Add basic support for `fish` shell [pr#3108] 
+- Add the `RUSTUP_TERM_COLOR` environment variable to force the use of colored output [pr#3435]
+- Improve `rustup-init.sh`'s compatibility with `ksh` and `zsh` [pr#3475]
+- Add a warning when running under Rosetta 2 [pr#3068]
+- Add browser detection for RISC-V 64 platform [pr#3642]
+- Add a warning when removing the last/host target for a toolchain [pr#3637]
+
+### Changed
+
+- Upgrade `clap` to v4 [pr#3444]
+- Fix incorrect platform detection on macOS aarch64 due to Rosetta 2 [pr#3438]
+- Fix incorrect platform detection on 32-bit Linux userland with a 64-bit kernel [pr#3488] [pr#3490]
+- Improve Windows system32 DLL loading mechanism [pr#3493]
+- Improve suggestions about missing components [pr#3453]
+- Fix handling of toolchain names with special characters [pr#3518]
+- Fix panic in `component list --toolchain stable` [pr#3548]
+- Rename `llvm-tools-preview` component to `llvm-tools` [pr#3578]
+- Bump a lot of dependencies to their latest versions [pr#renovate-bot]
+
+Thanks go to:
+
+- Anthony Perkins (acperkins)
+- Tianqi (airstone42)
+- Alex Gaynor (alex)
+- Alex Hudspith (alexhudspith)
+- Alan Somers (asomers)
+- Burak Emir (burakemir)
+- Chris Denton (ChrisDenton)
+- cui fliter (cuishuang)
+- Dirkjan Ochtman (djc)
+- Dezhi Wu (dzvon)
+- Eric Swanson (ericswanson-dfinity)
+- Prikshit Gautam (gautamprikshit1)
+- hev (heiher)
+- 二手掉包工程师 (hi-rustin)
+- Kamila Borowska (KamilaBorowska)
+- klensy (klensy)
+- Jakub Beránek (Kobzol)
+- Kornel (kornelski)
+- Matt Harding (majaha)
+- Mathias Brossard (mbrossard)
+- Christian Thackston (nan60)
+- Olivier Lemasle (olivierlemasle)
+- Chih Wang (ongchi)
+- Pavel Roskin (proski)
+- rami3l (rami3l)
+- Robert Collins (rbtcollins)
+- Sandesh  Pyakurel (Sandesh-Pyakurel)
+- Waffle Maybe (WaffleLapkin)
+- Jubilee (workingjubilee)
+- WÁNG Xuěruì (xen0n)
+- Yerkebulan Tulibergenov (yerke)
+- Renovate Bot (renovate)
+
+**Full Changelog**: https://github.com/rust-lang/rustup/compare/1.26.0...1.27.0
+
 ## [1.26.0] - 2023-04-05
 
 This version of Rustup involves a significant number of internal refactors, both in terms

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "download"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "anyhow",
  "curl",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.26.0"
+version = "1.27.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup"
-version = "1.26.0"
+version = "1.27.0"
 edition = "2021"
 description = "Manage multiple rust installations with ease"
 homepage = "https://github.com/rust-lang/rustup"

--- a/ci/changelog_helper.py
+++ b/ci/changelog_helper.py
@@ -1,0 +1,86 @@
+import json
+import re
+import subprocess
+import sys
+
+
+def extract_usernames(text):
+    return sorted(set(re.findall(r"@([\w-]+)", text)), key=str.casefold)
+
+
+def github_name(username):
+    # url = f"https://api.github.com/users/{username}"
+    # response = urlopen(url)
+    if username == "renovate":
+        return "Renovate Bot"
+    try:
+        response = subprocess.check_output(
+            [
+                "gh",
+                "api",
+                "-H",
+                "Accept: application/vnd.github+json",
+                "-H",
+                "X-GitHub-Api-Version: 2022-11-28",
+                f"/users/{username}",
+            ]
+        )
+        data = json.loads(response)
+        return data["name"]
+    except Exception as e:
+        print("An error occurred:", str(e))
+
+
+def read_file(file_name):
+    try:
+        with open(file_name, "r") as file:
+            return file.read()
+    except FileNotFoundError:
+        print("File not found")
+    except Exception as e:
+        print("An error occurred:", str(e))
+
+
+def help():
+    print("Usage:")
+    print("  python changelog_helper.py usernames GITHUB_GENERATED_CHANGELOG")
+    print("  python changelog_helper.py replace-nums CHANGELOG_MARKDOWN")
+    print()
+    print(
+        "A logged-in GitHub CLI (https://cli.github.com) is required for the `usernames` subcommand"
+    )
+    print(
+        "For a GitHub-generated changelog, see https://github.com/rust-lang/rustup/releases/new"
+    )
+    sys.exit(1)
+
+
+def main():
+    if len(sys.argv) < 3:
+        help()
+
+    _, subcmd, file_name = sys.argv[:3]
+
+    if subcmd == "usernames":
+        content = read_file(file_name)
+        if not content:
+            return
+        for username in extract_usernames(content):
+            print(f"- {github_name(username)} ({username})")
+    elif subcmd == "replace-nums":
+        content = read_file(file_name)
+        footer = ""
+        if not content:
+            return
+        for match in re.findall(r"(?<=#)(\d+)", content):
+            # Replace issue number with fully-qualified link
+            link = f"[pr#{match}]"
+            footer += f"{link}: https://github.com/rust-lang/rustup/pull/{match}\n"
+            content = content.replace(f"#{match}", link)
+        print(f"{content}\n{footer}")
+    else:
+        help()
+
+
+if __name__ == "__main__":
+    main()

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "download"
-version = "1.26.0"
+version = "1.27.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -31,7 +31,7 @@ RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.26.0 (577bf51ae 2023-04-05)
+rustup-init 1.27.0 (30fe8f03f 2024-01-29)
 
 The installer for rustup
 


### PR DESCRIPTION
cc #3501.

## Concerns

- [x] Should we make a beta-driving phase for this?

---

# Changelog

## [1.27.0] - 2024-03-08

This long-awaited Rustup release has gathered all the new features and fixes since April 2023.
These changes include improvements in Rustup's maintainability, user experience, compatibility and documentation quality.

The headlines of this release are:
- Basic support for `fish` shell has been added.
- Support for the `loongarch64-unknown-linux-gnu` host platform has been added.

Also, it's worth mentioning that Dirkjan Ochtman and rami3l have joined the team and are coordinating this new release.

Finally, the project seems to have attracted a total of 23 new contributors within this release cycle. Looking forward to seeing you again in the future!

### Added

- Add basic support for `fish` shell [pr#3108] 
- Add the `RUSTUP_TERM_COLOR` environment variable to force the use of colored output [pr#3435]
- Improve `rustup-init.sh`'s compatibility with `ksh` and `zsh` [pr#3475]
- Add a warning when running under Rosetta 2 [pr#3068]
- Add browser detection for RISC-V 64 platform [pr#3642]
- Add a warning when removing the last/host target for a toolchain [pr#3637]

### Changed

- Upgrade `clap` to v4 [pr#3444]
- Fix incorrect platform detection on macOS aarch64 due to Rosetta 2 [pr#3438]
- Fix incorrect platform detection on 32-bit Linux userland with a 64-bit kernel [pr#3488] [pr#3490]
- Improve Windows system32 DLL loading mechanism [pr#3493]
- Improve suggestions about missing components [pr#3453]
- Fix handling of toolchain names with special characters [pr#3518]
- Fix panic in `component list --toolchain stable` [pr#3548]
- Rename `llvm-tools-preview` component to `llvm-tools` [pr#3578]
- Try using symlinks if possible on Windows [pr#3687]
- Bump a lot of dependencies to their latest versions [pr#renovate-bot]

Thanks go to:

- Anthony Perkins (acperkins)
- Tianqi (airstone42)
- Alex Gaynor (alex)
- Alex Hudspith (alexhudspith)
- Alan Somers (asomers)
- Brett (brettearle)
- Burak Emir (burakemir)
- Chris Denton (ChrisDenton)
- cui fliter (cuishuang)
- Dirkjan Ochtman (djc)
- Dezhi Wu (dzvon)
- Eric Swanson (ericswanson-dfinity)
- Prikshit Gautam (gautamprikshit1)
- hev (heiher)
- 二手掉包工程师 (hi-rustin)
- Kamila Borowska (KamilaBorowska)
- klensy (klensy)
- Jakub Beránek (Kobzol)
- Kornel (kornelski)
- Matt Harding (majaha)
- Mathias Brossard (mbrossard)
- Christian Thackston (nan60)
- Ruohui Wang (noirgif)
- Olivier Lemasle (olivierlemasle)
- Chih Wang (ongchi)
- Pavel Roskin (proski)
- rami3l (rami3l)
- Robert Collins (rbtcollins)
- Sandesh  Pyakurel (Sandesh-Pyakurel)
- Waffle Maybe (WaffleLapkin)
- Jubilee (workingjubilee)
- WÁNG Xuěruì (xen0n)
- Yerkebulan Tulibergenov (yerke)
- Renovate Bot (renovate)

**Full Changelog**: https://github.com/rust-lang/rustup/compare/1.26.0...1.27.0

[1.27.0]: https://github.com/rust-lang/rustup/releases/tag/1.27.0
[pr#3108]: https://github.com/rust-lang/rustup/pull/3108
[pr#3435]: https://github.com/rust-lang/rustup/pull/3435
[pr#3475]: https://github.com/rust-lang/rustup/pull/3475
[pr#3068]: https://github.com/rust-lang/rustup/pull/3068
[pr#3642]: https://github.com/rust-lang/rustup/pull/3642
[pr#3637]: https://github.com/rust-lang/rustup/pull/3637
[pr#3444]: https://github.com/rust-lang/rustup/pull/3444
[pr#3438]: https://github.com/rust-lang/rustup/pull/3438
[pr#3488]: https://github.com/rust-lang/rustup/pull/3488
[pr#3490]: https://github.com/rust-lang/rustup/pull/3490
[pr#3493]: https://github.com/rust-lang/rustup/pull/3493
[pr#3453]: https://github.com/rust-lang/rustup/pull/3453
[pr#3518]: https://github.com/rust-lang/rustup/pull/3518
[pr#3548]: https://github.com/rust-lang/rustup/pull/3548
[pr#3578]: https://github.com/rust-lang/rustup/pull/3578
[pr#3687]: https://github.com/rust-lang/rustup/pull/3687
[pr#renovate-bot]: https://github.com/rust-lang/rustup/pulls?q=is:pr+author:app/renovate+is:merged