### PR TITLE
Replace remaining `winapi` usage with `windows-sys`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1966,7 +1966,6 @@ dependencies = [
  "url",
  "wait-timeout",
  "walkdir",
- "winapi",
  "windows-sys 0.52.0",
  "winreg",
  "xz2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,43 +104,21 @@ zstd = "0.13"
 cc = "1"
 winreg = "0.52"
 
-[target."cfg(windows)".dependencies.winapi]
-features = [
-    "combaseapi",
-    "errhandlingapi",
-    "fileapi",
-    "handleapi",
-    "ioapiset",
-    "jobapi",
-    "jobapi2",
-    "minwindef",
-    "processthreadsapi",
-    "psapi",
-    "shlobj",
-    "shtypes",
-    "synchapi",
-    "sysinfoapi",
-    "tlhelp32",
-    "userenv",
-    "winbase",
-    "winerror",
-    "winioctl",
-    "winnt",
-    "winuser",
-]
-version = "0.3"
-
 [target."cfg(windows)".dependencies.windows-sys]
 features = [
     "Win32_Foundation",
+    "Win32_Security",
     "Win32_Storage_FileSystem",
+    "Win32_System_Diagnostics_ToolHelp",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+    "Win32_System_JobObjects",
+    "Win32_System_Kernel",
+    "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
     "Win32_System_SystemServices",
     "Win32_System_Threading",
     "Win32_System_WindowsProgramming",
-    "Win32_Security",
-    "Win32_System_Kernel",
-    "Win32_System_IO",
-    "Win32_System_Ioctl",
 ]
 version = "0.52.0"
 

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -176,7 +176,9 @@ fn do_recursion_guard() -> Result<()> {
 /// rustup-init in the user's download folder.
 #[cfg(windows)]
 pub fn pre_rustup_main_init() {
-    use winapi::um::libloaderapi::{SetDefaultDllDirectories, LOAD_LIBRARY_SEARCH_SYSTEM32};
+    use windows_sys::Win32::System::LibraryLoader::{
+        SetDefaultDllDirectories, LOAD_LIBRARY_SEARCH_SYSTEM32,
+    };
     // Default to loading delay loaded DLLs from the system directory.
     // For DLLs loaded at load time, this relies on the `delayload` linker flag.
     // This is only necessary prior to Windows 10 RS1. See build.rs for details.

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -181,7 +181,7 @@ impl DownloadTracker {
                         let percent = (self.total_downloaded as f64 / content_len as f64) * 100.;
                         let remaining = content_len - self.total_downloaded;
                         let eta_h = Duration::from_secs(if speed == 0 {
-                            std::u64::MAX
+                            u64::MAX
                         } else {
                             (remaining / speed) as u64
                         });

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -40,12 +40,9 @@ mod imp {
     use std::mem;
     use std::ptr;
 
-    use winapi::shared::minwindef::*;
-    use winapi::um::handleapi::*;
-    use winapi::um::jobapi2::*;
-    use winapi::um::processthreadsapi::*;
-    use winapi::um::winnt::HANDLE;
-    use winapi::um::winnt::*;
+    use windows_sys::Win32::Foundation::*;
+    use windows_sys::Win32::System::JobObjects::*;
+    use windows_sys::Win32::System::Threading::*;
 
     pub(crate) struct Setup {
         job: Handle,
@@ -70,7 +67,7 @@ mod imp {
         // we're otherwise part of someone else's job object in this case.
 
         let job = CreateJobObjectW(ptr::null_mut(), ptr::null());
-        if job.is_null() {
+        if job == 0 {
             return None;
         }
         let job = Handle { inner: job };
@@ -85,8 +82,8 @@ mod imp {
         let r = SetInformationJobObject(
             job.inner,
             JobObjectExtendedLimitInformation,
-            &mut info as *mut _ as LPVOID,
-            mem::size_of_val(&info) as DWORD,
+            &mut info as *mut _ as *const std::ffi::c_void,
+            mem::size_of_val(&info) as u32,
         );
         if r == 0 {
             return None;
@@ -114,8 +111,8 @@ mod imp {
                 let r = SetInformationJobObject(
                     self.job.inner,
                     JobObjectExtendedLimitInformation,
-                    &mut info as *mut _ as LPVOID,
-                    mem::size_of_val(&info) as DWORD,
+                    &mut info as *mut _ as *const std::ffi::c_void,
+                    mem::size_of_val(&info) as u32,
                 );
                 if r == 0 {
                     info!("failed to configure job object to defaults: {}", last_err());

--- a/src/command.rs
+++ b/src/command.rs
@@ -36,10 +36,10 @@ pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
 
     #[cfg(windows)]
     fn exec(cmd: &mut Command) -> io::Result<ExitCode> {
-        use winapi::shared::minwindef::{BOOL, DWORD, FALSE, TRUE};
-        use winapi::um::consoleapi::SetConsoleCtrlHandler;
+        use windows_sys::Win32::Foundation::{BOOL, FALSE, TRUE};
+        use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
 
-        unsafe extern "system" fn ctrlc_handler(_: DWORD) -> BOOL {
+        unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
             // Do nothing. Let the child process handle it.
             TRUE
         }


### PR DESCRIPTION
I noticed that the `rustup` project already started adopting the `windows-sys` crate. This update merely replaces the remaining direct dependencies on the older `winapi` crate with `windows-sys`.