### PR TITLE
Fix dead_code and unused_imports warnings

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -79,7 +79,7 @@ use crate::{
 };
 
 use os::*;
-pub(crate) use os::{delete_rustup_and_cargo_home, run_update, self_replace};
+pub(crate) use os::{run_update, self_replace};
 #[cfg(windows)]
 pub use windows::complete_windows_uninstall;
 

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -1,6 +1,4 @@
-use std::boxed::Box;
 use std::cell::RefCell;
-use std::default::Default;
 use std::env;
 use std::ffi::OsString;
 use std::fmt::Debug;

--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -59,6 +59,7 @@ pub struct ColorableTerminal {
 enum TerminalInner {
     StandardStream(StandardStream, ColorSpec),
     #[cfg(feature = "test")]
+    #[allow(dead_code)] // ColorChoice only read in test code
     TestWriter(TestWriter, ColorChoice),
 }
 

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -206,6 +206,7 @@ pub(crate) enum CompletedIo {
     /// A submitted Item has completed
     Item(Item),
     /// An IncrementalFile has completed a single chunk
+    #[allow(dead_code)] // chunk size only used in test code
     Chunk(usize),
 }
 

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -137,6 +137,7 @@ impl Package for DirectoryPackage {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)] // temp::Dir is held for drop.
 pub(crate) struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
 
 impl<'a> TarPackage<'a> {

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -21,7 +21,6 @@ use crate::{
         manifestation::{Changes, Manifestation, UpdateStatus},
         notifications::*,
         prefix::InstallPrefix,
-        temp,
     },
     errors::RustupError,
     process,
@@ -621,9 +620,6 @@ impl TryFrom<&ToolchainName> for ToolchainDesc {
         }
     }
 }
-
-#[derive(Debug)]
-pub(crate) struct Manifest<'a>(temp::File<'a>, String);
 
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub enum Profile {

--- a/src/install.rs
+++ b/src/install.rs
@@ -71,10 +71,7 @@ impl<'a> InstallMethod<'a> {
             _ => (nh)(RootNotification::UpdatingToolchain(&self.dest_basename())),
         }
 
-        (self.cfg().notify_handler)(RootNotification::ToolchainDirectory(
-            &self.dest_path(),
-            &self.dest_basename(),
-        ));
+        (self.cfg().notify_handler)(RootNotification::ToolchainDirectory(&self.dest_path()));
         let updated = self.run(&self.dest_path(), &|n| {
             (self.cfg().notify_handler)(n.into())
         })?;

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -18,7 +18,7 @@ pub(crate) enum Notification<'a> {
     SetProfile(&'a str),
     SetSelfUpdate(&'a str),
     LookingForToolchain(&'a ToolchainDesc),
-    ToolchainDirectory(&'a Path, &'a str),
+    ToolchainDirectory(&'a Path),
     UpdatingToolchain(&'a str),
     InstallingToolchain(&'a str),
     InstalledToolchain(&'a str),
@@ -62,7 +62,7 @@ impl<'a> Notification<'a> {
             Install(n) => n.level(),
             Utils(n) => n.level(),
             Temp(n) => n.level(),
-            ToolchainDirectory(_, _)
+            ToolchainDirectory(_)
             | LookingForToolchain(_)
             | InstallingToolchain(_)
             | UpdatingToolchain(_)
@@ -103,7 +103,7 @@ impl<'a> Display for Notification<'a> {
             SetProfile(name) => write!(f, "profile set to '{name}'"),
             SetSelfUpdate(mode) => write!(f, "auto-self-update mode set to '{mode}'"),
             LookingForToolchain(name) => write!(f, "looking for installed toolchain '{name}'"),
-            ToolchainDirectory(path, _) => write!(f, "toolchain directory: '{}'", path.display()),
+            ToolchainDirectory(path) => write!(f, "toolchain directory: '{}'", path.display()),
             UpdatingToolchain(name) => write!(f, "updating existing install for '{name}'"),
             InstallingToolchain(name) => write!(f, "installing toolchain '{name}'"),
             InstalledToolchain(name) => write!(f, "toolchain '{name}' installed"),

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -8,9 +8,6 @@ use std::path::Path;
 use std::str;
 
 #[cfg(not(windows))]
-use libc;
-
-#[cfg(not(windows))]
 use crate::{currentprocess::varsource::VarSource, process};
 
 pub(crate) fn ensure_dir_exists<P: AsRef<Path>, F: FnOnce(&Path)>(


### PR DESCRIPTION
This fixes some warnings for dead_code and unused_imports, where I believe rustc has recently started emitting in more recent versions.