### PR TITLE
doc(dev-guide): Fix test Lint and add explanation

### DIFF
--- a/doc/dev-guide/src/SUMMARY.md
+++ b/doc/dev-guide/src/SUMMARY.md
@@ -1,6 +1,7 @@
 # Summary
 
 - [Introduction](index.md)
+    - [Linting](linting.md)
 - [Coding standards](coding-standards.md)
 - [Version numbers](version-numbers.md)
 - [Release process](release-process.md)

--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -34,7 +34,7 @@ clippy is a moving target that can make it hard to merge for little benefit.
 
 We do ask that contributors keep the clippy status clean themselves.
 
-Minimally, run `cargo +beta clippy --all --all-targets -- -D warnings` before
+Minimally, run `cargo clippy --all --all-targets --features test -- -D warnings` before
 submitting code.
 
 If possible, adding `--all-features` to the command is useful, but will require

--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -3,7 +3,7 @@
 1. Fork it!
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Test it: `cargo test --features=test`
-4. Lint it: `cargo +beta clippy --all --all-targets -- -D warnings`
+4. [Lint it!](linting.md)
 
 > We use `cargo clippy` to ensure high-quality code and to enforce a set of best practices for Rust programming. However, not all lints provided by `cargo clippy` are relevant or applicable to our project.
 > We may choose to ignore some lints if they are unstable, experimental, or specific to our project.

--- a/doc/dev-guide/src/linting.md
+++ b/doc/dev-guide/src/linting.md
@@ -1,0 +1,33 @@
+# Linting
+
+## Manual linting
+
+When checking the codebase with [`clippy`](https://doc.rust-lang.org/stable/clippy/index.html), it is recommended to use:
+
+```console
+$ cargo clippy --all --all-targets --all-features -- -D warnings
+```
+
+## Rust-Analyzer
+
+When using  [`rust-analyzer`](https://rust-analyzer.github.io/) integration in the IDE of your choice, you might want to set the `rust-analyzer.cargo.features` configuration to `"all"` (check the [`rust-analyzer` manual](https://rust-analyzer.github.io/manual.html#configuration) for more details).
+
+### VSCode/VSCodium setup
+
+Add 
+
+```json
+"rust-analyzer.cargo.features": "all":,
+```
+
+in your project at `.vscode/settings.json`
+
+or
+
+to your global configuration `~/.config/Code/User/settings.json` (although you need to be aware that this will apply to all your Rust projects).
+
+
+## Rationale
+
+`rustup` uses cargo [features](https://doc.rust-lang.org/cargo/reference/features.html) in order to setup [conditional compilation](https://doc.rust-lang.org/reference/conditional-compilation.html) for integration tests as the `#[cfg(test)]` is only available for unit tests. To this end, the `test` feature has been created, however it then needs to be activated in order for tests and linting to fully work. As a shortcut we then propose to activate all features. However, if you encounter an issue, you could try activating only the `test` feature by setting the `rust-analyzer.cargo.features` configuration to `["test"]`.
+


### PR DESCRIPTION
# What

- Fixing `Clippy` command line instruction for linting code
- Adding an explanatory sub-chapter about linting and why it is done in this way

# Why

After trying to clean clone from `master` and contribute, even after following the instructions present in the [`developer-guide`](https://rust-lang.github.io/rustup/dev-guide/), both manual linting and `Rust-Analyzer` didn't work as intended.

# How

By modifying the `developer-guide` `mdbook`