### PR TITLE
fix(windows): update `DisplayVersion` on `rustup self update`

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1106,12 +1106,9 @@ pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
 
     match prepare_update()? {
         Some(setup_path) => {
-            let version = match get_new_rustup_version(&setup_path) {
-                Some(new_version) => parse_new_rustup_version(new_version),
-                None => {
-                    err!("failed to get rustup version");
-                    return Ok(utils::ExitCode(1));
-                }
+            let Some(version) = get_and_parse_new_rustup_version(&setup_path) else {
+                err!("failed to get rustup version");
+                return Ok(utils::ExitCode(1));
             };
 
             let _ = common::show_channel_update(
@@ -1133,6 +1130,10 @@ pub(crate) fn update(cfg: &Cfg) -> Result<utils::ExitCode> {
     }
 
     Ok(utils::ExitCode(0))
+}
+
+fn get_and_parse_new_rustup_version(path: &Path) -> Option<String> {
+    get_new_rustup_version(path).map(parse_new_rustup_version)
 }
 
 fn get_new_rustup_version(path: &Path) -> Option<String> {

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -2,13 +2,13 @@
 
 use std::sync::Mutex;
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 use winreg::{
     enums::{HKEY_CURRENT_USER, KEY_READ, KEY_WRITE},
     RegKey, RegValue,
 };
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 pub fn get_path() -> std::io::Result<Option<RegValue>> {
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root
@@ -21,7 +21,7 @@ pub fn get_path() -> std::io::Result<Option<RegValue>> {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn restore_path(p: Option<RegValue>) {
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -8,6 +8,28 @@ use winreg::{
     RegKey, RegValue,
 };
 
+/// Support testing of code that mutates global state
+pub fn with_saved_global_state<S>(
+    getter: impl Fn() -> io::Result<S>,
+    setter: impl Fn(S),
+    f: &mut dyn FnMut(),
+) {
+    // Lock protects concurrent mutation of registry
+    static LOCK: Mutex<()> = Mutex::new(());
+    let _g = LOCK.lock();
+
+    // Save and restore the global state here to keep from trashing things.
+    let saved_state =
+        getter().expect("Error getting global state: Better abort to avoid trashing it");
+    let _g = scopeguard::guard(saved_state, setter);
+
+    f();
+}
+
+pub fn with_saved_path(f: &mut dyn FnMut()) {
+    with_saved_global_state(get_path, restore_path, f)
+}
+
 #[cfg(windows)]
 pub fn get_path() -> io::Result<Option<RegValue>> {
     let root = RegKey::predef(HKEY_CURRENT_USER);
@@ -32,20 +54,6 @@ fn restore_path(p: Option<RegValue>) {
     } else {
         let _ = environment.delete_value("PATH");
     }
-}
-
-/// Support testing of code that mutates global path state
-pub fn with_saved_path(f: &mut dyn FnMut()) {
-    // Lock protects concurrent mutation of registry
-    static LOCK: Mutex<()> = Mutex::new(());
-    let _g = LOCK.lock();
-
-    // On windows these tests mess with the user's PATH. Save
-    // and restore them here to keep from trashing things.
-    let saved_path = get_path().expect("Error getting PATH: Better abort to avoid trashing it.");
-    let _g = scopeguard::guard(saved_path, restore_path);
-
-    f();
 }
 
 #[cfg(unix)]

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -1,6 +1,6 @@
 //! Support for functional tests.
 
-use std::sync::Mutex;
+use std::{io, sync::Mutex};
 
 #[cfg(windows)]
 use winreg::{
@@ -9,14 +9,14 @@ use winreg::{
 };
 
 #[cfg(windows)]
-pub fn get_path() -> std::io::Result<Option<RegValue>> {
+pub fn get_path() -> io::Result<Option<RegValue>> {
     let root = RegKey::predef(HKEY_CURRENT_USER);
     let environment = root
         .open_subkey_with_flags("Environment", KEY_READ | KEY_WRITE)
         .unwrap();
     match environment.get_raw_value("PATH") {
         Ok(val) => Ok(Some(val)),
-        Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
         Err(e) => Err(e),
     }
 }
@@ -49,7 +49,7 @@ pub fn with_saved_path(f: &mut dyn FnMut()) {
 }
 
 #[cfg(unix)]
-pub fn get_path() -> std::io::Result<Option<()>> {
+pub fn get_path() -> io::Result<Option<()>> {
     Ok(None)
 }
 

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -26,18 +26,19 @@ pub fn with_saved_global_state<S>(
     f();
 }
 
+#[cfg(windows)]
 pub fn with_saved_path(f: &mut dyn FnMut()) {
-    with_saved_global_state(get_path, restore_path, f)
+    with_saved_reg_value(&RegKey::predef(HKEY_CURRENT_USER), "Environment", "PATH", f)
+}
+
+#[cfg(unix)]
+pub fn with_saved_path(f: &mut dyn FnMut()) {
+    f()
 }
 
 #[cfg(windows)]
 pub fn get_path() -> io::Result<Option<RegValue>> {
     get_reg_value(&RegKey::predef(HKEY_CURRENT_USER), "Environment", "PATH")
-}
-
-#[cfg(windows)]
-fn restore_path(p: Option<RegValue>) {
-    restore_reg_value(&RegKey::predef(HKEY_CURRENT_USER), "Environment", "PATH", p)
 }
 
 #[cfg(windows)]
@@ -70,11 +71,3 @@ fn restore_reg_value(root: &RegKey, subkey: &str, name: &str, p: Option<RegValue
         let _ = subkey.delete_value(name);
     }
 }
-
-#[cfg(unix)]
-pub fn get_path() -> io::Result<Option<()>> {
-    Ok(None)
-}
-
-#[cfg(unix)]
-fn restore_path(_: Option<()>) {}

--- a/src/cli/self_update/test.rs
+++ b/src/cli/self_update/test.rs
@@ -41,6 +41,15 @@ fn restore_path(p: Option<RegValue>) {
 }
 
 #[cfg(windows)]
+pub fn with_saved_reg_value(root: &RegKey, subkey: &str, name: &str, f: &mut dyn FnMut()) {
+    with_saved_global_state(
+        || get_reg_value(root, subkey, name),
+        |p| restore_reg_value(root, subkey, name, p),
+        f,
+    )
+}
+
+#[cfg(windows)]
 fn get_reg_value(root: &RegKey, subkey: &str, name: &str) -> io::Result<Option<RegValue>> {
     let subkey = root.open_subkey_with_flags(subkey, KEY_READ | KEY_WRITE)?;
     match subkey.get_raw_value(name) {

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -510,7 +510,7 @@ fn rustup_uninstall_reg_key() -> Result<RegKey> {
 pub(crate) fn do_update_programs_display_version(version: &str) -> Result<()> {
     rustup_uninstall_reg_key()?
         .set_value("DisplayVersion", &version)
-        .context("Failed to set display version")
+        .context("Failed to set `DisplayVersion`")
 }
 
 pub(crate) fn do_add_to_programs() -> Result<()> {
@@ -542,9 +542,9 @@ pub(crate) fn do_add_to_programs() -> Result<()> {
     };
 
     key.set_raw_value("UninstallString", &reg_value)
-        .context("Failed to set uninstall string")?;
+        .context("Failed to set `UninstallString`")?;
     key.set_value("DisplayName", &"Rustup: the Rust toolchain installer")
-        .context("Failed to set display name")?;
+        .context("Failed to set `DisplayName`")?;
     do_update_programs_display_version(env!("CARGO_PKG_VERSION"))?;
 
     Ok(())

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -593,6 +593,12 @@ pub(crate) fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
         .spawn()
         .context("unable to run updater")?;
 
+    let Some(version) = super::get_and_parse_new_rustup_version(setup_path) else {
+        warn!("failed to get the new rustup version in order to update `DisplayVersion`");
+        return Ok(utils::ExitCode(1));
+    };
+    do_update_programs_display_version(&version)?;
+
     Ok(utils::ExitCode(0))
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -15,12 +15,12 @@ use std::process::Command;
 #[cfg(test)]
 use anyhow::Result;
 
-pub use crate::cli::self_update::test::{get_path, with_saved_global_state, with_saved_path};
+pub use crate::cli::self_update::test::{with_saved_global_state, with_saved_path};
 use crate::currentprocess;
 use crate::dist::dist::TargetTriple;
 
 #[cfg(windows)]
-pub use crate::cli::self_update::test::with_saved_reg_value;
+pub use crate::cli::self_update::test::{get_path, with_saved_reg_value};
 
 // Things that can have environment variables applied to them.
 pub trait Env {

--- a/src/test.rs
+++ b/src/test.rs
@@ -19,6 +19,9 @@ pub use crate::cli::self_update::test::{get_path, with_saved_global_state, with_
 use crate::currentprocess;
 use crate::dist::dist::TargetTriple;
 
+#[cfg(windows)]
+pub use crate::cli::self_update::test::with_saved_reg_value;
+
 // Things that can have environment variables applied to them.
 pub trait Env {
     fn env<K, V>(&mut self, key: K, val: V)

--- a/src/test.rs
+++ b/src/test.rs
@@ -15,7 +15,7 @@ use std::process::Command;
 #[cfg(test)]
 use anyhow::Result;
 
-pub use crate::cli::self_update::test::{get_path, with_saved_path};
+pub use crate::cli::self_update::test::{get_path, with_saved_global_state, with_saved_path};
 use crate::currentprocess;
 use crate::dist::dist::TargetTriple;
 


### PR DESCRIPTION
Closes #3739.

My daily driver is a Mac (and OpenSSL refuses to cross-build here) so this is pretty much a best-effort blind fix.

cc @ChrisDenton 

## Concerns

- [x] ~~Is it necessary to add a test case for this one? If so, how? (Considering the sandboxing requirements, doing this properly might be hard.)~~ A sandboxed test case has been added.