### PR TITLE
Rename temp::Cfg to temp::Context

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1008,7 +1008,7 @@ fn update(cfg: &mut Cfg, m: &ArgMatches) -> Result<utils::ExitCode> {
         common::update_all_channels(cfg, self_update, m.get_flag("force"))?;
         info!("cleaning up downloads & tmp directories");
         utils::delete_dir_contents_following_links(&cfg.download_dir);
-        cfg.temp_cfg.clean();
+        cfg.tmp_cx.clean();
     }
 
     if !self_update::NEVER_SELF_UPDATE && self_update_mode == SelfUpdateMode::CheckOnly {

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,7 +179,7 @@ pub(crate) struct Cfg {
     pub toolchains_dir: PathBuf,
     pub update_hash_dir: PathBuf,
     pub download_dir: PathBuf,
-    pub temp_cfg: temp::Cfg,
+    pub tmp_cx: temp::Context,
     pub toolchain_override: Option<ResolvableToolchainName>,
     pub env_override: Option<LocalToolchainName>,
     pub dist_root_url: String,
@@ -241,7 +241,7 @@ impl Cfg {
         };
 
         let notify_clone = notify_handler.clone();
-        let temp_cfg = temp::Cfg::new(
+        let tmp_cx = temp::Context::new(
             rustup_dir.join("tmp"),
             dist_root_server.as_str(),
             Box::new(move |n| (notify_clone)(n.into())),
@@ -256,7 +256,7 @@ impl Cfg {
             toolchains_dir,
             update_hash_dir,
             download_dir,
-            temp_cfg,
+            tmp_cx,
             notify_handler,
             toolchain_override: None,
             env_override,
@@ -281,7 +281,7 @@ impl Cfg {
     ) -> DownloadCfg<'a> {
         DownloadCfg {
             dist_root: &self.dist_root_url,
-            temp_cfg: &self.temp_cfg,
+            tmp_cx: &self.tmp_cx,
             download_dir: &self.download_dir,
             notify_handler,
         }
@@ -961,7 +961,7 @@ impl Debug for Cfg {
             .field("toolchains_dir", &self.toolchains_dir)
             .field("update_hash_dir", &self.update_hash_dir)
             .field("download_dir", &self.download_dir)
-            .field("temp_cfg", &self.temp_cfg)
+            .field("tmp_cx", &self.tmp_cx)
             .field("toolchain_override", &self.toolchain_override)
             .field("env_override", &self.env_override)
             .field("dist_root_url", &self.dist_root_url)

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -143,10 +143,10 @@ pub(crate) struct TarPackage<'a>(DirectoryPackage, temp::Dir<'a>);
 impl<'a> TarPackage<'a> {
     pub(crate) fn new<R: Read>(
         stream: R,
-        temp_cfg: &'a temp::Cfg,
+        tmp_cx: &'a temp::Context,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
     ) -> Result<Self> {
-        let temp_dir = temp_cfg.new_directory()?;
+        let temp_dir = tmp_cx.new_directory()?;
         let mut archive = tar::Archive::new(stream);
         // The rust-installer packages unpack to a directory called
         // $pkgname-$version-$target. Skip that directory when
@@ -555,13 +555,13 @@ pub(crate) struct TarGzPackage<'a>(TarPackage<'a>);
 impl<'a> TarGzPackage<'a> {
     pub(crate) fn new<R: Read>(
         stream: R,
-        temp_cfg: &'a temp::Cfg,
+        tmp_cx: &'a temp::Context,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
     ) -> Result<Self> {
         let stream = flate2::read::GzDecoder::new(stream);
         Ok(TarGzPackage(TarPackage::new(
             stream,
-            temp_cfg,
+            tmp_cx,
             notify_handler,
         )?))
     }
@@ -591,13 +591,13 @@ pub(crate) struct TarXzPackage<'a>(TarPackage<'a>);
 impl<'a> TarXzPackage<'a> {
     pub(crate) fn new<R: Read>(
         stream: R,
-        temp_cfg: &'a temp::Cfg,
+        tmp_cx: &'a temp::Context,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
     ) -> Result<Self> {
         let stream = xz2::read::XzDecoder::new(stream);
         Ok(TarXzPackage(TarPackage::new(
             stream,
-            temp_cfg,
+            tmp_cx,
             notify_handler,
         )?))
     }
@@ -627,13 +627,13 @@ pub(crate) struct TarZStdPackage<'a>(TarPackage<'a>);
 impl<'a> TarZStdPackage<'a> {
     pub(crate) fn new<R: Read>(
         stream: R,
-        temp_cfg: &'a temp::Cfg,
+        tmp_cx: &'a temp::Context,
         notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
     ) -> Result<Self> {
         let stream = zstd::stream::read::Decoder::new(stream)?;
         Ok(TarZStdPackage(TarPackage::new(
             stream,
-            temp_cfg,
+            tmp_cx,
             notify_handler,
         )?))
     }

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -20,14 +20,14 @@ fn add_file() {
 
     let prefix = InstallPrefix::from(prefixdir.path());
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let mut file = tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     write!(file, "test").unwrap();
@@ -48,14 +48,14 @@ fn add_file_then_rollback() {
 
     let prefix = InstallPrefix::from(prefixdir.path());
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -68,7 +68,7 @@ fn add_file_that_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -77,7 +77,7 @@ fn add_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     fs::create_dir_all(prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
@@ -99,7 +99,7 @@ fn copy_file() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -108,7 +108,7 @@ fn copy_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -126,7 +126,7 @@ fn copy_file_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -135,7 +135,7 @@ fn copy_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -153,7 +153,7 @@ fn copy_file_that_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -162,7 +162,7 @@ fn copy_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -189,7 +189,7 @@ fn copy_dir() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -198,7 +198,7 @@ fn copy_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -223,7 +223,7 @@ fn copy_dir_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -232,7 +232,7 @@ fn copy_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -257,7 +257,7 @@ fn copy_dir_that_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -266,7 +266,7 @@ fn copy_dir_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     fs::create_dir_all(prefix.path().join("a")).unwrap();
 
@@ -288,7 +288,7 @@ fn remove_file() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -297,7 +297,7 @@ fn remove_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -313,7 +313,7 @@ fn remove_file_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -322,7 +322,7 @@ fn remove_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -338,7 +338,7 @@ fn remove_file_that_not_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -347,7 +347,7 @@ fn remove_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let err = tx.remove_file("c", PathBuf::from("foo")).unwrap_err();
 
@@ -365,7 +365,7 @@ fn remove_dir() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -374,7 +374,7 @@ fn remove_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -391,7 +391,7 @@ fn remove_dir_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -400,7 +400,7 @@ fn remove_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -417,7 +417,7 @@ fn remove_dir_that_not_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -426,7 +426,7 @@ fn remove_dir_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
 
     let err = tx.remove_dir("c", PathBuf::from("foo")).unwrap_err();
 
@@ -444,7 +444,7 @@ fn write_file() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -453,7 +453,7 @@ fn write_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content.clone())
@@ -471,7 +471,7 @@ fn write_file_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -480,7 +480,7 @@ fn write_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content)
@@ -495,7 +495,7 @@ fn write_file_that_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -504,7 +504,7 @@ fn write_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let content = "hi".to_string();
     utils_raw::write_file(&prefix.path().join("a"), &content).unwrap();
@@ -526,7 +526,7 @@ fn modify_file_that_not_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -535,7 +535,7 @@ fn modify_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     tx.commit();
@@ -550,7 +550,7 @@ fn modify_file_that_exists() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -559,7 +559,7 @@ fn modify_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -574,7 +574,7 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -583,7 +583,7 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -596,7 +596,7 @@ fn modify_file_that_exists_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -605,7 +605,7 @@ fn modify_file_that_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -623,7 +623,7 @@ fn modify_twice_then_rollback() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -632,7 +632,7 @@ fn modify_twice_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -650,7 +650,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -659,7 +659,7 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     // copy_file
     let relpath1 = PathBuf::from("bin/rustc");
@@ -751,7 +751,7 @@ fn rollback_failure_keeps_going() {
     let prefixdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let txdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         txdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
@@ -760,7 +760,7 @@ fn rollback_failure_keeps_going() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     write!(tx.add_file("", PathBuf::from("foo")).unwrap(), "").unwrap();
     write!(tx.add_file("", PathBuf::from("bar")).unwrap(), "").unwrap();

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -1068,7 +1068,7 @@ fn try_update_from_dist_(
     let result = manifestation.update_v1(
         &manifest,
         update_hash,
-        download.temp_cfg,
+        download.tmp_cx,
         &download.notify_handler,
     );
     // inspect, determine what context to add, then process afterwards.

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -16,7 +16,7 @@ const UPDATE_HASH_LEN: usize = 20;
 #[derive(Copy, Clone)]
 pub struct DownloadCfg<'a> {
     pub dist_root: &'a str,
-    pub temp_cfg: &'a temp::Cfg,
+    pub tmp_cx: &'a temp::Context,
     pub download_dir: &'a PathBuf,
     pub notify_handler: &'a dyn Fn(Notification<'_>),
 }
@@ -126,7 +126,7 @@ impl<'a> DownloadCfg<'a> {
 
     fn download_hash(&self, url: &str) -> Result<String> {
         let hash_url = utils::parse_url(&(url.to_owned() + ".sha256"))?;
-        let hash_file = self.temp_cfg.new_file()?;
+        let hash_file = self.tmp_cx.new_file()?;
 
         utils::download_file(&hash_url, &hash_file, None, &|n| {
             (self.notify_handler)(n.into())
@@ -165,7 +165,7 @@ impl<'a> DownloadCfg<'a> {
         }
 
         let url = utils::parse_url(url_str)?;
-        let file = self.temp_cfg.new_file_with_ext("", ext)?;
+        let file = self.tmp_cx.new_file_with_ext("", ext)?;
 
         let mut hasher = Sha256::new();
         utils::download_file(&url, &file, Some(&mut hasher), &|n| {

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -4,7 +4,7 @@ use std::io;
 use std::ops;
 use std::path::{Path, PathBuf};
 
-pub(crate) use anyhow::{Context, Result};
+pub(crate) use anyhow::{Context as _, Result};
 use thiserror::Error as ThisError;
 
 use crate::utils::notify::NotificationLevel;
@@ -23,7 +23,7 @@ pub(crate) enum CreatingError {
 
 #[derive(Debug)]
 pub(crate) struct Dir<'a> {
-    cfg: &'a Cfg,
+    cfg: &'a Context,
     path: PathBuf,
 }
 
@@ -49,7 +49,7 @@ impl<'a> Drop for Dir<'a> {
 
 #[derive(Debug)]
 pub struct File<'a> {
-    cfg: &'a Cfg,
+    cfg: &'a Context,
     path: PathBuf,
 }
 
@@ -120,13 +120,13 @@ impl<'a> Display for Notification<'a> {
     }
 }
 
-pub struct Cfg {
+pub struct Context {
     root_directory: PathBuf,
     pub dist_server: String,
     notify_handler: Box<dyn Fn(Notification<'_>)>,
 }
 
-impl Cfg {
+impl Context {
     pub fn new(
         root_directory: PathBuf,
         dist_server: &str,
@@ -199,7 +199,7 @@ impl Cfg {
     }
 }
 
-impl fmt::Debug for Cfg {
+impl fmt::Debug for Context {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Cfg")
             .field("root_directory", &self.root_directory)

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -111,13 +111,13 @@ fn basic_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         tmpdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let components = Components::open(prefix).unwrap();
 
@@ -157,13 +157,13 @@ fn multiple_component_install() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         tmpdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let components = Components::open(prefix).unwrap();
 
@@ -207,13 +207,13 @@ fn uninstall() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         tmpdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -225,7 +225,7 @@ fn uninstall() {
 
     // Now uninstall
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmpcfg, &notify);
+    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
     for component in components.list().unwrap() {
         tx = component.uninstall(tx).unwrap();
     }
@@ -264,13 +264,13 @@ fn component_bad_version() {
     let prefix = InstallPrefix::from(instdir.path().to_owned());
 
     let tmpdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         tmpdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -310,13 +310,13 @@ fn install_to_prefix_that_does_not_exist() {
     let prefix = InstallPrefix::from(does_not_exist.clone());
 
     let tmpdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let tmpcfg = temp::Cfg::new(
+    let tmp_cx = temp::Context::new(
         tmpdir.path().to_owned(),
         DEFAULT_DIST_SERVER,
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmpcfg, &notify);
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
 
     let components = Components::open(prefix).unwrap();
 


### PR DESCRIPTION
While reviewing #3754 I was a little surprised to note that the `temp::Cfg` type was different from `config::Config` (and then apparently there's also `dist::config::Config`). As far as I can see `temp::Cfg` also really doesn't represent "configuration" in the sense that it's input provided by the user or an external process. Renamed it to `TemporaryContext` instead.