### PR TITLE
fix(utils): make `ExitCode` `#[must_use]`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -864,7 +864,7 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
             }
         }
         if self_update {
-            common::self_update(|| Ok(()), cfg.process).await?;
+            exit_code &= common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else {
         exit_code &= common::update_all_channels(cfg, self_update, opts.force).await?;
@@ -1205,8 +1205,7 @@ async fn component_list(
         installed_only,
         quiet,
         cfg.process,
-    )?;
-    Ok(utils::ExitCode(0))
+    )
 }
 
 async fn component_add(

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -108,8 +108,7 @@ pub async fn main(
     }
 
     if dump_testament {
-        common::dump_testament(process)?;
-        return Ok(utils::ExitCode(0));
+        return common::dump_testament(process);
     }
 
     if profile == Profile::Complete {

--- a/src/utils/utils.rs
+++ b/src/utils/utils.rs
@@ -22,6 +22,7 @@ pub(crate) use crate::utils::utils::raw::is_directory;
 
 pub use crate::utils::utils::raw::{is_file, path_exists};
 
+#[must_use]
 #[derive(Debug, PartialEq, Eq)]
 pub struct ExitCode(pub i32);
 


### PR DESCRIPTION
This PR is a continuation of #3952 to "properly" address similar linting-related issues regarding `ExitCode`.

I should've done this yesterday, but it didn't occur to me till this morning... Still it's better late than never.