### PR TITLE
chore(dist): update commit shasum in `rustup-init.sh`, take 2

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -31,7 +31,7 @@ RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.27.1 (c9662f94b 2024-04-23)
+rustup-init 1.27.1 (a8e4f5c64 2024-04-24)
 
 The installer for rustup
 


### PR DESCRIPTION
Following https://github.com/rust-lang/rustup/pull/3773, this is the 2nd PR for the `1.27.1` release according to our [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#making-a-release).

Supersedes #3785.

It's tedious, but the commit shasum should be renewed, or otherwise the dates won't match 😞 