### PR TITLE
fix(utils): don't use `O_NOFOLLOW` in `open_dir()`

### DIFF
--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -19,7 +19,7 @@ use crate::{
     currentprocess::{process, varsource::VarSource},
     env_var, install,
     notifications::Notification,
-    utils::{raw::open_dir, utils},
+    utils::{raw::open_dir_following_links, utils},
     RustupError,
 };
 
@@ -62,7 +62,7 @@ impl<'a> Toolchain<'a> {
         let base_name = path
             .file_name()
             .ok_or_else(|| RustupError::InvalidToolchainName(name.to_string()))?;
-        let parent_dir = match open_dir(parent) {
+        let parent_dir = match open_dir_following_links(parent) {
             Ok(d) => d,
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
             e => e?,

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -45,11 +45,9 @@ pub fn open_dir(p: &Path) -> std::io::Result<File> {
 #[cfg(not(windows))]
 pub fn open_dir(p: &Path) -> std::io::Result<File> {
     use std::fs::OpenOptions;
-    use std::os::unix::fs::OpenOptionsExt;
 
     let mut options = OpenOptions::new();
     options.read(true);
-    options.custom_flags(libc::O_NOFOLLOW);
     options.open(p)
 }
 

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -31,7 +31,7 @@ pub fn is_file<P: AsRef<Path>>(path: P) -> bool {
 }
 
 #[cfg(windows)]
-pub fn open_dir(p: &Path) -> std::io::Result<File> {
+pub fn open_dir_following_links(p: &Path) -> std::io::Result<File> {
     use std::fs::OpenOptions;
     use std::os::windows::fs::OpenOptionsExt;
 
@@ -42,8 +42,9 @@ pub fn open_dir(p: &Path) -> std::io::Result<File> {
     options.custom_flags(FILE_FLAG_BACKUP_SEMANTICS);
     options.open(p)
 }
+
 #[cfg(not(windows))]
-pub fn open_dir(p: &Path) -> std::io::Result<File> {
+pub fn open_dir_following_links(p: &Path) -> std::io::Result<File> {
     use std::fs::OpenOptions;
 
     let mut options = OpenOptions::new();


### PR DESCRIPTION
Fixes #3737.

For more context on this particular approach, see https://github.com/rust-lang/rustup/issues/3737#issuecomment-2021842441.

## Concerns
- [x] Testing: can we bake a smoke test to prevent regression?