### PR TITLE
fix(rustup-mode): improve `clap` error format

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -529,7 +529,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
 
     use clap::error::ErrorKind::*;
     let matches = match Rustup::try_parse_from(process.args_os()) {
-        Ok(matches) => Ok(matches),
+        Ok(matches) => matches,
         Err(err) if err.kind() == DisplayHelp => {
             write!(process.stdout().lock(), "{err}")?;
             return Ok(utils::ExitCode(0));
@@ -554,15 +554,12 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
             .contains(&err.kind())
             {
                 write!(process.stdout().lock(), "{err}")?;
-                return Ok(utils::ExitCode(1));
-            }
-            if err.kind() == ValueValidation && err.to_string().contains(TOOLCHAIN_OVERRIDE_ERROR) {
+            } else {
                 write!(process.stderr().lock(), "{err}")?;
-                return Ok(utils::ExitCode(1));
             }
-            Err(err)
+            return Ok(utils::ExitCode(1));
         }
-    }?;
+    };
 
     let cfg = &mut common::set_globals(current_dir, matches.verbose, matches.quiet, process)?;
 


### PR DESCRIPTION
Closes #3905 by preventing `clap` errors from surfacing upwards in `rustup_mode::main`.

### Before

```console
> rustup update self
error: error: invalid value 'self' for '[toolchain]...': invalid toolchain name: 'self'

For more information, try '--help'.
: invalid toolchain name: 'self'
```

### After

```console
> RUSTUP_FORCE_ARG0=rustup rustup run stable cargo run -- update self
[..]
error: invalid value 'self' for '[TOOLCHAIN]...': invalid toolchain name: 'self'

For more information, try '--help'.
```