### PR TITLE
refactor: restrict `run_future()` usages to tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,6 +1988,7 @@ dependencies = [
  "threadpool",
  "tokio",
  "tokio-retry",
+ "tokio-stream",
  "toml",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ thiserror.workspace = true
 threadpool = "1"
 tokio-retry.workspace = true
 tokio.workspace = true
+tokio-stream.workspace = true
 toml = "0.8"
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true, features = ["env-filter"] }

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -140,7 +140,7 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
         }
         Some(n) => {
             is_proxyable_tools(n)?;
-            proxy_mode::main(n).map(ExitCode::from)
+            proxy_mode::main(n).await.map(ExitCode::from)
         }
         None => {
             // Weird case. No arg0, or it's unparsable.

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -290,7 +290,7 @@ pub(crate) async fn update_all_channels(
     do_self_update: bool,
     force_update: bool,
 ) -> Result<utils::ExitCode> {
-    let toolchains = cfg.update_all_channels(force_update)?;
+    let toolchains = cfg.update_all_channels(force_update).await?;
 
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -55,7 +55,7 @@ async fn direct_proxy(
             cfg.create_command_for_dir(&utils::current_dir()?, arg0)
                 .await?
         }
-        Some(tc) => cfg.create_command_for_toolchain(&tc, false, arg0)?,
+        Some(tc) => cfg.create_command_for_toolchain(&tc, false, arg0).await?,
     };
     run_command_for_dir(cmd, arg0, args)
 }

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-pub fn main(arg0: &str) -> Result<ExitStatus> {
+pub async fn main(arg0: &str) -> Result<ExitStatus> {
     self_update::cleanup_self_updater()?;
 
     let _setup = job::setup();
@@ -40,18 +40,21 @@ pub fn main(arg0: &str) -> Result<ExitStatus> {
     let toolchain = toolchain
         .map(|t| t.resolve(&cfg.get_default_host_triple()?))
         .transpose()?;
-    direct_proxy(&cfg, arg0, toolchain, &cmd_args)
+    direct_proxy(&cfg, arg0, toolchain, &cmd_args).await
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument(skip(cfg)))]
-fn direct_proxy(
+async fn direct_proxy(
     cfg: &Cfg,
     arg0: &str,
     toolchain: Option<LocalToolchainName>,
     args: &[OsString],
 ) -> Result<ExitStatus> {
     let cmd = match toolchain {
-        None => cfg.create_command_for_dir(&utils::current_dir()?, arg0)?,
+        None => {
+            cfg.create_command_for_dir(&utils::current_dir()?, arg0)
+                .await?
+        }
         Some(tc) => cfg.create_command_for_toolchain(&tc, false, arg0)?,
     };
     run_command_for_dir(cmd, arg0, args)

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -675,7 +675,9 @@ pub async fn main() -> Result<utils::ExitCode> {
             toolchain,
             command,
             install,
-        } => run(cfg, toolchain, command, install).map(ExitCode::from),
+        } => run(cfg, toolchain, command, install)
+            .await
+            .map(ExitCode::from),
         RustupSubcmd::Which { command, toolchain } => which(cfg, &command, toolchain).await,
         RustupSubcmd::Doc {
             path,
@@ -893,14 +895,16 @@ async fn update(cfg: &mut Cfg, opts: UpdateOpts) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-fn run(
+async fn run(
     cfg: &Cfg,
     toolchain: ResolvableLocalToolchainName,
     command: Vec<String>,
     install: bool,
 ) -> Result<ExitStatus> {
     let toolchain = toolchain.resolve(&cfg.get_default_host_triple()?)?;
-    let cmd = cfg.create_command_for_toolchain(&toolchain, install, &command[0])?;
+    let cmd = cfg
+        .create_command_for_toolchain(&toolchain, install, &command[0])
+        .await?;
     command::run_command_for_dir(cmd, &command[0], &command[1..])
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -808,11 +808,9 @@ impl Cfg {
             }
             Ok(mut distributable) => {
                 if !distributable.components_exist(&components, &targets)? {
-                    utils::run_future(distributable.update(
-                        &components,
-                        &targets,
-                        profile.unwrap_or(Profile::Default),
-                    ))?;
+                    distributable
+                        .update(&components, &targets, profile.unwrap_or(Profile::Default))
+                        .await?;
                 }
                 distributable
             }
@@ -942,7 +940,7 @@ impl Cfg {
         self.create_command_for_toolchain_(toolchain, binary)
     }
 
-    pub(crate) fn create_command_for_toolchain(
+    pub(crate) async fn create_command_for_toolchain(
         &self,
         toolchain_name: &LocalToolchainName,
         install_if_missing: bool,
@@ -953,14 +951,15 @@ impl Cfg {
                 match DistributableToolchain::new(self, desc.clone()) {
                     Err(RustupError::ToolchainNotInstalled(_)) => {
                         if install_if_missing {
-                            utils::run_future(DistributableToolchain::install(
+                            DistributableToolchain::install(
                                 self,
                                 desc,
                                 &[],
                                 &[],
                                 self.get_profile()?,
                                 true,
-                            ))?;
+                            )
+                            .await?;
                         }
                     }
                     o => {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -33,11 +33,13 @@ pub(crate) struct DistributableToolchain<'a> {
 }
 
 impl<'a> DistributableToolchain<'a> {
-    pub(crate) fn from_partial(
+    pub(crate) async fn from_partial(
         toolchain: Option<PartialToolchainDesc>,
         cfg: &'a Cfg,
     ) -> anyhow::Result<Self> {
-        Ok(Self::try_from(&Toolchain::from_partial(toolchain, cfg)?)?)
+        Ok(Self::try_from(
+            &Toolchain::from_partial(toolchain, cfg).await?,
+        )?)
     }
 
     pub(crate) fn new(cfg: &'a Cfg, desc: ToolchainDesc) -> Result<Self, RustupError> {

--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -37,7 +37,7 @@ pub(crate) struct Toolchain<'a> {
 }
 
 impl<'a> Toolchain<'a> {
-    pub(crate) fn from_partial(
+    pub(crate) async fn from_partial(
         toolchain: Option<PartialToolchainDesc>,
         cfg: &'a Cfg,
     ) -> anyhow::Result<Self> {
@@ -48,7 +48,7 @@ impl<'a> Toolchain<'a> {
             }
             None => {
                 let cwd = utils::current_dir()?;
-                let (toolchain, _) = cfg.find_or_install_active_toolchain(&cwd)?;
+                let (toolchain, _) = cfg.find_or_install_active_toolchain(&cwd).await?;
 
                 Ok(toolchain)
             }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -1,6 +1,5 @@
 use std::env;
 use std::fs::{self, File};
-use std::future::Future;
 use std::io::{self, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
@@ -10,8 +9,6 @@ use home::env as home;
 use retry::delay::{jitter, Fibonacci};
 use retry::{retry, OperationResult};
 use sha2::Sha256;
-use tokio::runtime::Handle;
-use tokio::task;
 use url::Url;
 
 use crate::currentprocess::{
@@ -266,24 +263,6 @@ async fn download_file_(
     notify_handler(Notification::DownloadFinished);
 
     res
-}
-
-/// Temporary thunk to support asyncifying from underneath.
-pub(crate) fn run_future<F, R, E>(f: F) -> Result<R, E>
-where
-    F: Future<Output = Result<R, E>>,
-    E: std::convert::From<std::io::Error>,
-{
-    match Handle::try_current() {
-        Ok(current) => {
-            // hide the asyncness for now.
-            task::block_in_place(|| current.block_on(f))
-        }
-        Err(_) => {
-            // Make a runtime to hide the asyncness.
-            tokio::runtime::Runtime::new()?.block_on(f)
-        }
-    }
 }
 
 pub(crate) fn parse_url(url: &str) -> Result<Url> {


### PR DESCRIPTION
Continuation of #3367, supersedes #3847.

This PR simply makes more function async, and thus the necessity of `run_future()` in non-test code is completely eliminated.

The only usages remaining are in `manifestation`'s tests, which is seemingly a bit harder than others considering lifetime restrictions and such.