### PR TITLE
Replace `winreg` with `windows-registry`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1984,7 +1984,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
+ "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -2184,8 +2184,9 @@ dependencies = [
  "url",
  "wait-timeout",
  "walkdir",
+ "windows-registry 0.3.0",
+ "windows-result",
  "windows-sys 0.59.0",
- "winreg",
  "xz2",
  "zstd",
 ]
@@ -3182,7 +3183,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafa604f2104cf5ae2cc2db1dee84b7e6a5d11b05f737b60def0ffdc398cbc0a"
+dependencies = [
+ "windows-result",
+ "windows-strings 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -3202,6 +3214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
  "windows-result",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978d65aedf914c664c510d9de43c8fd85ca745eaff1ed53edf409b479e441663"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -3360,16 +3381,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,8 @@ zstd = "0.13"
 
 [target."cfg(windows)".dependencies]
 cc = "1"
-winreg = "0.52"
+windows-registry = "0.3.0"
+windows-result = "0.2.0"
 
 [target."cfg(windows)".dependencies.windows-sys]
 features = [

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -23,6 +23,8 @@ use rustup::test::{
 use rustup::test::{RegistryGuard, RegistryValueId, USER_PATH};
 use rustup::utils::{raw, utils};
 use rustup::{for_host, DUP_TOOLS, TOOLS};
+#[cfg(windows)]
+use windows_registry::Value;
 
 const TEST_VERSION: &str = "1.1.1";
 
@@ -350,12 +352,12 @@ async fn update_overwrites_programs_display_version() {
         .await;
 
     USER_RUSTUP_VERSION
-        .set_value(Some(PLACEHOLDER_VERSION))
+        .set_value(Some(&Value::from(PLACEHOLDER_VERSION)))
         .unwrap();
     cx.config.expect_ok(&["rustup", "self", "update"]).await;
     assert_eq!(
-        USER_RUSTUP_VERSION.get_value::<String>().unwrap().unwrap(),
-        version,
+        USER_RUSTUP_VERSION.get_value().unwrap().unwrap(),
+        Value::from(version)
     );
 }
 


### PR DESCRIPTION
Closes #3779.

APIs provided by `winreg` crate is not safe, simple and abstract enough. Besides that, it probably also contains protential bugs. Because of that, it is better to replace it with `windows-registry` crate, which is officially published and maintained by Microsoft.