### PR TITLE
refactor(toolchain/names): replace `toolchain_sort()` with `ToolchainName`'s `Ord` instance

### DIFF
--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -24,7 +24,7 @@ pub enum CLIError {
 fn maybe_suggest_toolchain(bad_name: &str) -> String {
     let bad_name = &bad_name.to_ascii_lowercase();
     static VALID_CHANNELS: &[&str] = &["stable", "beta", "nightly"];
-    static NUMBERED: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\d+\.\d+$").unwrap());
+    static NUMBERED: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[0-9]+\.[0-9]+$").unwrap());
     if NUMBERED.is_match(bad_name) {
         return format!(". Toolchain numbers tend to have three parts, e.g. {bad_name}.0");
     }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1086,7 +1086,8 @@ fn parse_new_rustup_version(version: String) -> String {
     use once_cell::sync::Lazy;
     use regex::Regex;
 
-    static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\d+.\d+.\d+[0-9a-zA-Z-]*").unwrap());
+    static RE: Lazy<Regex> =
+        Lazy::new(|| Regex::new(r"[0-9]+.[0-9]+.[0-9]+[0-9a-zA-Z-]*").unwrap());
 
     let capture = RE.captures(&version);
     let matched_version = match capture {

--- a/src/config.rs
+++ b/src/config.rs
@@ -867,7 +867,7 @@ impl<'a> Cfg<'a> {
                 .filter_map(|n| ToolchainName::try_from(&n).ok())
                 .collect();
 
-            crate::toolchain::toolchain_sort(&mut toolchains);
+            toolchains.sort();
 
             Ok(toolchains)
         } else {

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -256,7 +256,7 @@ impl FromStr for ParsedToolchainDesc {
         // and an optional match of the date (2) and target (3)
         static TOOLCHAIN_CHANNEL_RE: Lazy<Regex> = Lazy::new(|| {
             Regex::new(&format!(
-                r"^({})(?:-(\d{{4}}-\d{{2}}-\d{{2}}))?(?:-(.+))?$",
+                r"^({})(?:-([0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}))?(?:-(.+))?$",
                 // The channel patterns we support
                 [
                     "nightly",
@@ -264,7 +264,7 @@ impl FromStr for ParsedToolchainDesc {
                     "stable",
                     // Allow from 1.0.0 through to 9.999.99 with optional patch version
                     // and optional beta tag
-                    r"\d{1}\.\d{1,3}(?:\.\d{1,2})?(?:-beta(?:\.\d{1,2})?)?",
+                    r"[0-9]{1}\.[0-9]{1,3}(?:\.[0-9]{1,2})?(?:-beta(?:\.[0-9]{1,2})?)?",
                 ]
                 .join("|")
             ))

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ use url::Url;
 use crate::{
     dist::{
         manifest::{Component, Manifest},
-        {TargetTriple, ToolchainDesc},
+        Channel, TargetTriple, ToolchainDesc,
     },
     toolchain::{PathBasedToolchainName, ToolchainName},
 };
@@ -97,7 +97,7 @@ pub enum RustupError {
     ToolchainNotSelected(String),
     #[error("toolchain '{}' does not contain component {}{}{}", .desc, .component, suggest_message(.suggestion), if .component.contains("rust-std") {
         format!("\nnote: not all platforms have the standard library pre-compiled: https://doc.rust-lang.org/nightly/rustc/platform-support.html{}",
-            if desc.channel == "nightly" { "\nhelp: consider using `cargo build -Z build-std` instead" } else { "" }
+            if desc.channel == Channel::Nightly { "\nhelp: consider using `cargo build -Z build-std` instead" } else { "" }
         )
     } else { "".to_string() })]
     UnknownComponent {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -29,7 +29,7 @@ pub(crate) use distributable::DistributableToolchain;
 
 mod names;
 pub(crate) use names::{
-    toolchain_sort, CustomToolchainName, LocalToolchainName, MaybeOfficialToolchainName,
+    CustomToolchainName, LocalToolchainName, MaybeOfficialToolchainName,
     MaybeResolvableToolchainName, PathBasedToolchainName, ResolvableLocalToolchainName,
     ResolvableToolchainName, ToolchainName,
 };

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -480,11 +480,7 @@ mod tests {
             LIST_OSES.join("|"),
             LIST_ENVS.join("|")
         );
-        let partial_toolchain_desc_re = format!(
-            r"(nightly|beta|stable|\d{{1}}\.\d{{1,3}}(\.\d{{1,2}})?)(-(\d{{4}}-\d{{2}}-\d{{2}}))?{triple_re}"
-        );
-
-        partial_toolchain_desc_re
+        r"(nightly|beta|stable|[0-9]{1}(\.(0|[1-9][0-9]{0,2}))(\.(0|[1-9][0-9]{0,1}))?(-beta(\.(0|[1-9][1-9]{0,1}))?)?)(-([0-9]{4}-[0-9]{2}-[0-9]{2}))?".to_owned() + &triple_re
     }
 
     prop_compose! {

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1218,11 +1218,11 @@ rustup home:  {1}
 
 installed toolchains
 --------------------
-nightly-2015-01-01-{0}
-  1.2.0 (hash-nightly-1)
-
 nightly-{0} (active, default)
   1.3.0 (hash-nightly-2)
+
+nightly-2015-01-01-{0}
+  1.2.0 (hash-nightly-1)
 
 active toolchain
 ----------------


### PR DESCRIPTION
Closes #3884.

This new implementation also tries to correct the handling of `X.Y`, `X.Y-beta.W` and `X.Y.Z-beta.W` versions' ordering by abusing [`semver::Comparator`](https://docs.rs/semver/latest/semver/struct.Comparator.html)'s `FromStr` implementation.