### PR TITLE
feat(download-backend)!: make `reqwest/rustls` the new default

### DIFF
--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -226,7 +226,7 @@ fn download_file_(
         .map_or(false, |it| it != "0");
     let use_rustls = process()
         .var_os("RUSTUP_USE_RUSTLS")
-        .map_or(false, |it| it != "0");
+        .map_or(true, |it| it != "0");
     let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)
     } else {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -221,8 +221,12 @@ fn download_file_(
     // Download the file
 
     // Keep the curl env var around for a bit
-    let use_curl_backend = process().var_os("RUSTUP_USE_CURL").is_some();
-    let use_rustls = process().var_os("RUSTUP_USE_RUSTLS").is_some();
+    let use_curl_backend = process()
+        .var_os("RUSTUP_USE_CURL")
+        .map_or(false, |it| it != "0");
+    let use_rustls = process()
+        .var_os("RUSTUP_USE_RUSTLS")
+        .map_or(false, |it| it != "0");
     let (backend, notification) = if use_curl_backend {
         (Backend::Curl, Notification::UsingCurl)
     } else {


### PR DESCRIPTION
Part of #3790.

---

This PR has also fixed the weird business logic where `RUSTUP_USE_CURL=0` actually instructs Rustup to **_use_** the curl backend, which might surprise many people including myself and @fh-igd-mueller-roemer from https://github.com/rust-lang/rustup/issues/3791#issuecomment-2079234203.

A more ideal solution OTOH would be borrowing from my previous work on https://github.com/clap-rs/clap/pull/2664 (Aha, dots connected!), however I'm not sure about its interactions with our current `process().var_os()`. Maybe only the parsing part should be copied over.