### PR TITLE
Store current_dir in Cfg

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -403,10 +403,9 @@ pub(crate) fn list_toolchains(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCod
         writeln!(process().stdout().lock(), "no installed toolchains")?;
     } else {
         let default_toolchain_name = cfg.get_default()?;
-        let cwd = utils::current_dir()?;
         let active_toolchain_name: Option<ToolchainName> =
             if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
-                cfg.find_active_toolchain(&cwd)
+                cfg.find_active_toolchain()
             {
                 Some(toolchain)
             } else {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -9,7 +9,6 @@ use crate::{
     config::Cfg,
     currentprocess::process,
     toolchain::names::{LocalToolchainName, ResolvableLocalToolchainName},
-    utils::utils,
 };
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
@@ -52,10 +51,7 @@ async fn direct_proxy(
     args: &[OsString],
 ) -> Result<ExitStatus> {
     let cmd = match toolchain {
-        None => {
-            cfg.create_command_for_dir(&utils::current_dir()?, arg0)
-                .await?
-        }
+        None => cfg.create_command_for_dir(arg0).await?,
         Some(tc) => cfg.create_command_for_toolchain(&tc, false, arg0).await?,
     };
     run_command_for_dir(cmd, arg0, args)

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -732,8 +732,7 @@ async fn default_(
             }
         };
 
-        let cwd = utils::current_dir()?;
-        if let Some((toolchain, reason)) = cfg.find_active_toolchain(&cwd)? {
+        if let Some((toolchain, reason)) = cfg.find_active_toolchain()? {
             if !matches!(reason, ActiveReason::Default) {
                 info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
             }
@@ -947,11 +946,10 @@ fn show(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
         writeln!(t.lock())?;
     }
 
-    let cwd = utils::current_dir()?;
     let installed_toolchains = cfg.list_toolchains()?;
     let active_toolchain_and_reason: Option<(ToolchainName, ActiveReason)> =
         if let Ok(Some((LocalToolchainName::Named(toolchain_name), reason))) =
-            cfg.find_active_toolchain(&cwd)
+            cfg.find_active_toolchain()
         {
             Some((toolchain_name, reason))
         } else {
@@ -1064,8 +1062,7 @@ fn show(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
 
 #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
 fn show_active_toolchain(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
-    let cwd = utils::current_dir()?;
-    match cfg.find_active_toolchain(&cwd)? {
+    match cfg.find_active_toolchain()? {
         Some((toolchain_name, reason)) => {
             let toolchain = new_toolchain_with_reason(cfg, toolchain_name.clone(), &reason)?;
             writeln!(

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1292,13 +1292,6 @@ async fn override_add(
     path: Option<&Path>,
 ) -> Result<utils::ExitCode> {
     let toolchain_name = toolchain.resolve(&cfg.get_default_host_triple()?)?;
-
-    let path = if let Some(path) = path {
-        PathBuf::from(path)
-    } else {
-        utils::current_dir()?
-    };
-
     match Toolchain::new(cfg, (&toolchain_name).into()) {
         Ok(_) => {}
         Err(e @ RustupError::ToolchainNotInstalled(_)) => match &toolchain_name {
@@ -1319,7 +1312,7 @@ async fn override_add(
         Err(e) => Err(e)?,
     }
 
-    cfg.make_override(&path, &toolchain_name)?;
+    cfg.make_override(path.unwrap_or(&cfg.current_dir), &toolchain_name)?;
     Ok(utils::ExitCode(0))
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -914,7 +914,7 @@ async fn which(
         let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
         Toolchain::new(cfg, desc.into())?.binary_file(binary)
     } else {
-        cfg.which_binary(&utils::current_dir()?, binary).await?
+        cfg.which_binary(binary).await?
     };
 
     utils::assert_is_file(&binary_path)?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1334,7 +1334,7 @@ fn override_remove(cfg: &Cfg, path: Option<&Path>, nonexistent: bool) -> Result<
     } else if let Some(path) = path {
         vec![path.to_owned()]
     } else {
-        vec![utils::current_dir()?]
+        vec![cfg.current_dir.clone()]
     };
 
     for p in &paths {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -541,14 +541,13 @@ pub async fn main() -> Result<utils::ExitCode> {
             #[cfg_attr(feature = "otel", tracing::instrument)]
             async fn rustc_version() -> std::result::Result<String, Box<dyn std::error::Error>> {
                 let cfg = &mut common::set_globals(false, true)?;
-                let cwd = std::env::current_dir()?;
 
                 if let Some(t) = process().args().find(|x| x.starts_with('+')) {
                     debug!("Fetching rustc version from toolchain `{}`", t);
                     cfg.set_toolchain_override(&ResolvableToolchainName::try_from(&t[1..])?);
                 }
 
-                let toolchain = cfg.find_or_install_active_toolchain(&cwd).await?.0;
+                let toolchain = cfg.find_or_install_active_toolchain().await?.0;
 
                 Ok(toolchain.rustc_version())
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -494,9 +494,7 @@ impl Cfg {
     }
 
     pub(crate) async fn which_binary(&self, binary: &str) -> Result<PathBuf> {
-        let (toolchain, _) = self
-            .find_or_install_active_toolchain(&self.current_dir)
-            .await?;
+        let (toolchain, _) = self.find_or_install_active_toolchain().await?;
         Ok(toolchain.binary_file(binary))
     }
 
@@ -732,9 +730,8 @@ impl Cfg {
 
     pub(crate) async fn find_or_install_active_toolchain(
         &self,
-        path: &Path,
     ) -> Result<(Toolchain<'_>, ActiveReason)> {
-        self.maybe_find_or_install_active_toolchain(path)
+        self.maybe_find_or_install_active_toolchain(&self.current_dir)
             .await?
             .ok_or(RustupError::ToolchainNotSelected.into())
     }
@@ -935,9 +932,7 @@ impl Cfg {
     }
 
     pub(crate) async fn create_command_for_dir(&self, binary: &str) -> Result<Command> {
-        let (toolchain, _) = self
-            .find_or_install_active_toolchain(&self.current_dir)
-            .await?;
+        let (toolchain, _) = self.find_or_install_active_toolchain().await?;
         self.create_command_for_toolchain_(toolchain, binary)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -493,8 +493,10 @@ impl Cfg {
         Ok(self.update_hash_dir.join(toolchain.to_string()))
     }
 
-    pub(crate) async fn which_binary(&self, path: &Path, binary: &str) -> Result<PathBuf> {
-        let (toolchain, _) = self.find_or_install_active_toolchain(path).await?;
+    pub(crate) async fn which_binary(&self, binary: &str) -> Result<PathBuf> {
+        let (toolchain, _) = self
+            .find_or_install_active_toolchain(&self.current_dir)
+            .await?;
         Ok(toolchain.binary_file(binary))
     }
 
@@ -932,11 +934,10 @@ impl Cfg {
         })
     }
 
-    pub(crate) async fn create_command_for_dir(
-        &self,
-        binary: &str,
-    ) -> Result<Command> {
-        let (toolchain, _) = self.find_or_install_active_toolchain(&self.current_dir).await?;
+    pub(crate) async fn create_command_for_dir(&self, binary: &str) -> Result<Command> {
+        let (toolchain, _) = self
+            .find_or_install_active_toolchain(&self.current_dir)
+            .await?;
         self.create_command_for_toolchain_(toolchain, binary)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -934,10 +934,9 @@ impl Cfg {
 
     pub(crate) async fn create_command_for_dir(
         &self,
-        path: &Path,
         binary: &str,
     ) -> Result<Command> {
-        let (toolchain, _) = self.find_or_install_active_toolchain(path).await?;
+        let (toolchain, _) = self.find_or_install_active_toolchain(&self.current_dir).await?;
         self.create_command_for_toolchain_(toolchain, binary)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -285,6 +285,7 @@ pub(crate) struct Cfg {
     pub env_override: Option<LocalToolchainName>,
     pub dist_root_url: String,
     pub notify_handler: Arc<dyn Fn(Notification<'_>)>,
+    pub current_dir: PathBuf,
 }
 
 impl Cfg {
@@ -366,6 +367,7 @@ impl Cfg {
             toolchain_override: None,
             env_override,
             dist_root_url: dist_root,
+            current_dir: utils::current_dir()?,
         };
 
         // Run some basic checks against the constructed configuration
@@ -546,10 +548,9 @@ impl Cfg {
 
     pub(crate) fn find_active_toolchain(
         &self,
-        path: &Path,
     ) -> Result<Option<(LocalToolchainName, ActiveReason)>> {
         Ok(
-            if let Some((override_config, reason)) = self.find_override_config(path)? {
+            if let Some((override_config, reason)) = self.find_override_config(&self.current_dir)? {
                 Some((override_config.into_local_toolchain_name(), reason))
             } else {
                 self.get_default()?
@@ -1080,6 +1081,7 @@ impl Debug for Cfg {
             env_override,
             dist_root_url,
             notify_handler: _,
+            current_dir,
         } = self;
 
         f.debug_struct("Cfg")
@@ -1094,6 +1096,7 @@ impl Debug for Cfg {
             .field("toolchain_override", toolchain_override)
             .field("env_override", env_override)
             .field("dist_root_url", dist_root_url)
+            .field("current_dir", current_dir)
             .finish()
     }
 }

--- a/src/toolchain/toolchain.rs
+++ b/src/toolchain/toolchain.rs
@@ -46,12 +46,7 @@ impl<'a> Toolchain<'a> {
                 let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
                 Ok(Toolchain::new(cfg, desc.into())?)
             }
-            None => {
-                let cwd = utils::current_dir()?;
-                let (toolchain, _) = cfg.find_or_install_active_toolchain(&cwd).await?;
-
-                Ok(toolchain)
-            }
+            None => Ok(cfg.find_or_install_active_toolchain().await?.0),
         }
     }
 


### PR DESCRIPTION
Stores the `current_dir` in `Cfg` to avoid having to pass it into a number of its methods. Eventually I think we can use this to completely get rid of `utils::current_dir()` and `Process::current_dir()` in favor of passing down the `current_dir` from the original `main()` in `rustup-init.rs`, but that last step is triggering some weird stuff that needs more investigation.