### PR TITLE
chore(dist/features): ship `tracing` and friends by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ no-self-update = []
 otel = [
     "dep:opentelemetry-otlp",
     "dep:tracing-opentelemetry",
-    "dep:tracing-subscriber",
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
 ]
@@ -87,7 +86,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 toml = "0.8"
 tracing-opentelemetry = { workspace = true, optional = true }
-tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true
 url.workspace = true
 wait-timeout = "0.2"

--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -1,5 +1,10 @@
 # Environment variables
 
+- `RUST_LOG` (default: none). Enables Rustup's "custom logging mode". In this mode,
+  the verbosity of Rustup's log lines can be specified with `tracing_subscriber`'s
+  [directive syntax]. For example, set `RUST_LOG=rustup=DEBUG` to receive log lines
+  from `rustup` itself with a maximal verbosity of `DEBUG`.
+
 - `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%/.rustup`). Sets the
   root `rustup` folder, used for storing installed toolchains and
   configuration options.
@@ -29,8 +34,6 @@
   determines the directory that traces will be written too. Traces are of the
   form PID.trace. Traces can be read by the Catapult project [tracing viewer].
 
-- `RUSTUP_DEBUG` *unstable*. When set, enables rustup's debug logging.
-
 - `RUSTUP_TERM_COLOR` (default: `auto`). Controls whether colored output is used in the terminal.
   Set to `auto` to use colors only in tty streams, to `always` to always enable colors,
   or to `never` to disable colors.
@@ -47,6 +50,7 @@
   feature sacrifices some transactions protections and may be removed at any
   point. Linux only.
 
+[directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md
 [tracing viewer]: https://github.com/catapult-project/catapult/blob/master/tracing/README.md

--- a/rustup-macros/src/lib.rs
+++ b/rustup-macros/src/lib.rs
@@ -95,7 +95,7 @@ fn test_inner(mod_path: String, mut input: ItemFn) -> syn::Result<TokenStream> {
     let name = input.sig.ident.clone();
     let new_block: Block = parse_quote! {
         {
-            let _guard = #before_ident().await;
+            #before_ident().await;
             // Define a function with same name we can instrument inside the
             // tracing enablement logic.
             #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
@@ -118,7 +118,6 @@ fn test_inner(mod_path: String, mut input: ItemFn) -> syn::Result<TokenStream> {
     input.block = Box::new(new_block);
 
     Ok(quote! {
-        #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
         #[::tokio::test(flavor = "multi_thread", worker_threads = 1)]
         #input
     })

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -18,24 +18,24 @@ use opentelemetry_sdk::trace::Tracer;
 
 use crate::{currentprocess::Process, utils::notify::NotificationLevel};
 
-macro_rules! warn {
-    ( $ ( $ arg : tt ) * ) => ( ::tracing::warn ! ( $ ( $ arg ) * )  )
-}
-
-macro_rules! err {
-    ( $ ( $ arg : tt ) * ) => ( ::tracing::error ! ( $ ( $ arg ) * )  )
-}
-
-macro_rules! info {
-    ( $ ( $ arg : tt ) * ) => ( ::tracing::info ! ( $ ( $ arg ) * )  )
+macro_rules! debug {
+    ( $ ( $ arg : tt ) * ) => ( ::tracing::trace ! ( $ ( $ arg ) * )  )
 }
 
 macro_rules! verbose {
     ( $ ( $ arg : tt ) * ) => ( ::tracing::debug ! ( $ ( $ arg ) * )  )
 }
 
-macro_rules! debug {
-    ( $ ( $ arg : tt ) * ) => ( ::tracing::trace ! ( $ ( $ arg ) * )  )
+macro_rules! info {
+    ( $ ( $ arg : tt ) * ) => ( ::tracing::info ! ( $ ( $ arg ) * )  )
+}
+
+macro_rules! warn {
+    ( $ ( $ arg : tt ) * ) => ( ::tracing::warn ! ( $ ( $ arg ) * )  )
+}
+
+macro_rules! err {
+    ( $ ( $ arg : tt ) * ) => ( ::tracing::error ! ( $ ( $ arg ) * )  )
 }
 
 pub fn tracing_subscriber(process: Process) -> impl tracing::Subscriber {

--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -84,12 +84,9 @@ impl ColorableTerminal {
     /// then color commands will be sent to the stream.
     /// Otherwise color commands are discarded.
     pub(super) fn new(stream: StreamSelector) -> Self {
-        let env_override = process()
-            .var("RUSTUP_TERM_COLOR")
-            .map(|it| it.to_lowercase());
-        let choice = match env_override.as_deref() {
-            Ok("always") => ColorChoice::Always,
-            Ok("never") => ColorChoice::Never,
+        let choice = match process().var("RUSTUP_TERM_COLOR") {
+            Ok(s) if s.eq_ignore_ascii_case("always") => ColorChoice::Always,
+            Ok(s) if s.eq_ignore_ascii_case("never") => ColorChoice::Never,
             _ if stream.is_a_tty() => ColorChoice::Auto,
             _ => ColorChoice::Never,
         };

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -305,13 +305,6 @@ impl<'a> Executor for Threaded<'a> {
         self.tx
             .send(Task::Sentinel)
             .expect("must still be listening");
-        if crate::currentprocess::process().var("RUSTUP_DEBUG").is_ok() {
-            // debug! is in the cli layer. erg. And notification stack is still terrible.
-            debug!("");
-            for (bucket, pool) in &self.vec_pools {
-                debug!("{:?}: {:?}", bucket, pool);
-            }
-        }
         Box::new(JoinIterator {
             executor: self,
             consume_sentinel: false,

--- a/src/test.rs
+++ b/src/test.rs
@@ -224,25 +224,12 @@ where
     f(&rustup_home)
 }
 
-pub async fn before_test_async() -> Option<tracing::dispatcher::DefaultGuard> {
+pub async fn before_test_async() {
     #[cfg(feature = "otel")]
     {
-        use tracing_subscriber::{layer::SubscriberExt, Registry};
-
-        let telemetry = {
-            use opentelemetry::global;
-            use opentelemetry_sdk::propagation::TraceContextPropagator;
-
-            global::set_text_map_propagator(TraceContextPropagator::new());
-            crate::cli::log::telemetry()
-        };
-
-        let subscriber = Registry::default().with(telemetry);
-        Some(tracing::subscriber::set_default(subscriber))
-    }
-    #[cfg(not(feature = "otel"))]
-    {
-        None
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+        );
     }
 }
 

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -4,11 +4,11 @@ use tracing::Level;
 
 #[derive(Debug)]
 pub(crate) enum NotificationLevel {
+    Debug,
     Verbose,
     Info,
     Warn,
     Error,
-    Debug,
 }
 
 impl fmt::Display for NotificationLevel {

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+
+use tracing::Level;
+
 #[derive(Debug)]
 pub(crate) enum NotificationLevel {
     Verbose,
@@ -5,4 +9,28 @@ pub(crate) enum NotificationLevel {
     Warn,
     Error,
     Debug,
+}
+
+impl fmt::Display for NotificationLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            NotificationLevel::Debug => "debug",
+            NotificationLevel::Verbose => "verbose",
+            NotificationLevel::Info => "info",
+            NotificationLevel::Warn => "warning",
+            NotificationLevel::Error => "error",
+        })
+    }
+}
+
+impl From<Level> for NotificationLevel {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::TRACE => Self::Debug,
+            Level::DEBUG => Self::Verbose,
+            Level::INFO => Self::Info,
+            Level::WARN => Self::Warn,
+            Level::ERROR => Self::Error,
+        }
+    }
 }


### PR DESCRIPTION
> [!WARNING]  
> Since https://github.com/rust-lang/rustup/pull/3876, `RUST_LOG` has been replaced with **`RUSTUP_LOG`** for configuring Rustup's internal logging system. The rest of the thread has used `RUST_LOG` due to historic reasons.

Part of #3790.

## Rationale

Currently, helping out the Rustup team by enabling local tracing is quite a tedious process (esp. for community contributors), requiring rebuilding Rustup from the exact commit with an extra feature, `otel`:

https://github.com/rust-lang/rustup/blob/54dd3d00fd20e64dc522517a0d7be4285570a2f1/doc/dev-guide/src/tracing.md?plain=1#L13-L36

After some experiment, it turned out that we actually can ship the tracing features by default without forcing the user to face OTEL connection errors on a daily basis.

To clarify, this *does not* mean Rustup is setting up a central (a.k.a. phone-home-style) telemetry mechanism, and we will keep the tracing disabled by default unless `RUST_LOG` has been explicitly set.

## Concerns

- [x] Should we eliminate `RUSTUP_DEBUG` in favor of `RUST_LOG=trace`? (Yes.)
- [x] ~~Should we remove `opentelemetry` while keeping `tracing` (https://github.com/rust-lang/rustup/pull/3788#issuecomment-2079165721)? If we should, the `otel` feature should be renamed.~~ (Not yet, see https://github.com/rust-lang/rustup/pull/3803#issuecomment-2092349333.)