### PR TITLE
feat(cli): warn when removing the default/active toolchain

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1165,7 +1165,7 @@ async fn target_remove(
         let target = TargetTriple::new(target);
         let default_target = cfg.get_default_host_triple()?;
         if target == default_target {
-            warn!("after removing the default host target, proc-macros and build scripts might no longer build");
+            warn!("removing the default host target; proc-macros and build scripts might no longer build");
         }
         // Whether we have at most 1 component target that is not `None` (wildcard).
         let has_at_most_one_target = distributable
@@ -1179,7 +1179,7 @@ async fn target_remove(
             .at_most_one()
             .is_ok();
         if has_at_most_one_target {
-            warn!("after removing the last target, no build targets will be available");
+            warn!("removing the last target; no build targets will be available");
         }
         let new_component = Component::new("rust-std".to_string(), Some(target), false);
         distributable.remove_component(new_component).await?;

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -359,6 +359,15 @@ from_variant!(
     LocalToolchainName::Path
 );
 
+impl PartialEq<ToolchainName> for LocalToolchainName {
+    fn eq(&self, other: &ToolchainName) -> bool {
+        match self {
+            LocalToolchainName::Named(n) => n == other,
+            _ => false,
+        }
+    }
+}
+
 impl Display for LocalToolchainName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1208,10 +1208,12 @@ async fn remove_target_host() {
     cx.config
         .expect_ok(&["rustup", "target", "add", clitools::CROSS_ARCH1])
         .await;
-    cx.config.expect_stderr_ok(
-        &["rustup", "target", "remove", &host],
-        "after removing the default host target, proc-macros and build scripts might no longer build",
-    ).await;
+    cx.config
+        .expect_stderr_ok(
+            &["rustup", "target", "remove", &host],
+            "removing the default host target; proc-macros and build scripts might no longer build",
+        )
+        .await;
     let path = format!("toolchains/nightly-{host}/lib/rustlib/{host}/lib/libstd.rlib");
     assert!(!cx.config.rustupdir.has(path));
     let path = format!("toolchains/nightly-{host}/lib/rustlib/{host}/lib");
@@ -1228,7 +1230,7 @@ async fn remove_target_last() {
     cx.config
         .expect_stderr_ok(
             &["rustup", "target", "remove", &host],
-            "after removing the last target, no build targets will be available",
+            "removing the last target; no build targets will be available",
         )
         .await;
 }


### PR DESCRIPTION
Continuation of #3637, addresses the concern 3) in https://github.com/rust-lang/rustup/issues/3319.

Closes #3319.