### PR TITLE
Pass Process around explicitly

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -27,7 +27,7 @@ use rustup::cli::rustup_mode;
 #[cfg(windows)]
 use rustup::cli::self_update;
 use rustup::cli::setup_mode;
-use rustup::currentprocess::{process, with_runtime, Process};
+use rustup::currentprocess::{with_runtime, Process};
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
 use rustup::errors::RustupError;
 use rustup::is_proxyable_tools;
@@ -40,11 +40,11 @@ fn main() {
     let process = Process::os();
     let mut builder = Builder::new_multi_thread();
     builder.enable_all();
-    with_runtime(process, builder, {
-        async {
-            match maybe_trace_rustup().await {
+    with_runtime(process.clone(), builder, {
+        async move {
+            match maybe_trace_rustup(&process).await {
                 Err(e) => {
-                    common::report_error(&e);
+                    common::report_error(&e, &process);
                     std::process::exit(1);
                 }
                 Ok(utils::ExitCode(c)) => std::process::exit(c),
@@ -53,14 +53,14 @@ fn main() {
     });
 }
 
-async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
+async fn maybe_trace_rustup(process: &Process) -> Result<utils::ExitCode> {
     #[cfg(feature = "otel")]
     opentelemetry::global::set_text_map_propagator(
         opentelemetry_sdk::propagation::TraceContextPropagator::new(),
     );
-    let subscriber = rustup::cli::log::tracing_subscriber(process());
+    let subscriber = rustup::cli::log::tracing_subscriber(process);
     tracing::subscriber::set_global_default(subscriber)?;
-    let result = run_rustup().await;
+    let result = run_rustup(process).await;
     // We're tracing, so block until all spans are exported.
     #[cfg(feature = "otel")]
     opentelemetry::global::shutdown_tracer_provider();
@@ -68,45 +68,45 @@ async fn maybe_trace_rustup() -> Result<utils::ExitCode> {
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument)]
-async fn run_rustup() -> Result<utils::ExitCode> {
-    if let Ok(dir) = process().var("RUSTUP_TRACE_DIR") {
+async fn run_rustup(process: &Process) -> Result<utils::ExitCode> {
+    if let Ok(dir) = process.var("RUSTUP_TRACE_DIR") {
         open_trace_file!(dir)?;
     }
-    let result = run_rustup_inner().await;
-    if process().var("RUSTUP_TRACE_DIR").is_ok() {
+    let result = run_rustup_inner(process).await;
+    if process.var("RUSTUP_TRACE_DIR").is_ok() {
         close_trace_file!();
     }
     result
 }
 
 #[cfg_attr(feature = "otel", tracing::instrument(err))]
-async fn run_rustup_inner() -> Result<utils::ExitCode> {
+async fn run_rustup_inner(process: &Process) -> Result<utils::ExitCode> {
     // Guard against infinite proxy recursion. This mostly happens due to
     // bugs in rustup.
-    do_recursion_guard()?;
+    do_recursion_guard(process)?;
 
     // Before we do anything else, ensure we know where we are and who we
     // are because otherwise we cannot proceed usefully.
-    let current_dir = process()
+    let current_dir = process
         .current_dir()
         .context(RustupError::LocatingWorkingDir)?;
     utils::current_exe()?;
 
-    match process().name().as_deref() {
-        Some("rustup") => rustup_mode::main(current_dir).await,
+    match process.name().as_deref() {
+        Some("rustup") => rustup_mode::main(current_dir, process).await,
         Some(n) if n.starts_with("rustup-setup") || n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to
             // e.g. rustup-setup(2), and this allows all variations
             // to work.
-            setup_mode::main(current_dir).await
+            setup_mode::main(current_dir, process).await
         }
         Some(n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where
             // rustup deletes its own exe
             cfg_if! {
                 if #[cfg(windows)] {
-                    self_update::complete_windows_uninstall()
+                    self_update::complete_windows_uninstall(process)
                 } else {
                     unreachable!("Attempted to use Windows-specific code on a non-Windows platform. Aborting.")
                 }
@@ -114,7 +114,9 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
         }
         Some(n) => {
             is_proxyable_tools(n)?;
-            proxy_mode::main(n, current_dir).await.map(ExitCode::from)
+            proxy_mode::main(n, current_dir, process)
+                .await
+                .map(ExitCode::from)
         }
         None => {
             // Weird case. No arg0, or it's unparsable.
@@ -123,8 +125,8 @@ async fn run_rustup_inner() -> Result<utils::ExitCode> {
     }
 }
 
-fn do_recursion_guard() -> Result<()> {
-    let recursion_count = process()
+fn do_recursion_guard(process: &Process) -> Result<()> {
+    let recursion_count = process
         .var("RUST_RECURSION_COUNT")
         .ok()
         .and_then(|s| s.parse().ok())

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1341,17 +1341,17 @@ mod tests {
     use crate::cli::self_update::InstallOpts;
     use crate::dist::dist::{PartialToolchainDesc, Profile};
     use crate::test::{test_dir, with_rustup_home, Env};
-    use crate::{currentprocess, for_host};
+    use crate::{
+        currentprocess::{self, TestProcess},
+        for_host,
+    };
 
     #[test]
     fn default_toolchain_is_stable() {
         with_rustup_home(|home| {
             let mut vars = HashMap::new();
             home.apply(&mut vars);
-            let tp = currentprocess::TestProcess {
-                vars,
-                ..Default::default()
-            };
+            let tp = TestProcess::with_vars(vars);
 
             let opts = InstallOpts {
                 default_host_triple: None,
@@ -1399,10 +1399,7 @@ info: default host triple is {0}
         let cargo_home = root_dir.path().join("cargo");
         let mut vars = HashMap::new();
         vars.env("CARGO_HOME", cargo_home.to_string_lossy().to_string());
-        let tp = currentprocess::TestProcess {
-            vars,
-            ..Default::default()
-        };
+        let tp = TestProcess::with_vars(vars);
         currentprocess::with(tp.clone().into(), || -> Result<()> {
             let process = tp.clone().into();
             super::install_bins(&process).unwrap();

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -5,25 +5,25 @@ use anyhow::{bail, Context, Result};
 
 use super::install_bins;
 use super::shell;
-use crate::currentprocess::process;
+use crate::currentprocess::Process;
 use crate::utils::utils;
 use crate::utils::Notification;
 
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because
 // sudo is configured not to change $HOME. Don't let that bogosity happen.
-pub(crate) fn do_anti_sudo_check(no_prompt: bool) -> Result<utils::ExitCode> {
-    pub(crate) fn home_mismatch() -> (bool, PathBuf, PathBuf) {
+pub(crate) fn do_anti_sudo_check(no_prompt: bool, process: &Process) -> Result<utils::ExitCode> {
+    pub(crate) fn home_mismatch(process: &Process) -> (bool, PathBuf, PathBuf) {
         let fallback = || (false, PathBuf::new(), PathBuf::new());
         // test runner should set this, nothing else
-        if process()
+        if process
             .var_os("RUSTUP_INIT_SKIP_SUDO_CHECK")
             .map_or(false, |s| s == "yes")
         {
             return fallback();
         }
 
-        match (utils::home_dir_from_passwd(), process().var_os("HOME")) {
+        match (utils::home_dir_from_passwd(), process.var_os("HOME")) {
             (Some(pw), Some(eh)) if eh != pw => return (true, PathBuf::from(eh), pw),
             (None, _) => warn!("getpwuid_r: couldn't get user data"),
             _ => {}
@@ -31,7 +31,7 @@ pub(crate) fn do_anti_sudo_check(no_prompt: bool) -> Result<utils::ExitCode> {
         fallback()
     }
 
-    match home_mismatch() {
+    match home_mismatch(process) {
         (false, _, _) => {}
         (true, env_home, euid_home) => {
             err!("$HOME differs from euid-obtained home directory: you may be using sudo");
@@ -47,17 +47,17 @@ pub(crate) fn do_anti_sudo_check(no_prompt: bool) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn delete_rustup_and_cargo_home() -> Result<()> {
-    let cargo_home = utils::cargo_home()?;
+pub(crate) fn delete_rustup_and_cargo_home(process: &Process) -> Result<()> {
+    let cargo_home = utils::cargo_home(process)?;
     utils::remove_dir("cargo_home", &cargo_home, &|_: Notification<'_>| ())
 }
 
-pub(crate) fn do_remove_from_path() -> Result<()> {
-    for sh in shell::get_available_shells() {
-        let source_bytes = format!("{}\n", sh.source_string()?).into_bytes();
+pub(crate) fn do_remove_from_path(process: &Process) -> Result<()> {
+    for sh in shell::get_available_shells(process) {
+        let source_bytes = format!("{}\n", sh.source_string(process)?).into_bytes();
 
         // Check more files for cleanup than normally are updated.
-        for rc in sh.rcfiles().iter().filter(|rc| rc.is_file()) {
+        for rc in sh.rcfiles(process).iter().filter(|rc| rc.is_file()) {
             let file = utils::read_file("rcfile", rc)?;
             let file_bytes = file.into_bytes();
             // FIXME: This is whitespace sensitive where it should not be.
@@ -74,17 +74,17 @@ pub(crate) fn do_remove_from_path() -> Result<()> {
         }
     }
 
-    remove_legacy_paths()?;
+    remove_legacy_paths(process)?;
 
     Ok(())
 }
 
-pub(crate) fn do_add_to_path() -> Result<()> {
-    for sh in shell::get_available_shells() {
-        let source_cmd = sh.source_string()?;
+pub(crate) fn do_add_to_path(process: &Process) -> Result<()> {
+    for sh in shell::get_available_shells(process) {
+        let source_cmd = sh.source_string(process)?;
         let source_cmd_with_newline = format!("\n{}", &source_cmd);
 
-        for rc in sh.update_rcs() {
+        for rc in sh.update_rcs(process) {
             let cmd_to_write = match utils::read_file("rcfile", &rc) {
                 Ok(contents) if contents.contains(&source_cmd) => continue,
                 Ok(contents) if !contents.ends_with('\n') => &source_cmd_with_newline,
@@ -103,19 +103,19 @@ pub(crate) fn do_add_to_path() -> Result<()> {
         }
     }
 
-    remove_legacy_paths()?;
+    remove_legacy_paths(process)?;
 
     Ok(())
 }
 
-pub(crate) fn do_write_env_files() -> Result<()> {
+pub(crate) fn do_write_env_files(process: &Process) -> Result<()> {
     let mut written = vec![];
 
-    for sh in shell::get_available_shells() {
+    for sh in shell::get_available_shells(process) {
         let script = sh.env_script();
         // Only write each possible script once.
         if !written.contains(&script) {
-            script.write()?;
+            script.write(process)?;
             written.push(script);
         }
     }
@@ -141,15 +141,15 @@ pub(crate) fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
 /// This function is as the final step of a self-upgrade. It replaces
 /// `CARGO_HOME`/bin/rustup with the running exe, and updates the
 /// links to it.
-pub(crate) fn self_replace() -> Result<utils::ExitCode> {
-    install_bins()?;
+pub(crate) fn self_replace(process: &Process) -> Result<utils::ExitCode> {
+    install_bins(process)?;
 
     Ok(utils::ExitCode(0))
 }
 
-fn remove_legacy_source_command(source_cmd: String) -> Result<()> {
+fn remove_legacy_source_command(source_cmd: String, process: &Process) -> Result<()> {
     let cmd_bytes = source_cmd.into_bytes();
-    for rc in shell::legacy_paths().filter(|rc| rc.is_file()) {
+    for rc in shell::legacy_paths(process).filter(|rc| rc.is_file()) {
         let file = utils::read_file("rcfile", &rc)?;
         let file_bytes = file.into_bytes();
         // FIXME: This is whitespace sensitive where it should not be.
@@ -167,18 +167,24 @@ fn remove_legacy_source_command(source_cmd: String) -> Result<()> {
     Ok(())
 }
 
-fn remove_legacy_paths() -> Result<()> {
+fn remove_legacy_paths(process: &Process) -> Result<()> {
     // Before the work to support more kinds of shells, which was released in
     // version 1.23.0 of Rustup, we always inserted this line instead, which is
     // now considered legacy
-    remove_legacy_source_command(format!(
-        "export PATH=\"{}/bin:$PATH\"\n",
-        shell::cargo_home_str()?
-    ))?;
+    remove_legacy_source_command(
+        format!(
+            "export PATH=\"{}/bin:$PATH\"\n",
+            shell::cargo_home_str(process)?
+        ),
+        process,
+    )?;
     // Unfortunately in 1.23, we accidentally used `source` rather than `.`
     // which, while widely supported, isn't actually POSIX, so we also
     // clean that up here.  This issue was filed as #2623.
-    remove_legacy_source_command(format!("source \"{}/env\"\n", shell::cargo_home_str()?))?;
+    remove_legacy_source_command(
+        format!("source \"{}/env\"\n", shell::cargo_home_str(process)?),
+        process,
+    )?;
 
     Ok(())
 }

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -836,13 +836,12 @@ mod tests {
     #[test]
     fn windows_doesnt_mess_with_a_non_string_path() {
         // This writes an error, so we want a sink for it.
-        let tp = currentprocess::TestProcess {
-            vars: [("HOME".to_string(), "/unused".to_string())]
+        let tp = currentprocess::TestProcess::with_vars(
+            [("HOME".to_string(), "/unused".to_string())]
                 .iter()
                 .cloned()
                 .collect(),
-            ..Default::default()
-        };
+        );
         let process = Process::from(tp.clone());
         with_saved_path(&mut || {
             currentprocess::with(tp.clone().into(), || {

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -15,8 +15,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-#[cfg(feature = "test")]
-use rand::{thread_rng, Rng};
 use tracing_subscriber::util::SubscriberInitExt;
 
 pub mod filesource;
@@ -287,7 +285,6 @@ pub struct TestProcess {
     pub cwd: PathBuf,
     pub args: Vec<String>,
     pub vars: HashMap<String, String>,
-    pub id: u64,
     pub stdin: filesource::TestStdinInner,
     pub stdout: filesource::TestWriterInner,
     pub stderr: filesource::TestWriterInner,
@@ -305,18 +302,10 @@ impl TestProcess {
             cwd: cwd.as_ref().to_path_buf(),
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
             vars,
-            id: TestProcess::new_id(),
             stdin: Arc::new(Mutex::new(Cursor::new(stdin.to_string()))),
             stdout: Arc::new(Mutex::new(Vec::new())),
             stderr: Arc::new(Mutex::new(Vec::new())),
         }
-    }
-
-    fn new_id() -> u64 {
-        let low_bits: u64 = std::process::id() as u64;
-        let mut rng = thread_rng();
-        let high_bits = rng.gen_range(0..u32::MAX) as u64;
-        high_bits << 32 | low_bits
     }
 
     /// Extracts the stdout from the process

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -283,15 +283,22 @@ impl Default for OSProcess {
 #[derive(Clone, Debug, Default)]
 pub struct TestProcess {
     pub cwd: PathBuf,
-    pub args: Vec<String>,
-    pub vars: HashMap<String, String>,
-    pub stdin: filesource::TestStdinInner,
-    pub stdout: filesource::TestWriterInner,
-    pub stderr: filesource::TestWriterInner,
+    args: Vec<String>,
+    vars: HashMap<String, String>,
+    stdin: filesource::TestStdinInner,
+    stdout: filesource::TestWriterInner,
+    stderr: filesource::TestWriterInner,
 }
 
 #[cfg(feature = "test")]
 impl TestProcess {
+    pub fn with_vars(vars: HashMap<String, String>) -> Self {
+        Self {
+            vars,
+            ..Default::default()
+        }
+    }
+
     pub fn new<P: AsRef<Path>, A: AsRef<str>>(
         cwd: P,
         args: &[A],

--- a/src/currentprocess/filesource.rs
+++ b/src/currentprocess/filesource.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, Read, Result, Write};
 
 use super::terminalsource::{ColorableTerminal, StreamSelector};
-use crate::currentprocess::process;
+use crate::currentprocess::Process;
 
 /// Stand-in for std::io::Stdin
 pub trait Stdin {
@@ -40,10 +40,10 @@ pub trait Writer: Write + Send + Sync {
     /// Query whether a TTY is present. Used in download_tracker - we may want
     /// to remove this entirely with a better progress bar system (in favour of
     /// filtering in the Terminal layer?)
-    fn is_a_tty(&self) -> bool;
+    fn is_a_tty(&self, process: &Process) -> bool;
 
     /// Construct a terminal on this writer.
-    fn terminal(&self) -> ColorableTerminal;
+    fn terminal(&self, process: &Process) -> ColorableTerminal;
 }
 
 // ----------------- OS support for writers -----------------
@@ -51,8 +51,8 @@ pub trait Writer: Write + Send + Sync {
 impl WriterLock for io::StdoutLock<'_> {}
 
 impl Writer for io::Stdout {
-    fn is_a_tty(&self) -> bool {
-        match process() {
+    fn is_a_tty(&self, process: &Process) -> bool {
+        match process {
             crate::currentprocess::Process::OSProcess(p) => p.stdout_is_a_tty,
             #[cfg(feature = "test")]
             crate::currentprocess::Process::TestProcess(_) => unreachable!(),
@@ -63,16 +63,16 @@ impl Writer for io::Stdout {
         Box::new(io::Stdout::lock(self))
     }
 
-    fn terminal(&self) -> ColorableTerminal {
-        ColorableTerminal::new(StreamSelector::Stdout)
+    fn terminal(&self, process: &Process) -> ColorableTerminal {
+        ColorableTerminal::new(StreamSelector::Stdout, process)
     }
 }
 
 impl WriterLock for io::StderrLock<'_> {}
 
 impl Writer for io::Stderr {
-    fn is_a_tty(&self) -> bool {
-        match process() {
+    fn is_a_tty(&self, process: &Process) -> bool {
+        match process {
             crate::currentprocess::Process::OSProcess(p) => p.stderr_is_a_tty,
             #[cfg(feature = "test")]
             crate::currentprocess::Process::TestProcess(_) => unreachable!(),
@@ -83,8 +83,8 @@ impl Writer for io::Stderr {
         Box::new(io::Stderr::lock(self))
     }
 
-    fn terminal(&self) -> ColorableTerminal {
-        ColorableTerminal::new(StreamSelector::Stderr)
+    fn terminal(&self, process: &Process) -> ColorableTerminal {
+        ColorableTerminal::new(StreamSelector::Stderr, process)
     }
 }
 
@@ -173,7 +173,7 @@ mod test_support {
     }
 
     impl Writer for TestWriter {
-        fn is_a_tty(&self) -> bool {
+        fn is_a_tty(&self, _: &Process) -> bool {
             false
         }
 
@@ -181,8 +181,8 @@ mod test_support {
             Box::new(self.lock())
         }
 
-        fn terminal(&self) -> ColorableTerminal {
-            ColorableTerminal::new(StreamSelector::TestWriter(self.clone()))
+        fn terminal(&self, process: &Process) -> ColorableTerminal {
+            ColorableTerminal::new(StreamSelector::TestWriter(self.clone()), process)
         }
     }
 

--- a/src/currentprocess/terminalsource.rs
+++ b/src/currentprocess/terminalsource.rs
@@ -241,26 +241,22 @@ mod tests {
     use rustup_macros::unit_test as test;
 
     use super::*;
-    use crate::{currentprocess, test::Env};
+    use crate::currentprocess::TestProcess;
+    use crate::test::Env;
 
     #[test]
     fn term_color_choice() {
         fn assert_color_choice(env_val: &str, stream: StreamSelector, color_choice: ColorChoice) {
             let mut vars = HashMap::new();
             vars.env("RUSTUP_TERM_COLOR", env_val);
-            let tp = currentprocess::TestProcess {
-                vars,
-                ..Default::default()
-            };
-            currentprocess::with(tp.clone().into(), || {
-                let process = Process::from(tp);
-                let term = ColorableTerminal::new(stream, &process);
-                let inner = term.inner.lock().unwrap();
-                assert!(matches!(
-                    &*inner,
-                    &TerminalInner::TestWriter(_, choice) if choice == color_choice
-                ));
-            });
+            let tp = TestProcess::with_vars(vars);
+
+            let term = ColorableTerminal::new(stream, &tp.process);
+            let inner = term.inner.lock().unwrap();
+            assert!(matches!(
+                &*inner,
+                &TerminalInner::TestWriter(_, choice) if choice == color_choice
+            ));
         }
 
         assert_color_choice(

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -66,7 +66,7 @@ use std::{fmt::Debug, fs::OpenOptions};
 
 use anyhow::{Context, Result};
 
-use crate::currentprocess::process;
+use crate::currentprocess::Process;
 use crate::utils::notifications::Notification;
 use threaded::PoolReference;
 
@@ -450,9 +450,10 @@ pub(crate) fn create_dir<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub(crate) fn get_executor<'a>(
     notify_handler: Option<&'a dyn Fn(Notification<'_>)>,
     ram_budget: usize,
+    process: &Process,
 ) -> Result<Box<dyn Executor + 'a>> {
     // If this gets lots of use, consider exposing via the config file.
-    let thread_count = match process().var("RUSTUP_IO_THREADS") {
+    let thread_count = match process.var("RUSTUP_IO_THREADS") {
         Err(_) => available_parallelism().map(|p| p.get()).unwrap_or(1),
         Ok(n) => n
             .parse::<usize>()

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -7,7 +7,7 @@ use rustup_macros::unit_test as test;
 use crate::test::test_dir;
 
 use super::{get_executor, Executor, Item, Kind};
-use crate::currentprocess::{self, TestProcess};
+use crate::currentprocess::TestProcess;
 
 impl Item {
     /// The length of the file, for files (for stats)
@@ -24,64 +24,61 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
     let tp = TestProcess::with_vars(vars);
-    currentprocess::with(tp.clone().into(), || -> Result<()> {
-        let mut written = 0;
-        let mut file_finished = false;
-        let process = tp.clone().into();
-        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &process)?;
-        let (item, mut sender) = Item::write_file_segmented(
-            work_dir.path().join("scratch"),
-            0o666,
-            io_executor.incremental_file_state(),
-        )?;
 
-        // The file should be open and incomplete, and no completed chunks
-        assert!(io_executor.execute(item).collect::<Vec<_>>().is_empty());
+    let mut written = 0;
+    let mut file_finished = false;
+    let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &tp.process)?;
+    let (item, mut sender) = Item::write_file_segmented(
+        work_dir.path().join("scratch"),
+        0o666,
+        io_executor.incremental_file_state(),
+    )?;
 
-        let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
-        chunk.extend(b"0123456789");
-        chunk = chunk.finished();
-        sender(chunk);
-        let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
-        chunk.extend(b"0123456789");
-        chunk = chunk.finished();
-        sender(chunk);
-        loop {
-            for work in io_executor.completed().collect::<Vec<_>>() {
-                match work {
-                    super::CompletedIo::Chunk(size) => written += size,
-                    super::CompletedIo::Item(item) => unreachable!("{:?}", item),
-                }
-            }
-            if written == 20 {
-                break;
+    // The file should be open and incomplete, and no completed chunks
+    assert!(io_executor.execute(item).collect::<Vec<_>>().is_empty());
+
+    let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
+    chunk.extend(b"0123456789");
+    chunk = chunk.finished();
+    sender(chunk);
+    let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
+    chunk.extend(b"0123456789");
+    chunk = chunk.finished();
+    sender(chunk);
+    loop {
+        for work in io_executor.completed().collect::<Vec<_>>() {
+            match work {
+                super::CompletedIo::Chunk(size) => written += size,
+                super::CompletedIo::Item(item) => unreachable!("{:?}", item),
             }
         }
-        // sending a zero length chunk closes the file
-        let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
-        chunk = chunk.finished();
-        sender(chunk);
-        loop {
-            for work in io_executor.completed().collect::<Vec<_>>() {
-                match work {
-                    super::CompletedIo::Chunk(_) => {}
-                    super::CompletedIo::Item(_) => {
-                        file_finished = true;
-                    }
+        if written == 20 {
+            break;
+        }
+    }
+    // sending a zero length chunk closes the file
+    let mut chunk = io_executor.get_buffer(super::IO_CHUNK_SIZE);
+    chunk = chunk.finished();
+    sender(chunk);
+    loop {
+        for work in io_executor.completed().collect::<Vec<_>>() {
+            match work {
+                super::CompletedIo::Chunk(_) => {}
+                super::CompletedIo::Item(_) => {
+                    file_finished = true;
                 }
             }
-            if file_finished {
-                break;
-            }
         }
+        if file_finished {
+            break;
+        }
+    }
 
-        // no more work should be outstanding
-        assert!(file_finished);
-        assert!(io_executor.join().collect::<Vec<_>>().is_empty());
-        assert_eq!(io_executor.buffer_used(), 0);
+    // no more work should be outstanding
+    assert!(file_finished);
+    assert!(io_executor.join().collect::<Vec<_>>().is_empty());
+    assert_eq!(io_executor.buffer_used(), 0);
 
-        Ok(())
-    })?;
     // We should be able to read back the file
     assert_eq!(
         std::fs::read_to_string(work_dir.path().join("scratch"))?,
@@ -95,54 +92,51 @@ fn test_complete_file(io_threads: &str) -> Result<()> {
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
     let tp = TestProcess::with_vars(vars);
-    currentprocess::with(tp.clone().into(), || -> Result<()> {
-        let process = tp.clone().into();
-        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &process)?;
-        let mut chunk = io_executor.get_buffer(10);
-        chunk.extend(b"0123456789");
-        assert_eq!(chunk.len(), 10);
-        chunk = chunk.finished();
-        let item = Item::write_file(work_dir.path().join("scratch"), 0o666, chunk);
+
+    let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &tp.process)?;
+    let mut chunk = io_executor.get_buffer(10);
+    chunk.extend(b"0123456789");
+    assert_eq!(chunk.len(), 10);
+    chunk = chunk.finished();
+    let item = Item::write_file(work_dir.path().join("scratch"), 0o666, chunk);
+    assert_eq!(item.size(), Some(10));
+    let mut items = 0;
+    let mut check_item = |item: Item| {
         assert_eq!(item.size(), Some(10));
-        let mut items = 0;
-        let mut check_item = |item: Item| {
-            assert_eq!(item.size(), Some(10));
-            items += 1;
-            assert_eq!(1, items);
-        };
-        let mut finished = false;
-        for work in io_executor.execute(item).collect::<Vec<_>>() {
-            // The file might complete immediately
-            match work {
-                super::CompletedIo::Chunk(size) => unreachable!("{:?}", size),
-                super::CompletedIo::Item(item) => {
-                    check_item(item);
-                    finished = true;
-                }
+        items += 1;
+        assert_eq!(1, items);
+    };
+    let mut finished = false;
+    for work in io_executor.execute(item).collect::<Vec<_>>() {
+        // The file might complete immediately
+        match work {
+            super::CompletedIo::Chunk(size) => unreachable!("{:?}", size),
+            super::CompletedIo::Item(item) => {
+                check_item(item);
+                finished = true;
             }
         }
-        if !finished {
-            loop {
-                for work in io_executor.completed().collect::<Vec<_>>() {
-                    match work {
-                        super::CompletedIo::Chunk(size) => unreachable!("{:?}", size),
-                        super::CompletedIo::Item(item) => {
-                            check_item(item);
-                            finished = true;
-                        }
+    }
+    if !finished {
+        loop {
+            for work in io_executor.completed().collect::<Vec<_>>() {
+                match work {
+                    super::CompletedIo::Chunk(size) => unreachable!("{:?}", size),
+                    super::CompletedIo::Item(item) => {
+                        check_item(item);
+                        finished = true;
                     }
                 }
-                if finished {
-                    break;
-                }
+            }
+            if finished {
+                break;
             }
         }
-        assert!(items > 0);
-        // no more work should be outstanding
-        assert!(io_executor.join().collect::<Vec<_>>().is_empty());
+    }
+    assert!(items > 0);
+    // no more work should be outstanding
+    assert!(io_executor.join().collect::<Vec<_>>().is_empty());
 
-        Ok(())
-    })?;
     // We should be able to read back the file with correct content
     assert_eq!(
         std::fs::read_to_string(work_dir.path().join("scratch"))?,

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -7,7 +7,7 @@ use rustup_macros::unit_test as test;
 use crate::test::test_dir;
 
 use super::{get_executor, Executor, Item, Kind};
-use crate::currentprocess;
+use crate::currentprocess::{self, TestProcess};
 
 impl Item {
     /// The length of the file, for files (for stats)
@@ -23,10 +23,7 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
-    let tp = currentprocess::TestProcess {
-        vars,
-        ..Default::default()
-    };
+    let tp = TestProcess::with_vars(vars);
     currentprocess::with(tp.clone().into(), || -> Result<()> {
         let mut written = 0;
         let mut file_finished = false;
@@ -97,10 +94,7 @@ fn test_complete_file(io_threads: &str) -> Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
-    let tp = currentprocess::TestProcess {
-        vars,
-        ..Default::default()
-    };
+    let tp = TestProcess::with_vars(vars);
     currentprocess::with(tp.clone().into(), || -> Result<()> {
         let process = tp.clone().into();
         let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &process)?;

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -27,10 +27,11 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
         vars,
         ..Default::default()
     };
-    currentprocess::with(tp.into(), || -> Result<()> {
+    currentprocess::with(tp.clone().into(), || -> Result<()> {
         let mut written = 0;
         let mut file_finished = false;
-        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024)?;
+        let process = tp.clone().into();
+        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &process)?;
         let (item, mut sender) = Item::write_file_segmented(
             work_dir.path().join("scratch"),
             0o666,
@@ -100,8 +101,9 @@ fn test_complete_file(io_threads: &str) -> Result<()> {
         vars,
         ..Default::default()
     };
-    currentprocess::with(tp.into(), || -> Result<()> {
-        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024)?;
+    currentprocess::with(tp.clone().into(), || -> Result<()> {
+        let process = tp.clone().into();
+        let mut io_executor: Box<dyn Executor> = get_executor(None, 32 * 1024 * 1024, &process)?;
         let mut chunk = io_executor.get_buffer(10);
         chunk.extend(b"0123456789");
         assert_eq!(chunk.len(), 10);

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use rustup_macros::unit_test as test;
 
+use crate::currentprocess::{Process, TestProcess};
 use crate::dist::component::Transaction;
 use crate::dist::dist::DEFAULT_DIST_SERVER;
 use crate::dist::prefix::InstallPrefix;
@@ -27,7 +28,8 @@ fn add_file() {
     );
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let mut file = tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     write!(file, "test").unwrap();
@@ -55,7 +57,8 @@ fn add_file_then_rollback() {
     );
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -77,7 +80,8 @@ fn add_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     fs::create_dir_all(prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
@@ -108,7 +112,8 @@ fn copy_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -135,7 +140,8 @@ fn copy_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -162,7 +168,8 @@ fn copy_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -198,7 +205,8 @@ fn copy_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -232,7 +240,8 @@ fn copy_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -266,7 +275,8 @@ fn copy_dir_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     fs::create_dir_all(prefix.path().join("a")).unwrap();
 
@@ -297,7 +307,8 @@ fn remove_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -322,7 +333,8 @@ fn remove_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -347,7 +359,8 @@ fn remove_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let err = tx.remove_file("c", PathBuf::from("foo")).unwrap_err();
 
@@ -374,7 +387,8 @@ fn remove_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -400,7 +414,8 @@ fn remove_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -426,7 +441,8 @@ fn remove_dir_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let err = tx.remove_dir("c", PathBuf::from("foo")).unwrap_err();
 
@@ -453,7 +469,8 @@ fn write_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content.clone())
@@ -480,7 +497,8 @@ fn write_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content)
@@ -504,7 +522,8 @@ fn write_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let content = "hi".to_string();
     utils_raw::write_file(&prefix.path().join("a"), &content).unwrap();
@@ -535,7 +554,8 @@ fn modify_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     tx.commit();
@@ -559,7 +579,8 @@ fn modify_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -583,7 +604,8 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -605,7 +627,8 @@ fn modify_file_that_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -632,7 +655,8 @@ fn modify_twice_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -659,7 +683,8 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     // copy_file
     let relpath1 = PathBuf::from("bin/rustc");
@@ -760,7 +785,8 @@ fn rollback_failure_keeps_going() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     write!(tx.add_file("", PathBuf::from("foo")).unwrap(), "").unwrap();
     write!(tx.add_file("", PathBuf::from("bar")).unwrap(), "").unwrap();

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use rustup_macros::unit_test as test;
 
-use crate::currentprocess::{Process, TestProcess};
+use crate::currentprocess::TestProcess;
 use crate::dist::component::Transaction;
 use crate::dist::dist::DEFAULT_DIST_SERVER;
 use crate::dist::prefix::InstallPrefix;
@@ -28,8 +28,8 @@ fn add_file() {
     );
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let mut file = tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     write!(file, "test").unwrap();
@@ -57,8 +57,8 @@ fn add_file_then_rollback() {
     );
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     tx.add_file("c", PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -80,8 +80,8 @@ fn add_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     fs::create_dir_all(prefixdir.path().join("foo")).unwrap();
     utils::write_file("", &prefixdir.path().join("foo/bar"), "").unwrap();
@@ -112,8 +112,8 @@ fn copy_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -140,8 +140,8 @@ fn copy_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -168,8 +168,8 @@ fn copy_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let srcpath = srcdir.path().join("bar");
     utils::write_file("", &srcpath, "").unwrap();
@@ -205,8 +205,8 @@ fn copy_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -240,8 +240,8 @@ fn copy_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let srcpath1 = srcdir.path().join("foo");
     let srcpath2 = srcdir.path().join("bar/baz");
@@ -275,8 +275,8 @@ fn copy_dir_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     fs::create_dir_all(prefix.path().join("a")).unwrap();
 
@@ -307,8 +307,8 @@ fn remove_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -333,8 +333,8 @@ fn remove_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let filepath = prefixdir.path().join("foo");
     utils::write_file("", &filepath, "").unwrap();
@@ -359,8 +359,8 @@ fn remove_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let err = tx.remove_file("c", PathBuf::from("foo")).unwrap_err();
 
@@ -387,8 +387,8 @@ fn remove_dir() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -414,8 +414,8 @@ fn remove_dir_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let filepath = prefixdir.path().join("foo/bar");
     fs::create_dir_all(filepath.parent().unwrap()).unwrap();
@@ -441,8 +441,8 @@ fn remove_dir_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let err = tx.remove_dir("c", PathBuf::from("foo")).unwrap_err();
 
@@ -469,8 +469,8 @@ fn write_file() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content.clone())
@@ -497,8 +497,8 @@ fn write_file_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let content = "hi".to_string();
     tx.write_file("c", PathBuf::from("foo/bar"), content)
@@ -522,8 +522,8 @@ fn write_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let content = "hi".to_string();
     utils_raw::write_file(&prefix.path().join("a"), &content).unwrap();
@@ -554,8 +554,8 @@ fn modify_file_that_not_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     tx.commit();
@@ -579,8 +579,8 @@ fn modify_file_that_exists() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -604,8 +604,8 @@ fn modify_file_that_not_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     tx.modify_file(PathBuf::from("foo/bar")).unwrap();
     drop(tx);
@@ -627,8 +627,8 @@ fn modify_file_that_exists_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -655,8 +655,8 @@ fn modify_twice_then_rollback() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let path = prefix.path().join("foo");
     utils_raw::write_file(&path, "wow").unwrap();
@@ -683,8 +683,8 @@ fn do_multiple_op_transaction(rollback: bool) {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     // copy_file
     let relpath1 = PathBuf::from("bin/rustc");
@@ -785,8 +785,8 @@ fn rollback_failure_keeps_going() {
     let prefix = InstallPrefix::from(prefixdir.path());
 
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     write!(tx.add_file("", PathBuf::from("foo")).unwrap(), "").unwrap();
     write!(tx.add_file("", PathBuf::from("bar")).unwrap(), "").unwrap();

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -17,7 +17,7 @@ use url::Url;
 use rustup_macros::unit_test as test;
 
 use crate::{
-    currentprocess::{self, Process, TestProcess},
+    currentprocess::{Process, TestProcess},
     dist::{
         dist::{Profile, TargetTriple, ToolchainDesc, DEFAULT_DIST_SERVER},
         download::DownloadCfg,
@@ -581,8 +581,7 @@ fn setup_from_dist_server(
         &["rustup"],
         HashMap::default(),
         "",
-    )
-    .into();
+    );
 
     let download_cfg = DownloadCfg {
         dist_root: "phony",
@@ -591,12 +590,10 @@ fn setup_from_dist_server(
         notify_handler: &|event| {
             println!("{event}");
         },
-        process: &tp,
+        process: &tp.process,
     };
 
-    currentprocess::with(tp.clone(), || {
-        f(url, &toolchain, &prefix, &download_cfg, &tmp_cx)
-    });
+    f(url, &toolchain, &prefix, &download_cfg, &tmp_cx)
 }
 
 fn initial_install(comps: Compressions) {

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -49,7 +49,7 @@ mod tests {
     use rustup_macros::unit_test as test;
 
     use super::*;
-    use crate::currentprocess;
+    use crate::currentprocess::{self, TestProcess};
     use crate::test::{with_saved_path, Env};
 
     #[test]
@@ -59,10 +59,7 @@ mod tests {
             "PATH",
             env::join_paths(["/home/a/.cargo/bin", "/home/b/.cargo/bin"].iter()).unwrap(),
         );
-        let tp = currentprocess::TestProcess {
-            vars,
-            ..Default::default()
-        };
+        let tp = TestProcess::with_vars(vars);
         with_saved_path(&mut || {
             currentprocess::with(tp.clone().into(), || {
                 let mut path_entries = vec![];

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -49,7 +49,7 @@ mod tests {
     use rustup_macros::unit_test as test;
 
     use super::*;
-    use crate::currentprocess::{self, TestProcess};
+    use crate::currentprocess::TestProcess;
     use crate::test::{with_saved_path, Env};
 
     #[test]
@@ -61,45 +61,42 @@ mod tests {
         );
         let tp = TestProcess::with_vars(vars);
         with_saved_path(&mut || {
-            currentprocess::with(tp.clone().into(), || {
-                let mut path_entries = vec![];
-                let mut cmd = Command::new("test");
+            let mut path_entries = vec![];
+            let mut cmd = Command::new("test");
 
-                let a = OsString::from("/home/a/.cargo/bin");
-                let path_a = PathBuf::from(a);
-                path_entries.push(path_a);
+            let a = OsString::from("/home/a/.cargo/bin");
+            let path_a = PathBuf::from(a);
+            path_entries.push(path_a);
 
-                let _a = OsString::from("/home/a/.cargo/bin");
-                let _path_a = PathBuf::from(_a);
-                path_entries.push(_path_a);
+            let _a = OsString::from("/home/a/.cargo/bin");
+            let _path_a = PathBuf::from(_a);
+            path_entries.push(_path_a);
 
-                let z = OsString::from("/home/z/.cargo/bin");
-                let path_z = PathBuf::from(z);
-                path_entries.push(path_z);
+            let z = OsString::from("/home/z/.cargo/bin");
+            let path_z = PathBuf::from(z);
+            path_entries.push(path_z);
 
-                let process = tp.clone().into();
-                prepend_path("PATH", path_entries, &mut cmd, &process);
-                let envs: Vec<_> = cmd.get_envs().collect();
+            prepend_path("PATH", path_entries, &mut cmd, &tp.process);
+            let envs: Vec<_> = cmd.get_envs().collect();
 
-                assert_eq!(
-                    envs,
-                    &[(
-                        OsStr::new("PATH"),
-                        Some(
-                            env::join_paths(
-                                [
-                                    "/home/z/.cargo/bin",
-                                    "/home/a/.cargo/bin",
-                                    "/home/b/.cargo/bin"
-                                ]
-                                .iter()
-                            )
-                            .unwrap()
-                            .as_os_str()
+            assert_eq!(
+                envs,
+                &[(
+                    OsStr::new("PATH"),
+                    Some(
+                        env::join_paths(
+                            [
+                                "/home/z/.cargo/bin",
+                                "/home/a/.cargo/bin",
+                                "/home/b/.cargo/bin"
+                            ]
+                            .iter()
                         )
-                    ),]
-                );
-            });
+                        .unwrap()
+                        .as_os_str()
+                    )
+                ),]
+            );
         });
     }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use thiserror::Error as ThisError;
 use url::Url;
 
-use crate::dist::dist::{TargetTriple, ToolchainDesc};
 use crate::{
+    dist::dist::{TargetTriple, ToolchainDesc},
     dist::manifest::{Component, Manifest},
     toolchain::names::{PathBasedToolchainName, ToolchainName},
 };

--- a/src/install.rs
+++ b/src/install.rs
@@ -28,15 +28,15 @@ pub(crate) enum InstallMethod<'a> {
     Copy {
         src: &'a Path,
         dest: &'a CustomToolchainName,
-        cfg: &'a Cfg,
+        cfg: &'a Cfg<'a>,
     },
     Link {
         src: &'a Path,
         dest: &'a CustomToolchainName,
-        cfg: &'a Cfg,
+        cfg: &'a Cfg<'a>,
     },
     Dist {
-        cfg: &'a Cfg,
+        cfg: &'a Cfg<'a>,
         desc: &'a dist::ToolchainDesc,
         profile: dist::Profile,
         update_hash: Option<&'a Path>,
@@ -165,7 +165,7 @@ impl<'a> InstallMethod<'a> {
         }
     }
 
-    fn cfg(&self) -> &Cfg {
+    fn cfg(&self) -> &Cfg<'_> {
         match self {
             InstallMethod::Copy { cfg, .. } => cfg,
             InstallMethod::Link { cfg, .. } => cfg,

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use anyhow::Result;
 
 pub use crate::cli::self_update::test::{with_saved_global_state, with_saved_path};
-use crate::currentprocess::{self, Process};
+use crate::currentprocess::TestProcess;
 use crate::dist::dist::TargetTriple;
 
 #[cfg(windows)]
@@ -127,11 +127,8 @@ pub fn this_host_triple() -> String {
         // For windows, this host may be different to the target: we may be
         // building with i686 toolchain, but on an x86_64 host, so run the
         // actual detection logic and trust it.
-        let tp = currentprocess::TestProcess::default();
-        return currentprocess::with(tp.clone().into(), || {
-            let process = Process::from(tp);
-            TargetTriple::from_host(&process).unwrap().to_string()
-        });
+        let tp = TestProcess::default();
+        return TargetTriple::from_host(&tp.process).unwrap().to_string();
     }
     let arch = if cfg!(target_arch = "x86") {
         "i686"

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,7 +16,7 @@ use std::process::Command;
 use anyhow::Result;
 
 pub use crate::cli::self_update::test::{with_saved_global_state, with_saved_path};
-use crate::currentprocess;
+use crate::currentprocess::{self, Process};
 use crate::dist::dist::TargetTriple;
 
 #[cfg(windows)]
@@ -128,7 +128,10 @@ pub fn this_host_triple() -> String {
         // building with i686 toolchain, but on an x86_64 host, so run the
         // actual detection logic and trust it.
         let tp = currentprocess::TestProcess::default();
-        return currentprocess::with(tp.into(), || TargetTriple::from_host().unwrap().to_string());
+        return currentprocess::with(tp.clone().into(), || {
+            let process = Process::from(tp);
+            TargetTriple::from_host(&process).unwrap().to_string()
+        });
     }
     let arch = if cfg!(target_arch = "x86") {
         "i686"

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::str;
 
 #[cfg(not(windows))]
-use crate::currentprocess::process;
+use crate::currentprocess::Process;
 
 pub(crate) fn ensure_dir_exists<P: AsRef<Path>, F: FnOnce(&Path)>(
     path: P,
@@ -272,17 +272,17 @@ pub(crate) fn copy_dir(src: &Path, dest: &Path) -> io::Result<()> {
 }
 
 #[cfg(not(windows))]
-fn has_cmd(cmd: &str) -> bool {
+fn has_cmd(cmd: &str, process: &Process) -> bool {
     let cmd = format!("{}{}", cmd, env::consts::EXE_SUFFIX);
-    let path = process().var_os("PATH").unwrap_or_default();
+    let path = process.var_os("PATH").unwrap_or_default();
     env::split_paths(&path)
         .map(|p| p.join(&cmd))
         .any(|p| p.exists())
 }
 
 #[cfg(not(windows))]
-pub(crate) fn find_cmd<'a>(cmds: &[&'a str]) -> Option<&'a str> {
-    cmds.iter().cloned().find(|&s| has_cmd(s))
+pub(crate) fn find_cmd<'a>(cmds: &[&'a str], process: &Process) -> Option<&'a str> {
+    cmds.iter().cloned().find(|&s| has_cmd(s, process))
 }
 
 #[cfg(windows)]

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 
-use rustup::currentprocess::{Process, TestProcess};
+use rustup::currentprocess::TestProcess;
 use rustup::dist::component::Components;
 use rustup::dist::component::Transaction;
 use rustup::dist::component::{DirectoryPackage, Package};
@@ -118,8 +118,8 @@ fn basic_install() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let components = Components::open(prefix).unwrap();
 
@@ -165,8 +165,8 @@ fn multiple_component_install() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let components = Components::open(prefix).unwrap();
 
@@ -216,8 +216,8 @@ fn uninstall() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -229,10 +229,10 @@ fn uninstall() {
 
     // Now uninstall
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
     for component in components.list().unwrap() {
-        tx = component.uninstall(tx, &process).unwrap();
+        tx = component.uninstall(tx, &tp.process).unwrap();
     }
     tx.commit();
 
@@ -275,8 +275,8 @@ fn component_bad_version() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -322,8 +322,8 @@ fn install_to_prefix_that_does_not_exist() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let process = Process::from(TestProcess::default());
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
+    let tp = TestProcess::default();
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &tp.process);
 
     let components = Components::open(prefix).unwrap();
 

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,6 +1,7 @@
 use std::fs::File;
 use std::io::Write;
 
+use rustup::currentprocess::{Process, TestProcess};
 use rustup::dist::component::Components;
 use rustup::dist::component::Transaction;
 use rustup::dist::component::{DirectoryPackage, Package};
@@ -117,7 +118,8 @@ fn basic_install() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let components = Components::open(prefix).unwrap();
 
@@ -163,7 +165,8 @@ fn multiple_component_install() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let components = Components::open(prefix).unwrap();
 
@@ -213,7 +216,8 @@ fn uninstall() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -225,9 +229,10 @@ fn uninstall() {
 
     // Now uninstall
     let notify = |_: Notification<'_>| ();
-    let mut tx = Transaction::new(prefix, &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let mut tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
     for component in components.list().unwrap() {
-        tx = component.uninstall(tx).unwrap();
+        tx = component.uninstall(tx, &process).unwrap();
     }
     tx.commit();
 
@@ -270,7 +275,8 @@ fn component_bad_version() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let components = Components::open(prefix.clone()).unwrap();
 
@@ -316,7 +322,8 @@ fn install_to_prefix_that_does_not_exist() {
         Box::new(|_| ()),
     );
     let notify = |_: Notification<'_>| ();
-    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify);
+    let process = Process::from(TestProcess::default());
+    let tx = Transaction::new(prefix.clone(), &tmp_cx, &notify, &process);
 
     let components = Components::open(prefix).unwrap();
 


### PR DESCRIPTION
> OTOH I do have a feeling that the overall Rust testing ecosystem as it stands is hostile to global states/injections, so when working on https://github.com/rust-lang/rustup/pull/3803, I'm constantly thinking maybe we should get rid of that part altogether. Maybe that's too radical though?
_#3868_

I think that's kind of what this is? Doesn't seem too radical to me.

I haven't quite finished the tests and the I'm not sure yet what to do about the logging macros, but this seems viable (and should enable ripping out a bunch of stuff like `with()` and `with_runtime()` etc).