### PR TITLE
refactor(test): execute all `#[rustup_macros::unit_test]`s within a `tokio` context

### DIFF
--- a/rustup-macros/src/lib.rs
+++ b/rustup-macros/src/lib.rs
@@ -95,7 +95,7 @@ fn test_inner(mod_path: String, mut input: ItemFn) -> syn::Result<TokenStream> {
     let name = input.sig.ident.clone();
     let new_block: Block = parse_quote! {
         {
-            #before_ident().await;
+            let _guard = #before_ident().await;
             // Define a function with same name we can instrument inside the
             // tracing enablement logic.
             #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]

--- a/src/test.rs
+++ b/src/test.rs
@@ -277,26 +277,10 @@ static TRACER: Lazy<opentelemetry_sdk::trace::Tracer> = Lazy::new(|| {
     tracer
 });
 
-pub fn before_test() {
-    #[cfg(feature = "otel")]
-    {
-        Lazy::force(&TRACER);
-    }
-}
-
 pub async fn before_test_async() {
     #[cfg(feature = "otel")]
     {
         Lazy::force(&TRACER);
-    }
-}
-
-pub fn after_test() {
-    #[cfg(feature = "otel")]
-    {
-        let handle = TRACE_RUNTIME.handle();
-        let _guard = handle.enter();
-        TRACER.provider().map(|p| p.force_flush());
     }
 }
 


### PR DESCRIPTION
Split from #3803.

With this PR, all tests under the `#[rustup_macros::unit_test]` attribute now execute within a `tokio` runtime, eliminating the need of static `TRACER` and `TRACE_RUNTIME` variables. Also, the setup of `tracing` subscribers in both `bin` and `test` targets has also been unified, to prepare for the addition of another `stderr`-oriented subscriber in #3803.

## Rationale

Currently, the `tracing` subscriber registration will fail if a tokio runtime is not present. To mitigate this problem, static `TRACER` and `TRACE_RUNTIME` variables are added as an ad-hoc fallback if we're running a non-tokio unit test.

https://github.com/rust-lang/rustup/blob/3ba08da98221b2941aeb858e54cebc059859ffb7/src/test.rs#L230-L237

However, the fact that the subscriber state is **global** in tests has made some unnecessary complications especially WRT adding other `tracing` subscribers, such as the `stderr`-oriented tracing subscriber proposed in https://github.com/rust-lang/rustup/pull/3803#issuecomment-2090333256, which is bound to the **local** `currentprocess:process()` context (see https://github.com/rust-lang/rustup/pull/3803#issuecomment-2143703392).

I decided to go with local contexts all the way, and it did work. However, the main downside to this approach is that #2367 has to be reverted, since `run_inprocess()` calls `with_runtime()`, and for the latter to correctly alter `static PROCESS` in-process, a `tokio` runtime builder is required, which in this case will cause a "runtime-in-runtime" error once the builder is run.

Fortunately, no obvious slowdown has been observed WRT our CI so far. Also, as now `main()` seems to be the only caller to `with_runtime()`, this gets us closer to using `#[tokio::main]`. 
