### PR TITLE
docs(dev-guide): mention that we need to keep mdBook links stable

### DIFF
--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -35,6 +35,11 @@ We use `rustfmt` to keep our codebase consistently formatted. Please ensure that
 you have correctly formatted your code (most editors will do this automatically
 when saving) or it may not pass the CI tests.
 
+If you are moving, renaming or removing an existing mdBook page, please use mdBook's
+[`output.html.redirect`] feature to ensure that the old URL gets redirected.
+
+[`output.html.redirect`]: https://rust-lang.github.io/mdBook/format/configuration/renderers.html#outputhtmlredirect
+
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the
 Apache-2.0 license, shall be dual licensed as in the README, without any

--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -4,11 +4,6 @@
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Test it: `cargo test --features=test`
 4. [Lint it!](linting.md)
-
-> We use `cargo clippy` to ensure high-quality code and to enforce a set of best practices for Rust programming. However, not all lints provided by `cargo clippy` are relevant or applicable to our project.
-> We may choose to ignore some lints if they are unstable, experimental, or specific to our project.
-> If you are unsure about a lint, please ask us in the [rustup Discord channel](https://discord.com/channels/442252698964721669/463480252723888159).
-
 5. Commit your changes: `git commit -am 'Add some feature'`
 6. Push to the branch: `git push origin my-new-feature`
 7. Submit a pull request :D

--- a/doc/dev-guide/src/linting.md
+++ b/doc/dev-guide/src/linting.md
@@ -1,5 +1,9 @@
 # Linting
 
+We use `cargo clippy` to ensure high-quality code and to enforce a set of best practices for Rust programming. However, not all lints provided by `cargo clippy` are relevant or applicable to our project.
+We may choose to ignore some lints if they are unstable, experimental, or specific to our project.
+If you are unsure about a lint, please ask us in the [rustup Discord channel](https://discord.com/channels/442252698964721669/463480252723888159).
+
 ## Manual linting
 
 When checking the codebase with [`clippy`](https://doc.rust-lang.org/stable/clippy/index.html), it is recommended to use:


### PR DESCRIPTION
Closes #3759.

I also moved the `cargo clippy` box over to `linting.md` since [the current render](https://rust-lang.github.io/rustup/dev-guide/index.html) looks a bit weird:

<img width="764" alt="image" src="https://github.com/rust-lang/rustup/assets/33851577/2dba5740-9170-44e1-9625-1ae41addca97">
