### PR TITLE
fix(ci/freebsd): fix `invalid peer certificate: UnknownIssuer`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1158,7 +1158,7 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo
+          pkg install -y git gmake bash sudo ca_root_nss
         run: |
           echo "========="
           echo "create non-root user and log into it"
@@ -1188,7 +1188,7 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo
+          pkg install -y git gmake bash sudo ca_root_nss
         run: |
           echo "========="
           echo "create non-root user and log into it"

--- a/ci/actions-templates/freebsd-builds-template.yaml
+++ b/ci/actions-templates/freebsd-builds-template.yaml
@@ -22,7 +22,7 @@ jobs: # skip-master skip-stable
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo
+          pkg install -y git gmake bash sudo ca_root_nss
         run: |
           echo "========="
           echo "create non-root user and log into it"


### PR DESCRIPTION
Caused by #3798, this is essentially https://github.com/astral-sh/uv/issues/3369. However, we didn't choose to switch to bundled CA certs, otherwise suddenly Rustup binaries will come with an expiration date :/

https://github.com/rust-lang/rustup/actions/runs/8978258543/job/24658381207 has passed after adding `pkg install -y ca_root_nss` to the setup.