### PR TITLE
fix(rustup-mode)!: don't install toolchain on `rustup --version`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -548,12 +548,9 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
             let mut cfg = common::set_globals(current_dir, false, true, process)?;
             match cfg.active_rustc_version() {
-                Ok(Some(version)) => info!("The currently active `rustc` version is `{}`", version),
+                Ok(Some(version)) => info!("The currently active `rustc` version is `{version}`"),
                 Ok(None) => info!("No `rustc` is currently active"),
-                Err(err) => trace!(
-                    "Wanted to tell you the current rustc version, too, but ran into this error: {}",
-                    err
-                ),
+                Err(err) => trace!("Failed to display the current `rustc` version: {err}"),
             }
             return Ok(utils::ExitCode(0));
         }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -547,9 +547,13 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
             write!(process.stdout().lock(), "{err}")?;
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
             let mut cfg = common::set_globals(current_dir, false, true, process)?;
-            match cfg.active_rustc_version().await {
-                Ok(version) => info!("The currently active `rustc` version is `{}`", version),
-                Err(err) => trace!("Wanted to tell you the current rustc version, too, but ran into this error: {}", err),
+            match cfg.active_rustc_version() {
+                Ok(Some(version)) => info!("The currently active `rustc` version is `{}`", version),
+                Ok(None) => info!("No `rustc` is currently active"),
+                Err(err) => trace!(
+                    "Wanted to tell you the current rustc version, too, but ran into this error: {}",
+                    err
+                ),
             }
             return Ok(utils::ExitCode(0));
         }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -22,24 +22,24 @@ async fn smoke_test() {
 #[tokio::test]
 async fn version_mentions_rustc_version_confusion() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = cx.config.run("rustup", vec!["--version"], &[]).await;
-    assert!(out.ok);
-    assert!(out
-        .stderr
-        .contains("This is the version for the rustup toolchain manager"));
+
+    cx.config
+        .expect_stderr_ok(
+            &["rustup", "--version"],
+            "This is the version for the rustup toolchain manager",
+        )
+        .await;
 
     cx.config
         .expect_ok(&["rustup", "toolchain", "install", "nightly"])
         .await;
 
-    let out = cx
-        .config
-        .run("rustup", vec!["+nightly", "--version"], &[])
+    cx.config
+        .expect_stderr_ok(
+            &["rustup", "+nightly", "--version"],
+            "The currently active `rustc` version is `1.3.0",
+        )
         .await;
-    assert!(out.ok);
-    assert!(out
-        .stderr
-        .contains("The currently active `rustc` version is `1.3.0"));
 }
 
 #[tokio::test]

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -21,12 +21,16 @@ async fn smoke_test() {
 
 #[tokio::test]
 async fn version_mentions_rustc_version_confusion() {
-    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let out = cx.config.run("rustup", vec!["--version"], &[]).await;
     assert!(out.ok);
     assert!(out
         .stderr
         .contains("This is the version for the rustup toolchain manager"));
+
+    cx.config
+        .expect_ok(&["rustup", "toolchain", "install", "nightly"])
+        .await;
 
     let out = cx
         .config


### PR DESCRIPTION
Supersedes #2658.