### PR TITLE
Add hr to Windows instructions

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -48,6 +48,7 @@
     then follow the onscreen instructions.
   </p>
   <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequisites</a>.</p>
+  <hr/>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
     <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
@@ -70,6 +71,7 @@
     then follow the onscreen instructions.
   </p>
   <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequisites</a>.</p>
+  <hr/>
   <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
   <div class="copy-container">
     <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>


### PR DESCRIPTION
This makes it more visually distinct that there are two different sets of instructions for Windows, in case you are ignoring all of the text and skipping straight to the command. A user on Discord did this and was very confused.