### PR TITLE
feat(download/rustls): use `aws-lc` instead of `ring`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,11 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\registry" -ItemType Directory -Force
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: matrix.mingwdir == ''
       - name: Install mingw
         uses: bwoodsend/setup-winlibs-action@v1
         if: matrix.mingwdir != ''
@@ -220,6 +225,11 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\registry" -ItemType Directory -Force
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: matrix.mingwdir == ''
       - name: Install mingw
         uses: bwoodsend/setup-winlibs-action@v1
         if: matrix.mingwdir != ''
@@ -384,6 +394,11 @@ jobs:
           New-Item "${env:USERPROFILE}\.cargo\registry" -ItemType Directory -Force
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: matrix.mingwdir == ''
       - name: Install mingw
         uses: bwoodsend/setup-winlibs-action@v1
         if: matrix.mingwdir != ''
@@ -1447,6 +1462,11 @@ jobs:
           echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV
           echo "OPENSSL_DIR=C:/Program Files/OpenSSL/" >> $env:GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL/include" >> $env:GITHUB_ENV
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: ${{ contains(matrix.os, 'windows') }}
       - name: Set environment variables appropriately for the build
         shell: bash
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +262,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn",
+ "which",
+]
 
 [[package]]
 name = "bit-set"
@@ -318,6 +368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +401,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -393,6 +463,15 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -719,6 +798,12 @@ dependencies = [
  "nix",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -1093,6 +1178,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1151,6 +1245,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,6 +1264,16 @@ checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1235,6 +1345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,6 +1370,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "native-tls"
@@ -1282,6 +1404,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1517,6 +1649,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1721,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18bec9b0adc4eba778b33684b7ba3e7137789434769ee3ce3930463ef904cfca"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1876,6 +2024,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,9 +2048,9 @@ version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1965,6 +2119,7 @@ version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1987,7 +2142,7 @@ dependencies = [
  "fs_at",
  "git-testament",
  "home",
- "itertools",
+ "itertools 0.13.0",
  "libc",
  "opener",
  "openssl",
@@ -2953,6 +3108,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3196,6 +3363,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zstd"

--- a/ci/actions-templates/all-features-template.yaml
+++ b/ci/actions-templates/all-features-template.yaml
@@ -38,6 +38,11 @@ jobs: # skip-all
           echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV
           echo "OPENSSL_DIR=C:/Program Files/OpenSSL/" >> $env:GITHUB_ENV
           echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL/include" >> $env:GITHUB_ENV
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: ${{ contains(matrix.os, 'windows') }}
       - name: Set environment variables appropriately for the build
         shell: bash
         run: |

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -55,6 +55,11 @@ jobs: # skip-master skip-pr skip-stable
           New-Item "${env:USERPROFILE}\.cargo\registry" -ItemType Directory -Force
           New-Item "${env:USERPROFILE}\.cargo\git" -ItemType Directory -Force
         shell: powershell
+      - name: Install NASM
+        # Building `aws-lc-rs` for Windows MSVC depends on `NASM`.
+        # See: https://aws.github.io/aws-lc-rs/requirements/windows.html
+        uses: ilammy/setup-nasm@v1
+        if: matrix.mingwdir == ''
       - name: Install mingw
         uses: bwoodsend/setup-winlibs-action@v1
         if: matrix.mingwdir != ''

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-aarch64-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-gcc

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -1,5 +1,11 @@
 FROM rust-aarch64-unknown-linux-musl
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \
     RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-lgcc"

--- a/ci/docker/android/Dockerfile
+++ b/ci/docker/android/Dockerfile
@@ -1,6 +1,13 @@
 FROM rust-android
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV PATH=$PATH:/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin \
+    ANDROID_NDK=/android/ndk/ \
     AR_arm_linux_androideabi=llvm-ar \
     AR_armv7_linux_androideabi=llvm-ar \
     AR_aarch64_linux_android=llvm-ar \

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-arm-unknown-linux-gnueabi
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-unknown-linux-gnueabi-gcc

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-arm-unknown-linux-gnueabihf
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-unknown-linux-gnueabihf-gcc

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-armv7-unknown-linux-gnueabihf
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=armv7-unknown-linux-gnueabihf-gcc

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,5 +1,11 @@
 FROM rust-i686-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
  # Install `perl-IPC-Cmd` to make OpenSSL v3 happy.
  # See: <https://github.com/sfackler/rust-openssl/issues/1550>
  RUN yum upgrade -y && \

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-loongarch64-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-gcc \
     CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-unknown-linux-gnu-gcc

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-loongarch64-unknown-linux-musl
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-gcc \
     CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER=loongarch64-unknown-linux-musl-gcc

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-powerpc-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_powerpc_unknown_linux_gnu=powerpc-unknown-linux-gnu-gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-unknown-linux-gnu-gcc

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-powerpc64-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_powerpc64_unknown_linux_gnu=powerpc64-unknown-linux-gnu-gcc \
     CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-unknown-linux-gnu-gcc

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-powerpc64le-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-riscv64gc-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
     CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-unknown-linux-gnu-gcc

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,4 +1,10 @@
 FROM rust-s390x-unknown-linux-gnu
 
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
+  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
+  && mv $HOME/.cargo/bin/bindgen /usr/bin
+
 ENV CC_s390x_unknown_linux_gnu=s390x-ibm-linux-gnu-gcc \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-ibm-linux-gnu-gcc

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -20,7 +20,7 @@ anyhow.workspace = true
 curl = { version = "0.4.44", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "socks", "stream"], optional = true }
-rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "ring", "tls12"] }
+rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "aws_lc_rs", "tls12"] }
 rustls-platform-verifier = { version = "0.3", optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -303,7 +303,7 @@ pub mod reqwest_be {
     use anyhow::{anyhow, Context, Result};
     use reqwest::{header, Client, ClientBuilder, Proxy, Response};
     #[cfg(feature = "reqwest-rustls-tls")]
-    use rustls::crypto::ring;
+    use rustls::crypto::aws_lc_rs;
     use tokio_stream::StreamExt;
     use url::Url;
 
@@ -359,7 +359,7 @@ pub mod reqwest_be {
             client_generic()
                 .use_preconfigured_tls(
                     rustls_platform_verifier::tls_config_with_provider(Arc::new(
-                        ring::default_provider(),
+                        aws_lc_rs::default_provider(),
                     ))
                     .expect("failed to initialize pre-configured rustls backend"),
                 )


### PR DESCRIPTION
Closes #3820 by replacing the `ring` backend with `aws-lc`.

Fortunately, with https://github.com/seanmonstar/reqwest/pull/2301, it's now possible to **totally disable `ring` at compile time**.

Tested locally on macOS 14.5 via the following command with positive outcome:
```console
> RUSTUP_LOG=TRACE RUSTUP_FORCE_ARG0=rustup rustup run stable cargo run -- update
```