### PR TITLE
feat(log): unhide `tracing::instrument` from behind `feature = "otel"`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }} # skip-master skip-stable
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+      RUST_MIN_STACK: 16777216
     permissions:
       id-token: write
       contents: read
@@ -181,6 +182,7 @@ jobs:
     if: ${{ (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'schedule' }} # skip-pr skip-stable
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+      RUST_MIN_STACK: 16777216
     permissions:
       id-token: write
       contents: read
@@ -338,6 +340,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+      RUST_MIN_STACK: 16777216
     permissions:
       id-token: write
       contents: read

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -11,6 +11,7 @@ jobs: # skip-master skip-pr skip-stable
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+      RUST_MIN_STACK: 16777216
     permissions:
       id-token: write
       contents: read

--- a/doc/dev-guide/src/tracing.md
+++ b/doc/dev-guide/src/tracing.md
@@ -101,7 +101,7 @@ when enabled. Instrumenting a currently uninstrumented function is mostly simply
 done like so:
 
 ```rust
-#[tracing::instrument(level = "trace", err, skip_all)]
+#[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
 ```
 
 `skip_all` is not required, but some core structs don't implement Debug yet, and

--- a/doc/dev-guide/src/tracing.md
+++ b/doc/dev-guide/src/tracing.md
@@ -101,7 +101,7 @@ when enabled. Instrumenting a currently uninstrumented function is mostly simply
 done like so:
 
 ```rust
-#[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+#[tracing::instrument(level = "trace", err, skip_all)]
 ```
 
 `skip_all` is not required, but some core structs don't implement Debug yet, and

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -76,7 +76,7 @@ async fn run_rustup(
     result
 }
 
-#[tracing::instrument(level = "trace", err)]
+#[tracing::instrument(level = "trace", err(level = "trace"))]
 async fn run_rustup_inner(
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<ExitCode> {
     }
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 async fn run_rustup(
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,
@@ -76,7 +76,7 @@ async fn run_rustup(
     result
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument(err))]
+#[tracing::instrument(level = "trace", err)]
 async fn run_rustup_inner(
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -177,7 +177,7 @@ impl Notifier {
     }
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 pub(crate) fn set_globals(
     current_dir: PathBuf,
     verbose: bool,

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -9,7 +9,7 @@ use crate::{
     toolchain::ResolvableLocalToolchainName,
 };
 
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result<ExitStatus> {
     self_update::cleanup_self_updater(process)?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -532,7 +532,7 @@ enum SetSubcmd {
     },
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument(fields(args = format!("{:?}", process.args_os().collect::<Vec<_>>()))))]
+#[tracing::instrument(level = "trace", fields(args = format!("{:?}", process.args_os().collect::<Vec<_>>())))]
 pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::ExitCode> {
     self_update::cleanup_self_updater(process)?;
 
@@ -907,7 +907,7 @@ async fn which(
     Ok(utils::ExitCode(0))
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+#[tracing::instrument(level = "trace", skip_all)]
 fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
@@ -1048,7 +1048,7 @@ fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+#[tracing::instrument(level = "trace", skip_all)]
 fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     match cfg.find_active_toolchain()? {
         Some((toolchain_name, reason)) => {
@@ -1075,7 +1075,7 @@ fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode
     Ok(utils::ExitCode(0))
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+#[tracing::instrument(level = "trace", skip_all)]
 fn show_rustup_home(cfg: &Cfg<'_>) -> Result<utils::ExitCode> {
     writeln!(cfg.process.stdout().lock(), "{}", cfg.rustup_dir.display())?;
     Ok(utils::ExitCode(0))

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1237,7 +1237,7 @@ pub(crate) async fn check_rustup_update(process: &Process) -> Result<()> {
     Ok(())
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 pub(crate) fn cleanup_self_updater(process: &Process) -> Result<()> {
     let cargo_home = process.cargo_home()?;
     let setup = cargo_home.join(format!("bin/rustup-init{EXE_SUFFIX}"));

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -362,7 +362,7 @@ fn has_windows_sdk_libs(process: &Process) -> bool {
 }
 
 /// Run by rustup-gc-$num.exe to delete CARGO_HOME
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 pub fn complete_windows_uninstall(process: &Process) -> Result<utils::ExitCode> {
     use std::process::Stdio;
 

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -73,7 +73,7 @@ struct RustupInit {
     dump_testament: bool,
 }
 
-#[cfg_attr(feature = "otel", tracing::instrument)]
+#[tracing::instrument(level = "trace")]
 pub async fn main(
     current_dir: PathBuf,
     process: &Process,

--- a/src/command.rs
+++ b/src/command.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 
 use crate::errors::*;
 
-#[tracing::instrument(level = "trace", err)]
+#[tracing::instrument(level = "trace", err(level = "trace"))]
 pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
     mut cmd: Command,
     arg0: &str,

--- a/src/command.rs
+++ b/src/command.rs
@@ -9,7 +9,7 @@ use anyhow::{Context, Result};
 
 use crate::errors::*;
 
-#[cfg_attr(feature = "otel", tracing::instrument(err))]
+#[tracing::instrument(level = "trace", err)]
 pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
     mut cmd: Command,
     arg0: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -448,7 +448,7 @@ impl<'a> Cfg<'a> {
         Ok(self.update_hash_dir.join(toolchain.to_string()))
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn upgrade_data(&self) -> Result<()> {
         let current_version = self.settings_file.with(|s| Ok(s.version))?;
         if current_version == MetadataVersion::default() {
@@ -693,7 +693,7 @@ impl<'a> Cfg<'a> {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[tracing::instrument(level = "trace")]
     pub(crate) async fn active_rustc_version(&mut self) -> Result<String> {
         if let Some(t) = self.process.args().find(|x| x.starts_with('+')) {
             trace!("Fetching rustc version from toolchain `{}`", t);
@@ -734,7 +734,7 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     async fn find_or_install_active_toolchain(&'a self) -> Result<(Toolchain<'a>, ActiveReason)> {
         match self.find_override_config()? {
             Some((override_config, reason)) => match override_config {
@@ -839,7 +839,7 @@ impl<'a> Cfg<'a> {
     /// - not files
     /// - named with a valid resolved toolchain name
     /// Currently no notification of incorrect names or entry type is done.
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn list_toolchains(&self) -> Result<Vec<ToolchainName>> {
         if utils::is_directory(&self.toolchains_dir) {
             let mut toolchains: Vec<_> = utils::read_dir("toolchains", &self.toolchains_dir)?
@@ -921,7 +921,7 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn get_default_host_triple(&self) -> Result<dist::TargetTriple> {
         self.settings_file
             .with(|s| Ok(get_default_host_triple(s, self.process)))

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -401,7 +401,7 @@ impl Manifestation {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[tracing::instrument(level = "trace")]
     pub fn load_manifest(&self) -> Result<Option<Manifest>> {
         let prefix = self.installation.prefix();
         let old_manifest_path = prefix.manifest_file(DIST_MANIFEST);

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -823,7 +823,7 @@ pub(crate) struct DistOptions<'a> {
 // an upgrade then all the existing components will be upgraded.
 //
 // Returns the manifest's hash if anything changed.
-#[tracing::instrument(level = "trace", err, skip_all, fields(profile=format!("{:?}", opts.profile), prefix=prefix.path().to_string_lossy().to_string()))]
+#[tracing::instrument(level = "trace", err(level = "trace"), skip_all, fields(profile=format!("{:?}", opts.profile), prefix=prefix.path().to_string_lossy().to_string()))]
 pub(crate) async fn update_from_dist(
     prefix: &InstallPrefix,
     opts: &DistOptions<'_>,

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -823,7 +823,7 @@ pub(crate) struct DistOptions<'a> {
 // an upgrade then all the existing components will be upgraded.
 //
 // Returns the manifest's hash if anything changed.
-#[cfg_attr(feature = "otel", tracing::instrument(err, skip_all, fields(profile=format!("{:?}", opts.profile), prefix=prefix.path().to_string_lossy().to_string())))]
+#[tracing::instrument(level = "trace", err, skip_all, fields(profile=format!("{:?}", opts.profile), prefix=prefix.path().to_string_lossy().to_string()))]
 pub(crate) async fn update_from_dist(
     prefix: &InstallPrefix,
     opts: &DistOptions<'_>,

--- a/src/install.rs
+++ b/src/install.rs
@@ -37,7 +37,7 @@ pub(crate) enum InstallMethod<'a> {
 
 impl<'a> InstallMethod<'a> {
     // Install a toolchain
-    #[tracing::instrument(level = "trace", err, skip_all)]
+    #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn install(&self) -> Result<UpdateStatus> {
         let nh = &self.cfg().notify_handler;
         match self {

--- a/src/install.rs
+++ b/src/install.rs
@@ -37,7 +37,7 @@ pub(crate) enum InstallMethod<'a> {
 
 impl<'a> InstallMethod<'a> {
     // Install a toolchain
-    #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+    #[tracing::instrument(level = "trace", err, skip_all)]
     pub(crate) async fn install(&self) -> Result<UpdateStatus> {
         let nh = &self.cfg().notify_handler;
         match self {

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -769,7 +769,7 @@ impl Config {
         output
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) async fn run_inprocess<I, A>(
         &self,
         name: &str,
@@ -1059,7 +1059,7 @@ impl Release {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn link(&self, path: &Path) {
         // Also create the manifests for releases by version
         let _ = hard_link(
@@ -1112,7 +1112,7 @@ impl Release {
 }
 
 // Creates a mock dist server populated with some test data
-#[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+#[tracing::instrument(level = "trace", skip_all)]
 fn create_mock_dist_server(path: &Path, s: Scenario) {
     let chans = match s {
         Scenario::None => return,

--- a/src/test/mock/dist.rs
+++ b/src/test/mock/dist.rs
@@ -132,7 +132,7 @@ pub enum MockManifestVersion {
 }
 
 impl MockDistServer {
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn write(&self, vs: &[MockManifestVersion], enable_xz: bool, enable_zst: bool) {
         fs::create_dir_all(&self.path).unwrap();
 
@@ -151,7 +151,7 @@ impl MockDistServer {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn build_package(
         &self,
         channel: &MockChannel,
@@ -192,7 +192,7 @@ impl MockDistServer {
     }
 
     // Returns the hash of the tarball
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all, fields(format=%format)))]
+    #[tracing::instrument(level = "trace", skip_all, fields(format=%format))]
     fn build_target_package(
         &self,
         channel: &MockChannel,
@@ -279,7 +279,7 @@ impl MockDistServer {
     }
 
     // The v1 manifest is just the directory listing of the rust tarballs
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn write_manifest_v1(&self, channel: &MockChannel) {
         let mut buf = String::new();
         let package = channel.packages.iter().find(|p| p.name == "rust").unwrap();
@@ -308,7 +308,7 @@ impl MockDistServer {
         hard_link(&hash_path, archive_hash_path).unwrap();
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn write_manifest_v2(
         &self,
         channel: &MockChannel,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -253,7 +253,7 @@ impl<'a> Toolchain<'a> {
     }
 
     /// Infallible function that describes the version of rustc in an installed distribution
-    #[cfg_attr(feature = "otel", tracing::instrument)]
+    #[tracing::instrument(level = "trace")]
     pub fn rustc_version(&self) -> String {
         match self.create_command("rustc") {
             Ok(mut cmd) => {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -301,14 +301,14 @@ impl<'a> DistributableToolchain<'a> {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn get_manifestation(&self) -> anyhow::Result<Manifestation> {
         let prefix = InstallPrefix::from(self.toolchain.path());
         Manifestation::open(prefix, self.desc.target.clone())
     }
 
     /// Get the manifest associated with this distribution
-    #[cfg_attr(feature = "otel", tracing::instrument(skip_all))]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn get_manifest(&self) -> anyhow::Result<Manifest> {
         self.get_manifestation()?
             .load_manifest()
@@ -324,7 +324,7 @@ impl<'a> DistributableToolchain<'a> {
         InstallPrefix::from(self.toolchain.path().to_owned()).guess_v1_manifest()
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+    #[tracing::instrument(level = "trace", err, skip_all)]
     pub(crate) async fn install(
         cfg: &'a Cfg<'a>,
         toolchain: &ToolchainDesc,
@@ -354,7 +354,7 @@ impl<'a> DistributableToolchain<'a> {
         Ok((status, Self::new(cfg, toolchain.clone())?))
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+    #[tracing::instrument(level = "trace", err, skip_all)]
     pub async fn install_if_not_installed(
         cfg: &'a Cfg<'a>,
         desc: &ToolchainDesc,
@@ -372,7 +372,7 @@ impl<'a> DistributableToolchain<'a> {
         }
     }
 
-    #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+    #[tracing::instrument(level = "trace", err, skip_all)]
     pub(crate) async fn update(
         &mut self,
         components: &[&str],
@@ -384,7 +384,7 @@ impl<'a> DistributableToolchain<'a> {
     }
 
     /// Update a toolchain with control over the channel behaviour
-    #[cfg_attr(feature = "otel", tracing::instrument(err, skip_all))]
+    #[tracing::instrument(level = "trace", err, skip_all)]
     pub(crate) async fn update_extra(
         &mut self,
         components: &[&str],

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -324,7 +324,7 @@ impl<'a> DistributableToolchain<'a> {
         InstallPrefix::from(self.toolchain.path().to_owned()).guess_v1_manifest()
     }
 
-    #[tracing::instrument(level = "trace", err, skip_all)]
+    #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn install(
         cfg: &'a Cfg<'a>,
         toolchain: &ToolchainDesc,
@@ -354,7 +354,7 @@ impl<'a> DistributableToolchain<'a> {
         Ok((status, Self::new(cfg, toolchain.clone())?))
     }
 
-    #[tracing::instrument(level = "trace", err, skip_all)]
+    #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub async fn install_if_not_installed(
         cfg: &'a Cfg<'a>,
         desc: &ToolchainDesc,
@@ -372,7 +372,7 @@ impl<'a> DistributableToolchain<'a> {
         }
     }
 
-    #[tracing::instrument(level = "trace", err, skip_all)]
+    #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn update(
         &mut self,
         components: &[&str],
@@ -384,7 +384,7 @@ impl<'a> DistributableToolchain<'a> {
     }
 
     /// Update a toolchain with control over the channel behaviour
-    #[tracing::instrument(level = "trace", err, skip_all)]
+    #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn update_extra(
         &mut self,
         components: &[&str],


### PR DESCRIPTION
Cherry-picked from #3803 as discussed in https://github.com/rust-lang/rustup/pull/3803#issuecomment-2168125917.

## Note

This is done by simply replacing `cfg_attr\(feature = \"otel\", tracing::instrument(\((.*)\))?\)\]` with `tracing::instrument(level = "trace", $2)]`, then replacing `, \)\]` with `)]`.