### PR TITLE
docs(dev-guide): remove “pushing to master” in the release process

### DIFF
--- a/doc/dev-guide/src/release-process.md
+++ b/doc/dev-guide/src/release-process.md
@@ -60,7 +60,6 @@ or an official [r]elease:
    latest `stable` commit.
    - `git tag -as $VER_NUM -m $VER_NUM` (optionally without `-s` if not GPG
      signing the tag)
-   - `git push origin HEAD:master`
    - `git push origin $VER_NUM`
 
 [Rust Blog]: https://github.com/rust-lang/blog.rust-lang.org


### PR DESCRIPTION
Pushing to master is no longer possible with GitHub Merge Queue enabled.

> 漏網之魚 lòu wǎng zhī yú
> - a fish that escaped the net