### PR TITLE
Change default for RUSTUP_WINDOWS_PATH_ADD_BIN

### DIFF
--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -165,7 +165,7 @@ impl<'a> Toolchain<'a> {
         }
 
         if cfg!(target_os = "windows") {
-            // Historically rustup has included the bin directory in PATH to
+            // Historically rustup included the bin directory in PATH to
             // work around some bugs (see
             // https://github.com/rust-lang/rustup/pull/3178 for more
             // information). This shouldn't be needed anymore, and it causes
@@ -174,10 +174,13 @@ impl<'a> Toolchain<'a> {
             // recursive call won't work because it is not executing the
             // proxy, so the `+` toolchain override doesn't work.
             //
-            // This is opt-in to allow us to get more real-world testing.
+            // The RUSTUP_WINDOWS_PATH_ADD_BIN env var was added to opt-in to
+            // testing the fix. The default is now off, but this is left here
+            // just in case there are problems. Consider removing in the
+            // future if it doesn't seem necessary.
             if process()
                 .var_os("RUSTUP_WINDOWS_PATH_ADD_BIN")
-                .map_or(true, |s| s == "1")
+                .map_or(false, |s| s == "1")
             {
                 path_entries.push(self.path.join("bin"));
             }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -586,21 +586,7 @@ fn recursive_cargo() {
             fs::create_dir_all(&cargo_bin_path).unwrap();
             fs::copy(real_mock_cargo, cargo_subcommand).unwrap();
 
-            // Verify the default behavior, which is currently broken on Windows.
-            let args = &["cargo", "--recursive-cargo-subcommand"];
-            if cfg!(windows) {
-                config.expect_err(
-                    &["cargo", "--recursive-cargo-subcommand"],
-                    "bad mock proxy commandline",
-                );
-            }
-
-            // Try the opt-in, which should fix it.
-            let out = config.run(args[0], &args[1..], &[("RUSTUP_WINDOWS_PATH_ADD_BIN", "0")]);
-            if !out.ok || !out.stdout.contains("hash-nightly-2") {
-                clitools::print_command(args, &out);
-                panic!("expected hash-nightly-2 in output");
-            }
+            config.expect_stdout_ok(&["cargo", "--recursive-cargo-subcommand"], "hash-nightly-2");
         });
     });
 }


### PR DESCRIPTION
This changes the default for the RUSTUP_WINDOWS_PATH_ADD_BIN opt-in to fix the issue where adding the `bin` directory on windows was preventing recursive calls to programs like cargo from being able to use the rustup proxies.

There was a call for testing at https://internals.rust-lang.org/t/help-test-windows-behavior-between-rustup-and-cargo/20237 and https://users.rust-lang.org/t/help-test-windows-behavior-between-rustup-and-cargo/106145. AFAIK, there have not been any indications of anyone having problems.

Fixes #3036
