### PR TITLE
fix(shell): create parent dir before appending to rcfiles

### DIFF
--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -233,7 +233,11 @@ impl UnixShell for Fish {
     }
 
     fn update_rcs(&self) -> Vec<PathBuf> {
-        self.rcfiles()
+        // The first rcfile takes precedence.
+        match self.rcfiles().into_iter().next() {
+            Some(path) => vec![path],
+            None => vec![],
+        }
     }
 
     fn env_script(&self) -> ShellScript {

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -92,6 +92,13 @@ pub(crate) fn do_add_to_path() -> Result<()> {
                 _ => &source_cmd,
             };
 
+            let rc_dir = rc.parent().with_context(|| {
+                format!(
+                    "parent directory doesn't exist for rcfile path: `{}`",
+                    rc.display()
+                )
+            })?;
+            utils::ensure_dir_exists("rcfile dir", rc_dir, &|_: Notification<'_>| ())?;
             utils::append_file("rcfile", &rc, cmd_to_write)
                 .with_context(|| format!("could not amend shell profile: '{}'", rc.display()))?;
         }


### PR DESCRIPTION
Fixes #3706, ~~addressing https://rust-lang.github.io/rust-clippy/master/#/ineffective_open_options at the same time~~ (superseded by https://github.com/rust-lang/rustup/pull/3713).

## Concerns

- [x] ~~It's better to test the CI build in a container or something before actually merging this PR.~~ (Tested on Ubuntu 22.04.4 LTS x86_64.)