### PR TITLE
Add missing period in warning while checking existing Rust installations

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -637,7 +637,7 @@ fn check_existence_of_rustc_or_cargo_in_path(no_prompt: bool, process: &Process)
         warn!("it looks like you have an existing installation of Rust at:");
         warn!("{}", path);
         warn!("It is recommended that rustup be the primary Rust installation.");
-        warn!("Otherwise you may have confusion unless you are careful with your PATH");
+        warn!("Otherwise you may have confusion unless you are careful with your PATH.");
         warn!("If you are sure that you want both rustup and your already installed Rust");
         warn!("then please reply `y' or `yes' or set RUSTUP_INIT_SKIP_PATH_CHECK to yes");
         warn!("or pass `-y' to ignore all ignorable checks.");


### PR DESCRIPTION
It seems like there's a missing period in the warning that gets triggered if an user already has an existing installation of Rust.

![Screenshot 2024-06-24 at 12 12 01](https://github.com/rust-lang/rustup/assets/97030518/1c47a697-1478-42d0-8beb-45c30ab46f4c)
