### PR TITLE
Grant GitHub Actions workflows access to OIDC token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,9 @@ jobs:
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }} # skip-master skip-stable
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -178,6 +181,9 @@ jobs:
     if: ${{ (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'schedule' }} # skip-pr skip-stable
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -332,6 +338,9 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -490,6 +499,9 @@ jobs:
   build-linux-pr: # job-name skip-master skip-stable
     runs-on: ubuntu-latest
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }} # skip-master skip-stable
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -646,6 +658,9 @@ jobs:
   build-linux-master: # job-name skip-pr skip-stable
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'schedule' }} # skip-pr skip-stable
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -807,6 +822,9 @@ jobs:
   build-linux-stable: # job-name skip-master skip-pr
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -990,6 +1008,9 @@ jobs:
     runs-on: macos-13 # skip-aarch64
     env: # skip-aarch64
       MACOSX_DEPLOYMENT_TARGET: 10.12 # skip-aarch64
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         mode:
@@ -1118,6 +1139,9 @@ jobs:
     runs-on: macos-latest # skip-x86_64
     env: # skip-x86_64
       MACOSX_DEPLOYMENT_TARGET: 11.0 # skip-x86_64
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         mode:

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -9,6 +9,9 @@ jobs: # skip-master skip-pr skip-stable
     if: ${{ contains('["pull_request", "merge_group"]', github.event_name) }} # skip-master skip-stable
     if: ${{ (github.event_name == 'push' && github.ref_name == 'master') || github.event_name == 'schedule' }} # skip-pr skip-stable
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -10,6 +10,9 @@ jobs: # skip-x86_64 skip-aarch64
     runs-on: macos-13 # skip-aarch64
     env: # skip-aarch64
       MACOSX_DEPLOYMENT_TARGET: 10.12 # skip-aarch64
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         mode:

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -11,6 +11,9 @@ jobs: # skip-master skip-pr skip-stable
     if: ${{ github.event_name == 'push' && github.ref_name == 'stable' }} # skip-pr skip-master
     env:
       RUSTFLAGS: -Ctarget-feature=+crt-static
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
In #3909, new steps were added to the GitHub Actions workflows that upload the build artifacts to a new S3 bucket. Authentication is done using short-lived tokens that are provisioned using OIDC. This scheme requires additional permissions[^1], which have been granted to the workflows.

[^1]: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect#adding-permissions-settings