### PR TITLE
fix(log): use `RUSTUP_LOG` for internal `tracing` instead of `RUST_LOG`

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -1,8 +1,8 @@
 # Environment variables
 
-- `RUST_LOG` (default: none). Enables Rustup's "custom logging mode". In this mode,
+- `RUSTUP_LOG` (default: none). Enables Rustup's "custom logging mode". In this mode,
   the verbosity of Rustup's log lines can be specified with `tracing_subscriber`'s
-  [directive syntax]. For example, set `RUST_LOG=rustup=DEBUG` to receive log lines
+  [directive syntax]. For example, set `RUSTUP_LOG=rustup=DEBUG` to receive log lines
   from `rustup` itself with a maximal verbosity of `DEBUG`.
 
 - `RUSTUP_HOME` (default: `~/.rustup` or `%USERPROFILE%/.rustup`). Sets the

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -57,7 +57,7 @@ pub fn tracing_subscriber(process: &Process) -> impl tracing::Subscriber {
 /// A [`tracing::Subscriber`] [`Layer`][`tracing_subscriber::Layer`] that prints out the log
 /// lines to the current [`Process`]' `stderr`.
 ///
-/// When the `RUST_LOG` environment variable is present, a standard [`tracing_subscriber`]
+/// When the `RUSTUP_LOG` environment variable is present, a standard [`tracing_subscriber`]
 /// formatter will be used according to the filtering directives set in its value.
 /// Otherwise, this logger will use [`EventFormatter`] to mimic "classic" Rustup `stderr` output.
 fn console_logger<S>(process: &Process) -> impl Layer<S>
@@ -71,12 +71,12 @@ where
         _ if process.var("NO_COLOR").is_ok() => false,
         _ => process.stderr().is_a_tty(process),
     };
-    let maybe_rust_log_directives = process.var("RUST_LOG");
+    let maybe_rustup_log_directives = process.var("RUSTUP_LOG");
     let process = process.clone();
     let logger = tracing_subscriber::fmt::layer()
         .with_writer(move || process.stderr())
         .with_ansi(has_ansi);
-    if let Ok(directives) = maybe_rust_log_directives {
+    if let Ok(directives) = maybe_rustup_log_directives {
         let env_filter = EnvFilter::builder()
             .with_default_directive(LevelFilter::INFO.into())
             .parse_lossy(directives);
@@ -143,7 +143,7 @@ fn telemetry<S>(process: &Process) -> impl Layer<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
-    let env_filter = if let Ok(directives) = process.var("RUST_LOG") {
+    let env_filter = if let Ok(directives) = process.var("RUSTUP_LOG") {
         EnvFilter::builder()
             .with_default_directive(LevelFilter::TRACE.into())
             .parse_lossy(directives)

--- a/src/config.rs
+++ b/src/config.rs
@@ -109,7 +109,7 @@ impl Display for ActiveReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
         match self {
             Self::Default => write!(f, "it's the default toolchain"),
-            Self::Environment => write!(f, "overriden by environment variable RUSTUP_TOOLCHAIN"),
+            Self::Environment => write!(f, "overridden by environment variable RUSTUP_TOOLCHAIN"),
             Self::CommandLine => write!(f, "overridden by +toolchain on the command line"),
             Self::OverrideDB(path) => write!(f, "directory override for '{}'", path.display()),
             Self::ToolchainFile(path) => write!(f, "overridden by '{}'", path.display()),

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -272,8 +272,8 @@ impl TestProcess {
             args: args.iter().map(|s| s.as_ref().to_string()).collect(),
             vars,
             stdin: Arc::new(Mutex::new(Cursor::new(stdin.to_string()))),
-            stdout: Arc::new(Mutex::new(Vec::new())),
-            stderr: Arc::new(Mutex::new(Vec::new())),
+            stdout: Arc::default(),
+            stderr: Arc::default(),
         })
     }
 

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -256,8 +256,7 @@ impl Default for OSProcess {
 #[cfg(feature = "test")]
 pub struct TestProcess {
     pub process: Process,
-    #[allow(dead_code)] // guard is dropped at the end of the test
-    guard: DefaultGuard,
+    _guard: DefaultGuard, // guard is dropped at the end of the test
 }
 
 #[cfg(feature = "test")]
@@ -303,7 +302,7 @@ impl From<TestContext> for TestProcess {
         let guard = crate::cli::log::tracing_subscriber(&inner).set_default();
         Self {
             process: inner,
-            guard,
+            _guard: guard,
         }
     }
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1145,7 +1145,7 @@ active toolchain
 ----------------
 name: nightly-{0}
 compiler: 1.3.0 (hash-nightly-2)
-active because: overriden by environment variable RUSTUP_TOOLCHAIN
+active because: overridden by environment variable RUSTUP_TOOLCHAIN
 installed targets:
   {0}
 "


### PR DESCRIPTION
Closes #3875, plus some random trivial cleanups along the way.