### PR TITLE
Add Windows Arm64 to Other Installation Methods

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@ jobs:
           - release
         target:
           - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
           - x86_64-pc-windows-gnu
         include:
           - target: x86_64-pc-windows-msvc
@@ -173,7 +174,7 @@ jobs:
           - release
         target:
           - x86_64-pc-windows-msvc
-          - aarch64-pc-windows-msvc # skip-pr
+          - aarch64-pc-windows-msvc
           - x86_64-pc-windows-gnu
         include:
           - target: x86_64-pc-windows-msvc
@@ -316,7 +317,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
-          - aarch64-pc-windows-msvc # skip-pr
+          - aarch64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-gnu # skip-pr skip-master
         include:

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -20,7 +20,7 @@ jobs: # skip-master skip-pr skip-stable
         target:
           - x86_64-pc-windows-msvc
           - i686-pc-windows-msvc # skip-pr skip-master
-          - aarch64-pc-windows-msvc # skip-pr
+          - aarch64-pc-windows-msvc
           - x86_64-pc-windows-gnu
           - i686-pc-windows-gnu # skip-pr skip-master
         include:

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -1,8 +1,12 @@
 rustup/*
 rustup/www/*
 rustup/stable-release.toml
+rustup/dist/aarch64-apple-darwin/rustup-init
+rustup/dist/aarch64-apple-darwin/rustup-init.sha256
 rustup/dist/aarch64-linux-android/rustup-init
 rustup/dist/aarch64-linux-android/rustup-init.sha256
+rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe
+rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe.sha256
 rustup/dist/aarch64-unknown-linux-gnu/rustup-init
 rustup/dist/aarch64-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/aarch64-unknown-linux-musl/rustup-init

--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -3,8 +3,9 @@
 The primary installation method, as described at <https://rustup.rs>, differs
 by platform:
 
-* On Windows, download and run the [`rustup-init.exe` built for the
-  `x86_64-pc-windows-msvc` target][setup]. In general, this is the build of
+* On Windows, download and run the `rustup-init.exe` built for the
+  [`x86_64-pc-windows-msvc`] or [`aarch64-pc-windows-msvc`] target,
+  depending on your OS architecture. In general, this is the build of
   `rustup` one should install on Windows. This will require the Visual C++
   Build Tools 2019 or equivalent (Visual Studio 2019, etc.) to already be
   installed. If you would prefer to install GNU toolchains or the i686
@@ -15,7 +16,8 @@ by platform:
   downloads and runs [`rustup-init.sh`], which in turn downloads and runs the
   correct version of the `rustup-init` executable for your platform.
 
-[setup]: https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
+[`x86_64-pc-windows-msvc`]: https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe
+[`aarch64-pc-windows-msvc`]: https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe
 [`rustup-init.sh`]: https://static.rust-lang.org/rustup/rustup-init.sh
 
 `rustup-init` accepts arguments, which can be passed through the shell script.
@@ -74,6 +76,8 @@ You can manually download `rustup-init` for a given target from
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-apple-darwin/rustup-init.sha256)
 - [aarch64-linux-android](https://static.rust-lang.org/rustup/dist/aarch64-linux-android/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-linux-android/rustup-init.sha256)
+- [aarch64-pc-windows-msvc](https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe.sha256)
 - [aarch64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init.sha256)
 - [aarch64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-musl/rustup-init)


### PR DESCRIPTION
Split-off from #3840:

* Adds `aarch64-pc-windows-msvc` download link to cloud-invalidation.txt so that [this script](https://github.com/rust-lang/rust-forge/blob/master/blacksmith/src/lib.rs) could pick it up.
  * Does the same for `aarch64-apple-darwin` because why not?
* Updates the [Other Installation Methods page](https://forge.rust-lang.org/infra/other-installation-methods.html) to include Windows Arm64 version of Rustup.
* Enables running the `aarch64-pc-windows-msvc` build on PR.