### PR TITLE
fix(download): fix build error with `--no-default-features --features=curl-backend`

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -507,7 +507,7 @@ pub mod reqwest_be {
 
     use super::{DownloadError, Event, TlsBackend};
 
-    pub fn download(
+    pub async fn download(
         _url: &Url,
         _resume_from: u64,
         _callback: &dyn Fn(Event<'_>) -> Result<()>,


### PR DESCRIPTION
Supersedes #3918 by applying the fix mentioned in https://github.com/rust-lang/rustup/pull/3918#issuecomment-2198406869.

I don't really want to test it with the CI since we're removing that part of the code real soon (like in v1.29), and I don't think they are going to change too much before then.

Tested locally with the flags as specified in the title.