### PR TITLE
Add help message for missing toolchain

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -86,7 +86,14 @@ pub enum RustupError {
     RunningCommand { name: OsString },
     #[error("toolchain '{0}' is not installable")]
     ToolchainNotInstallable(String),
-    #[error("toolchain '{0}' is not installed")]
+    #[error(
+        "toolchain '{0}' is not installed{}",
+        if let ToolchainName::Official(t) = .0 {
+            format!("\nhelp: run `rustup toolchain install {t}` to install it")
+        } else {
+            String::new()
+        },
+    )]
     ToolchainNotInstalled(ToolchainName),
     #[error("path '{0}' not found")]
     PathToolchainNotInstalled(PathBasedToolchainName),

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -691,6 +691,23 @@ info: installing component 'rust-std' for '{0}'
         .await;
 }
 
+// issue #3573
+#[tokio::test]
+async fn show_suggestion_for_missing_toolchain() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect_err_ex(
+            &["cargo", "+nightly", "fmt"],
+            r"",
+            for_host!(
+                r"error: toolchain 'nightly-{0}' is not installed
+help: run `rustup toolchain install nightly-{0}` to install it
+"
+            ),
+        )
+        .await;
+}
+
 // issue #927
 #[tokio::test]
 async fn undefined_linked_toolchain() {


### PR DESCRIPTION
Closes #3573.

This patch adds a suggestion to run `rustup install <toolchain>` for missing toolchain.