### PR TITLE
Remove derivative dependency in favor of manual implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -141,7 +141,7 @@ checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -502,17 +502,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,7 +571,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -594,7 +583,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -736,7 +725,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -813,7 +802,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "time",
 ]
 
@@ -1371,7 +1360,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1524,7 +1513,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1606,7 +1595,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -1929,7 +1918,6 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
- "derivative",
  "download",
  "effective-limits",
  "enum-map",
@@ -1990,7 +1978,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2087,7 +2075,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2236,17 +2224,6 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
@@ -2331,7 +2308,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2434,7 +2411,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2608,7 +2585,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
 ]
 
 [[package]]
@@ -2834,7 +2811,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2868,7 +2845,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["wrap_help"] }
 clap_complete = "4"
-derivative.workspace = true
 download = { path = "download", default-features = false }
 effective-limits = "0.5.5"
 enum-map = "2.5.0"
@@ -160,7 +159,6 @@ members = ["download", "rustup-macros"]
 
 [workspace.dependencies]
 anyhow = "1.0.69"
-derivative = "2.2.0"
 enum_dispatch = "0.3.11"
 fs_at = "0.1.6"
 once_cell = "1.18.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::fmt::{self, Display};
+use std::fmt::{self, Debug, Display};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -7,7 +7,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
-use derivative::Derivative;
 use serde::Deserialize;
 use thiserror::Error as ThisError;
 
@@ -172,8 +171,6 @@ impl OverrideCfg {
 
 pub(crate) const UNIX_FALLBACK_SETTINGS: &str = "/etc/rustup/settings.toml";
 
-#[derive(Derivative)]
-#[derivative(Debug)]
 pub(crate) struct Cfg {
     profile_override: Option<dist::Profile>,
     pub rustup_dir: PathBuf,
@@ -186,7 +183,6 @@ pub(crate) struct Cfg {
     pub toolchain_override: Option<ResolvableToolchainName>,
     pub env_override: Option<LocalToolchainName>,
     pub dist_root_url: String,
-    #[derivative(Debug = "ignore")]
     pub notify_handler: Arc<dyn Fn(Notification<'_>)>,
 }
 
@@ -952,6 +948,24 @@ impl Cfg {
             LocalToolchainName::Named(name) => self.toolchains_dir.join(name.to_string()),
             LocalToolchainName::Path(p) => p.to_path_buf(),
         }
+    }
+}
+
+impl Debug for Cfg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Cfg")
+            .field("profile_override", &self.profile_override)
+            .field("rustup_dir", &self.rustup_dir)
+            .field("settings_file", &self.settings_file)
+            .field("fallback_settings", &self.fallback_settings)
+            .field("toolchains_dir", &self.toolchains_dir)
+            .field("update_hash_dir", &self.update_hash_dir)
+            .field("download_dir", &self.download_dir)
+            .field("temp_cfg", &self.temp_cfg)
+            .field("toolchain_override", &self.toolchain_override)
+            .field("env_override", &self.env_override)
+            .field("dist_root_url", &self.dist_root_url)
+            .finish()
     }
 }
 

--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use anyhow::{anyhow, bail};
-use derivative::Derivative;
 use fs_at::OpenOptions;
 use wait_timeout::ChildExt;
 
@@ -30,8 +29,7 @@ use super::{
 };
 
 /// A toolchain installed on the local disk
-#[derive(Derivative)]
-#[derivative(Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct Toolchain<'a> {
     cfg: &'a Cfg,
     name: LocalToolchainName,


### PR DESCRIPTION
As an added benefit, derivative was the only dependency still relying on syn 1, so this should help compile times.