### PR TITLE
Replaced `.` with `source` in fish shell's `source_string`

### DIFF
--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -244,7 +244,7 @@ impl UnixShell for Fish {
     }
 
     fn source_string(&self) -> Result<String> {
-        Ok(format!(r#". "{}/env.fish""#, cargo_home_str()?))
+        Ok(format!(r#"source "{}/env.fish""#, cargo_home_str()?))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/rust-lang/rustup/issues/3714