### PR TITLE
Fix ambiguous "Proceed with installation" prompt

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -56,12 +56,13 @@ pub(crate) enum Confirm {
     Advanced,
 }
 
-pub(crate) fn confirm_advanced() -> Result<Confirm> {
+pub(crate) fn confirm_advanced(customized_install: bool) -> Result<Confirm> {
     writeln!(process().stdout().lock())?;
-    writeln!(
-        process().stdout().lock(),
-        "1) Proceed with installation (default)"
-    )?;
+    let first_option = match customized_install {
+        true => "1) Proceed with selected options (default - just press enter)",
+        false => "1) Proceed with standard installation (default - just press enter)",
+    };
+    writeln!(process().stdout().lock(), "{first_option}")?;
     writeln!(process().stdout().lock(), "2) Customize installation")?;
     writeln!(process().stdout().lock(), "3) Cancel installation")?;
     write!(process().stdout().lock(), ">")?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -433,10 +433,10 @@ pub(crate) fn install(
         let msg = pre_install_msg(opts.no_modify_path)?;
 
         md(&mut term, msg);
-
+        let mut customized_install = false;
         loop {
             md(&mut term, current_install_opts(&opts));
-            match common::confirm_advanced()? {
+            match common::confirm_advanced(customized_install)? {
                 Confirm::No => {
                     info!("aborting installation");
                     return Ok(utils::ExitCode(0));
@@ -445,6 +445,7 @@ pub(crate) fn install(
                     break;
                 }
                 Confirm::Advanced => {
+                    customized_install = true;
                     opts = customize_install(opts)?;
                 }
             }

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -90,7 +90,7 @@ Current installation options:
                profile: default
   modify PATH variable: no
 
-1) Proceed with installation (default)
+1) Proceed with standard installation (default - just press enter)
 2) Customize installation
 3) Cancel installation
 >


### PR DESCRIPTION
Changed test and prompt of default prompt in stdout.
Fix #3429 