### PR TITLE
add NO_OP mode to rustup-init.sh

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -23,8 +23,6 @@ is_zsh() {
     [ -n "${ZSH_VERSION-}" ]
 }
 
-set -u
-
 # If RUSTUP_UPDATE_ROOT is unset or empty, default it.
 RUSTUP_UPDATE_ROOT="${RUSTUP_UPDATE_ROOT:-https://static.rust-lang.org/rustup}"
 
@@ -808,4 +806,6 @@ get_strong_ciphersuites_for() {
     fi
 }
 
-main "$@" || exit 1
+if [ "$NO_OP" != "1" ]; then
+    main "$@" || exit 1
+fi


### PR DESCRIPTION
As part of one of my tasks I need to resolve the target triple at the shell script level during the initial bootstrap phase (before rustc is available). The functionality is already implemented in the rustup script and I don't want to duplicate it in the upstream rust repository. My plan is to fetch the rustup script from https://sh.rustup.rs using curl and then `source` it from the caller script, so I can access/execute the `get_architecture` function. However, this is not possible because it immediately initiates the download process. As a solution to that, I propose this PR (which is a dead-simple change) that allows us to source this file easily (like `NO_OP=1 . ./rustup-init.sh`) without runnig the actual workflow.