### PR TITLE
fix(ci): disable `cargo clippy` on `*-windows-gnu`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,7 +110,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           BUILD_PROFILE: ${{ matrix.mode }}
         run: bash ci/run.bash
-      - name: Run cargo check and clippy
+      - name: Run cargo check
         if: matrix.mode != 'release'
         env:
           TARGET: ${{ matrix.target }}
@@ -118,7 +118,12 @@ jobs:
         run: |
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
-          cargo clippy --all-targets --all-features -- --deny warnings
+      - name: Run cargo clippy
+        if: matrix.mode != 'release' && matrix.mingw == ''
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Upload the built artifact
         if: matrix.mode == 'release'
         uses: actions/upload-artifact@v4
@@ -247,7 +252,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           BUILD_PROFILE: ${{ matrix.mode }}
         run: bash ci/run.bash
-      - name: Run cargo check and clippy
+      - name: Run cargo check
         if: matrix.mode != 'release'
         env:
           TARGET: ${{ matrix.target }}
@@ -255,7 +260,12 @@ jobs:
         run: |
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
-          cargo clippy --all-targets --all-features -- --deny warnings
+      - name: Run cargo clippy
+        if: matrix.mode != 'release' && matrix.mingw == ''
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Upload the built artifact
         if: matrix.mode == 'release'
         uses: actions/upload-artifact@v4
@@ -389,7 +399,7 @@ jobs:
           TARGET: ${{ matrix.target }}
           BUILD_PROFILE: ${{ matrix.mode }}
         run: bash ci/run.bash
-      - name: Run cargo check and clippy
+      - name: Run cargo check
         if: matrix.mode != 'release'
         env:
           TARGET: ${{ matrix.target }}
@@ -397,7 +407,12 @@ jobs:
         run: |
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
-          cargo clippy --all-targets --all-features -- --deny warnings
+      - name: Run cargo clippy
+        if: matrix.mode != 'release' && matrix.mingw == ''
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Upload the built artifact
         if: matrix.mode == 'release'
         uses: actions/upload-artifact@v4

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -107,7 +107,7 @@ jobs: # skip-master skip-pr skip-stable
           TARGET: ${{ matrix.target }}
           BUILD_PROFILE: ${{ matrix.mode }}
         run: bash ci/run.bash
-      - name: Run cargo check and clippy
+      - name: Run cargo check
         if: matrix.mode != 'release'
         env:
           TARGET: ${{ matrix.target }}
@@ -115,7 +115,12 @@ jobs: # skip-master skip-pr skip-stable
         run: |
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
-          cargo clippy --all-targets --all-features -- --deny warnings
+      - name: Run cargo clippy
+        if: matrix.mode != 'release' && matrix.mingw == ''
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
       - name: Upload the built artifact
         if: matrix.mode == 'release'
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The solution at https://stackoverflow.com/a/43974521 doesn't seem to be working for us, maybe that's because we're not controlling what distribution of Perl we'll be using for our CI builds that easily.

As a workaround, I think it's reasonable to disable `cargo clippy` on `*-windows-gnu` altogether, and keep it this way at least until the removal of OpenSSL. Otherwise, we won't be able to even ship v1.27.1.

Fixes #3718.