### PR TITLE
Revert "fix(utils): unlink input path in `delete_dir_contents()` if it's a link"

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1007,7 +1007,7 @@ fn update(cfg: &mut Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
     } else {
         common::update_all_channels(cfg, self_update, m.get_flag("force"))?;
         info!("cleaning up downloads & tmp directories");
-        utils::delete_dir_contents_or_unlink(&cfg.download_dir);
+        utils::delete_dir_contents(&cfg.download_dir);
         cfg.temp_cfg.clean();
     }
 

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -158,7 +158,7 @@ impl Cfg {
     }
 
     pub(crate) fn clean(&self) {
-        utils::delete_dir_contents_or_unlink(&self.root_directory);
+        utils::delete_dir_contents(&self.root_directory);
     }
 }
 

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -611,12 +611,7 @@ where
 }
 
 pub(crate) fn delete_dir_contents(dir_path: &Path) {
-    let remove = if dir_path.is_symlink() {
-        fs::remove_dir_all
-    } else {
-        remove_dir_all::remove_dir_contents
-    };
-    match remove(dir_path) {
+    match remove_dir_all::remove_dir_contents(dir_path) {
         Err(e) if e.kind() != io::ErrorKind::NotFound => {
             panic!("Unable to clean up {}: {:?}", dir_path.display(), e);
         }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -610,7 +610,7 @@ where
     })
 }
 
-pub(crate) fn delete_dir_contents_or_unlink(dir_path: &Path) {
+pub(crate) fn delete_dir_contents(dir_path: &Path) {
     let remove = if dir_path.is_symlink() {
         fs::remove_dir_all
     } else {

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -702,33 +702,6 @@ fn toolchains_symlink() {
     });
 }
 
-// issue #3344
-/// `~/.rustup/tmp` and `~/.rustup/downloads` are permitted to be symlinks.
-#[test]
-#[cfg(any(unix, windows))]
-fn tmp_downloads_symlink() {
-    use rustup::utils::raw::symlink_dir;
-    use std::fs;
-
-    clitools::test(Scenario::ArchivesV2, &|config| {
-        let cwd = config.current_dir();
-
-        let test_tmp = cwd.join("tmp-test");
-        fs::create_dir(&test_tmp).unwrap();
-        symlink_dir(&test_tmp, &config.rustupdir.join("tmp")).unwrap();
-
-        let test_downloads = cwd.join("tmp-downloads");
-        fs::create_dir(&test_downloads).unwrap();
-        symlink_dir(&test_downloads, &config.rustupdir.join("downloads")).unwrap();
-
-        set_current_dist_date(config, "2015-01-01");
-        config.expect_ok(&["rustup", "default", "nightly"]);
-
-        set_current_dist_date(config, "2015-01-02");
-        config.expect_ok(&["rustup", "update"]);
-    });
-}
-
 // issue #1169
 /// A toolchain that is a stale symlink should be correctly uninstalled.
 #[test]


### PR DESCRIPTION
Reverts rust-lang/rustup#3752

This commit  looks like a regression in multiple directiions: it uses fs::remove_dir_all which has had issues with Windows reliable deletiing in the past - and is single threads vs remove_dir_all; and it removes the link which will regress https://github.com/rust-lang/rustup/issues/2430.

A better fix is to resolve the link in the calling code and then use remove_dir_contents as before.