### PR TITLE
feat: log `RUSTUP_UPDATE_ROOT`, `RUSTUP_DIST_SERVER` or `RUSTUP_DIST_ROOT` on `RUSTUP_DEBUG`

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -1,23 +1,23 @@
 # Environment variables
 
-- `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%/.rustup`) Sets the
+- `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%/.rustup`). Sets the
   root `rustup` folder, used for storing installed toolchains and
   configuration options.
 
-- `RUSTUP_TOOLCHAIN` (default: none) If set, will [override] the toolchain used
+- `RUSTUP_TOOLCHAIN` (default: none). If set, will [override] the toolchain used
   for all rust tool invocations. A toolchain with this name should be installed,
   or invocations will fail. This can specify custom toolchains, installable
   toolchains, or the absolute path to a toolchain.
 
-- `RUSTUP_DIST_SERVER` (default: `https://static.rust-lang.org`) Sets the root
+- `RUSTUP_DIST_SERVER` (default: `https://static.rust-lang.org`). Sets the root
   URL for downloading static resources related to Rust. You can change this to
   instead use a local mirror, or to test the binaries from the staging
   directory.
 
-- `RUSTUP_DIST_ROOT` (default: `https://static.rust-lang.org/dist`)
-  Deprecated. Use `RUSTUP_DIST_SERVER` instead.
+- ~~`RUSTUP_DIST_ROOT`~~ *deprecated* (default: `https://static.rust-lang.org/dist`).
+  Use `RUSTUP_DIST_SERVER` instead.
 
-- `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup`) Sets
+- `RUSTUP_UPDATE_ROOT` (default `https://static.rust-lang.org/rustup`). Sets
   the root URL for downloading self-update.
 
 - `RUSTUP_IO_THREADS` *unstable* (defaults to reported cpu count). Sets the
@@ -25,21 +25,23 @@
   single-threaded IO for troubleshooting, or an arbitrary number to override
   automatic detection.
 
-- `RUSTUP_TRACE_DIR` *unstable* (default: no tracing) Enables tracing and
+- `RUSTUP_TRACE_DIR` *unstable* (default: no tracing). Enables tracing and
   determines the directory that traces will be written too. Traces are of the
   form PID.trace. Traces can be read by the Catapult project [tracing viewer].
 
-- `RUSTUP_TERM_COLOR` (default: `auto`) Controls whether colored output is used in the terminal.
+- `RUSTUP_DEBUG` *unstable*. When set, enables rustup's debug logging.
+
+- `RUSTUP_TERM_COLOR` (default: `auto`). Controls whether colored output is used in the terminal.
   Set to `auto` to use colors only in tty streams, to `always` to always enable colors,
   or to `never` to disable colors.
 
-- `RUSTUP_UNPACK_RAM` *unstable* (default free memory or 500MiB if unable to tell, min 210MiB) Caps the amount of
+- `RUSTUP_UNPACK_RAM` *unstable* (default free memory or 500MiB if unable to tell, min 210MiB). Caps the amount of
   RAM `rustup` will use for IO tasks while unpacking.
 
-- `RUSTUP_NO_BACKTRACE` Disables backtraces on non-panic errors even when
+- `RUSTUP_NO_BACKTRACE`. Disables backtraces on non-panic errors even when
   `RUST_BACKTRACE` is set.
 
-- `RUSTUP_PERMIT_COPY_RENAME` *unstable* When set, allows rustup to fall-back
+- `RUSTUP_PERMIT_COPY_RENAME` *unstable*. When set, allows rustup to fall-back
   to copying files if attempts to `rename` result in cross-device link
   errors. These errors occur on OverlayFS, which is used by [Docker][dc]. This
   feature sacrifices some transactions protections and may be removed at any

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -332,12 +332,12 @@ These components can be acquired through a Visual Studio installer.
 
 "#;
 
-static UPDATE_ROOT: &str = "https://static.rust-lang.org/rustup";
+static DEFAULT_UPDATE_ROOT: &str = "https://static.rust-lang.org/rustup";
 
 fn update_root() -> String {
     process()
         .var("RUSTUP_UPDATE_ROOT")
-        .unwrap_or_else(|_| String::from(UPDATE_ROOT))
+        .unwrap_or_else(|_| String::from(DEFAULT_UPDATE_ROOT))
 }
 
 /// `CARGO_HOME` suitable for display, possibly with $HOME

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -337,6 +337,7 @@ static DEFAULT_UPDATE_ROOT: &str = "https://static.rust-lang.org/rustup";
 fn update_root() -> String {
     process()
         .var("RUSTUP_UPDATE_ROOT")
+        .inspect(|url| debug!("`RUSTUP_UPDATE_ROOT` has been set to `{url}`"))
         .unwrap_or_else(|_| String::from(DEFAULT_UPDATE_ROOT))
 }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -334,6 +334,12 @@ These components can be acquired through a Visual Studio installer.
 
 static UPDATE_ROOT: &str = "https://static.rust-lang.org/rustup";
 
+fn update_root() -> String {
+    process()
+        .var("RUSTUP_UPDATE_ROOT")
+        .unwrap_or_else(|_| String::from(UPDATE_ROOT))
+}
+
 /// `CARGO_HOME` suitable for display, possibly with $HOME
 /// substituted for the directory prefix
 fn canonical_cargo_home() -> Result<Cow<'static, str>> {
@@ -1179,9 +1185,7 @@ pub(crate) fn prepare_update() -> Result<Option<PathBuf>> {
     let triple = dist::TargetTriple::from_host().unwrap_or(triple);
 
     // Get update root.
-    let update_root = process()
-        .var("RUSTUP_UPDATE_ROOT")
-        .unwrap_or_else(|_| String::from(UPDATE_ROOT));
+    let update_root = update_root();
 
     // Get current version
     let current_version = env!("CARGO_PKG_VERSION");
@@ -1212,9 +1216,7 @@ pub(crate) fn prepare_update() -> Result<Option<PathBuf>> {
 }
 
 pub(crate) fn get_available_rustup_version() -> Result<String> {
-    let update_root = process()
-        .var("RUSTUP_UPDATE_ROOT")
-        .unwrap_or_else(|_| String::from(UPDATE_ROOT));
+    let update_root = update_root();
     let tempdir = tempfile::Builder::new()
         .prefix("rustup-update")
         .tempdir()

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,9 +230,9 @@ impl Cfg {
             .transpose()?;
 
         let dist_root_server = match process().var("RUSTUP_DIST_SERVER") {
-            Ok(ref s) if !s.is_empty() => {
+            Ok(s) if !s.is_empty() => {
                 debug!("`RUSTUP_DIST_SERVER` has been set to `{s}`");
-                s.clone()
+                s
             }
             _ => {
                 // For backward compatibility

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,13 +230,17 @@ impl Cfg {
             .transpose()?;
 
         let dist_root_server = match process().var("RUSTUP_DIST_SERVER") {
-            Ok(ref s) if !s.is_empty() => s.clone(),
+            Ok(ref s) if !s.is_empty() => {
+                debug!("`RUSTUP_DIST_SERVER` has been set to `{s}`");
+                s.clone()
+            }
             _ => {
                 // For backward compatibility
                 process()
                     .var("RUSTUP_DIST_ROOT")
                     .ok()
                     .and_then(utils::if_not_empty)
+                    .inspect(|url| debug!("`RUSTUP_DIST_ROOT` has been set to `{url}`"))
                     .map_or(Cow::Borrowed(dist::DEFAULT_DIST_ROOT), Cow::Owned)
                     .as_ref()
                     .trim_end_matches("/dist")


### PR DESCRIPTION
Closes #3680.

This PR makes log the value(s) of `RUSTUP_UPDATE_ROOT`, `RUSTUP_DIST_SERVER` or `RUSTUP_DIST_ROOT` if:
- The environment variable is itself set, and
- `RUSTUP_DEBUG` is set.

This is a tiny yet important feature addition for our users who need to manually designate a Rustup update/dist server, either because they have to [use a mirror server for acceleration](https://mirrors.tuna.tsinghua.edu.cn/help/rustup), or because they need to [switch to the `dev` environment for beta testing](https://rust-lang.github.io/rustup/dev-guide/release-process.html).

The `RUSTUP_DEBUG` predicate minimizes both the extra noise and the required changes to the current test suite.