### PR TITLE
feat(dist): refine suggestions regarding manifest checksum mismatches

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -293,21 +293,7 @@ impl<'a> Cfg<'a> {
             .map(|t| t.resolve(&default_host_triple))
             .transpose()?;
 
-        let dist_root_server = match non_empty_env_var("RUSTUP_DIST_SERVER", process)? {
-            Some(s) => {
-                trace!("`RUSTUP_DIST_SERVER` has been set to `{s}`");
-                s
-            }
-            None => {
-                // For backward compatibility
-                non_empty_env_var("RUSTUP_DIST_ROOT", process)?
-                    .inspect(|url| trace!("`RUSTUP_DIST_ROOT` has been set to `{url}`"))
-                    .as_ref()
-                    .map(|root| root.trim_end_matches("/dist"))
-                    .unwrap_or(dist::DEFAULT_DIST_SERVER)
-                    .to_owned()
-            }
-        };
+        let dist_root_server = dist_root_server(process)?;
 
         let notify_clone = notify_handler.clone();
         let tmp_cx = temp::Context::new(
@@ -948,6 +934,24 @@ impl<'a> Cfg<'a> {
             LocalToolchainName::Path(p) => p.to_path_buf(),
         }
     }
+}
+
+pub(crate) fn dist_root_server(process: &Process) -> Result<String> {
+    Ok(match non_empty_env_var("RUSTUP_DIST_SERVER", process)? {
+        Some(s) => {
+            trace!("`RUSTUP_DIST_SERVER` has been set to `{s}`");
+            s
+        }
+        None => {
+            // For backward compatibility
+            non_empty_env_var("RUSTUP_DIST_ROOT", process)?
+                .inspect(|url| trace!("`RUSTUP_DIST_ROOT` has been set to `{url}`"))
+                .as_ref()
+                .map(|root| root.trim_end_matches("/dist"))
+                .unwrap_or(dist::DEFAULT_DIST_SERVER)
+                .to_owned()
+        }
+    })
 }
 
 impl<'a> Debug for Cfg<'a> {

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -10,6 +10,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
+use tracing::info;
 
 use crate::{
     config::Cfg, currentprocess::Process, errors::RustupError, toolchain::ToolchainName,
@@ -1169,7 +1170,7 @@ pub(crate) async fn dl_v2_manifest(
         Err(any) => {
             if let Some(RustupError::ChecksumFailed { .. }) = any.downcast_ref::<RustupError>() {
                 // Checksum failed - issue warning to try again later
-                (download.notify_handler)(Notification::ManifestChecksumFailedHack);
+                info!("update not yet available, sorry! try again later")
             }
             Err(any)
         }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1153,9 +1153,7 @@ pub(crate) async fn dl_v2_manifest(
     {
         Ok(manifest_dl) => {
             // Downloaded ok!
-            let (manifest_file, manifest_hash) = if let Some(m) = manifest_dl {
-                m
-            } else {
+            let Some((manifest_file, manifest_hash)) = manifest_dl else {
                 return Ok(None);
             };
             let manifest_str = utils::read_file("manifest", &manifest_file)?;

--- a/src/dist/notifications.rs
+++ b/src/dist/notifications.rs
@@ -32,7 +32,6 @@ pub enum Notification<'a> {
     DownloadingLegacyManifest,
     SkippingNightlyMissingComponent(&'a ToolchainDesc, &'a Manifest, &'a [Component]),
     ForcingUnavailableComponent(&'a str),
-    ManifestChecksumFailedHack,
     ComponentUnavailable(&'a str, Option<&'a TargetTriple>),
     StrayHash(&'a Path),
     SignatureInvalid(&'a str),
@@ -67,7 +66,6 @@ impl<'a> Notification<'a> {
             | RemovingComponent(_, _, _)
             | RemovingOldComponent(_, _, _)
             | ComponentAlreadyInstalled(_)
-            | ManifestChecksumFailedHack
             | RollingBack
             | DownloadingManifest(_)
             | SkippingNightlyMissingComponent(_, _, _)
@@ -150,9 +148,6 @@ impl<'a> Display for Notification<'a> {
                 write!(f, "latest update on {date}, no rust version")
             }
             DownloadingLegacyManifest => write!(f, "manifest not found. trying legacy manifest"),
-            ManifestChecksumFailedHack => {
-                write!(f, "update not yet available, sorry! try again later")
-            }
             ComponentUnavailable(pkg, toolchain) => {
                 if let Some(tc) = toolchain {
                     write!(f, "component '{pkg}' is not available on target '{tc}'")

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -381,7 +381,7 @@ async fn bad_sha_on_manifest() {
     cx.config
         .expect_err(
             &["rustup", "default", "nightly"],
-            "update not yet available",
+            "info: this might indicate an issue with the third-party release server",
         )
         .await;
 }


### PR DESCRIPTION
Closes #3885.

>  I've made the following update to the error messages nonetheless:
> 
> ### Before
> 
> ```console
>     info: syncing channel updates for 'nightly-aarch64-apple-darwin'
>     info: update not yet available, sorry! try again later
>     error: toolchain 'nightly-aarch64-apple-darwin' is not installable
> ```
> 
> ### After
> 
> ```console
>     info: syncing channel updates for 'nightly-aarch64-apple-darwin'
>     warn: checksum failed for <SNIP>, expected: 'aaaaaaaaaa0f87d2df5e0cff356df307b6649a7b0b4effdf4b6dbd15070206de', calculated: '907f97b96e0f87d2df5e0cff356df307b6649a7b0b4effdf4b6dbd15070206de'
>     info: if you are on the official release server, this is most likely due to an update happening right now, please try again later
>     info: if you are on a third-party release server, this might indicate a problem with the server's configuration
>     error: toolchain 'nightly-aarch64-apple-darwin' is not installable
> ```
> 
> _https://github.com/rust-lang/rustup/issues/3885#issuecomment-2212318125_
            