### PR TITLE
fix(rustup-mode): return `ExitCode(1)` when `update()` fails

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -308,13 +308,14 @@ pub(crate) async fn update_all_channels(
                 .collect();
             show_channel_updates(cfg, t)?;
         }
-        Ok(utils::ExitCode(0))
+        Ok(())
     };
 
     if do_self_update {
         self_update(show_channel_updates, cfg.process).await
     } else {
-        show_channel_updates()
+        show_channel_updates()?;
+        Ok(utils::ExitCode(0))
     }
 }
 
@@ -358,7 +359,7 @@ pub(crate) fn self_update_permitted(explicit: bool) -> Result<SelfUpdatePermissi
 /// Performs all of a self-update: check policy, download, apply and exit.
 pub(crate) async fn self_update<F>(before_restart: F, process: &Process) -> Result<utils::ExitCode>
 where
-    F: FnOnce() -> Result<utils::ExitCode>,
+    F: FnOnce() -> Result<()>,
 {
     match self_update_permitted(false)? {
         SelfUpdatePermission::HardFail => {

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -314,10 +314,7 @@ pub(crate) async fn update_all_channels(
     };
 
     if do_self_update {
-        let self_update_exit_code = self_update(show_channel_updates, cfg.process).await?;
-        if self_update_exit_code != utils::ExitCode(0) {
-            exit_code = self_update_exit_code;
-        }
+        exit_code &= self_update(show_channel_updates, cfg.process).await?;
     } else {
         show_channel_updates()?;
     }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -867,7 +867,7 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
             common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else {
-        exit_code = common::update_all_channels(cfg, self_update, opts.force).await?;
+        exit_code &= common::update_all_channels(cfg, self_update, opts.force).await?;
         info!("cleaning up downloads & tmp directories");
         utils::delete_dir_contents_following_links(&cfg.download_dir);
         cfg.tmp_cx.clean();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -862,7 +862,7 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
             }
         }
         if self_update {
-            common::self_update(|| Ok(utils::ExitCode(0)), cfg.process).await?;
+            common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else {
         common::update_all_channels(cfg, self_update, opts.force).await?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -789,6 +789,8 @@ async fn check_updates(cfg: &Cfg<'_>) -> Result<utils::ExitCode> {
 }
 
 async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> {
+    let mut exit_code = utils::ExitCode(0);
+
     common::warn_if_host_is_emulated(cfg.process);
     let self_update_mode = cfg.get_self_update_mode()?;
     // Priority: no-self-update feature > self_update_mode > no-self-update args.
@@ -865,7 +867,7 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
             common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else {
-        common::update_all_channels(cfg, self_update, opts.force).await?;
+        exit_code = common::update_all_channels(cfg, self_update, opts.force).await?;
         info!("cleaning up downloads & tmp directories");
         utils::delete_dir_contents_following_links(&cfg.download_dir);
         cfg.tmp_cx.clean();
@@ -880,7 +882,7 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
         info!("any updates to rustup will need to be fetched with your system package manager")
     }
 
-    Ok(utils::ExitCode(0))
+    Ok(exit_code)
 }
 
 async fn run(

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -21,6 +21,7 @@ pub(crate) use crate::utils::utils::raw::is_directory;
 
 pub use crate::utils::utils::raw::{is_file, path_exists};
 
+#[derive(Debug, PartialEq, Eq)]
 pub struct ExitCode(pub i32);
 
 impl From<ExitStatus> for ExitCode {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -1,6 +1,7 @@
 use std::env;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Write};
+use std::ops::{BitAnd, BitAndAssign};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
@@ -23,6 +24,27 @@ pub use crate::utils::utils::raw::{is_file, path_exists};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ExitCode(pub i32);
+
+impl BitAnd for ExitCode {
+    type Output = Self;
+
+    // If `self` is `0` (success), yield `rhs`.
+    fn bitand(self, rhs: Self) -> Self::Output {
+        match self.0 {
+            0 => rhs,
+            _ => self,
+        }
+    }
+}
+
+impl BitAndAssign for ExitCode {
+    // If `self` is `0` (success), set `self` to `rhs`.
+    fn bitand_assign(&mut self, rhs: Self) {
+        if self.0 == 0 {
+            *self = rhs
+        }
+    }
+}
 
 impl From<ExitStatus> for ExitCode {
     fn from(status: ExitStatus) -> Self {


### PR DESCRIPTION
Closes #3476, verified via local testing.