### PR TITLE
Update mdbook and update some source issues.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1190,7 +1190,7 @@ jobs:
       - name: Install mdbook
         run: |
           mkdir mdbook
-          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.6/mdbook-v0.4.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo "`pwd`/mdbook" >> $GITHUB_PATH
       - name: Build user-guide
         run: |

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Install mdbook
         run: |
           mkdir mdbook
-          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.6/mdbook-v0.4.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo "`pwd`/mdbook" >> $GITHUB_PATH
       - name: Build book
         run: |

--- a/ci/actions-templates/test-docs-template.yaml
+++ b/ci/actions-templates/test-docs-template.yaml
@@ -15,7 +15,7 @@ jobs: # skip-all
       - name: Install mdbook
         run: |
           mkdir mdbook
-          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.6/mdbook-v0.4.6-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
+          curl -Lf https://github.com/rust-lang/mdBook/releases/download/v0.4.37/mdbook-v0.4.37-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
           echo "`pwd`/mdbook" >> $GITHUB_PATH
       - name: Build user-guide
         run: |

--- a/doc/dev-guide/book.toml
+++ b/doc/dev-guide/book.toml
@@ -6,6 +6,7 @@ src = "src"
 title = "The Rustup developer guide"
 
 [output.html]
+curly-quotes = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/master/doc/dev-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/master/doc/dev-guide"
 site-url = "https://rust-lang.github.io/rustup/dev-guide"

--- a/doc/user-guide/book.toml
+++ b/doc/user-guide/book.toml
@@ -3,6 +3,7 @@ authors = ["The Rust Project Developers"]
 title = "The rustup book"
 
 [output.html]
+curly-quotes = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/master/doc/user-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/master/doc/user-guide"
 site-url = "https://rust-lang.github.io/rustup/"

--- a/doc/user-guide/src/concepts/components.md
+++ b/doc/user-guide/src/concepts/components.md
@@ -30,31 +30,31 @@ Most components have a target-triple suffix, such as
 The set of available components may vary with different releases and
 toolchains. The following is an overview of the different components:
 
-* `rustc` — The Rust compiler and [Rustdoc].
-* `cargo` — [Cargo] is a package manager and build tool.
-* `rustfmt` — [Rustfmt] is a tool for automatically formatting code.
-* `rust-std` — This is the Rust [standard library]. There is a separate
+* `rustc` --- The Rust compiler and [Rustdoc].
+* `cargo` --- [Cargo] is a package manager and build tool.
+* `rustfmt` --- [Rustfmt] is a tool for automatically formatting code.
+* `rust-std` --- This is the Rust [standard library]. There is a separate
   `rust-std` component for each target that `rustc` supports, such as
   `rust-std-x86_64-pc-windows-msvc`. See the [Cross-compilation] chapter for
   more detail.
-* `rust-docs` — This is a local copy of the [Rust documentation]. Use the
+* `rust-docs` --- This is a local copy of the [Rust documentation]. Use the
   `rustup doc` command to open the documentation in a web browser. Run `rustup
   doc --help` for more options.
-* `rust-analyzer` — [rust-analyzer] is a language server that provides support
+* `rust-analyzer` --- [rust-analyzer] is a language server that provides support
   for editors and IDEs.
-* `clippy` — [Clippy] is a lint tool that provides extra checks for common
+* `clippy` --- [Clippy] is a lint tool that provides extra checks for common
   mistakes and stylistic choices.
-* `miri` — [Miri] is an experimental Rust interpreter, which can be used for
+* `miri` --- [Miri] is an experimental Rust interpreter, which can be used for
   checking for undefined-behavior.
-* `rust-src` — This is a local copy of the source code of the Rust standard
+* `rust-src` --- This is a local copy of the source code of the Rust standard
   library. This can be used by some tools, such as [rust-analyzer], to provide
   auto-completion for functions within the standard library; [Miri] which is a
   Rust interpreter; and Cargo's experimental [build-std] feature, which allows
   you to rebuild the standard library locally.
-* `rust-mingw` — This contains a linker and platform libraries for building on
+* `rust-mingw` --- This contains a linker and platform libraries for building on
   the `x86_64-pc-windows-gnu` platform.
-* `llvm-tools` — This component contains a collection of [LLVM] tools.
-* `rustc-dev` — This component contains the compiler as a library. Most users
+* `llvm-tools` --- This component contains a collection of [LLVM] tools.
+* `rustc-dev` --- This component contains the compiler as a library. Most users
   will not need this; it is only needed for development *of* tools that link
   to the compiler, such as making modifications to [Clippy].
 
@@ -62,9 +62,9 @@ toolchains. The following is an overview of the different components:
 
 These components have been deprecated and are not published in new Rust releases.
 
-* `rls` — [RLS] is a language server that is deprecated and has been replaced
+* `rls` --- [RLS] is a language server that is deprecated and has been replaced
   by rust-analyzer.
-* `rust-analysis` — Metadata about the standard library, used by [RLS].
+* `rust-analysis` --- Metadata about the standard library, used by [RLS].
 
 ## Component availability
 

--- a/doc/user-guide/src/concepts/index.md
+++ b/doc/user-guide/src/concepts/index.md
@@ -25,30 +25,30 @@ This is similar to Ruby's [rbenv], Python's [pyenv], or Node's [nvm].
 
 ## Terminology
 
-* **channel** — Rust is released to three different "channels": stable, beta,
+* **channel** --- Rust is released to three different "channels": stable, beta,
   and nightly. See the [Channels] chapter for more details.
 
-* **toolchain** — A "toolchain" is a complete installation of the Rust
+* **toolchain** --- A "toolchain" is a complete installation of the Rust
   compiler (`rustc`) and related tools (like `cargo`). A [toolchain
   specification] includes the release channel or version, and the host
   platform that the toolchain runs on.
 
-* **target** — `rustc` is capable of generating code for many platforms. The
+* **target** --- `rustc` is capable of generating code for many platforms. The
   "target" specifies the platform that the code will be generated for. By
   default, `cargo` and `rustc` use the host toolchain's platform as the
   target. To build for a different target, usually the target's standard
   library needs to be installed first via the `rustup target` command. See the
   [Cross-compilation] chapter for more details.
 
-* **component** — Each release of Rust includes several "components", some of
+* **component** --- Each release of Rust includes several "components", some of
   which are required (like `rustc`) and some that are optional (like
   [`clippy`]). See the [Components] chapter for more detail.
 
-* **profile** — In order to make it easier to work with components, a
+* **profile** --- In order to make it easier to work with components, a
   "profile" defines a grouping of components. See the [Profiles] chapter for
   more details.
 
-* **proxy** —  A wrapper for a common Rust component (like `rustc`), built to forward
+* **proxy** ---  A wrapper for a common Rust component (like `rustc`), built to forward
   CLI invocations to the active Rust toolchain. See the [Proxies] chapter for more details.
 
 [`clippy`]: https://github.com/rust-lang/rust-clippy


### PR DESCRIPTION
This updates `mdbook` for the docs deploy, and updates the source markdown to not include unicode that may not be obvious to someone editing it.

* Updates mdbook to 0.4.37. There have been quite a few small changes since the last update: https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-0437
* Removes the invisible U+00A0 no-break-space spaces. Those weren't intentional, it was just an artifact of how I used my keyboard.
* Changes the em-dash to `---` so that it is clearer to people editing the doc.
* Adds `curly-quotes=true` which enables [Smart Punctuation](https://rust-lang.github.io/mdBook/format/markdown.html#smart-punctuation) which is needed for the em-dash translation.

