### PR TITLE
www: Fix copy icon position in Safari

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -165,7 +165,7 @@ hr {
     position: relative;
     width: fit-content;
     height: fit-content;
-    top: 50%;
+    top: 27px;
     left: 50%;
     transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
This patch fixes the copy-icon position in Safari Version 17.3.1 (19617.2.4.11.12). It appears out of the box because "top: 50%" has no effect on Safari.

The 27px is from 50% of `height(58px) - border-top-width(2px) - border-bottom-width(2px)`.

Before:
![image](https://github.com/rust-lang/rustup/assets/23432548/81cf34ba-257c-4fea-baa0-9c78edbfc6f9)

After:
![image](https://github.com/rust-lang/rustup/assets/23432548/9653f25e-024d-4564-b45d-3aee7d3d1494)

It does not change the position of the icon on my Chrome 122.0.6261.94.

Fixes #3512.