### PR TITLE
ci: remove direct `renovate/*` tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,6 @@ on:
     branches:
       - master
       - stable
-      - renovate/*
   schedule:
     - cron: "30 0 * * 1" # Every Monday at half past midnight UTC
 

--- a/ci/actions-templates/gen-workflows.sh
+++ b/ci/actions-templates/gen-workflows.sh
@@ -22,7 +22,6 @@ on:
     branches:
       - master
       - stable
-      - renovate/*
   schedule:
     - cron: "30 0 * * 1" # Every Monday at half past midnight UTC
 


### PR DESCRIPTION
Partially reverts #3160 by removing direct `renovate/*` tests.

The original intention seems to be that

>  This permits Renovate to pre-test branches, and when we're comfortable will permit automatic merging if desired.

However as GHMQ is now enabled every `renovate` PR already should go through double check (on PR changes & on enqueuing) before actually getting merged, this config looks redundant.

cc @rbtcollins