### PR TITLE
chore(deps/renovate): update `automerge` schedule for `lockFileMaintenance`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,10 @@
     ],
     "lockFileMaintenance": {
         "enabled": true,
-        "automerge": true
+        "automerge": true,
+        "schedule": "before 4am on Monday",
+        "automergeSchedule": "after 4am on Monday",
+        "platformAutomerge": false
     },
     "prCreation": "immediate",
     "rangeStrategy": "update-lockfile",


### PR DESCRIPTION
Follow-up of #3928.

Tries to address the concern raised in https://github.com/rust-lang/rustup/pull/3949#issuecomment-2227630908 regarding too many "lock file maintenance" PRs being created.

The basic idea is that we should only auto-merge after the update schedule, but for this to take effect, we [have to disable `platformAutomerge`](https://docs.renovatebot.com/configuration-options/#automergeschedule).

I have no idea if this would work at all, we'll have to wait for next Monday to see.