### PR TITLE
refactor(cli): rewrite `rustup-init` with `clap_derive`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -321,6 +321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -343,6 +344,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -844,6 +857,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ test = ["dep:walkdir"]
 anyhow.workspace = true
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-clap = { version = "4", features = ["wrap_help"] }
+clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = "4"
 download = { path = "download", default-features = false }
 effective-limits = "0.5.5"

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -43,16 +43,16 @@ Options:
   -q, --quiet
           Disable progress output
   -y
-          Disable confirmation prompt.
-      --default-host <default-host>
+          Disable confirmation prompt
+      --default-host <DEFAULT_HOST>
           Choose a default host triple
-      --default-toolchain <default-toolchain>
+      --default-toolchain <DEFAULT_TOOLCHAIN>
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-      --profile <profile>
+      --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <components>...
+  -c, --components <COMPONENTS>...
           Component name to also install
-  -t, --target <targets>...
+  -t, --targets <TARGETS>...
           Target name to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -109,19 +109,19 @@ pub fn main() -> Result<utils::ExitCode> {
         return Ok(utils::ExitCode(0));
     }
 
+    if &profile == "complete" {
+        warn!("{}", common::WARN_COMPLETE_PROFILE);
+    }
+
     let opts = InstallOpts {
         default_host_triple: default_host,
         default_toolchain,
-        profile: profile.to_owned(),
+        profile,
         no_modify_path,
         no_update_toolchain: no_update_default_toolchain,
         components: &components.iter().map(|s| &**s).collect::<Vec<_>>(),
         targets: &targets.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
-
-    if profile == "complete" {
-        warn!("{}", common::WARN_COMPLETE_PROFILE);
-    }
 
     self_update::install(no_prompt, verbose, quiet, opts)
 }

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -240,7 +240,7 @@ pub(crate) fn maybe_resolvable_toolchainame_parser(
 
 /// ResolvableToolchainName + none, for overriding default-has-a-value
 /// situations in the CLI with an official toolchain name or none
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) enum MaybeOfficialToolchainName {
     None,
     Some(PartialToolchainDesc),

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -14,16 +14,16 @@ Options:
   -q, --quiet
           Disable progress output
   -y
-          Disable confirmation prompt.
-      --default-host <default-host>
+          Disable confirmation prompt
+      --default-host <DEFAULT_HOST>
           Choose a default host triple
-      --default-toolchain <default-toolchain>
+      --default-toolchain <DEFAULT_TOOLCHAIN>
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-      --profile <profile>
+      --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <components>...
+  -c, --components <COMPONENTS>...
           Component name to also install
-  -t, --target <targets>...
+  -t, --targets <TARGETS>...
           Target name to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -14,16 +14,16 @@ Options:
   -q, --quiet
           Disable progress output
   -y
-          Disable confirmation prompt.
-      --default-host <default-host>
+          Disable confirmation prompt
+      --default-host <DEFAULT_HOST>
           Choose a default host triple
-      --default-toolchain <default-toolchain>
+      --default-toolchain <DEFAULT_TOOLCHAIN>
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
-      --profile <profile>
+      --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <components>...
+  -c, --components <COMPONENTS>...
           Component name to also install
-  -t, --target <targets>...
+  -t, --targets <TARGETS>...
           Target name to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install


### PR DESCRIPTION
Cherry-picked from #3596, already approved by @djc in https://github.com/rust-lang/rustup/pull/3596#issuecomment-1867496267.