### PR TITLE
Fix home_dir() and current_dir() regression

### DIFF
--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -20,9 +20,9 @@ order. Any file that is not grouped like this can be rearranged whenever the
 file is touched - we're not precious about having it done in a separate commit,
 though that is helpful.
 
-## No direct use of process state outside rustup::currentprocess
+## No direct use of process state outside rustup::process
 
-The `rustup::currentprocess` module abstracts the global state that is
+The `rustup::process` module abstracts the global state that is
 `std::env::args`, `std::env::vars`, `std::io::std*`, `std::process::id`,
 `std::env::current_dir` and `std::process::exit` permitting threaded tests of
 the CLI logic; use `process()` rather than those APIs directly.

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -29,10 +29,10 @@ use rustup::cli::rustup_mode;
 #[cfg(windows)]
 use rustup::cli::self_update;
 use rustup::cli::setup_mode;
-use rustup::currentprocess::Process;
 use rustup::env_var::RUST_RECURSION_COUNT_MAX;
 use rustup::errors::RustupError;
 use rustup::is_proxyable_tools;
+use rustup::process::Process;
 use rustup::utils::utils;
 
 #[tokio::main]

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -15,11 +15,11 @@ use tracing::{debug, error, info, trace, warn};
 
 use super::self_update;
 use crate::cli::download_tracker::DownloadTracker;
-use crate::currentprocess::{terminalsource, Process};
 use crate::dist::{
     manifest::ComponentStatus, notifications as dist_notifications, TargetTriple, ToolchainDesc,
 };
 use crate::install::UpdateStatus;
+use crate::process::{terminalsource, Process};
 use crate::toolchain::{DistributableToolchain, LocalToolchainName, Toolchain, ToolchainName};
 use crate::utils::notifications as util_notifications;
 use crate::utils::notify::NotificationLevel;

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -3,9 +3,9 @@ use std::fmt;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
-use crate::currentprocess::{terminalsource, Process};
 use crate::dist::Notification as In;
 use crate::notifications::Notification;
+use crate::process::{terminalsource, Process};
 use crate::utils::units::{Size, Unit, UnitMode};
 use crate::utils::Notification as Un;
 

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::{
     reload, EnvFilter, Layer, Registry,
 };
 
-use crate::{currentprocess::Process, utils::notify::NotificationLevel};
+use crate::{process::Process, utils::notify::NotificationLevel};
 
 pub fn tracing_subscriber(
     process: &Process,

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use pulldown_cmark::{Event, Tag, TagEnd};
 
-use crate::currentprocess::terminalsource::{Attr, Color, ColorableTerminal};
+use crate::process::terminalsource::{Attr, Color, ColorableTerminal};
 
 // Handles the wrapping of text written to the console
 struct LineWrapper<'a> {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::{
     cli::{common::set_globals, job, self_update},
     command::run_command_for_dir,
-    currentprocess::Process,
+    process::Process,
     toolchain::ResolvableLocalToolchainName,
 };
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -21,16 +21,16 @@ use crate::{
     },
     command,
     config::{ActiveReason, Cfg},
-    currentprocess::{
-        terminalsource::{self, ColorableTerminal},
-        Process,
-    },
     dist::{
         manifest::{Component, ComponentStatus},
         PartialToolchainDesc, Profile, TargetTriple,
     },
     errors::RustupError,
     install::{InstallMethod, UpdateStatus},
+    process::{
+        terminalsource::{self, ColorableTerminal},
+        Process,
+    },
     toolchain::{
         CustomToolchainName, DistributableToolchain, LocalToolchainName,
         MaybeResolvableToolchainName, ResolvableLocalToolchainName, ResolvableToolchainName,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -55,10 +55,10 @@ use crate::{
         markdown::md,
     },
     config::Cfg,
-    currentprocess::{terminalsource, Process},
     dist::{self, PartialToolchainDesc, Profile, TargetTriple, ToolchainDesc},
     errors::RustupError,
     install::UpdateStatus,
+    process::{terminalsource, Process},
     toolchain::{
         DistributableToolchain, MaybeOfficialToolchainName, ResolvableToolchainName, Toolchain,
         ToolchainName,
@@ -1257,7 +1257,7 @@ mod tests {
     use crate::cli::self_update::InstallOpts;
     use crate::dist::{PartialToolchainDesc, Profile};
     use crate::test::{test_dir, with_rustup_home, Env};
-    use crate::{currentprocess::TestProcess, for_host};
+    use crate::{for_host, process::TestProcess};
 
     #[test]
     fn default_toolchain_is_stable() {

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -29,7 +29,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 
 use super::utils;
-use crate::currentprocess::Process;
+use crate::process::Process;
 
 pub(crate) type Shell = Box<dyn UnixShell>;
 

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -6,7 +6,7 @@ use tracing::{error, warn};
 
 use super::install_bins;
 use super::shell;
-use crate::currentprocess::Process;
+use crate::process::Process;
 use crate::utils::utils;
 use crate::utils::Notification;
 

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -22,8 +22,8 @@ use super::super::errors::*;
 use super::common;
 use super::{install_bins, report_error, InstallOpts};
 use crate::cli::{download_tracker::DownloadTracker, markdown::md};
-use crate::currentprocess::{terminalsource::ColorableTerminal, Process};
 use crate::dist::TargetTriple;
+use crate::process::{terminalsource::ColorableTerminal, Process};
 use crate::utils::utils;
 use crate::utils::Notification;
 
@@ -890,7 +890,7 @@ impl RegistryValueId {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::currentprocess::TestProcess;
+    use crate::process::TestProcess;
 
     fn wide(str: &str) -> Vec<u16> {
         OsString::from(str).encode_wide().collect()

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -10,8 +10,8 @@ use crate::{
         common,
         self_update::{self, InstallOpts},
     },
-    currentprocess::Process,
     dist::Profile,
+    process::Process,
     toolchain::MaybeOfficialToolchainName,
     utils::utils,
 };

--- a/src/command.rs
+++ b/src/command.rs
@@ -19,7 +19,7 @@ pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
 
     // FIXME rust-lang/rust#32254. It's not clear to me
     // when and why this is needed.
-    // TODO: currentprocess support for mocked file descriptor inheritance here: until
+    // TODO: process support for mocked file descriptor inheritance here: until
     // then tests that depend on rustups stdin being inherited won't work in-process.
     cmd.stdin(process::Stdio::inherit());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,12 +12,12 @@ use tracing::trace;
 
 use crate::{
     cli::self_update::SelfUpdateMode,
-    currentprocess::Process,
     dist::{self, download::DownloadCfg, temp, PartialToolchainDesc, Profile, ToolchainDesc},
     errors::RustupError,
     fallback_settings::FallbackSettings,
     install::UpdateStatus,
     notifications::*,
+    process::Process,
     settings::{MetadataVersion, Settings, SettingsFile},
     toolchain::{
         CustomToolchainName, DistributableToolchain, LocalToolchainName, PathBasedToolchainName,

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -145,11 +145,7 @@ impl home::env::Env for Process {
     }
 
     fn var_os(&self, key: &str) -> Option<OsString> {
-        match self {
-            Process::OSProcess(_) => self.var_os(key),
-            #[cfg(feature = "test")]
-            Process::TestProcess(_) => self.var_os(key),
-        }
+        self.var_os(key)
     }
 }
 

--- a/src/currentprocess.rs
+++ b/src/currentprocess.rs
@@ -130,17 +130,17 @@ impl Process {
 impl home::env::Env for Process {
     fn home_dir(&self) -> Option<PathBuf> {
         match self {
-            Process::OSProcess(_) => self.var("HOME").ok().map(|v| v.into()),
+            Process::OSProcess(_) => home::env::OS_ENV.home_dir(),
             #[cfg(feature = "test")]
-            Process::TestProcess(_) => home::env::OS_ENV.home_dir(),
+            Process::TestProcess(_) => self.var("HOME").ok().map(|v| v.into()),
         }
     }
 
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
         match self {
-            Process::OSProcess(_) => self.current_dir(),
+            Process::OSProcess(_) => home::env::OS_ENV.current_dir(),
             #[cfg(feature = "test")]
-            Process::TestProcess(_) => home::env::OS_ENV.current_dir(),
+            Process::TestProcess(_) => self.current_dir(),
         }
     }
 

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -66,7 +66,7 @@ use std::{fmt::Debug, fs::OpenOptions};
 
 use anyhow::{Context, Result};
 
-use crate::currentprocess::Process;
+use crate::process::Process;
 use crate::utils::notifications::Notification;
 use threaded::PoolReference;
 

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use anyhow::Result;
 
 use super::{get_executor, Executor, Item, Kind};
-use crate::currentprocess::TestProcess;
+use crate::process::TestProcess;
 use crate::test::test_dir;
 
 impl Item {

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -7,11 +7,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
 
-use crate::currentprocess::Process;
 use crate::dist::component::package::{INSTALLER_VERSION, VERSION_FILE};
 use crate::dist::component::transaction::Transaction;
 use crate::dist::prefix::InstallPrefix;
 use crate::errors::RustupError;
+use crate::process::Process;
 use crate::utils::utils;
 
 const COMPONENTS_FILE: &str = "components";

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -12,12 +12,12 @@ use anyhow::{anyhow, bail, Context, Result};
 use tar::EntryType;
 use tracing::warn;
 
-use crate::currentprocess::Process;
 use crate::diskio::{get_executor, CompletedIo, Executor, FileBuffer, Item, Kind, IO_CHUNK_SIZE};
 use crate::dist::component::components::*;
 use crate::dist::component::transaction::*;
 use crate::dist::temp;
 use crate::errors::*;
+use crate::process::Process;
 use crate::utils::notifications::Notification;
 use crate::utils::utils;
 

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -2,13 +2,13 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
-use crate::currentprocess::TestProcess;
 use crate::dist::component::Transaction;
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
 use crate::dist::Notification;
 use crate::dist::DEFAULT_DIST_SERVER;
 use crate::errors::RustupError;
+use crate::process::TestProcess;
 use crate::utils::raw as utils_raw;
 use crate::utils::utils;
 

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -14,11 +14,11 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 
-use crate::currentprocess::Process;
 use crate::dist::notifications::*;
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
 use crate::errors::*;
+use crate::process::Process;
 use crate::utils::utils;
 
 /// A Transaction tracks changes to the file system, allowing them to

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -6,10 +6,10 @@ use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
 use url::Url;
 
-use crate::currentprocess::Process;
 use crate::dist::notifications::*;
 use crate::dist::temp;
 use crate::errors::*;
+use crate::process::Process;
 use crate::utils::utils;
 
 const UPDATE_HASH_LEN: usize = 20;

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -9,7 +9,6 @@ use std::path::Path;
 use anyhow::{anyhow, bail, Context, Result};
 use tokio_retry::{strategy::FixedInterval, RetryIf};
 
-use crate::currentprocess::Process;
 use crate::dist::component::{
     Components, Package, TarGzPackage, TarXzPackage, TarZStdPackage, Transaction,
 };
@@ -21,6 +20,7 @@ use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
 use crate::dist::{Profile, TargetTriple, DEFAULT_DIST_SERVER};
 use crate::errors::RustupError;
+use crate::process::Process;
 use crate::utils::utils;
 
 pub(crate) const DIST_MANIFEST: &str = "multirust-channel-manifest.toml";

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -15,7 +15,6 @@ use anyhow::{anyhow, Result};
 use url::Url;
 
 use crate::{
-    currentprocess::TestProcess,
     dist::{
         download::DownloadCfg,
         manifest::{Component, Manifest},
@@ -24,6 +23,7 @@ use crate::{
         temp, Notification, Profile, TargetTriple, ToolchainDesc, DEFAULT_DIST_SERVER,
     },
     errors::RustupError,
+    process::TestProcess,
     test::mock::{dist::*, MockComponentBuilder, MockFile, MockInstallerBuilder},
     utils::{raw as utils_raw, utils},
 };

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -14,8 +14,8 @@ use tracing::{info, warn};
 
 use crate::{
     config::{dist_root_server, Cfg},
-    currentprocess::Process,
     errors::RustupError,
+    process::Process,
     toolchain::ToolchainName,
     utils::utils,
 };

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-use crate::currentprocess::Process;
+use crate::process::Process;
 
 pub const RUST_RECURSION_COUNT_MAX: u32 = 20;
 
@@ -49,7 +49,7 @@ mod tests {
     use super::*;
     #[cfg(windows)]
     use crate::cli::self_update::{RegistryGuard, USER_PATH};
-    use crate::currentprocess::TestProcess;
+    use crate::process::TestProcess;
     use crate::test::Env;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,6 @@ fn component_for_bin(binary: &str) -> Option<&'static str> {
 pub mod cli;
 mod command;
 mod config;
-pub mod currentprocess;
 mod diskio;
 pub mod dist;
 pub mod env_var;
@@ -80,6 +79,7 @@ pub mod errors;
 mod fallback_settings;
 mod install;
 pub mod notifications;
+pub mod process;
 mod settings;
 #[cfg(feature = "test")]
 pub mod test;

--- a/src/process.rs
+++ b/src/process.rs
@@ -24,14 +24,14 @@ pub mod terminalsource;
 /// Allows concrete types for the process abstraction.
 #[derive(Clone, Debug)]
 pub enum Process {
-    OSProcess(OSProcess),
+    OsProcess(OsProcess),
     #[cfg(feature = "test")]
     TestProcess(TestContext),
 }
 
 impl Process {
     pub fn os() -> Self {
-        Self::OSProcess(OSProcess::new())
+        Self::OsProcess(OsProcess::new())
     }
 
     pub fn name(&self) -> Option<String> {
@@ -61,7 +61,7 @@ impl Process {
 
     pub fn var(&self, key: &str) -> Result<String, env::VarError> {
         match self {
-            Process::OSProcess(_) => env::var(key),
+            Process::OsProcess(_) => env::var(key),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => match p.vars.get(key) {
                 Some(val) => Ok(val.to_owned()),
@@ -72,7 +72,7 @@ impl Process {
 
     pub(crate) fn var_os(&self, key: &str) -> Option<OsString> {
         match self {
-            Process::OSProcess(_) => env::var_os(key),
+            Process::OsProcess(_) => env::var_os(key),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => p.vars.get(key).map(OsString::from),
         }
@@ -80,7 +80,7 @@ impl Process {
 
     pub(crate) fn args(&self) -> Box<dyn Iterator<Item = String> + '_> {
         match self {
-            Process::OSProcess(_) => Box::new(env::args()),
+            Process::OsProcess(_) => Box::new(env::args()),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Box::new(p.args.iter().cloned()),
         }
@@ -88,7 +88,7 @@ impl Process {
 
     pub(crate) fn args_os(&self) -> Box<dyn Iterator<Item = OsString> + '_> {
         match self {
-            Process::OSProcess(_) => Box::new(env::args_os()),
+            Process::OsProcess(_) => Box::new(env::args_os()),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Box::new(p.args.iter().map(OsString::from)),
         }
@@ -96,7 +96,7 @@ impl Process {
 
     pub(crate) fn stdin(&self) -> Box<dyn filesource::Stdin> {
         match self {
-            Process::OSProcess(_) => Box::new(io::stdin()),
+            Process::OsProcess(_) => Box::new(io::stdin()),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Box::new(filesource::TestStdin(p.stdin.clone())),
         }
@@ -104,7 +104,7 @@ impl Process {
 
     pub(crate) fn stdout(&self) -> Box<dyn filesource::Writer> {
         match self {
-            Process::OSProcess(_) => Box::new(io::stdout()),
+            Process::OsProcess(_) => Box::new(io::stdout()),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Box::new(filesource::TestWriter(p.stdout.clone())),
         }
@@ -112,7 +112,7 @@ impl Process {
 
     pub(crate) fn stderr(&self) -> Box<dyn filesource::Writer> {
         match self {
-            Process::OSProcess(_) => Box::new(io::stderr()),
+            Process::OsProcess(_) => Box::new(io::stderr()),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Box::new(filesource::TestWriter(p.stderr.clone())),
         }
@@ -120,7 +120,7 @@ impl Process {
 
     pub fn current_dir(&self) -> io::Result<PathBuf> {
         match self {
-            Process::OSProcess(_) => env::current_dir(),
+            Process::OsProcess(_) => env::current_dir(),
             #[cfg(feature = "test")]
             Process::TestProcess(p) => Ok(p.cwd.clone()),
         }
@@ -130,7 +130,7 @@ impl Process {
 impl home::env::Env for Process {
     fn home_dir(&self) -> Option<PathBuf> {
         match self {
-            Process::OSProcess(_) => home::env::OS_ENV.home_dir(),
+            Process::OsProcess(_) => home::env::OS_ENV.home_dir(),
             #[cfg(feature = "test")]
             Process::TestProcess(_) => self.var("HOME").ok().map(|v| v.into()),
         }
@@ -138,7 +138,7 @@ impl home::env::Env for Process {
 
     fn current_dir(&self) -> Result<PathBuf, io::Error> {
         match self {
-            Process::OSProcess(_) => home::env::OS_ENV.current_dir(),
+            Process::OsProcess(_) => home::env::OS_ENV.current_dir(),
             #[cfg(feature = "test")]
             Process::TestProcess(_) => self.current_dir(),
         }
@@ -152,23 +152,23 @@ impl home::env::Env for Process {
 // ----------- real process -----------------
 
 #[derive(Clone, Debug)]
-pub struct OSProcess {
+pub struct OsProcess {
     pub(self) stderr_is_a_tty: bool,
     pub(self) stdout_is_a_tty: bool,
 }
 
-impl OSProcess {
+impl OsProcess {
     pub fn new() -> Self {
-        OSProcess {
+        OsProcess {
             stderr_is_a_tty: io::stderr().is_terminal(),
             stdout_is_a_tty: io::stdout().is_terminal(),
         }
     }
 }
 
-impl Default for OSProcess {
+impl Default for OsProcess {
     fn default() -> Self {
-        OSProcess::new()
+        OsProcess::new()
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -21,7 +21,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 pub mod filesource;
 pub mod terminalsource;
 
-/// Allows concrete types for the currentprocess abstraction.
+/// Allows concrete types for the process abstraction.
 #[derive(Clone, Debug)]
 pub enum Process {
     OSProcess(OSProcess),

--- a/src/process/filesource.rs
+++ b/src/process/filesource.rs
@@ -48,7 +48,7 @@ impl WriterLock for io::StdoutLock<'_> {}
 impl Writer for io::Stdout {
     fn is_a_tty(&self, process: &Process) -> bool {
         match process {
-            crate::process::Process::OSProcess(p) => p.stdout_is_a_tty,
+            crate::process::Process::OsProcess(p) => p.stdout_is_a_tty,
             #[cfg(feature = "test")]
             crate::process::Process::TestProcess(_) => unreachable!(),
         }
@@ -68,7 +68,7 @@ impl WriterLock for io::StderrLock<'_> {}
 impl Writer for io::Stderr {
     fn is_a_tty(&self, process: &Process) -> bool {
         match process {
-            crate::process::Process::OSProcess(p) => p.stderr_is_a_tty,
+            crate::process::Process::OsProcess(p) => p.stderr_is_a_tty,
             #[cfg(feature = "test")]
             crate::process::Process::TestProcess(_) => unreachable!(),
         }

--- a/src/process/filesource.rs
+++ b/src/process/filesource.rs
@@ -1,7 +1,7 @@
 use std::io::{self, BufRead, Read, Write};
 
 use super::terminalsource::{ColorableTerminal, StreamSelector};
-use crate::currentprocess::Process;
+use crate::process::Process;
 
 /// Stand-in for std::io::Stdin
 pub trait Stdin {
@@ -48,9 +48,9 @@ impl WriterLock for io::StdoutLock<'_> {}
 impl Writer for io::Stdout {
     fn is_a_tty(&self, process: &Process) -> bool {
         match process {
-            crate::currentprocess::Process::OSProcess(p) => p.stdout_is_a_tty,
+            crate::process::Process::OSProcess(p) => p.stdout_is_a_tty,
             #[cfg(feature = "test")]
-            crate::currentprocess::Process::TestProcess(_) => unreachable!(),
+            crate::process::Process::TestProcess(_) => unreachable!(),
         }
     }
 
@@ -68,9 +68,9 @@ impl WriterLock for io::StderrLock<'_> {}
 impl Writer for io::Stderr {
     fn is_a_tty(&self, process: &Process) -> bool {
         match process {
-            crate::currentprocess::Process::OSProcess(p) => p.stderr_is_a_tty,
+            crate::process::Process::OSProcess(p) => p.stderr_is_a_tty,
             #[cfg(feature = "test")]
-            crate::currentprocess::Process::TestProcess(_) => unreachable!(),
+            crate::process::Process::TestProcess(_) => unreachable!(),
         }
     }
 

--- a/src/process/terminalsource.rs
+++ b/src/process/terminalsource.rs
@@ -228,7 +228,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::currentprocess::TestProcess;
+    use crate::process::TestProcess;
     use crate::test::Env;
 
     #[test]

--- a/src/process/terminalsource.rs
+++ b/src/process/terminalsource.rs
@@ -27,12 +27,12 @@ impl StreamSelector {
     fn is_a_tty(&self, process: &Process) -> bool {
         match self {
             StreamSelector::Stdout => match process {
-                Process::OSProcess(p) => p.stdout_is_a_tty,
+                Process::OsProcess(p) => p.stdout_is_a_tty,
                 #[cfg(feature = "test")]
                 Process::TestProcess(_) => unreachable!(),
             },
             StreamSelector::Stderr => match process {
-                Process::OSProcess(p) => p.stderr_is_a_tty,
+                Process::OsProcess(p) => p.stderr_is_a_tty,
                 #[cfg(feature = "test")]
                 Process::TestProcess(_) => unreachable!(),
             },

--- a/src/test.rs
+++ b/src/test.rs
@@ -15,8 +15,8 @@ use std::process::Command;
 #[cfg(test)]
 use anyhow::Result;
 
-use crate::currentprocess::TestProcess;
 use crate::dist::TargetTriple;
+use crate::process::TestProcess;
 
 #[cfg(windows)]
 pub use crate::cli::self_update::{get_path, RegistryGuard, RegistryValueId, USER_PATH};
@@ -112,15 +112,15 @@ fn tempdir_in_with_prefix<P: AsRef<Path>>(path: P, prefix: &str) -> io::Result<P
 /// ... perhaps this is so that the test data we have is only exercised on known
 /// triples?
 ///
-/// NOTE: This *cannot* be called within a currentprocess context as it creates
+/// NOTE: This *cannot* be called within a process context as it creates
 /// its own context on Windows hosts. This is partly by chance but also partly
 /// deliberate: If you need the host triple, or to call for_host(), you can do
-/// so outside of calls to run() or unit test code that runs in a currentprocess
+/// so outside of calls to run() or unit test code that runs in a process
 /// context.
 ///
 /// IF it becomes very hard to workaround that, then we can either make a second
-/// this_host_triple that doesn't make its own currentprocess or use
-/// TargetTriple::from_host() from within the currentprocess context as needed.
+/// this_host_triple that doesn't make its own process or use
+/// TargetTriple::from_host() from within the process context as needed.
 pub fn this_host_triple() -> String {
     if cfg!(target_os = "windows") {
         // For windows, this host may be different to the target: we may be

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -22,7 +22,7 @@ use tempfile::TempDir;
 use url::Url;
 
 use crate::cli::rustup_mode;
-use crate::currentprocess;
+use crate::process;
 use crate::test as rustup_test;
 use crate::test::const_dist_dir;
 use crate::test::this_host_triple;
@@ -797,7 +797,7 @@ impl Config {
             );
         }
 
-        let tp = currentprocess::TestProcess::new(&*self.workdir.borrow(), &arg_strings, vars, "");
+        let tp = process::TestProcess::new(&*self.workdir.borrow(), &arg_strings, vars, "");
         let process_res = rustup_mode::main(tp.process.current_dir().unwrap(), &tp.process).await;
         // convert Err's into an ec
         let ec = match process_res {

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::str;
 
 #[cfg(not(windows))]
-use crate::currentprocess::Process;
+use crate::process::Process;
 
 pub(crate) fn ensure_dir_exists<P: AsRef<Path>, F: FnOnce(&Path)>(
     path: P,

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -10,8 +10,8 @@ use retry::{retry, OperationResult};
 use sha2::Sha256;
 use url::Url;
 
-use crate::currentprocess::Process;
 use crate::errors::*;
+use crate::process::Process;
 use crate::utils::notifications::Notification;
 use crate::utils::raw;
 

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,7 +1,6 @@
 use std::fs::File;
 use std::io::Write;
 
-use rustup::currentprocess::TestProcess;
 use rustup::dist::component::Components;
 use rustup::dist::component::Transaction;
 use rustup::dist::component::{DirectoryPackage, Package};
@@ -9,6 +8,7 @@ use rustup::dist::prefix::InstallPrefix;
 use rustup::dist::temp;
 use rustup::dist::Notification;
 use rustup::dist::DEFAULT_DIST_SERVER;
+use rustup::process::TestProcess;
 use rustup::utils::utils;
 
 use rustup::test::mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};


### PR DESCRIPTION
In #3764 (specifically https://github.com/rust-lang/rustup/commit/204c8a9ca4e8a516865e381262a16b9eacb53901), I moved a bunch of code around and in the process mixed up the `OS` and `Test` cases. Fix my mistake.

Thanks @ChrisDenton for paying attention and bisecting!

As discussed in #3936.