### PR TITLE
Finalise Rustup Windows Arm64 support

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -87,6 +87,29 @@
   <p class="other-platforms-help">You appear to be running Windows 64-bit. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
 </div>
 
+<div id="platform-instructions-win-arm64" class="instructions display-none">
+  <p>
+    To install Rust, download and run
+    <a class="windows-download" href="https://win.rustup.rs/aarch64">rustup&#x2011;init.exe</a>
+    then follow the onscreen instructions.
+  </p>
+  <p>You may also need the <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio prerequisites</a>.</p>
+  <hr/>
+  <p>If you're a Windows Subsystem for Linux user run the following in your terminal, then follow the onscreen instructions to install Rust.</p>
+  <div class="copy-container">
+    <pre class="rustup-command">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</pre>
+    <button id="copy-button-win-arm64" class="copy-button" title="Copy curl command to clipboard to download Rustup" type="button">
+      <div class="copy-icon">
+        <svg width="24" height="25" viewBox="0 0 24 25" xmlns="http://www.w3.org/2000/svg" alt="Copy curl command to clipboard to download Rustup">
+          <path d="M18 20h2v3c0 1-1 2-2 2H2c-.998 0-2-1-2-2V5c0-.911.755-1.667 1.667-1.667h5A3.323 3.323 0 0110 0a3.323 3.323 0 013.333 3.333h5C19.245 3.333 20 4.09 20 5v8.333h-2V9H2v14h16v-3zM3 7h14c0-.911-.793-1.667-1.75-1.667H13.5c-.957 0-1.75-.755-1.75-1.666C11.75 2.755 10.957 2 10 2s-1.75.755-1.75 1.667c0 .911-.793 1.666-1.75 1.666H4.75C3.793 5.333 3 6.09 3 7z"></path><path d="M4 19h6v2H4zM12 11H4v2h8zM4 17h4v-2H4zM15 15v-3l-4.5 4.5L15 21v-3l8.027-.032L23 15z"></path>
+        </svg>
+      </div>
+      <div id="copy-status-message-win-arm64" class="copy-button-text">Copied!</div>
+    </button>
+  </div>
+  <p class="other-platforms-help">You appear to be running Windows on Arm. If not, <a class="default-platform-button" href="#">display all supported installers</a>.</p>
+</div>
+
 <div id="platform-instructions-unknown" class="instructions display-none">
   <!-- unrecognized platform: ask for help -->
   <p>I don't recognize your platform.</p>
@@ -134,6 +157,16 @@
 
   <div>
     <p>
+      If you are running Windows on Arm,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/aarch64">rustup&#x2011;init.exe</a>
+      then follow the onscreen instructions.
+    </p>
+  </div>
+
+  <hr/>
+
+  <div>
+    <p>
       If you are running Windows 32-bit,<br/>download and run
       <a class="windows-download" href="https://win.rustup.rs/i686">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
@@ -165,6 +198,16 @@
     <p>
       If you are running Windows 64-bit,<br/>download and run
       <a class="windows-download" href="https://win.rustup.rs/x86_64">rustup&#x2011;init.exe</a>
+      then follow the onscreen instructions.
+    </p>
+  </div>
+
+  <hr/>
+
+  <div>
+    <p>
+      If you are running Windows on Arm,<br/>download and run
+      <a class="windows-download" href="https://win.rustup.rs/aarch64">rustup&#x2011;init.exe</a>
       then follow the onscreen instructions.
     </p>
   </div>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -108,6 +108,7 @@ hr {
 #platform-instructions-unix > p,
 #platform-instructions-win32 > p,
 #platform-instructions-win64 > p,
+#platform-instructions-win-arm64 > p,
 #platform-instructions-default > p,
 #platform-instructions-unknown > p {
     width: 40rem;
@@ -138,6 +139,7 @@ hr {
 #platform-instructions-unix div.copy-container,
 #platform-instructions-win32 div.copy-container,
 #platform-instructions-win64 div.copy-container,
+#platform-instructions-win-arm64 div.copy-container,
 #platform-instructions-default div.copy-container,
 #platform-instructions-unknown div.copy-container {
     display: flex;
@@ -147,6 +149,7 @@ hr {
 #platform-instructions-unix button.copy-button,
 #platform-instructions-win32 button.copy-button,
 #platform-instructions-win64 button.copy-button,
+#platform-instructions-win-arm64 button.copy-button,
 #platform-instructions-default button.copy-button,
 #platform-instructions-unknown button.copy-button {
     height: 58px;
@@ -160,6 +163,7 @@ hr {
 #platform-instructions-unix div.copy-icon,
 #platform-instructions-win32 div.copy-icon,
 #platform-instructions-win64 div.copy-icon,
+#platform-instructions-win-arm64 div.copy-icon,
 #platform-instructions-default div.copy-icon,
 #platform-instructions-unknown div.copy-icon {
     position: relative;
@@ -173,6 +177,7 @@ hr {
 #platform-instructions-unix div.copy-button-text,
 #platform-instructions-win32 div.copy-button-text,
 #platform-instructions-win64 div.copy-button-text,
+#platform-instructions-win-arm64 div.copy-button-text,
 #platform-instructions-default div.copy-button-text,
 #platform-instructions-unknown div.copy-button-text {
     transition: opacity 0.2s ease-in-out;
@@ -187,6 +192,7 @@ hr {
 
 #platform-instructions-win32 a.windows-download,
 #platform-instructions-win64 a.windows-download,
+#platform-instructions-win-arm64 a.windows-download,
 #platform-instructions-default a.windows-download,
 #platform-instructions-unknown a.windows-download {
     display: block;


### PR DESCRIPTION
This PR finalises Windows Arm64 support by doing the following:

* ~~Removes the workaround to exclude Ring on Windows Arm64. Ring 0.17.x fully supports it.~~ Split-off into #3845
* ~Adds `aarch64-pc-windows-msvc` download link to cloud-invalidation.txt so that [this script](https://github.com/rust-lang/rust-forge/blob/master/blacksmith/src/lib.rs) could pick it up.~
  * ~Does the same for `aarch64-apple-darwin` because why not?~
* ~Updates the [Other Installation Methods page](https://forge.rust-lang.org/infra/other-installation-methods.html) to include Windows Arm64 version of Rustup.~ Split-off into #3854 
* Updates the [rustup.rs](https://rustup.rs) website to offer the arm64 version of Rustup on Windows Arm64.

The last part is the most "fragile" in my view because I don't know how the artefacts get published on rustup.rs, and detecting the arm64 CPU also required some async code that won't work in Firefox (but VS Code website’s arm64 detection doesn't work in Firefox either).