### PR TITLE
ci(windows): fix CI failure on `x86_64-pc-windows-gnu`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,9 @@ jobs:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            arch: x86_64
             mingwdir: mingw64
+            gcc: x86_64-w64-mingw32-gcc
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -57,17 +58,16 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
       - name: Install mingw
-        run: |
-          # We retrieve mingw from the Rust CI buckets
-          # Disable the download progress bar which can cause perf issues
-          $ProgressPreference = "SilentlyContinue"
-          Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
-          7z x -y mingw.7z -oC:\msys64 | Out-Null
-          del mingw.7z
-          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        uses: bwoodsend/setup-winlibs-action@v1
+        if: matrix.mingwdir != ''
+        with:
+          architecture: ${{ matrix.arch }}
+      - name: Verify mingw gcc installation
         shell: powershell
-        if: matrix.mingw != ''
+        if: matrix.mingwdir != ''
+        run: |
+          Get-Command ${{ matrix.gcc }}
+          ${{ matrix.gcc }} --version
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -123,7 +123,7 @@ jobs:
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
       - name: Run cargo clippy
-        if: matrix.mode != 'release' && matrix.mingw == ''
+        if: matrix.mode != 'release' && matrix.mingwdir == ''
         env:
           TARGET: ${{ matrix.target }}
         run: |
@@ -179,8 +179,9 @@ jobs:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            arch: x86_64
             mingwdir: mingw64
+            gcc: x86_64-w64-mingw32-gcc
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -199,17 +200,16 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
       - name: Install mingw
-        run: |
-          # We retrieve mingw from the Rust CI buckets
-          # Disable the download progress bar which can cause perf issues
-          $ProgressPreference = "SilentlyContinue"
-          Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
-          7z x -y mingw.7z -oC:\msys64 | Out-Null
-          del mingw.7z
-          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        uses: bwoodsend/setup-winlibs-action@v1
+        if: matrix.mingwdir != ''
+        with:
+          architecture: ${{ matrix.arch }}
+      - name: Verify mingw gcc installation
         shell: powershell
-        if: matrix.mingw != ''
+        if: matrix.mingwdir != ''
+        run: |
+          Get-Command ${{ matrix.gcc }}
+          ${{ matrix.gcc }} --version
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -265,7 +265,7 @@ jobs:
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
       - name: Run cargo clippy
-        if: matrix.mode != 'release' && matrix.mingw == ''
+        if: matrix.mode != 'release' && matrix.mingwdir == ''
         env:
           TARGET: ${{ matrix.target }}
         run: |
@@ -323,11 +323,13 @@ jobs:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            arch: x86_64
             mingwdir: mingw64
+            gcc: x86_64-w64-mingw32-gcc
           - target: i686-pc-windows-gnu # skip-pr skip-master
+            arch: i686 # skip-pr skip-master
             mingwdir: mingw32 # skip-pr skip-master
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z # skip-pr skip-master
+            gcc: i686-w64-mingw32-gcc # skip-pr skip-master
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -346,17 +348,16 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
       - name: Install mingw
-        run: |
-          # We retrieve mingw from the Rust CI buckets
-          # Disable the download progress bar which can cause perf issues
-          $ProgressPreference = "SilentlyContinue"
-          Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
-          7z x -y mingw.7z -oC:\msys64 | Out-Null
-          del mingw.7z
-          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        uses: bwoodsend/setup-winlibs-action@v1
+        if: matrix.mingwdir != ''
+        with:
+          architecture: ${{ matrix.arch }}
+      - name: Verify mingw gcc installation
         shell: powershell
-        if: matrix.mingw != ''
+        if: matrix.mingwdir != ''
+        run: |
+          Get-Command ${{ matrix.gcc }}
+          ${{ matrix.gcc }} --version
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -412,7 +413,7 @@ jobs:
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
       - name: Run cargo clippy
-        if: matrix.mode != 'release' && matrix.mingw == ''
+        if: matrix.mode != 'release' && matrix.mingwdir == ''
         env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,13 @@ jobs:
           - release
         target:
           - x86_64-pc-windows-msvc
+          - x86_64-pc-windows-gnu
         include:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
+          - target: x86_64-pc-windows-gnu
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            mingwdir: mingw64
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -170,13 +174,13 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc # skip-pr
-          - x86_64-pc-windows-gnu # skip-pr
+          - x86_64-pc-windows-gnu
         include:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
-          - target: x86_64-pc-windows-gnu # skip-pr
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z # skip-pr
-            mingwdir: mingw64 # skip-pr
+          - target: x86_64-pc-windows-gnu
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            mingwdir: mingw64
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -313,14 +317,14 @@ jobs:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
           - aarch64-pc-windows-msvc # skip-pr
-          - x86_64-pc-windows-gnu # skip-pr
+          - x86_64-pc-windows-gnu
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
-          - target: x86_64-pc-windows-gnu # skip-pr
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z # skip-pr
-            mingwdir: mingw64 # skip-pr
+          - target: x86_64-pc-windows-gnu
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            mingwdir: mingw64
           - target: i686-pc-windows-gnu # skip-pr skip-master
             mingwdir: mingw32 # skip-pr skip-master
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z # skip-pr skip-master

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -27,11 +27,13 @@ jobs: # skip-master skip-pr skip-stable
           - target: x86_64-pc-windows-msvc
             run_tests: YES
           - target: x86_64-pc-windows-gnu
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            arch: x86_64
             mingwdir: mingw64
+            gcc: x86_64-w64-mingw32-gcc
           - target: i686-pc-windows-gnu # skip-pr skip-master
+            arch: i686 # skip-pr skip-master
             mingwdir: mingw32 # skip-pr skip-master
-            mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z # skip-pr skip-master
+            gcc: i686-w64-mingw32-gcc # skip-pr skip-master
     steps:
       - uses: actions/checkout@v4
         # v2 defaults to a shallow checkout, but we need at least to the previous tag
@@ -50,17 +52,16 @@ jobs: # skip-master skip-pr skip-stable
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
       - name: Install mingw
-        run: |
-          # We retrieve mingw from the Rust CI buckets
-          # Disable the download progress bar which can cause perf issues
-          $ProgressPreference = "SilentlyContinue"
-          Invoke-WebRequest ${{ matrix.mingw }} -OutFile mingw.7z
-          7z x -y mingw.7z -oC:\msys64 | Out-Null
-          del mingw.7z
-          echo "C:\msys64\usr\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          echo "C:\msys64\${{ matrix.mingwdir }}\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+        uses: bwoodsend/setup-winlibs-action@v1
+        if: matrix.mingwdir != ''
+        with:
+          architecture: ${{ matrix.arch }}
+      - name: Verify mingw gcc installation
         shell: powershell
-        if: matrix.mingw != ''
+        if: matrix.mingwdir != ''
+        run: |
+          Get-Command ${{ matrix.gcc }}
+          ${{ matrix.gcc }} --version
       - name: Set PATH
         run: |
           echo "%USERPROFILE%\.cargo\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
@@ -116,7 +117,7 @@ jobs: # skip-master skip-pr skip-stable
           cargo check --all --all-targets --features test
           git ls-files -- '*.rs' | xargs touch
       - name: Run cargo clippy
-        if: matrix.mode != 'release' && matrix.mingw == ''
+        if: matrix.mode != 'release' && matrix.mingwdir == ''
         env:
           TARGET: ${{ matrix.target }}
         run: |

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -21,14 +21,14 @@ jobs: # skip-master skip-pr skip-stable
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
           - aarch64-pc-windows-msvc # skip-pr
-          - x86_64-pc-windows-gnu # skip-pr
+          - x86_64-pc-windows-gnu
           - i686-pc-windows-gnu # skip-pr skip-master
         include:
           - target: x86_64-pc-windows-msvc
             run_tests: YES
-          - target: x86_64-pc-windows-gnu # skip-pr
-            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z # skip-pr
-            mingwdir: mingw64 # skip-pr
+          - target: x86_64-pc-windows-gnu
+            mingw: https://ci-mirrors.rust-lang.org/rustc/x86_64-6.3.0-release-posix-seh-rt_v5-rev2.7z 
+            mingwdir: mingw64
           - target: i686-pc-windows-gnu # skip-pr skip-master
             mingwdir: mingw32 # skip-pr skip-master
             mingw: https://ci-mirrors.rust-lang.org/rustc/i686-6.3.0-release-posix-dwarf-rt_v5-rev2.7z # skip-pr skip-master


### PR DESCRIPTION
Currently, the `master` CI fails on `x86_64-pc-windows-gnu` on

```console
error: linking with `x86_64-w64-mingw32-gcc` failed: exit code: 1
  |
  = note: "x86_64-w64-mingw32-gcc" "-fno-use-linker-plugin" "-Wl,--dynamicbase" "-Wl,--disable-auto-image-base" "-m64" "-Wl,--high-entropy-va" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsbegin.o" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\symbols.o" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\deps\\rustup_init-2e95520dda2997b5.rustup_init.61fa2ea700060ea9-cgu.0.rcgu.o" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\deps" "-L" "D:\\a\\rustup\\rustup\\target\\release\\deps" "-L" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\windows_x86_64_gnu-0.52.5\\lib" "-L" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\windows_x86_64_gnu-0.48.5\\lib" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\curl-sys-8fe5b342eab26db9\\out\\build" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\libz-sys-3694b72ddf7bf6f5\\out\\lib" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\libz-sys-3694b72ddf7bf6f5\\out\\lib" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\ring-da2b99278300f509\\out" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\sys-info-cd5759db882db8d7\\out" "-L" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\winapi-x86_64-pc-windows-gnu-0.4.0\\lib" "-L" "C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-6f17d22bba15001f\\windows_x86_64_gnu-0.42.2\\lib" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\lzma-sys-33f2e3f950e15d22\\out" "-L" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\build\\zstd-sys-efab3e8ff7683f87\\out" "-L" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-Wl,-Bstatic" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\libzstd_sys-0366df098ca69c70.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\liblzma_sys-8c956afe6bdd1895.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\libsys_info-bedaaef05679663a.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\libring-249b4006c64c178b.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\libcurl_sys-2691bd68069c2e05.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\liblibz_sys-b6ddfb1e1e5ff67a.rlib" "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\rustcvO6rlT\\libstd-a1f74822451877d1.rlib" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\libcompiler_builtins-b44a9797859024b2.rlib" "-Wl,-Bdynamic" "-lpsapi" "-lpowrprof" "-lwinapi_advapi32" "-lwinapi_cfgmgr32" "-lwinapi_gdi32" "-lwinapi_kernel32" "-lwinapi_msimg32" "-lwinapi_ole32" "-lwinapi_opengl32" "-lwinapi_psapi" "-lwinapi_shell32" "-lwinapi_synchronization" "-lwinapi_user32" "-lwinapi_userenv" "-lwinapi_winspool" "-lwindows" "-lws2_32" "-lcrypt32" "-lbcrypt" "-ladvapi32" "-ladvapi32" "-lkernel32" "-lole32" "-loleaut32" "-lwindows.0.52.0" "-lntdll" "-lwindows.0.48.5" "-lkernel32" "-ladvapi32" "-lkernel32" "-lntdll" "-luserenv" "-lws2_32" "-lkernel32" "-lws2_32" "-lkernel32" "-lgcc_eh" "-l:libpthread.a" "-lmsvcrt" "-lmingwex" "-lmingw32" "-lgcc" "-lmsvcrt" "-luser32" "-lkernel32" "-Wl,--nxcompat" "-L" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib" "-o" "D:\\a\\rustup\\rustup\\target\\x86_64-pc-windows-gnu\\release\\deps\\rustup_init-2e95520dda2997b5.exe" "-Wl,--gc-sections" "-no-pie" "-Wl,-O1" "-nodefaultlibs" "C:\\Users\\runneradmin\\.rustup\\toolchains\\stable-x86_64-pc-windows-msvc\\lib\\rustlib\\x86_64-pc-windows-gnu\\lib\\rsend.o"
  = note: Warning: corrupt .drectve at end of def file
          Warning: corrupt .drectve at end of def file
          collect2.exe: error: ld returned 5 exit status
```

This PR tries to address this issue while moving away from the previously hardcoded MinGW version (6.3.0 from 2017) at the same time.

## Concerns

- [x] ~~Should we keep the `x86_64-pc-windows-gnu` CI enabled even on PRs?~~ I guess we should, at least for the moment.