### PR TITLE
Remove `once_cell` dependency and use `LazyLock` instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,6 +290,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.73+curl-8.8.0"
+version = "0.4.74+curl-8.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "450ab250ecf17227c39afb9a2dd9261dc0035cb80f2612472fc0c4aac2dcb84d"
+checksum = "8af10b986114528fcdc4b63b6f5f021b7057618411046a4de2ba0f0149a097bf"
 dependencies = [
  "cc",
  "libc",
@@ -561,7 +567,6 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "once_cell",
  "reqwest",
  "rustls",
  "rustls-platform-verifier",
@@ -1569,9 +1574,13 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+dependencies = [
+ "zerocopy",
+ "zerocopy-derive",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1925,9 +1934,9 @@ checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3beb939bcd33c269f4bf946cc829fcd336370267c4a927ac0399c84a3151a1"
+checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -1946,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier-android"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e217e7fdc8466b5b35d30f8c0a30febd29173df4a3a0c2115d306b9c4117ad"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1980,7 +1989,6 @@ dependencies = [
  "home",
  "itertools",
  "libc",
- "once_cell",
  "opener",
  "openssl",
  "opentelemetry",
@@ -2523,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81967dd0dd2c1ab0bc3468bd7caecc32b8a4aa47d0c8c695d8c2b2108168d62c"
+checksum = "7a44eede9b727419af8095cb2d72fab15487a541f54647ad4414b34096ee4631"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2535,18 +2543,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fb9f64314842840f1d940ac544da178732128f1c78c21772e876579e0da1db"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.17"
+version = "0.22.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9f8729f5aea9562aac1cc0441f5d6de3cff1ee0c5d67293eeca5eb36ee7c16"
+checksum = "1490595c74d930da779e944f5ba2ecdf538af67df1a9848cbd156af43c1b7cf0"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -3151,6 +3159,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
 dependencies = [
  "lzma-sys",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ git-testament = "0.2"
 home = "0.5.4"
 itertools = "0.13"
 libc = "0.2"
-once_cell.workspace = true
 opener = "0.7.0"
 # `openssl` is used by `curl` or `reqwest` backend although it isn't imported by rustup: this
 # allows controlling the vendoring status without exposing the presence of the download crate.
@@ -124,7 +123,6 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 trycmd = "0.15.0"
 
 [build-dependencies]
-once_cell.workspace = true
 platforms.workspace = true
 regex = "1"
 
@@ -134,7 +132,6 @@ members = ["download"]
 [workspace.dependencies]
 anyhow = "1.0.69"
 fs_at = "0.2.1"
-once_cell = "1.18.0"
 opentelemetry = "0.24"
 opentelemetry-otlp = "0.17"
 opentelemetry_sdk = { version = "0.24", features = ["rt-tokio"] }

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -8,19 +8,17 @@ license = "MIT OR Apache-2.0"
 default = ["reqwest-backend", "reqwest-rustls-tls", "reqwest-native-tls"]
 curl-backend = ["curl"]
 reqwest-backend = ["reqwest", "env_proxy"]
-reqwest-native-tls = ["reqwest/native-tls", "dep:once_cell"]
+reqwest-native-tls = ["reqwest/native-tls"]
 reqwest-rustls-tls = [
   "reqwest/rustls-tls-manual-roots-no-provider",
   "dep:rustls",
   "dep:rustls-platform-verifier",
-  "dep:once_cell",
 ]
 
 [dependencies]
 anyhow.workspace = true
 curl = { version = "0.4.44", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
-once_cell = { workspace = true, optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "socks", "stream"], optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "ring", "tls12"] }
 rustls-platform-verifier = { version = "0.3", optional = true }

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -296,11 +296,11 @@ pub mod reqwest_be {
     use std::io;
     #[cfg(feature = "reqwest-rustls-tls")]
     use std::sync::Arc;
+    #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
+    use std::sync::LazyLock;
     use std::time::Duration;
 
     use anyhow::{anyhow, Context, Result};
-    #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
-    use once_cell::sync::Lazy;
     use reqwest::{header, Client, ClientBuilder, Proxy, Response};
     #[cfg(feature = "reqwest-rustls-tls")]
     use rustls::crypto::ring;
@@ -354,7 +354,7 @@ pub mod reqwest_be {
     }
 
     #[cfg(feature = "reqwest-rustls-tls")]
-    static CLIENT_RUSTLS_TLS: Lazy<Client> = Lazy::new(|| {
+    static CLIENT_RUSTLS_TLS: LazyLock<Client> = LazyLock::new(|| {
         let catcher = || {
             client_generic()
                 .use_preconfigured_tls(
@@ -377,7 +377,7 @@ pub mod reqwest_be {
     });
 
     #[cfg(feature = "reqwest-native-tls")]
-    static CLIENT_DEFAULT_TLS: Lazy<Client> = Lazy::new(|| {
+    static CLIENT_DEFAULT_TLS: LazyLock<Client> = LazyLock::new(|| {
         let catcher = || {
             client_generic()
                 .user_agent(super::REQWEST_DEFAULT_TLS_USER_AGENT)

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -4,16 +4,16 @@ use std::env::{remove_var, set_var};
 use std::error::Error;
 use std::net::TcpListener;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::LazyLock;
 use std::thread;
 use std::time::Duration;
 
 use env_proxy::for_url;
-use once_cell::sync::Lazy;
 use reqwest::{Client, Proxy};
 use tokio::sync::Mutex;
 use url::Url;
 
-static SERIALISE_TESTS: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+static SERIALISE_TESTS: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 fn scrub_env() {
     remove_var("http_proxy");

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -7,12 +7,11 @@ use std::fs;
 use std::io::ErrorKind;
 use std::io::{BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::{cmp, env};
 
 use anyhow::{anyhow, Context, Result};
 use git_testament::{git_testament, render_testament};
-use once_cell::sync::Lazy;
 use tracing::{debug, error, info, trace, warn};
 
 use super::self_update;
@@ -529,7 +528,7 @@ pub(crate) fn version() -> &'static str {
     // Because we trust our `stable` branch given the careful release
     // process, we mark it trusted here so that our version numbers look
     // right when built from CI before the tag is pushed
-    static RENDERED: Lazy<String> = Lazy::new(|| render_testament!(TESTAMENT, "stable"));
+    static RENDERED: LazyLock<String> = LazyLock::new(|| render_testament!(TESTAMENT, "stable"));
     &RENDERED
 }
 

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -3,8 +3,8 @@
 
 use std::io;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 use strsim::damerau_levenshtein;
 use thiserror::Error as ThisError;
@@ -24,7 +24,7 @@ pub enum CLIError {
 fn maybe_suggest_toolchain(bad_name: &str) -> String {
     let bad_name = &bad_name.to_ascii_lowercase();
     static VALID_CHANNELS: &[&str] = &["stable", "beta", "nightly"];
-    static NUMBERED: Lazy<Regex> = Lazy::new(|| Regex::new(r"^[0-9]+\.[0-9]+$").unwrap());
+    static NUMBERED: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9]+\.[0-9]+$").unwrap());
     if NUMBERED.is_match(bad_name) {
         return format!(". Toolchain numbers tend to have three parts, e.g. {bad_name}.0");
     }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1046,11 +1046,12 @@ fn get_new_rustup_version(path: &Path) -> Option<String> {
 }
 
 fn parse_new_rustup_version(version: String) -> String {
-    use once_cell::sync::Lazy;
+    use std::sync::LazyLock;
+
     use regex::Regex;
 
-    static RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"[0-9]+.[0-9]+.[0-9]+[0-9a-zA-Z-]*").unwrap());
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"[0-9]+.[0-9]+.[0-9]+[0-9a-zA-Z-]*").unwrap());
 
     let capture = RE.captures(&version);
     let matched_version = match capture {

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1,12 +1,13 @@
 //! Installation from a Rust distribution server
 
-use std::{collections::HashSet, env, fmt, io::Write, ops::Deref, path::Path, str::FromStr};
+use std::{
+    collections::HashSet, env, fmt, io::Write, ops::Deref, path::Path, str::FromStr, sync::LazyLock,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use chrono::NaiveDate;
 use clap::{builder::PossibleValue, ValueEnum};
 use itertools::Itertools;
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
@@ -272,7 +273,7 @@ impl FromStr for ParsedToolchainDesc {
     fn from_str(desc: &str) -> Result<Self> {
         // Note this regex gives you a guaranteed match of the channel (1)
         // and an optional match of the date (2) and target (3)
-        static TOOLCHAIN_CHANNEL_RE: Lazy<Regex> = Lazy::new(|| {
+        static TOOLCHAIN_CHANNEL_RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(&format!(
                 r"^({})(?:-([0-9]{{4}}-[0-9]{{2}}-[0-9]{{2}}))?(?:-(.+))?$",
                 // The channel patterns we support

--- a/src/dist/triple.rs
+++ b/src/dist/triple.rs
@@ -1,4 +1,5 @@
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 pub mod known;
@@ -24,7 +25,7 @@ impl PartialTargetTriple {
         // we can count  on all triple components being
         // delineated by it.
         let name = format!("-{name}");
-        static RE: Lazy<Regex> = Lazy::new(|| {
+        static RE: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(&format!(
                 r"^(?:-({}))?(?:-({}))?(?:-({}))?$",
                 known::LIST_ARCHS.join("|"),

--- a/src/test/mock/dist.rs
+++ b/src/test/mock/dist.rs
@@ -5,9 +5,8 @@ use std::collections::HashMap;
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 
-use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
 use url::Url;
 
@@ -226,7 +225,7 @@ impl MockDistServer {
         type Tarball = HashMap<(String, MockTargetedPackage, String), (Vec<u8>, String)>;
         // Tarball creation can be super slow, so cache created tarballs
         // globally to avoid recreating and recompressing tons of tarballs.
-        static TARBALLS: Lazy<Mutex<Tarball>> = Lazy::new(|| Mutex::new(HashMap::new()));
+        static TARBALLS: LazyLock<Mutex<Tarball>> = LazyLock::new(|| Mutex::new(HashMap::new()));
 
         let key = (
             installer_name.to_string(),


### PR DESCRIPTION
Since Rust 1.80.0 was released, which brought `LazyCell` and `LazyLock`, plus the only purpose of introducing `once_cell` was to use `Lazy` for initializations of static variables, it is good to replace `Lazy` with `LazyLock`.