### PR TITLE
feat(rustup-init): set log level to `WARN` on `-q` if `RUSTUP_LOG` is unset

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -41,7 +41,7 @@ Options:
   -v, --verbose
           Enable verbose output
   -q, --quiet
-          Disable progress output
+          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -234,7 +234,7 @@ impl TestProcess {
 impl From<TestContext> for TestProcess {
     fn from(inner: TestContext) -> Self {
         let inner = Process::TestProcess(inner);
-        let guard = crate::cli::log::tracing_subscriber(&inner).set_default();
+        let guard = crate::cli::log::tracing_subscriber(&inner).0.set_default();
         Self {
             process: inner,
             _guard: guard,

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -12,7 +12,7 @@ Options:
   -v, --verbose
           Enable verbose output
   -q, --quiet
-          Disable progress output
+          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -12,7 +12,7 @@ Options:
   -v, --verbose
           Enable verbose output
   -q, --quiet
-          Disable progress output
+          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>


### PR DESCRIPTION
Closes #3900.