### PR TITLE
fix(ci): fix file paths in CI-generated `*.sha256` files on *nix

### DIFF
--- a/ci/prepare-deploy.bash
+++ b/ci/prepare-deploy.bash
@@ -6,11 +6,13 @@ set -u -e
 cp target/"$TARGET"/release/rustup-init target/"$TARGET"/release/rustup-setup
 
 # Generate hashes
+pushd target/"$TARGET"/release/
 if [ "$(uname -s)" = "Darwin" ]; then
-    find target/"$TARGET"/release/ -maxdepth 1 -type f -exec sh -c 'fn="$1"; shasum -a 256 -b "$fn" > "$fn".sha256' sh {} \;
+    find . -maxdepth 1 -type f -exec sh -c 'fn="$1"; shasum -a 256 -b "$fn" > "$fn".sha256' sh {} \;
 else
-    find target/"$TARGET"/release/ -maxdepth 1 -type f -exec sh -c 'fn="$1"; sha256sum -b "$fn" > "$fn".sha256' sh {} \;
+    find . -maxdepth 1 -type f -exec sh -c 'fn="$1"; sha256sum -b "$fn" > "$fn".sha256' sh {} \;
 fi
+popd
 
 # The directory for deployment artifacts
 dest="deploy"


### PR DESCRIPTION
Fixes #3693.

See https://github.com/rust-lang/rustup/issues/3693#issuecomment-1977832321 for more context.

The `sha[256]sum` command on *nix relies on CWD if you use a relative path as the input arg. All file paths in its output are then relative to it.

The PowerShell script doesn't need to be fixed since there's no path in the sha256 file at all.

## Concerns

- [x] ~~How do I test this change? It does look quite correct though...~~ I've tested locally. Although this is expected to print out
    ```console
    f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a *./rustup-init
    ```
    which is not what @darthbanana13 originally asked for [^1], both `shasum --check rustup-init.sha256` and `sha256sum --check rustup-init.sha256` do pass. I hope this result remains satisfying.
    
[^1]: According to https://superuser.com/a/1566139, `f21c44b01678c645d8fbba1e55e4180a01ac5af2d38bcbd14aa665e0d96ed69a ./rustup-init` is NOT a legal output. The file path after the separating space must start with either a ` ` indicating "text input mode", or an `*` indicating "binary input mode". Given this, it's quite reasonable to see an `*` in a sha256 file for a compiled executable.