### PR TITLE
Windows: Try using symlinks if they're allowed

### DIFF
--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -136,6 +136,8 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {
         // On Windows creating symlinks isn't allowed by default so if it fails
         // we fallback to creating a directory junction.
+        // We prefer to use symlinks here because junction point paths, unlike symlinks,
+        // must always be absolute. This makes moving the rustup directory difficult.
         std::os::windows::fs::symlink_dir(src, dest).or_else(|_| symlink_junction_inner(src, dest))
     }
     #[cfg(not(windows))]

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -134,10 +134,9 @@ pub fn append_file(dest: &Path, line: &str) -> io::Result<()> {
 pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
     #[cfg(windows)]
     fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {
-        // std's symlink uses Windows's symlink function, which requires
-        // admin. We can create directory junctions the hard way without
-        // though.
-        symlink_junction_inner(src, dest)
+        // On Windows creating symlinks isn't allowed by default so if it fails
+        // we fallback to creating a directory junction.
+        std::os::windows::fs::symlink_dir(src, dest).or_else(|_| symlink_junction_inner(src, dest))
     }
     #[cfg(not(windows))]
     fn symlink_dir_inner(src: &Path, dest: &Path) -> io::Result<()> {


### PR DESCRIPTION
On Windows, creating symlinks is not allowed unless developer mode is enabled or a specific permission is granted. Therefore this optimistically attempts to use symlinks first, before falling back to juncture points in the event that fails.

Resolves #3677