### PR TITLE
fix(filesource): make some constructs only available via the `test` feature

### DIFF
--- a/src/currentprocess/filesource.rs
+++ b/src/currentprocess/filesource.rs
@@ -1,11 +1,14 @@
-use std::io::{self, BufRead, Cursor, Read, Result, Write};
-use std::sync::{Arc, Mutex, MutexGuard};
+use std::io::{self, BufRead, Read, Result, Write};
+#[cfg(feature = "test")]
+use std::{
+    io::Cursor,
+    sync::{Arc, Mutex, MutexGuard},
+};
 
 use enum_dispatch::enum_dispatch;
 
-use crate::currentprocess::process;
-
 use super::terminalsource::{ColorableTerminal, StreamSelector};
+use crate::currentprocess::process;
 
 /// Stand-in for std::io::Stdin
 pub trait Stdin {
@@ -44,18 +47,22 @@ impl StdinSource for super::OSProcess {
 
 // ----------------------- test support for stdin ------------------
 
+#[cfg(feature = "test")]
 struct TestStdinLock<'a> {
     inner: MutexGuard<'a, Cursor<String>>,
 }
 
+#[cfg(feature = "test")]
 impl StdinLock for TestStdinLock<'_> {}
 
+#[cfg(feature = "test")]
 impl Read for TestStdinLock<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
     }
 }
 
+#[cfg(feature = "test")]
 impl BufRead for TestStdinLock<'_> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         self.inner.fill_buf()
@@ -65,10 +72,13 @@ impl BufRead for TestStdinLock<'_> {
     }
 }
 
+#[cfg(feature = "test")]
 pub(crate) type TestStdinInner = Arc<Mutex<Cursor<String>>>;
 
+#[cfg(feature = "test")]
 struct TestStdin(TestStdinInner);
 
+#[cfg(feature = "test")]
 impl Stdin for TestStdin {
     fn lock(&self) -> Box<dyn StdinLock + '_> {
         Box::new(TestStdinLock {
@@ -179,12 +189,15 @@ impl StderrSource for super::OSProcess {
 
 // ----------------------- test support for writers ------------------
 
+#[cfg(feature = "test")]
 pub(super) struct TestWriterLock<'a> {
     inner: MutexGuard<'a, Vec<u8>>,
 }
 
+#[cfg(feature = "test")]
 impl WriterLock for TestWriterLock<'_> {}
 
+#[cfg(feature = "test")]
 impl Write for TestWriterLock<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize> {
         self.inner.write(buf)


### PR DESCRIPTION
Cherry-picked from #3803.

This PR has fixed the following warnings in https://github.com/rust-lang/rustup/actions/runs/8978258543/job/24658381207:

```rs
 warning: struct `TestStdinLock` is never constructed
    --> src/currentprocess/filesource.rs:47:8
     |
  47 | struct TestStdinLock<'a> {
     |        ^^^^^^^^^^^^^
     |
     = note: `#[warn(dead_code)]` on by default
  
  warning: type alias `TestStdinInner` is never used
    --> src/currentprocess/filesource.rs:68:17
     |
  68 | pub(crate) type TestStdinInner = Arc<Mutex<Cursor<String>>>;
     |                 ^^^^^^^^^^^^^^
  
  warning: struct `TestStdin` is never constructed
    --> src/currentprocess/filesource.rs:70:8
     |
  70 | struct TestStdin(TestStdinInner);
     |        ^^^^^^^^^
  
  warning: struct `TestWriterLock` is never constructed
     --> src/currentprocess/filesource.rs:182:19
      |
  182 | pub(super) struct TestWriterLock<'a> {
      |                   ^^^^^^^^^^^^^^
  
  warning: `rustup` (lib) generated 4 warnings
```