### PR TITLE
Fix uploading of Windows build artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,7 +166,7 @@ jobs:
       - name: Deploy build to rustup-builds bucket for release team
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.mode == 'release'
         run: |
-          aws --debug s3 cp --recursive deploy/ s3://rustup-builds/${{ github.sha }}
+          aws --debug s3 cp --recursive dist s3://rustup-builds/${{ github.sha }}
         env:
           AWS_DEFAULT_REGION: us-east-1
       - name: Clear the cargo caches
@@ -323,7 +323,7 @@ jobs:
       - name: Deploy build to rustup-builds bucket for release team
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.mode == 'release'
         run: |
-          aws --debug s3 cp --recursive deploy/ s3://rustup-builds/${{ github.sha }}
+          aws --debug s3 cp --recursive dist s3://rustup-builds/${{ github.sha }}
         env:
           AWS_DEFAULT_REGION: us-east-1
       - name: Clear the cargo caches
@@ -486,7 +486,7 @@ jobs:
       - name: Deploy build to rustup-builds bucket for release team
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.mode == 'release'
         run: |
-          aws --debug s3 cp --recursive deploy/ s3://rustup-builds/${{ github.sha }}
+          aws --debug s3 cp --recursive dist s3://rustup-builds/${{ github.sha }}
         env:
           AWS_DEFAULT_REGION: us-east-1
       - name: Clear the cargo caches

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -159,7 +159,7 @@ jobs: # skip-master skip-pr skip-stable
       - name: Deploy build to rustup-builds bucket for release team
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.mode == 'release'
         run: |
-          aws --debug s3 cp --recursive deploy/ s3://rustup-builds/${{ github.sha }}
+          aws --debug s3 cp --recursive dist s3://rustup-builds/${{ github.sha }}
         env:
           AWS_DEFAULT_REGION: us-east-1
       - name: Clear the cargo caches


### PR DESCRIPTION
On Windows, the `dist` folder is uploaded at the end of the build. This wasn't taken into consideration when introducing the new S3 bucket in