### PR TITLE
refactor(log): rename `NotificationLevel` variants to align with `tracing::Level`

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -287,7 +287,7 @@ ensure_loongarch_uapi() {
             exit 1
             ;;
         *)
-            echo "Warning: Cannot determine current system's ABI flavor, continuing anyway." >&2
+            echo "warn: Cannot determine current system's ABI flavor, continuing anyway." >&2
             echo >&2
             echo 'Note that the official Rust distribution only works with the upstream' >&2
             echo 'kernel ABI.  Installation will fail if your running kernel happens to be' >&2
@@ -601,9 +601,9 @@ downloader() {
             _err=$(curl $_retry --proto '=https' --tlsv1.2 --ciphers "$_ciphersuites" --silent --show-error --fail --location "$1" --output "$2" 2>&1)
             _status=$?
         else
-            echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+            echo "warn: Not enforcing strong cipher suites for TLS, this is potentially less secure"
             if ! check_help_for "$3" curl --proto --tlsv1.2; then
-                echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
+                echo "warn: Not enforcing TLS v1.2, this is potentially less secure"
                 _err=$(curl $_retry --silent --show-error --fail --location "$1" --output "$2" 2>&1)
                 _status=$?
             else
@@ -620,7 +620,7 @@ downloader() {
         return $_status
     elif [ "$_dld" = wget ]; then
         if [ "$(wget -V 2>&1|head -2|tail -1|cut -f1 -d" ")" = "BusyBox" ]; then
-            echo "Warning: using the BusyBox version of wget.  Not enforcing strong cipher suites for TLS or TLS v1.2, this is potentially less secure"
+            echo "warn: using the BusyBox version of wget.  Not enforcing strong cipher suites for TLS or TLS v1.2, this is potentially less secure"
             _err=$(wget "$1" -O "$2" 2>&1)
             _status=$?
         else
@@ -630,9 +630,9 @@ downloader() {
                 _err=$(wget --https-only --secure-protocol=TLSv1_2 --ciphers "$_ciphersuites" "$1" -O "$2" 2>&1)
                 _status=$?
             else
-                echo "Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure"
+                echo "warn: Not enforcing strong cipher suites for TLS, this is potentially less secure"
                 if ! check_help_for "$3" wget --https-only --secure-protocol; then
-                    echo "Warning: Not enforcing TLS v1.2, this is potentially less secure"
+                    echo "warn: Not enforcing TLS v1.2, this is potentially less secure"
                     _err=$(wget "$1" -O "$2" 2>&1)
                     _status=$?
                 else
@@ -679,7 +679,7 @@ check_help_for() {
                     # fail to find these options to force fallback
                     if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
                         # Older than 10.13
-                        echo "Warning: Detected macOS platform older than 10.13"
+                        echo "warn: Detected macOS platform older than 10.13"
                         return 1
                     fi
                     ;;
@@ -688,7 +688,7 @@ check_help_for() {
                     ;;
                 *)
                     # Unknown product version, warn and continue
-                    echo "Warning: Detected unknown macOS major version: $(sw_vers -productVersion)"
+                    echo "warn: Detected unknown macOS major version: $(sw_vers -productVersion)"
                     echo "Warning TLS capabilities detection may fail"
                     ;;
             esac

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -155,7 +155,7 @@ impl Notifier {
         let level = n.level();
         for n in format!("{n}").lines() {
             match level {
-                NotificationLevel::Verbose => {
+                NotificationLevel::Debug => {
                     if self.verbose {
                         debug!("{}", n);
                     }
@@ -169,7 +169,7 @@ impl Notifier {
                 NotificationLevel::Error => {
                     error!("{}", n);
                 }
-                NotificationLevel::Debug => {
+                NotificationLevel::Trace => {
                     trace!("{}", n);
                 }
             }

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -107,8 +107,8 @@ where
 impl NotificationLevel {
     fn fg_color(&self) -> Option<Color> {
         match self {
-            NotificationLevel::Debug => Some(Color::Blue),
-            NotificationLevel::Verbose => Some(Color::Magenta),
+            NotificationLevel::Trace => Some(Color::Blue),
+            NotificationLevel::Debug => Some(Color::Magenta),
             NotificationLevel::Info => None,
             NotificationLevel::Warn => Some(Color::Yellow),
             NotificationLevel::Error => Some(Color::Red),

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -852,7 +852,7 @@ mod tests {
             );
         });
         assert_eq!(
-            r"warning: the registry key HKEY_CURRENT_USER\Environment\PATH is not a string. Not modifying the PATH variable
+            r"warn: the registry key HKEY_CURRENT_USER\Environment\PATH is not a string. Not modifying the PATH variable
 ",
             String::from_utf8(tp.stderr()).unwrap()
         );

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -60,7 +60,7 @@ impl<'a> Notification<'a> {
             ChecksumValid(_)
             | NoUpdateHash(_)
             | FileAlreadyDownloaded
-            | DownloadingLegacyManifest => NotificationLevel::Verbose,
+            | DownloadingLegacyManifest => NotificationLevel::Debug,
             Extracting(_, _)
             | DownloadingComponent(_, _, _)
             | InstallingComponent(_, _, _)

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -83,10 +83,10 @@ impl<'a> Notification<'a> {
     pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
-            CreatingRoot(_) | CreatingFile(_) | CreatingDirectory(_) => NotificationLevel::Verbose,
+            CreatingRoot(_) | CreatingFile(_) | CreatingDirectory(_) => NotificationLevel::Debug,
             FileDeletion(_, result) | DirectoryDeletion(_, result) => {
                 if result.is_ok() {
-                    NotificationLevel::Verbose
+                    NotificationLevel::Debug
                 } else {
                     NotificationLevel::Warn
                 }

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -68,7 +68,7 @@ impl<'a> Notification<'a> {
             | UpdatingToolchain(_)
             | ReadMetadataVersion(_)
             | InstalledToolchain(_)
-            | UpdateHashMatches => NotificationLevel::Verbose,
+            | UpdateHashMatches => NotificationLevel::Debug,
             SetDefaultToolchain(_)
             | SetOverrideToolchain(_, _)
             | SetProfile(_)

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -46,7 +46,7 @@ impl<'a> Notification<'a> {
     pub(crate) fn level(&self) -> NotificationLevel {
         use self::Notification::*;
         match self {
-            SetDefaultBufferSize(_) => NotificationLevel::Debug,
+            SetDefaultBufferSize(_) => NotificationLevel::Trace,
             CreatingDirectory(_, _)
             | RemovingDirectory(_, _)
             | LinkingDirectory(_, _)
@@ -59,7 +59,7 @@ impl<'a> Notification<'a> {
             | DownloadFinished
             | ResumingPartialDownload
             | UsingCurl
-            | UsingReqwest => NotificationLevel::Verbose,
+            | UsingReqwest => NotificationLevel::Debug,
             RenameInUse(_, _) => NotificationLevel::Info,
             NoCanonicalPath(_) => NotificationLevel::Warn,
             Error(_) => NotificationLevel::Error,

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -17,7 +17,7 @@ impl fmt::Display for NotificationLevel {
             NotificationLevel::Trace => "trace",
             NotificationLevel::Debug => "debug",
             NotificationLevel::Info => "info",
-            NotificationLevel::Warn => "warning",
+            NotificationLevel::Warn => "warn",
             NotificationLevel::Error => "error",
         })
     }

--- a/src/utils/notify.rs
+++ b/src/utils/notify.rs
@@ -4,8 +4,8 @@ use tracing::Level;
 
 #[derive(Debug)]
 pub(crate) enum NotificationLevel {
+    Trace,
     Debug,
-    Verbose,
     Info,
     Warn,
     Error,
@@ -14,8 +14,8 @@ pub(crate) enum NotificationLevel {
 impl fmt::Display for NotificationLevel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
+            NotificationLevel::Trace => "trace",
             NotificationLevel::Debug => "debug",
-            NotificationLevel::Verbose => "verbose",
             NotificationLevel::Info => "info",
             NotificationLevel::Warn => "warning",
             NotificationLevel::Error => "error",
@@ -26,8 +26,8 @@ impl fmt::Display for NotificationLevel {
 impl From<Level> for NotificationLevel {
     fn from(level: Level) -> Self {
         match level {
-            Level::TRACE => Self::Debug,
-            Level::DEBUG => Self::Verbose,
+            Level::TRACE => Self::Trace,
+            Level::DEBUG => Self::Debug,
             Level::INFO => Self::Info,
             Level::WARN => Self::Warn,
             Level::ERROR => Self::Error,

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -432,7 +432,7 @@ fn install_forces_and_skips_rls() {
         assert!(out.ok);
         assert!(out
             .stderr
-            .contains("warning: Force-skipping unavailable component"));
+            .contains("warn: Force-skipping unavailable component"));
     });
 }
 
@@ -447,7 +447,7 @@ fn test_warn_if_complete_profile_is_used() {
                 "complete",
                 "--no-modify-path",
             ],
-            "warning: downloading with complete profile",
+            "warn: downloading with complete profile",
         );
     });
 }
@@ -460,7 +460,7 @@ fn test_prompt_fail_if_rustup_sh_already_installed_reply_nothing() {
         assert!(!out.ok);
         assert!(out
             .stderr
-            .contains("warning: it looks like you have existing rustup.sh metadata"));
+            .contains("warn: it looks like you have existing rustup.sh metadata"));
         assert!(out
             .stderr
             .contains("error: cannot install while rustup.sh is installed"));
@@ -476,7 +476,7 @@ fn test_prompt_fail_if_rustup_sh_already_installed_reply_no() {
         assert!(!out.ok);
         assert!(out
             .stderr
-            .contains("warning: it looks like you have existing rustup.sh metadata"));
+            .contains("warn: it looks like you have existing rustup.sh metadata"));
         assert!(out
             .stderr
             .contains("error: cannot install while rustup.sh is installed"));
@@ -491,14 +491,14 @@ fn test_prompt_succeed_if_rustup_sh_already_installed_reply_yes() {
         let out = run_input(config, &["rustup-init", "--no-modify-path"], "yes\n\n\n");
         assert!(out
             .stderr
-            .contains("warning: it looks like you have existing rustup.sh metadata"));
+            .contains("warn: it looks like you have existing rustup.sh metadata"));
         assert!(out
             .stderr
             .contains("error: cannot install while rustup.sh is installed"));
         assert!(out.stdout.contains("Continue? (y/N)"));
-        assert!(!out.stdout.contains(
-            "warning: continuing (because the -y flag is set and the error is ignorable)"
-        ));
+        assert!(!out
+            .stdout
+            .contains("warn: continuing (because the -y flag is set and the error is ignorable)"));
         assert!(out.ok);
     })
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2065,7 +2065,7 @@ components = [ "rust-bongo" ]
 
             config.expect_stderr_ok(
                 &["rustc", "--version"],
-                "warning: Force-skipping unavailable component 'rust-bongo",
+                "warn: Force-skipping unavailable component 'rust-bongo",
             );
         })
     });
@@ -2533,8 +2533,8 @@ fn warn_on_unmatch_build() {
         config.expect_stderr_ok(
             &["rustup", "toolchain", "install", &format!("nightly-{arch}")],
             &format!(
-                r"warning: toolchain 'nightly-{arch}' may not be able to run on this system.
-warning: If you meant to build software to target that platform, perhaps try `rustup target add {arch}` instead?",
+                r"warn: toolchain 'nightly-{arch}' may not be able to run on this system.
+warn: If you meant to build software to target that platform, perhaps try `rustup target add {arch}` instead?",
             ),
         );
         })
@@ -2560,7 +2560,7 @@ fn dont_warn_on_partial_build() {
                 r"info: syncing channel updates for 'nightly-{triple}'"
             )));
             assert!(!stderr.contains(&format!(
-                r"warning: toolchain 'nightly-{arch}' may not be able to run on this system."
+                r"warn: toolchain 'nightly-{arch}' may not be able to run on this system."
             )));
         })
     })
@@ -2613,7 +2613,7 @@ fn warn_on_duplicate_rust_toolchain_file() {
             config.expect_stderr_ok(
                 &["rustc", "--version"],
                 &format!(
-                    "warning: both `{0}` and `{1}` exist. Using `{0}`",
+                    "warn: both `{0}` and `{1}` exist. Using `{0}`",
                     toolchain_file_1.canonicalize().unwrap().display(),
                     toolchain_file_2.canonicalize().unwrap().display(),
                 ),

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -744,13 +744,13 @@ fn test_warn_succeed_if_rustup_sh_already_installed_y_flag() {
         assert!(out.ok);
         assert!(out
             .stderr
-            .contains("warning: it looks like you have existing rustup.sh metadata"));
+            .contains("warn: it looks like you have existing rustup.sh metadata"));
         assert!(out
             .stderr
             .contains("error: cannot install while rustup.sh is installed"));
-        assert!(out.stderr.contains(
-            "warning: continuing (because the -y flag is set and the error is ignorable)"
-        ));
+        assert!(out
+            .stderr
+            .contains("warn: continuing (because the -y flag is set and the error is ignorable)"));
         assert!(!out.stdout.contains("Continue? (y/N)"));
     })
 }
@@ -767,13 +767,13 @@ fn test_succeed_if_rustup_sh_already_installed_env_var_set() {
         assert!(out.ok);
         assert!(!out
             .stderr
-            .contains("warning: it looks like you have existing rustup.sh metadata"));
+            .contains("warn: it looks like you have existing rustup.sh metadata"));
         assert!(!out
             .stderr
             .contains("error: cannot install while rustup.sh is installed"));
-        assert!(!out.stderr.contains(
-            "warning: continuing (because the -y flag is set and the error is ignorable)"
-        ));
+        assert!(!out
+            .stderr
+            .contains("warn: continuing (because the -y flag is set and the error is ignorable)"));
         assert!(!out.stdout.contains("Continue? (y/N)"));
     })
 }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1353,7 +1353,7 @@ fn test_warn_if_complete_profile_is_used() {
                 "complete",
                 "stable",
             ],
-            "warning: downloading with complete profile",
+            "warn: downloading with complete profile",
         );
     });
 }
@@ -1377,7 +1377,7 @@ fn test_complete_profile_skips_missing_when_forced() {
         // Now try and force
         config.expect_stderr_ok(
             &["rustup", "toolchain", "install", "--force", "nightly"],
-            for_host!("warning: Force-skipping unavailable component 'rls-{}'"),
+            for_host!("warn: Force-skipping unavailable component 'rls-{}'"),
         );
 
         // Ensure that the skipped component (rls) is not installed
@@ -1407,7 +1407,7 @@ fn run_with_install_flag_against_unavailable_component() {
             for_host!(
                 r"info: syncing channel updates for 'nightly-{0}'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-warning: Force-skipping unavailable component 'rust-std-{0}'
+warn: Force-skipping unavailable component 'rust-std-{0}'
 info: downloading component 'cargo'
 info: downloading component 'rust-docs'
 info: downloading component 'rustc'


### PR DESCRIPTION
Split from https://github.com/rust-lang/rustup/pull/3879#discussion_r1642646581.