### PR TITLE
fix(dist): throw an error when a `PartialVersion` string doesn't start with an ASCII digit

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -208,6 +208,17 @@ impl fmt::Display for PartialVersion {
 impl FromStr for PartialVersion {
     type Err = anyhow::Error;
     fn from_str(ver: &str) -> Result<Self> {
+        // `semver::Comparator::from_str` supports an optional operator
+        // (e.g. `=`, `>`, `>=`, `<`, `<=`, `~`, `^`, `*`) before the
+        // partial version, so we should exclude that case first.
+        if let Some(ch) = ver.chars().nth(0) {
+            if !ch.is_ascii_digit() {
+                return Err(anyhow!(
+                    "expected ASCII digit at the beginning of `{ver}`, found `{ch}`"
+                )
+                .context("error parsing `PartialVersion`"));
+            }
+        }
         let (ver, pre) = ver.split_once('-').unwrap_or((ver, ""));
         let comparator =
             semver::Comparator::from_str(ver).context("error parsing `PartialVersion`")?;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -125,11 +125,11 @@ struct ParsedToolchainDesc {
     target: Option<String>,
 }
 
-// A toolchain descriptor from rustup's perspective. These contain
-// 'partial target triples', which allow toolchain names like
-// 'stable-msvc' to work. Partial target triples though are parsed
-// from a hardcoded set of known triples, whereas target triples
-// are nearly-arbitrary strings.
+/// A toolchain descriptor from rustup's perspective. These contain
+/// 'partial target triples', which allow toolchain names like
+/// 'stable-msvc' to work. Partial target triples though are parsed
+/// from a hardcoded set of known triples, whereas target triples
+/// are nearly-arbitrary strings.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PartialToolchainDesc {
     pub channel: Channel,
@@ -137,11 +137,11 @@ pub struct PartialToolchainDesc {
     pub target: PartialTargetTriple,
 }
 
-// Fully-resolved toolchain descriptors. These always have full target
-// triples attached to them and are used for canonical identification,
-// such as naming their installation directory.
-//
-// as strings they look like stable-x86_64-pc-windows-msvc or
+/// Fully-resolved toolchain descriptors. These always have full target
+/// triples attached to them and are used for canonical identification,
+/// such as naming their installation directory.
+///
+/// As strings they look like stable-x86_64-pc-windows-msvc or
 /// 1.55-x86_64-pc-windows-msvc
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ToolchainDesc {
@@ -181,6 +181,8 @@ impl FromStr for Channel {
     }
 }
 
+/// A possibly incomplete Rust toolchain version that
+/// can be converted from and to its string form.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PartialVersion {
     pub major: u64,


### PR DESCRIPTION
Continuation of #3892.

There is a logical bug in the previous implementation of `PartialVersion::from_str`: the parser will happily accept inputs like `^1.0` exactly because it was intended to be used that way (to parse version comparators instead of partial versions), it's just that it happens to have no effect thanks to where it's called in the current codebase. I think fixing it will make me feel safer :)