### PR TITLE
feat(dist): add notes for `stable` and `beta` in `components_missing_msg()`

### DIFF
--- a/doc/user-guide/src/concepts/components.md
+++ b/doc/user-guide/src/concepts/components.md
@@ -63,6 +63,9 @@ toolchains. The following is an overview of the different components:
 
 ### Previous components
 
+> See [here](https://rust-lang.github.io/rustup/devel/concepts/components.html#previous-components)
+> for the latest version of this section.
+
 These components have been deprecated and are not published in new Rust releases.
 
 * `rls` --- [RLS] is a language server that is deprecated and has been replaced

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -47,7 +47,7 @@ pub(crate) use triple::*;
 pub static DEFAULT_DIST_SERVER: &str = "https://static.rust-lang.org";
 
 const TOOLSTATE_MSG: &str =
-    "If you require these components, please install and use the latest successful build version,\n\
+    "If you require these components, please install and use the latest successfully built version,\n\
      which you can find at <https://rust-lang.github.io/rustup-components-history>.\n\nAfter determining \
      the correct date, install it with a command such as:\n\n    \
      rustup toolchain install nightly-2018-12-27\n\n\
@@ -93,7 +93,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
                 .join(", ");
             let _ = write!(
                 buf,
-                "some components unavailable for download for channel '{toolchain}': {cs_str}"
+                "some components are unavailable for download for channel '{toolchain}': {cs_str}"
             );
 
             if toolchain.starts_with("nightly") {

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -99,6 +99,23 @@ Then you can use the toolchain with commands such as:
 
     cargo +nightly-2018-12-27 build"
         );
+    } else if ["beta", "stable"].iter().any(|&p| toolchain.starts_with(p)) {
+        let _ = write!(
+            buf,
+            "\
+One or many components listed above might have been permanently removed from newer versions
+of the official Rust distribution due to deprecation.
+
+You can find the list of removed components at
+<https://rust-lang.github.io/rustup/devel/concepts/components.html#previous-components>.
+
+If you are updating an existing toolchain, after determining the deprecated component(s)
+in question, please remove them with a command such as:
+
+    rustup component remove --toolchain {toolchain} <COMPONENT>...
+
+After that, you should be able to continue with the update as usual.",
+        );
     }
 
     String::from_utf8(buf).unwrap()

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -75,15 +75,6 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
                 c.description(manifest),
                 toolchain,
             );
-
-            if toolchain.starts_with("nightly") {
-                let _ = write!(buf, "{nightly_tips}");
-            }
-
-            let _ = write!(
-                buf,
-                "If you don't need the component, you could try a minimal installation with:\n\n{suggestion}\n\n{TOOLSTATE_MSG}"
-            );
         }
         cs => {
             let cs_str = cs
@@ -95,18 +86,17 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
                 buf,
                 "some components are unavailable for download for channel '{toolchain}': {cs_str}"
             );
-
-            if toolchain.starts_with("nightly") {
-                let _ = write!(buf, "{nightly_tips}");
-            }
-
-            let _ = write!(
-                buf,
-                "If you don't need the components, you could try a minimal installation with:\n\n{suggestion}\n\n{TOOLSTATE_MSG}"
-            );
         }
     }
 
+    if toolchain.starts_with("nightly") {
+        let _ = write!(buf, "{nightly_tips}");
+
+        let _ = write!(
+            buf,
+            "If you don't need these components, you could try a minimal installation with:\n\n{suggestion}\n\n{TOOLSTATE_MSG}"
+        );
+    }
     String::from_utf8(buf).unwrap()
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -46,14 +46,6 @@ pub(crate) use triple::*;
 
 pub static DEFAULT_DIST_SERVER: &str = "https://static.rust-lang.org";
 
-const TOOLSTATE_MSG: &str =
-    "If you require these components, please install and use the latest successfully built version,\n\
-     which you can find at <https://rust-lang.github.io/rustup-components-history>.\n\nAfter determining \
-     the correct date, install it with a command such as:\n\n    \
-     rustup toolchain install nightly-2018-12-27\n\n\
-     Then you can use the toolchain with commands such as:\n\n    \
-     cargo +nightly-2018-12-27 build";
-
 /// Returns a error message indicating that certain [`Component`]s are missing in a toolchain distribution.
 ///
 /// This message is currently used exclusively in toolchain-wide operations,
@@ -63,8 +55,6 @@ const TOOLSTATE_MSG: &str =
 /// This function will panic when the collection of unavailable components `cs` is empty.
 fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &str) -> String {
     let mut buf = vec![];
-    let suggestion = format!("    rustup toolchain add {toolchain} --profile minimal");
-    let nightly_tips = "Sometimes not all components are available in any given nightly. ";
 
     match cs {
         [] => panic!("`components_missing_msg` should not be called with an empty collection of unavailable components"),
@@ -90,13 +80,27 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
     }
 
     if toolchain.starts_with("nightly") {
-        let _ = write!(buf, "{nightly_tips}");
-
         let _ = write!(
             buf,
-            "If you don't need these components, you could try a minimal installation with:\n\n{suggestion}\n\n{TOOLSTATE_MSG}"
+            "\
+Sometimes not all components are available in any given nightly.
+If you don't need these components, you could try a minimal installation with:
+
+    rustup toolchain add {toolchain} --profile minimal
+
+If you require these components, please install and use the latest successfully built version,
+which you can find at <https://rust-lang.github.io/rustup-components-history>.
+
+After determining the correct date, install it with a command such as:
+
+    rustup toolchain install nightly-2018-12-27
+
+Then you can use the toolchain with commands such as:
+
+    cargo +nightly-2018-12-27 build"
         );
     }
+
     String::from_utf8(buf).unwrap()
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -148,7 +148,7 @@ fn suggest_message(suggestion: &Option<String>) -> String {
 
 /// Returns a error message indicating that certain [`Component`]s are unavailable.
 ///
-/// See also [`component_missing_msg`](../dist/dist/fn.components_missing_msg.html)
+/// See also [`components_missing_msg`](../dist/dist/fn.components_missing_msg.html)
 /// which generates error messages for component unavailability toolchain-wide operations.
 ///
 /// # Panics
@@ -192,7 +192,7 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
 
             let _ = write!(
                 buf,
-                "some components unavailable for download for channel '{toolchain}': {cs_str}"
+                "some components are unavailable for download for channel '{toolchain}': {cs_str}"
             );
 
             if toolchain.starts_with("nightly") {

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -93,7 +93,7 @@ pub enum Scenario {
     Unavailable,
     /// Two dates, v2 manifests, RLS unavailable in first date, restored on second.
     UnavailableRls,
-    /// Three dates, v2 manifests, RLS available in first and last, not middle
+    /// Three dates, v2 manifests, RLS available in first and second, not last
     MissingComponent,
     /// Three dates, v2 manifests, RLS available in first, middle missing nightly
     MissingNightly,

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -93,6 +93,8 @@ pub enum Scenario {
     Unavailable,
     /// Two dates, v2 manifests, RLS unavailable in first date, restored on second.
     UnavailableRls,
+    /// Two dates, v2 manifests, RLS available in first stable, removed on second.
+    RemovedRls,
     /// Three dates, v2 manifests, RLS available in first and second, not last
     MissingComponent,
     /// Three dates, v2 manifests, RLS available in first, middle missing nightly
@@ -152,6 +154,7 @@ impl ConstState {
                 Scenario::MissingNightly => RwLock::new(None),
                 Scenario::MultiHost => RwLock::new(None),
                 Scenario::None => RwLock::new(None),
+                Scenario::RemovedRls => RwLock::new(None),
                 Scenario::SimpleV1 => RwLock::new(None),
                 Scenario::SimpleV2 => RwLock::new(None),
                 Scenario::Unavailable => RwLock::new(None),
@@ -1152,6 +1155,10 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
                 Release::stable("1.1.0", "2015-01-02"),
             ]
         }
+        Scenario::RemovedRls => vec![
+            Release::stable("1.78.0", "2024-05-01"),
+            Release::stable("1.79.0", "2024-06-15").with_rls(RlsStatus::Unavailable),
+        ],
         Scenario::SimpleV1 | Scenario::SimpleV2 => vec![
             Release::new("nightly", "1.3.0", "2015-01-02", "2").with_rls(RlsStatus::Renamed),
             Release::beta("1.2.0", "2015-01-02"),
@@ -1199,6 +1206,7 @@ fn create_mock_dist_server(path: &Path, s: Scenario) {
         | Scenario::MultiHost
         | Scenario::Unavailable
         | Scenario::UnavailableRls
+        | Scenario::RemovedRls
         | Scenario::MissingNightly
         | Scenario::HostGoesMissingBefore
         | Scenario::HostGoesMissingAfter

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1359,7 +1359,8 @@ async fn add_missing_component_toolchain() {
         &["rustup", "toolchain", "add", "nightly"],
         for_host!(
             r"component 'rust-std' for target '{0}' is unavailable for download for channel 'nightly'
-Sometimes not all components are available in any given nightly. If you don't need the component, you could try a minimal installation with:
+Sometimes not all components are available in any given nightly.
+If you don't need these components, you could try a minimal installation with:
 
     rustup toolchain add nightly --profile minimal
 

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1363,7 +1363,7 @@ Sometimes not all components are available in any given nightly. If you don't ne
 
     rustup toolchain add nightly --profile minimal
 
-If you require these components, please install and use the latest successful build version,
+If you require these components, please install and use the latest successfully built version,
 which you can find at <https://rust-lang.github.io/rustup-components-history>.
 
 After determining the correct date, install it with a command such as:


### PR DESCRIPTION
Prepares for `rls`' removal in the release channel.

Continuation of #3453, as requested by @onur-ozkan in https://github.com/rust-lang/rust/pull/126856#issuecomment-2197990717.

> The best thing we could do is to add a note saying some components may no longer be available (this note currently doesn't apply for stables), but:
>
> 1. We'll have to wait for v1.28 to ship it, and we're currently in the middle of the release cycle (we have limited bandwidth so we decided not to do backports), and
> 2. We should not hardcode the list of removed components in Rustup
> 
> _https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/excluding.20rls.20from.20the.20release/near/447968780_

~~The error message is not final, since I'd still like to add a link that provides more info about removed components (which is `rls` this time):~~ The message now includes a link to https://rust-lang.github.io/rustup/devel/concepts/components.html#previous-components.

> ... and for this I suggest adding a section in the Rust docs somewhere, and our notes should advise the user to check out the section above to see whether the component in question is missing as intended from what date (and if that is the case, they can choose to unblock the update with a clear consent by removing the component).
>
> But in any way we cannot simply skip RLS in an update if it's previously installed, since that would be a real backwards compatibility problem.
> _https://rust-lang.zulipchat.com/#narrow/stream/241545-t-release/topic/excluding.20rls.20from.20the.20release/near/447968780_

## Concerns

- [x] ~~To which document should we add the list of removed components?~~ To the Rustup User Guide, see above for details.
- [x] ~~Should the note be applied to `nightly` as well?~~ No, as https://github.com/rust-lang/rustup-components-history/pull/54 will add a link to https://rust-lang.github.io/rustup/devel/concepts/components.html#previous-components on the components history page.