### PR TITLE
Refactoring around use of `Process`

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -13,7 +13,7 @@
 
 #![recursion_limit = "1024"]
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use cfg_if::cfg_if;
 // Public macros require availability of the internal symbols
 use rs_tracing::{
@@ -29,6 +29,7 @@ use rustup::cli::self_update;
 use rustup::cli::setup_mode;
 use rustup::currentprocess::{process, with_runtime, Process};
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
+use rustup::errors::RustupError;
 use rustup::is_proxyable_tools;
 use rustup::utils::utils::{self, ExitCode};
 
@@ -115,7 +116,9 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
 
     // Before we do anything else, ensure we know where we are and who we
     // are because otherwise we cannot proceed usefully.
-    let current_dir = utils::current_dir()?;
+    let current_dir = process()
+        .current_dir()
+        .context(RustupError::LocatingWorkingDir)?;
     utils::current_exe()?;
 
     match process().name().as_deref() {

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -115,17 +115,17 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
 
     // Before we do anything else, ensure we know where we are and who we
     // are because otherwise we cannot proceed usefully.
-    utils::current_dir()?;
+    let current_dir = utils::current_dir()?;
     utils::current_exe()?;
 
     match process().name().as_deref() {
-        Some("rustup") => rustup_mode::main().await,
+        Some("rustup") => rustup_mode::main(current_dir).await,
         Some(n) if n.starts_with("rustup-setup") || n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to
             // e.g. rustup-setup(2), and this allows all variations
             // to work.
-            setup_mode::main().await
+            setup_mode::main(current_dir).await
         }
         Some(n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where
@@ -140,7 +140,7 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
         }
         Some(n) => {
             is_proxyable_tools(n)?;
-            proxy_mode::main(n).await.map(ExitCode::from)
+            proxy_mode::main(n, current_dir).await.map(ExitCode::from)
         }
         None => {
             // Weird case. No arg0, or it's unparsable.

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -1,5 +1,4 @@
-use std::{ffi::OsString, path::PathBuf};
-use std::process::ExitStatus;
+use std::{ffi::OsString, path::PathBuf, process::ExitStatus};
 
 use anyhow::Result;
 

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -51,13 +51,16 @@ async fn direct_proxy(
     args: &[OsString],
 ) -> Result<ExitStatus> {
     let cmd = match toolchain {
-        None => cfg.create_command_for_dir(arg0).await?,
+        None => {
+            let (toolchain, _) = cfg.find_or_install_active_toolchain().await?;
+            cfg.create_command_for_toolchain(toolchain, arg0)?
+        }
         Some(tc) => {
             let toolchain = Toolchain::from_local(&tc, false, cfg).await?;
 
             // NB this can only fail in race conditions since we handle existence above
             // for dir.
-            cfg.create_command_for_toolchain_(toolchain, arg0)?
+            cfg.create_command_for_toolchain(toolchain, arg0)?
         }
     };
     run_command_for_dir(cmd, arg0, args)

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsString;
+use std::{ffi::OsString, path::PathBuf};
 use std::process::ExitStatus;
 
 use anyhow::Result;
@@ -12,7 +12,7 @@ use crate::{
 };
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-pub async fn main(arg0: &str) -> Result<ExitStatus> {
+pub async fn main(arg0: &str, current_dir: PathBuf) -> Result<ExitStatus> {
     self_update::cleanup_self_updater()?;
 
     let _setup = job::setup();
@@ -35,7 +35,7 @@ pub async fn main(arg0: &str) -> Result<ExitStatus> {
         .skip(1 + toolchain.is_some() as usize)
         .collect();
 
-    let cfg = set_globals(false, true)?;
+    let cfg = set_globals(current_dir, false, true)?;
     cfg.check_metadata_version()?;
     let toolchain = toolchain
         .map(|t| t.resolve(&cfg.get_default_host_triple()?))

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -55,6 +55,6 @@ async fn direct_proxy(
         Some(tc) => Toolchain::from_local(&tc, false, cfg).await?,
     };
 
-    let cmd = cfg.create_command_for_toolchain(toolchain, arg0)?;
+    let cmd = toolchain.command(arg0)?;
     run_command_for_dir(cmd, arg0, args)
 }

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -50,18 +50,11 @@ async fn direct_proxy(
     toolchain: Option<LocalToolchainName>,
     args: &[OsString],
 ) -> Result<ExitStatus> {
-    let cmd = match toolchain {
-        None => {
-            let (toolchain, _) = cfg.find_or_install_active_toolchain().await?;
-            cfg.create_command_for_toolchain(toolchain, arg0)?
-        }
-        Some(tc) => {
-            let toolchain = Toolchain::from_local(&tc, false, cfg).await?;
-
-            // NB this can only fail in race conditions since we handle existence above
-            // for dir.
-            cfg.create_command_for_toolchain(toolchain, arg0)?
-        }
+    let toolchain = match toolchain {
+        None => cfg.find_or_install_active_toolchain().await?.0,
+        Some(tc) => Toolchain::from_local(&tc, false, cfg).await?,
     };
+
+    let cmd = cfg.create_command_for_toolchain(toolchain, arg0)?;
     run_command_for_dir(cmd, arg0, args)
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1267,7 +1267,7 @@ async fn toolchain_link(
 
     if true {
         InstallMethod::Link {
-            src: &utils::to_absolute(src, &cfg.current_dir),
+            src: &cfg.current_dir.join(src),
             dest,
             cfg,
         }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -914,7 +914,8 @@ async fn which(
         let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
         Toolchain::new(cfg, desc.into())?.binary_file(binary)
     } else {
-        cfg.which_binary(binary).await?
+        let (toolchain, _) = cfg.find_or_install_active_toolchain().await?;
+        toolchain.binary_file(binary)
     };
 
     utils::assert_is_file(&binary_path)?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -900,9 +900,11 @@ async fn run(
     install: bool,
 ) -> Result<ExitStatus> {
     let toolchain = toolchain.resolve(&cfg.get_default_host_triple()?)?;
-    let cmd = cfg
-        .create_command_for_toolchain(&toolchain, install, &command[0])
-        .await?;
+    let toolchain = Toolchain::from_local(&toolchain, install, cfg).await?;
+
+    // NB this can only fail in race conditions since we handle existence above
+    // for dir.
+    let cmd = cfg.create_command_for_toolchain_(toolchain, &command[0])?;
     command::run_command_for_dir(cmd, &command[0], &command[1..])
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -22,7 +22,7 @@ use crate::{
         topical_doc,
     },
     command,
-    config::{new_toolchain_with_reason, ActiveReason, Cfg},
+    config::{ActiveReason, Cfg},
     currentprocess::{
         process,
         terminalsource::{self, ColorableTerminal},
@@ -1021,7 +1021,7 @@ fn show(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
 
         match active_toolchain_and_reason {
             Some((active_toolchain_name, active_reason)) => {
-                let active_toolchain = new_toolchain_with_reason(
+                let active_toolchain = Toolchain::with_reason(
                     cfg,
                     active_toolchain_name.clone().into(),
                     &active_reason,
@@ -1064,7 +1064,7 @@ fn show(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
 fn show_active_toolchain(cfg: &Cfg, verbose: bool) -> Result<utils::ExitCode> {
     match cfg.find_active_toolchain()? {
         Some((toolchain_name, reason)) => {
-            let toolchain = new_toolchain_with_reason(cfg, toolchain_name.clone(), &reason)?;
+            let toolchain = Toolchain::with_reason(cfg, toolchain_name.clone(), &reason)?;
             writeln!(
                 process().stdout().lock(),
                 "{}\nactive because: {}",

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -904,7 +904,7 @@ async fn run(
 
     // NB this can only fail in race conditions since we handle existence above
     // for dir.
-    let cmd = cfg.create_command_for_toolchain_(toolchain, &command[0])?;
+    let cmd = cfg.create_command_for_toolchain(toolchain, &command[0])?;
     command::run_command_for_dir(cmd, &command[0], &command[1..])
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -539,7 +539,9 @@ pub async fn main(current_dir: PathBuf) -> Result<utils::ExitCode> {
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
 
             #[cfg_attr(feature = "otel", tracing::instrument)]
-            async fn rustc_version(current_dir: PathBuf) -> std::result::Result<String, Box<dyn std::error::Error>> {
+            async fn rustc_version(
+                current_dir: PathBuf,
+            ) -> std::result::Result<String, Box<dyn std::error::Error>> {
                 let cfg = &mut common::set_globals(current_dir, false, true)?;
 
                 if let Some(t) = process().args().find(|x| x.starts_with('+')) {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -901,10 +901,7 @@ async fn run(
 ) -> Result<ExitStatus> {
     let toolchain = toolchain.resolve(&cfg.get_default_host_triple()?)?;
     let toolchain = Toolchain::from_local(&toolchain, install, cfg).await?;
-
-    // NB this can only fail in race conditions since we handle existence above
-    // for dir.
-    let cmd = cfg.create_command_for_toolchain(toolchain, &command[0])?;
+    let cmd = toolchain.command(&command[0])?;
     command::run_command_for_dir(cmd, &command[0], &command[1..])
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1265,7 +1265,7 @@ async fn toolchain_link(
 
     if true {
         InstallMethod::Link {
-            src: &utils::to_absolute(src)?,
+            src: &utils::to_absolute(src, &cfg.current_dir),
             dest,
             cfg,
         }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -469,7 +469,16 @@ pub(crate) async fn install(
             do_add_to_programs()?;
             do_add_to_path()?;
         }
-        utils::create_rustup_home()?;
+
+        // If RUSTUP_HOME is not set, make sure it exists
+        if process().var_os("RUSTUP_HOME").is_none() {
+            let home = utils::home_dir()
+                .map(|p| p.join(".rustup"))
+                .ok_or_else(|| anyhow::anyhow!("could not find home dir to put .rustup in"))?;
+
+            fs::create_dir_all(home).context("unable to create ~/.rustup")?;
+        }
+
         maybe_install_rust(
             opts.default_toolchain,
             &opts.profile,

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{builder::PossibleValuesParser, Parser};
 
@@ -74,7 +76,7 @@ struct RustupInit {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-pub async fn main() -> Result<utils::ExitCode> {
+pub async fn main(current_dir: PathBuf) -> Result<utils::ExitCode> {
     use clap::error::ErrorKind;
 
     let RustupInit {
@@ -122,5 +124,5 @@ pub async fn main() -> Result<utils::ExitCode> {
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    self_update::install(no_prompt, verbose, quiet, opts).await
+    self_update::install(current_dir, no_prompt, verbose, quiet, opts).await
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -934,12 +934,7 @@ impl Cfg {
         })
     }
 
-    pub(crate) async fn create_command_for_dir(&self, binary: &str) -> Result<Command> {
-        let (toolchain, _) = self.find_or_install_active_toolchain().await?;
-        self.create_command_for_toolchain_(toolchain, binary)
-    }
-
-    pub fn create_command_for_toolchain_(
+    pub fn create_command_for_toolchain(
         &self,
         toolchain: Toolchain<'_>,
         binary: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -289,7 +289,10 @@ pub(crate) struct Cfg {
 }
 
 impl Cfg {
-    pub(crate) fn from_env(notify_handler: Arc<dyn Fn(Notification<'_>)>) -> Result<Self> {
+    pub(crate) fn from_env(
+        current_dir: PathBuf,
+        notify_handler: Arc<dyn Fn(Notification<'_>)>,
+    ) -> Result<Self> {
         // Set up the rustup home directory
         let rustup_dir = utils::rustup_home()?;
 
@@ -367,7 +370,7 @@ impl Cfg {
             toolchain_override: None,
             env_override,
             dist_root_url: dist_root,
-            current_dir: utils::current_dir()?,
+            current_dir,
         };
 
         // Run some basic checks against the constructed configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -934,28 +934,9 @@ impl Cfg {
         })
     }
 
-    pub fn create_command_for_toolchain(
-        &self,
-        toolchain: Toolchain<'_>,
-        binary: &str,
-    ) -> Result<Command> {
-        // Should push the cargo fallback into a custom toolchain type? And then
-        // perhaps a trait that create command layers on?
-        if !matches!(
-            toolchain.name(),
-            LocalToolchainName::Named(ToolchainName::Official(_))
-        ) {
-            if let Some(cmd) = self.maybe_do_cargo_fallback(&toolchain, binary)? {
-                return Ok(cmd);
-            }
-        }
-
-        toolchain.create_command(binary)
-    }
-
     // Custom toolchains don't have cargo, so here we detect that situation and
     // try to find a different cargo.
-    fn maybe_do_cargo_fallback(
+    pub(crate) fn maybe_do_cargo_fallback(
         &self,
         toolchain: &Toolchain<'_>,
         binary: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -457,11 +457,6 @@ impl Cfg {
         Ok(self.update_hash_dir.join(toolchain.to_string()))
     }
 
-    pub(crate) async fn which_binary(&self, binary: &str) -> Result<PathBuf> {
-        let (toolchain, _) = self.find_or_install_active_toolchain().await?;
-        Ok(toolchain.binary_file(binary))
-    }
-
     #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
     pub(crate) fn upgrade_data(&self) -> Result<()> {
         let current_version = self.settings_file.with(|s| Ok(s.version.clone()))?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -939,20 +939,7 @@ impl Cfg {
         self.create_command_for_toolchain_(toolchain, binary)
     }
 
-    pub(crate) async fn create_command_for_toolchain(
-        &self,
-        toolchain_name: &LocalToolchainName,
-        install_if_missing: bool,
-        binary: &str,
-    ) -> Result<Command> {
-        let toolchain = Toolchain::from_local(toolchain_name, install_if_missing, self).await?;
-
-        // NB this can only fail in race conditions since we handle existence above
-        // for dir.
-        self.create_command_for_toolchain_(toolchain, binary)
-    }
-
-    fn create_command_for_toolchain_(
+    pub fn create_command_for_toolchain_(
         &self,
         toolchain: Toolchain<'_>,
         binary: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -945,35 +945,7 @@ impl Cfg {
         install_if_missing: bool,
         binary: &str,
     ) -> Result<Command> {
-        match toolchain_name {
-            LocalToolchainName::Named(ToolchainName::Official(desc)) => {
-                match DistributableToolchain::new(self, desc.clone()) {
-                    Err(RustupError::ToolchainNotInstalled(_)) => {
-                        if install_if_missing {
-                            DistributableToolchain::install(
-                                self,
-                                desc,
-                                &[],
-                                &[],
-                                self.get_profile()?,
-                                true,
-                            )
-                            .await?;
-                        }
-                    }
-                    o => {
-                        o?;
-                    }
-                }
-            }
-            n => {
-                if !Toolchain::exists(self, n)? {
-                    return Err(RustupError::ToolchainNotInstallable(n.to_string()).into());
-                }
-            }
-        }
-
-        let toolchain = Toolchain::new(self, toolchain_name.clone())?;
+        let toolchain = Toolchain::from_local(toolchain_name, install_if_missing, self).await?;
 
         // NB this can only fail in race conditions since we handle existence above
         // for dir.

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -106,7 +106,7 @@ impl Process {
         }
     }
 
-    pub(crate) fn current_dir(&self) -> io::Result<PathBuf> {
+    pub fn current_dir(&self) -> io::Result<PathBuf> {
         match self {
             Process::OSProcess(_) => env::current_dir(),
             #[cfg(feature = "test")]

--- a/src/dist/dist.rs
+++ b/src/dist/dist.rs
@@ -96,7 +96,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
 }
 
 #[derive(Debug, ThisError)]
-pub(crate) enum DistError {
+pub enum DistError {
     #[error("{}", components_missing_msg(.0, .1, .2))]
     ToolchainComponentsMissing(Vec<Component>, Box<ManifestV2>, String),
     #[error("no release found for '{0}'")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,7 +25,7 @@ use crate::{
 pub struct OperationError(pub anyhow::Error);
 
 #[derive(ThisError, Debug)]
-pub(crate) enum RustupError {
+pub enum RustupError {
     #[error("partially downloaded file may have been damaged and was removed, please try again")]
     BrokenPartialFile,
     #[error("component download failed for {0}")]

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -731,8 +731,11 @@ impl Config {
             .enable_all()
             .worker_threads(2)
             .max_blocking_threads(2);
-        let process_res =
-            currentprocess::with_runtime(tp.clone().into(), builder, rustup_mode::main(tp.cwd.clone()));
+        let process_res = currentprocess::with_runtime(
+            tp.clone().into(),
+            builder,
+            rustup_mode::main(tp.cwd.clone()),
+        );
         // convert Err's into an ec
         let ec = match process_res {
             Ok(process_res) => process_res,

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -732,7 +732,7 @@ impl Config {
             .worker_threads(2)
             .max_blocking_threads(2);
         let process_res =
-            currentprocess::with_runtime(tp.clone().into(), builder, rustup_mode::main());
+            currentprocess::with_runtime(tp.clone().into(), builder, rustup_mode::main(tp.cwd.clone()));
         // convert Err's into an ec
         let ec = match process_res {
             Ok(process_res) => process_res,

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -249,7 +249,7 @@ impl Display for MaybeOfficialToolchainName {
 /// like setting overrides, or that depend on configuration, like calculating
 /// the toolchain directory.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) enum ToolchainName {
+pub enum ToolchainName {
     Custom(CustomToolchainName),
     Official(ToolchainDesc),
 }
@@ -396,7 +396,7 @@ impl Display for LocalToolchainName {
 /// A custom toolchain name, but not an official toolchain name
 /// (e.g. my-custom-toolchain)
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct CustomToolchainName(String);
+pub struct CustomToolchainName(String);
 
 impl CustomToolchainName {
     fn validate(candidate: &str) -> Result<CustomToolchainName, InvalidName> {
@@ -433,7 +433,7 @@ impl Display for CustomToolchainName {
 /// code execution in a rust dir, so as a partial mitigation is limited to
 /// absolute paths.
 #[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-pub(crate) struct PathBasedToolchainName(PathBuf, String);
+pub struct PathBasedToolchainName(PathBuf, String);
 
 impl Display for PathBasedToolchainName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -509,22 +509,6 @@ pub(crate) fn cargo_home() -> Result<PathBuf> {
     home::cargo_home_with_env(&home_process()).context("failed to determine cargo home")
 }
 
-// Creates a ~/.rustup folder
-pub(crate) fn create_rustup_home() -> Result<()> {
-    // If RUSTUP_HOME is set then don't make any assumptions about where it's
-    // ok to put ~/.rustup
-    if process().var_os("RUSTUP_HOME").is_some() {
-        return Ok(());
-    }
-
-    let home = home_dir()
-        .map(|p| p.join(".rustup"))
-        .ok_or_else(|| anyhow::anyhow!("could not find home dir to put .rustup in"))?;
-
-    fs::create_dir_all(home).context("unable to create ~/.rustup")?;
-    Ok(())
-}
-
 pub(crate) fn rustup_home() -> Result<PathBuf> {
     home::rustup_home_with_env(&home_process()).context("failed to determine rustup home dir")
 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -517,17 +517,13 @@ pub(crate) fn create_rustup_home() -> Result<()> {
         return Ok(());
     }
 
-    let home = rustup_home_in_user_dir()?;
-    fs::create_dir_all(home).context("unable to create ~/.rustup")?;
-
-    Ok(())
-}
-
-fn rustup_home_in_user_dir() -> Result<PathBuf> {
     // XXX: This error message seems wrong/bogus.
-    home_dir()
+    let home = home_dir()
         .map(|p| p.join(".rustup"))
-        .ok_or_else(|| anyhow::anyhow!("couldn't find value of RUSTUP_HOME"))
+        .ok_or_else(|| anyhow::anyhow!("couldn't find value of RUSTUP_HOME"))?;
+
+    fs::create_dir_all(home).context("unable to create ~/.rustup")?;
+    Ok(())
 }
 
 pub(crate) fn rustup_home() -> Result<PathBuf> {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -495,12 +495,6 @@ pub fn current_exe() -> Result<PathBuf> {
     env::current_exe().context(RustupError::LocatingWorkingDir)
 }
 
-pub(crate) fn to_absolute<P: AsRef<Path>>(path: P, cwd: &Path) -> PathBuf {
-    let mut new = PathBuf::from(cwd);
-    new.push(path);
-    new
-}
-
 pub(crate) fn home_dir() -> Option<PathBuf> {
     home::home_dir_with_env(&home_process())
 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -491,12 +491,6 @@ pub(crate) fn make_executable(path: &Path) -> Result<()> {
     inner(path)
 }
 
-pub fn current_dir() -> Result<PathBuf> {
-    process()
-        .current_dir()
-        .context(RustupError::LocatingWorkingDir)
-}
-
 pub fn current_exe() -> Result<PathBuf> {
     env::current_exe().context(RustupError::LocatingWorkingDir)
 }

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -523,13 +523,11 @@ pub(crate) fn create_rustup_home() -> Result<()> {
     Ok(())
 }
 
-fn dot_dir(name: &str) -> Option<PathBuf> {
-    home_dir().map(|p| p.join(name))
-}
-
 fn rustup_home_in_user_dir() -> Result<PathBuf> {
     // XXX: This error message seems wrong/bogus.
-    dot_dir(".rustup").ok_or_else(|| anyhow::anyhow!("couldn't find value of RUSTUP_HOME"))
+    home_dir()
+        .map(|p| p.join(".rustup"))
+        .ok_or_else(|| anyhow::anyhow!("couldn't find value of RUSTUP_HOME"))
 }
 
 pub(crate) fn rustup_home() -> Result<PathBuf> {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -501,11 +501,10 @@ pub fn current_exe() -> Result<PathBuf> {
     env::current_exe().context(RustupError::LocatingWorkingDir)
 }
 
-pub(crate) fn to_absolute<P: AsRef<Path>>(path: P) -> Result<PathBuf> {
-    current_dir().map(|mut v| {
-        v.push(path);
-        v
-    })
+pub(crate) fn to_absolute<P: AsRef<Path>>(path: P, cwd: &Path) -> PathBuf {
+    let mut new = PathBuf::from(cwd);
+    new.push(path);
+    new
 }
 
 pub(crate) fn home_dir() -> Option<PathBuf> {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -517,10 +517,9 @@ pub(crate) fn create_rustup_home() -> Result<()> {
         return Ok(());
     }
 
-    // XXX: This error message seems wrong/bogus.
     let home = home_dir()
         .map(|p| p.join(".rustup"))
-        .ok_or_else(|| anyhow::anyhow!("couldn't find value of RUSTUP_HOME"))?;
+        .ok_or_else(|| anyhow::anyhow!("could not find home dir to put .rustup in"))?;
 
     fs::create_dir_all(home).context("unable to create ~/.rustup")?;
     Ok(())


### PR DESCRIPTION
Various changes which I've made several times now that try to untangle the codebase mostly by inlining short and/or single-use methods. Preparation for moving more stuff out of the ambient `Process` global.