### PR TITLE
fix(download): work around `hyper` hang issue by adjusting `reqwest` config

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -345,6 +345,10 @@ pub mod reqwest_be {
 
     fn client_generic() -> ClientBuilder {
         Client::builder()
+            // HACK: set `pool_max_idle_per_host` to `0` to avoid an issue in the underlying
+            // `hyper` library that causes the `reqwest` client to hang in some cases.
+            // See <https://github.com/hyperium/hyper/issues/2312> for more details.
+            .pool_max_idle_per_host(0)
             .gzip(false)
             .proxy(Proxy::custom(env_proxy))
             .timeout(Duration::from_secs(30))

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -61,6 +61,10 @@ async fn socks_proxy_request() {
     let url = Url::parse("http://192.168.0.1/").unwrap();
 
     let client = Client::builder()
+        // HACK: set `pool_max_idle_per_host` to `0` to avoid an issue in the underlying
+        // `hyper` library that causes the `reqwest` client to hang in some cases.
+        // See <https://github.com/hyperium/hyper/issues/2312> for more details.
+        .pool_max_idle_per_host(0)
         .proxy(Proxy::custom(env_proxy))
         .timeout(Duration::from_secs(1))
         .build()


### PR DESCRIPTION
This PR tries to mitigate #3852 by applying https://github.com/Azure/azure-sdk-for-rust/pull/1550 's hack to all the `ClientBuilder`'s I can find across the repo.

The verification of the mitigation is not easy, since `async` execution is not so deterministic. Nevertheless, as this seems to be a widely encountered issue with `hyper` and `reqwest`, I suggest we merge this first and see how it goes.