### PR TITLE
ci: use stable Rust for all clippy lints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1215,18 +1215,7 @@ jobs:
           restore-keys: ${{ github.base_ref }}-${{ runner.os }}-cargo-clippy-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
-      - name: Ensure Beta is up to date
-        run: |
-          if rustc +beta -vV >/dev/null 2>/dev/null; then
-            rustup toolchain uninstall beta
-          fi
-          rustup toolchain install --profile=minimal beta
-          rustup default beta
-      - name: Ensure we have the components we need
-        run: |
-          rustup component add rustfmt
-          rustup component add clippy
+          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=rustfmt -c=clippy -y
       - name: Run the centos check within the docker image
         run: |
           docker run \

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -49,18 +49,7 @@ jobs: # skip-all
           restore-keys: ${{ github.base_ref }}-${{ runner.os }}-cargo-clippy-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=none --profile=minimal -y
-      - name: Ensure Beta is up to date
-        run: |
-          if rustc +beta -vV >/dev/null 2>/dev/null; then
-            rustup toolchain uninstall beta
-          fi
-          rustup toolchain install --profile=minimal beta
-          rustup default beta
-      - name: Ensure we have the components we need
-        run: |
-          rustup component add rustfmt
-          rustup component add clippy
+          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=rustfmt -c=clippy -y
       - name: Run the centos check within the docker image
         run: |
           docker run \

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -132,14 +132,13 @@ impl FromStr for SelfUpdateMode {
     }
 }
 
-impl ToString for SelfUpdateMode {
-    fn to_string(&self) -> String {
-        match self {
+impl std::fmt::Display for SelfUpdateMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
             SelfUpdateMode::Enable => "enable",
             SelfUpdateMode::Disable => "disable",
             SelfUpdateMode::CheckOnly => "check-only",
-        }
-        .into()
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -428,7 +428,7 @@ impl Cfg {
                 }
 
                 self.settings_file.with_mut(|s| {
-                    s.version = DEFAULT_METADATA_VERSION.to_owned();
+                    DEFAULT_METADATA_VERSION.clone_into(&mut s.version);
                     Ok(())
                 })
             }

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -982,7 +982,7 @@ fn try_update_from_dist_(
                 remove_components: Vec::new(),
             };
 
-            *fetched = m.date.clone();
+            fetched.clone_from(&m.date);
 
             return match manifestation.update(
                 &m,

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -351,7 +351,7 @@ impl Manifest {
     pub(crate) fn rename_component(&self, component: &Component) -> Option<Component> {
         self.renames.get(&component.pkg).map(|r| {
             let mut c = component.clone();
-            c.pkg = r.clone();
+            c.pkg.clone_from(r);
             c
         })
     }

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -575,7 +575,9 @@ impl Update {
             }
         } else {
             result.components_to_uninstall = starting_list;
-            result.components_to_install = result.final_component_list.clone();
+            result
+                .components_to_install
+                .clone_from(&result.final_component_list);
         }
 
         Ok(result)

--- a/src/test.rs
+++ b/src/test.rs
@@ -223,8 +223,6 @@ where
 
 #[cfg(feature = "otel")]
 use once_cell::sync::Lazy;
-#[cfg(feature = "otel")]
-use tokio;
 
 /// A tokio runtime for the sync tests, permitting the use of tracing. This is
 /// never shutdown, instead it is just dropped at end of process.

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -471,7 +471,7 @@ fn list_overrides() {
             let mut cwd_formatted = format!("{}", cwd.display());
 
             if cfg!(windows) {
-                cwd_formatted = cwd_formatted[4..].to_owned();
+                cwd_formatted.drain(..4);
             }
 
             let trip = this_host_triple();
@@ -511,7 +511,7 @@ fn list_overrides_with_nonexistent() {
             let mut path_formatted = format!("{}", nonexistent_path.display());
 
             if cfg!(windows) {
-                path_formatted = path_formatted[4..].to_owned();
+                path_formatted.drain(..4);
             }
 
             config.expect_ok_ex(


### PR DESCRIPTION
Addresses the CI failure in #3724.

## Concerns

- [x] Should we stop using `beta` for clippy lints, now that we're forcing clippy to pass? I don't believe many are actually using `beta` so `cargo clippy --fix` can be difficult as well.