### PR TITLE
dist: bump `rustup` version to `1.27.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,75 @@
 # Changelog
 
+## [1.27.1] - 2024-04-14
+
+This new Rustup release involves some minor bug fixes.
+
+The headlines for this release are:
+
+1. Prebuilt Rustup binaries should be working on older macOS versions again.
+2. `rustup-init` will no longer fail when `fish` is installed but `~/.config/fish/conf.d` hasn't been created.
+3. Regressions regarding symlinked `RUSTUP_HOME/(toolchains|downloads|tmp)` have been addressed.
+
+Since the release of 1.27.0, the project has welcomed a total of 7 new contributors.
+Many thanks for your hard work, and we hope to see you again!
+
+### Added
+
+- Added the logging of `RUSTUP_UPDATE_ROOT` and `RUSTUP_DIST_(SERVER|ROOT)` when `RUSTUP_DEBUG` is set [pr#3722]
+
+### Changed
+
+- Ensured that CI builds target macOS 10.12+ on x64 and macOS 11.0+ on arm64 [pr#3710]
+- Fixed an error when writing to rcfiles by ensuring the creation of their parent dir(s) first [pr#3712]
+- Fixed unexpected errors when `RUSTUP_HOME/(toolchains|downloads|tmp)` is symlinked [pr#3742] [pr#3754]
+- Fixed an unexpected error when removing a component by component name with explicit target triple [pr#3601]
+- Changed `RUSTUP_WINDOWS_PATH_ADD_BIN` to be false by default [pr#3703]
+- Fixed incorrect color state after `ColorableTerminal::reset` [pr#3711]
+- Replaced `.` with `source` in fish shell's `source_string` [pr#3715]
+- Fixed "component add" error message format [pr#3724]
+- Fixed file paths in CI-generated `*.sha256` files on *nix [pr#3730]
+- Removed an unnecessary debug print [pr#3734]
+- Disabled the "doc opening" output on `rustup doc --path` [pr#3748]
+- Fixed the update of `DisplayVersion` in the Windows registry on `rustup self update` [pr#3770]
+- Bumped a lot of dependencies to their latest versions [pr#renovate-bot]
+
+Thanks go to:
+
+- Anas (0x61nas)
+- cuiyourong (cuiyourong)
+- Dirkjan Ochtman (djc)
+- Eric Huss (ehuss)
+- eth3lbert (eth3lbert)
+- hev (heiher)
+- klensy (klensy)
+- Chih Wang (ongchi)
+- Adam (pie-flavor)
+- rami3l (rami3l)
+- Robert (rben01)
+- Robert Collins (rbtcollins)
+- Sun Bin (shandongbinzhou)
+- Samuel Moelius (smoelius)
+- vpochapuis (vpochapuis)
+- Renovate Bot (renovate)
+
+**Full Changelog**: https://github.com/rust-lang/rustup/compare/1.27.0...1.27.1
+
+[1.27.1]: https://github.com/rust-lang/rustup/releases/tag/1.27.1
+[pr#3601]: https://github.com/rust-lang/rustup/pull/3601
+[pr#3703]: https://github.com/rust-lang/rustup/pull/3703
+[pr#3711]: https://github.com/rust-lang/rustup/pull/3711
+[pr#3715]: https://github.com/rust-lang/rustup/pull/3715
+[pr#3710]: https://github.com/rust-lang/rustup/pull/3710
+[pr#3712]: https://github.com/rust-lang/rustup/pull/3712
+[pr#3722]: https://github.com/rust-lang/rustup/pull/3722
+[pr#3724]: https://github.com/rust-lang/rustup/pull/3724
+[pr#3730]: https://github.com/rust-lang/rustup/pull/3730
+[pr#3734]: https://github.com/rust-lang/rustup/pull/3734
+[pr#3748]: https://github.com/rust-lang/rustup/pull/3748
+[pr#3742]: https://github.com/rust-lang/rustup/pull/3742
+[pr#3754]: https://github.com/rust-lang/rustup/pull/3754
+[pr#3770]: https://github.com/rust-lang/rustup/pull/3770
+
 ## [1.27.0] - 2024-03-08
 
 This long-awaited Rustup release has gathered all the new features and fixes since April 2023.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "download"
-version = "1.27.0"
+version = "1.27.1"
 dependencies = [
  "anyhow",
  "curl",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.27.0"
+version = "1.27.1"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup"
-version = "1.27.0"
+version = "1.27.1"
 edition = "2021"
 description = "Manage multiple rust installations with ease"
 homepage = "https://github.com/rust-lang/rustup"

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "download"
-version = "1.27.0"
+version = "1.27.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
This is the 1st PR for the `1.27.1` release according to our [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#making-a-release).

I think this time we can ship the patch without beta testing: most of the finished items in this release cycle have been either manually tested or is accompanied by a regression test.

## Checklist

- [x] Bump version in the manifest.
- [x] Update the changelog.
- [x] Draft the release blog post (https://github.com/rust-lang/blog.rust-lang.org/pull/1318).