### PR TITLE
fix(cli): fix incorrect color state after `ColorableTerminal::reset`

### DIFF
--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -176,7 +176,10 @@ impl ColorableTerminal {
 
     pub fn reset(&mut self) -> io::Result<()> {
         match self.inner.lock().unwrap().deref_mut() {
-            TerminalInner::StandardStream(s, _color) => s.reset(),
+            TerminalInner::StandardStream(s, color) => {
+                color.clear();
+                s.reset()
+            }
             #[cfg(feature = "test")]
             TerminalInner::TestWriter(_, _) => Ok(()),
         }


### PR DESCRIPTION
Fixes #3705.

This seems like a regression introduced in #3351. See https://github.com/rust-lang/rustup/issues/3705#issuecomment-1992051261 for more details.