### PR TITLE
build(windows): fix typo in `build.rs`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -66,5 +66,5 @@ fn main() {
     // Rust hides linker warnings meaning mistakes may go unnoticed.
     // Turning them into errors forces them to be displayed (and the build to fail).
     // If we do want to ignore specific warnings then `/IGNORE:` should be used.
-    println!("cargo:cargo:rustc-link-arg-bin=rustup-init=/WX");
+    println!("cargo:rustc-link-arg-bin=rustup-init=/WX");
 }

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ fn main() {
     // This will work on all supported Windows versions but it relies on
     // us using `SetDefaultDllDirectories` before any libraries are loaded.
     // See also: src/bin/rustup-init.rs
-    let delay_load_dlls = ["bcrypt", "powrprof", "secur32"];
+    let delay_load_dlls = ["bcrypt", "secur32"];
     for dll in delay_load_dlls {
         println!("cargo:rustc-link-arg-bin=rustup-init=/delayload:{dll}.dll");
     }


### PR DESCRIPTION
Cherry-picked from #3898.

The first commit is deliberately failing to demonstrate that the fix is actually working.

See https://github.com/aws/aws-lc-rs/issues/453#issuecomment-2199337475 for the whole context:

> Another crucial difference between our setups is that we use the following linker option on Windows MSVC as well:
> 
> ```rs
> println!("cargo:rustc-link-arg-bin=rustup-init=/WX");
> ```
> 
> This was originally added by @ChrisDenton to prevent `cargo` from silencing linkage warnings, which is probably why your CI happens to turn green.