### PR TITLE
docs(dev-guide): update `coding-standards` to reflect recent API changes.

### DIFF
--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -1,4 +1,3 @@
-
 # Coding standards
 
 Generally we just follow good sensible Rust practices, clippy and so forth.
@@ -60,8 +59,3 @@ Clippy is also run in GitHub Actions, in the `General Checks / Checks` build
 task, but not currently run per-platform, which means there is no way to find
 out the status of clippy per platform without running it on that platform as a
 developer.
-
-### import rustup-macros::{integration,unit}_test into test modules
-
-These test helpers add pre-and-post logic to tests to enable the use of tracing
-inside tests, which can be helpful for tracking down behaviours in larger tests.

--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -23,9 +23,12 @@ though that is helpful.
 ## No direct use of process state outside rustup::process
 
 The `rustup::process` module abstracts the global state that is
-`std::env::args`, `std::env::vars`, `std::io::std*`, `std::process::id`,
-`std::env::current_dir` and `std::process::exit` permitting threaded tests of
-the CLI logic; use `process()` rather than those APIs directly.
+`std::env::args`, `std::env::vars`, `std::io::std*` and `std::env::current_dir`
+permitting threaded tests of the CLI logic; use the relevant methods of the
+`rustup::process::Process` type rather than those APIs directly.
+Usually, a `process: &Process` variable will be available to you in the current context.
+For example, it could be in the form of a parameter of the current function,
+or a field of a `Cfg` instance, etc.
 
 ## Clippy lints
 


### PR DESCRIPTION
Closes #3970:

> > it looks like [`coding-standards.md`] was not covered by our previous API changes. `process()` is long gone and so is the macros helper crate...
> 
> _[#3969 (comment)](https://github.com/rust-lang/rustup/pull/3969#issuecomment-2257263776)_
> 
> cc #3871, #3877

