### PR TITLE
Update MSVC requirements to VS 2017 to match Rust repo

### DIFF
--- a/doc/user-guide/src/installation/windows-msvc.md
+++ b/doc/user-guide/src/installation/windows-msvc.md
@@ -15,7 +15,7 @@ See [licensing terms][vs licences] for more details.
 ## Manual install
 
 [Download Visual Studio][vs downloads].
-Rust supports Visual Studio 2013 and later but it is recommended that you use the latest version (currently 2022) for new projects.
+Rust supports Visual Studio 2017 and later but it is recommended that you use the latest version (currently 2022) for new projects.
 You can opt to download only the Build Tools for Visual Studio, which does not include the IDE.
 However this requires you already have a license to the Community, Professional or Enterprise edition.
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -296,7 +296,7 @@ This will uninstall all Rust toolchains and data, and remove
 #[cfg(windows)]
 static MSVC_MESSAGE: &str = r#"# Rust Visual C++ prerequisites
 
-Rust requires the Microsoft C++ build tools for Visual Studio 2013 or
+Rust requires the Microsoft C++ build tools for Visual Studio 2017 or
 later, but they don't seem to be installed.
 
 "#;


### PR DESCRIPTION
The Rust Compiler's error message for not having Visual Studio installed suggest that VS 2017 is required: https://github.com/rust-lang/rust/blob/20aa2d81e36036073a9acf418c7d413cb4b22fa6/compiler/rustc_codegen_ssa/messages.ftl#L17

This change updates rustup's documentation to match.