### PR TITLE
feat: support for parsing beta versions with tags in the toolchain

### DIFF
--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -181,7 +181,8 @@ impl FromStr for ParsedToolchainDesc {
                     "beta",
                     "stable",
                     // Allow from 1.0.0 through to 9.999.99 with optional patch version
-                    r"\d{1}\.\d{1,3}(?:\.\d{1,2})?",
+                    // and optional beta tag
+                    r"\d{1}\.\d{1,3}(?:\.\d{1,2})?(?:-beta(?:\.\d{1,2})?)?",
                 ]
                 .join("|")
             ))
@@ -1185,6 +1186,25 @@ mod tests {
             ("1.6", ("1.6.0", None, None)),
             ("1.7", ("1.7.0", None, None)),
             ("1.8", ("1.8.0", None, None)),
+            // channels with beta tags
+            ("0.0.0-beta", ("0.0.0-beta", None, None)),
+            ("0.0.0-beta.1", ("0.0.0-beta.1", None, None)),
+            (
+                "0.0.0-beta.1-0000-00-00",
+                ("0.0.0-beta.1", Some("0000-00-00"), None),
+            ),
+            (
+                "0.0.0-beta.1-anything",
+                ("0.0.0-beta.1", None, Some("anything")),
+            ),
+            (
+                "0.0.0-beta-anything",
+                ("0.0.0-beta", None, Some("anything")),
+            ),
+            (
+                "0.0.0-beta.1-0000-00-00-any-other-thing",
+                ("0.0.0-beta.1", Some("0000-00-00"), Some("any-other-thing")),
+            ),
         ];
 
         for (input, (channel, date, target)) in success_cases {

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -794,6 +794,18 @@ fn install_unavailable_platform() {
     });
 }
 
+// issue #1329
+#[test]
+fn install_beta_with_tag() {
+    clitools::test(Scenario::BetaTag, &|config| {
+        config.expect_ok(&["rustup", "default", "1.78.0-beta"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "1.78.0-beta");
+
+        config.expect_ok(&["rustup", "default", "1.79.0-beta.2"]);
+        config.expect_stdout_ok(&["rustc", "--version"], "1.79.0-beta.2");
+    })
+}
+
 #[test]
 fn update_nightly_even_with_incompat() {
     clitools::test(Scenario::MissingComponent, &|config| {


### PR DESCRIPTION
Fix #1329.

This PR adds support for parsing toolchain names which containing beta channel and tags (like `1.23-beta`, `1.23.0-beta` or `1.23.0-beta.2`).

## Changes

- Add support for parsing beta versions with tags in the toolchain names and corresponding unit tests.
- Add scenario `BetaTag` and mock data.
- Add regression tests.