### PR TITLE
docs(dev-guide): add guideline for atomic commits to the developer guide

### DIFF
--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -1,9 +1,13 @@
-
 # Coding standards
 
 Generally we just follow good sensible Rust practices, clippy and so forth.
 However there are some practices we've agreed on that are not machine-enforced;
 meeting those requirements in a PR will make it easier to merge.
+
+## Atomic commits
+
+We use atomic commits across the repo. Each commit should represent a single unit of change.
+You can read more about atomic commits [here](https://www.aleksandrhovhannisyan.com/blog/atomic-git-commits).
 
 ## Import grouping
 


### PR DESCRIPTION
This PR updates the developer guide to include information on atomic commits.

> https://github.com/rust-lang/rustup/pull/3939#issuecomment-2222514924