### PR TITLE
refactor(ci/run): use more `target_cargo()` in `run.bash`

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -75,7 +75,7 @@ build_test() {
 }
 
 if [ -z "$SKIP_TESTS" ]; then
-  cargo run --locked --profile "$BUILD_PROFILE" --features test --target "$TARGET" "${FEATURES[@]}" -- --dump-testament
+  target_cargo run --features test -- --dump-testament
   build_test build
   build_test test
 fi


### PR DESCRIPTION
Cherry-picked from #3803.