### PR TITLE
Prepare deployment on master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -141,11 +141,11 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
       - name: Acquire the AWS tooling
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           choco upgrade awscli
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           .\ci\prepare-deploy.ps1
         shell: powershell
@@ -298,11 +298,11 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
       - name: Acquire the AWS tooling
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           choco upgrade awscli
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           .\ci\prepare-deploy.ps1
         shell: powershell
@@ -461,11 +461,11 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
       - name: Acquire the AWS tooling
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           choco upgrade awscli
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           .\ci\prepare-deploy.ps1
         shell: powershell
@@ -620,12 +620,12 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team
@@ -784,12 +784,12 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team
@@ -969,12 +969,12 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team
@@ -1094,12 +1094,12 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team
@@ -1225,12 +1225,12 @@ jobs:
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -157,12 +157,12 @@ jobs: # skip-master skip-pr skip-stable
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -97,12 +97,12 @@ jobs: # skip-x86_64 skip-aarch64
             target/${{ matrix.target }}/release/rustup-init
           retention-days: 7
       - name: Ensure that awscli is installed
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           which aws
           aws --version
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           bash ci/prepare-deploy.bash
       - name: Deploy build to dev-static dist tree for release team

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -134,11 +134,11 @@ jobs: # skip-master skip-pr skip-stable
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
       - name: Acquire the AWS tooling
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           choco upgrade awscli
       - name: Prepare the dist
-        if: github.event_name == 'push' && github.ref == 'refs/heads/stable' && matrix.mode == 'release'
+        if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
           .\ci\prepare-deploy.ps1
         shell: powershell


### PR DESCRIPTION
We added steps to the GitHub Actions workflows in #3909 to upload the build artifacts for the `master` branch as well as for the `stable` branch. But the scripts that prepare the `deploy/` directory were not set to run on `master`, causing the builds to fail.