### PR TITLE
chore(deps/renovate): set `prCreation` to `immediate`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,7 +10,7 @@
         "enabled": true,
         "automerge": true
     },
-    "prCreation": "not-pending",
+    "prCreation": "immediate",
     "rangeStrategy": "update-lockfile",
     "stabilityDays": 3,
     "github-actions": {


### PR DESCRIPTION
Closes #3927 by directly applying the fix proposed in https://github.com/renovatebot/renovate/issues/17332#issuecomment-1224192444.

See https://docs.renovatebot.com/configuration-options/#prcreation for the actual semantics of this option.

PS: As always, we have no means to verify this change other than observing what will happen after merging it.