### PR TITLE
fix(doc): don't show the opening message when --path is used

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1594,18 +1594,15 @@ fn doc(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
     };
 
     let topical_path: PathBuf;
+    let mut doc_name = m.get_one::<String>("topic").map(|s| s.as_str());
 
-    let doc_url = if let Some(topic) = m.get_one::<String>("topic") {
+    let doc_url = if let Some(topic) = doc_name {
         topical_path = topical_doc::local_path(&toolchain.doc_path("").unwrap(), topic)?;
         topical_path.to_str().unwrap()
     } else if let Some((name, _, path)) = DOCS_DATA.iter().find(|(name, _, _)| m.get_flag(name)) {
-        writeln!(
-            process().stderr().lock(),
-            "Opening docs named `{name}` in your browser"
-        )?;
+        doc_name = Some(name);
         path
     } else {
-        writeln!(process().stderr().lock(), "Opening docs in your browser")?;
         "index.html"
     };
 
@@ -1614,6 +1611,14 @@ fn doc(cfg: &Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
         writeln!(process().stdout().lock(), "{}", doc_path.display())?;
         Ok(utils::ExitCode(0))
     } else {
+        if let Some(name) = doc_name {
+            writeln!(
+                process().stderr().lock(),
+                "Opening docs named `{name}` in your browser"
+            )?;
+        } else {
+            writeln!(process().stderr().lock(), "Opening docs in your browser")?;
+        }
         toolchain.open_docs(doc_url)?;
         Ok(utils::ExitCode(0))
     }


### PR DESCRIPTION
This might seem like a travel or unnecessary thing, especially since the message is written to `stderr`  so it won't affect piping or similar use cases.
But since `stdout` and `stderr` are ambiguous in most terminals (i.e., they're printed in the output) this might cause some confusion and/or annoyance to some users.
