### PR TITLE
Omit "ETA 0s" output in download tracker

### DIFF
--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -186,13 +186,16 @@ impl DownloadTracker {
                             (remaining / speed) as u64
                         });
                         format!(
-                            "{} / {} ({:3.0} %) {} in {} ETA: {}",
+                            "{} / {} ({:3.0} %) {} in {}{}",
                             total_h,
                             content_len_h,
                             percent,
                             speed_h,
                             elapsed_h.display(),
-                            eta_h.display(),
+                            match eta_h {
+                                Duration::ZERO => format_args!(""),
+                                _ => format_args!(" ETA: {}", eta_h.display()),
+                            }
                         )
                     }
                     None => format!(


### PR DESCRIPTION
When running rustup, the ETA is shown and continuously updated. After a download has finished, ETA is 0, and it is printed for each download (marked **bold**)

info: downloading component 'cargo'
  8.0 MiB /   8.0 MiB (100 %)   5.0 MiB/s in  1s **ETA:  0s**
info: downloading component 'clippy'
info: downloading component 'rust-docs'
 15.1 MiB /  15.1 MiB (100 %)   5.3 MiB/s in  2s **ETA:  0s**
info: downloading component 'rust-std'
 24.3 MiB /  24.3 MiB (100 %)   5.3 MiB/s in  4s **ETA:  0s**

This change omits printing the ETA when it is 0s:

info: downloading component 'cargo'
  8.0 MiB /   8.0 MiB (100 %)   5.5 MiB/s in  1s         
info: downloading component 'clippy'
info: downloading component 'rust-docs'
 15.1 MiB /  15.1 MiB (100 %)   6.0 MiB/s in  2s         
info: downloading component 'rust-std'
 24.3 MiB /  24.3 MiB (100 %)   5.6 MiB/s in  4s

Not a big change :) lmk what you think :)