### PR TITLE
ci(windows): run `cargo all-features`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1286,14 +1286,17 @@ jobs:
   # nor run on the rust docker images. This permits a smaller workflow without the
   # templating and so on.
   build-all-features: # job-name
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }}
     strategy:
       fail-fast: false
       matrix:
-        # Might add more targets in future.
-        target:
-          - x86_64-unknown-linux-gnu
+        include:
+          # Might add more targets in future.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
@@ -1304,7 +1307,17 @@ jobs:
         with:
           version: "3.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install OpenSSL
+        if: ${{ contains(matrix.os, 'windows') }}
+        run: |
+          choco install openssl -y --no-progress
+          Get-Command openssl
+          openssl version
+          echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_DIR=C:/Program Files/OpenSSL/" >> $env:GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL/include" >> $env:GITHUB_ENV
       - name: Set environment variables appropriately for the build
+        shell: bash
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
@@ -1314,7 +1327,7 @@ jobs:
         run: cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
       - name: Ensure we have our goal target installed
         run: |
-          rustup target install "$TARGET"
+          rustup target install ${{ matrix.target }}
       - name: Build every combination
         env:
           RUSTFLAGS: -D warnings

--- a/ci/actions-templates/all-features-template.yaml
+++ b/ci/actions-templates/all-features-template.yaml
@@ -8,14 +8,17 @@ jobs: # skip-all
   # nor run on the rust docker images. This permits a smaller workflow without the
   # templating and so on.
   build-all-features: # job-name
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }}
     strategy:
       fail-fast: false
       matrix:
-        # Might add more targets in future.
-        target:
-          - x86_64-unknown-linux-gnu
+        include:
+          # Might add more targets in future.
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - name: Clone repo
         uses: actions/checkout@v4
@@ -26,7 +29,17 @@ jobs: # skip-all
         with:
           version: "3.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install OpenSSL
+        if: ${{ contains(matrix.os, 'windows') }}
+        run: |
+          choco install openssl -y --no-progress
+          Get-Command openssl
+          openssl version
+          echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV
+          echo "OPENSSL_DIR=C:/Program Files/OpenSSL/" >> $env:GITHUB_ENV
+          echo "OPENSSL_INCLUDE_DIR=C:/Program Files/OpenSSL/include" >> $env:GITHUB_ENV
       - name: Set environment variables appropriately for the build
+        shell: bash
         run: |
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           echo "TARGET=${{ matrix.target }}" >> $GITHUB_ENV
@@ -36,7 +49,7 @@ jobs: # skip-all
         run: cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
       - name: Ensure we have our goal target installed
         run: |
-          rustup target install "$TARGET"
+          rustup target install ${{ matrix.target }}
       - name: Build every combination
         env:
           RUSTFLAGS: -D warnings

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -1,14 +1,22 @@
 use std::env::{consts::EXE_SUFFIX, split_paths};
 use std::ffi::{OsStr, OsString};
 use std::fmt;
-use std::io::{self, Write};
+#[cfg(any(test, feature = "test"))]
+use std::io;
+use std::io::Write;
 use std::os::windows::ffi::{OsStrExt, OsStringExt};
 use std::path::Path;
 use std::process::Command;
-use std::sync::{Arc, LockResult, Mutex, MutexGuard};
+use std::sync::{Arc, Mutex};
+#[cfg(any(test, feature = "test"))]
+use std::sync::{LockResult, MutexGuard};
 
 use anyhow::{anyhow, Context, Result};
 use tracing::{info, warn};
+use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
+#[cfg(any(test, feature = "test"))]
+use winreg::types::{FromRegValue, ToRegValue};
+use winreg::{RegKey, RegValue};
 
 use super::super::errors::*;
 use super::common;
@@ -18,10 +26,6 @@ use crate::currentprocess::{terminalsource::ColorableTerminal, Process};
 use crate::dist::TargetTriple;
 use crate::utils::utils;
 use crate::utils::Notification;
-
-use winreg::enums::{RegType, HKEY_CURRENT_USER, KEY_READ, KEY_WRITE};
-use winreg::types::{FromRegValue, ToRegValue};
-use winreg::{RegKey, RegValue};
 
 pub(crate) fn ensure_prompt(process: &Process) -> Result<()> {
     writeln!(process.stdout().lock(),)?;


### PR DESCRIPTION
Addresses the warning found in https://github.com/rust-lang/rustup/actions/runs/9655583919/job/26631715641?pr=3903:

```rust
warning: unused import: `self`
 --> src\cli\self_update\windows.rs:4:15
  |
4 | use std::io::{self, Write};
  |               ^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `LockResult`, `MutexGuard`
 --> src\cli\self_update\windows.rs:8:22
  |
8 | use std::sync::{Arc, LockResult, Mutex, MutexGuard};
  |                      ^^^^^^^^^^         ^^^^^^^^^^

warning: unused imports: `FromRegValue`, `ToRegValue`
  --> src\cli\self_update\windows.rs:23:21
   |
23 | use winreg::types::{FromRegValue, ToRegValue};
   |                     ^^^^^^^^^^^^  ^^^^^^^^^^

warning: `rustup` (lib) generated 3 warnings (run `cargo fix --lib -p rustup` to apply 3 suggestions)
```

The CI runtime overhead is +11min on Windows. It's not a bottleneck though, since our macOS x64 full CI takes even longer.