### PR TITLE
fix: fix unreachable code lints on Android

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -489,19 +489,8 @@ impl TargetTriple {
                 )
             };
 
+            #[cfg(not(target_os = "android"))]
             let host_triple = match (sysname, machine) {
-                #[cfg(target_os = "android")]
-                (_, b"arm") => Some("arm-linux-androideabi"),
-                #[cfg(target_os = "android")]
-                (_, b"armv7l") => Some("armv7-linux-androideabi"),
-                #[cfg(target_os = "android")]
-                (_, b"armv8l") => Some("armv7-linux-androideabi"),
-                #[cfg(target_os = "android")]
-                (_, b"aarch64") => Some("aarch64-linux-android"),
-                #[cfg(target_os = "android")]
-                (_, b"i686") => Some("i686-linux-android"),
-                #[cfg(target_os = "android")]
-                (_, b"x86_64") => Some("x86_64-linux-android"),
                 (b"Linux", b"x86_64") => Some(TRIPLE_X86_64_UNKNOWN_LINUX),
                 (b"Linux", b"i686") => Some("i686-unknown-linux-gnu"),
                 (b"Linux", b"mips") => Some(TRIPLE_MIPS_UNKNOWN_LINUX_GNU),
@@ -525,6 +514,17 @@ impl TargetTriple {
                 (b"NetBSD", b"i686") => Some("i686-unknown-netbsd"),
                 (b"DragonFly", b"x86_64") => Some("x86_64-unknown-dragonfly"),
                 (b"SunOS", b"i86pc") => Some("x86_64-unknown-illumos"),
+                _ => None,
+            };
+
+            #[cfg(target_os = "android")]
+            let host_triple = match (sysname, machine) {
+                (_, b"arm") => Some("arm-linux-androideabi"),
+                (_, b"armv7l") => Some("armv7-linux-androideabi"),
+                (_, b"armv8l") => Some("armv7-linux-androideabi"),
+                (_, b"aarch64") => Some("aarch64-linux-android"),
+                (_, b"i686") => Some("i686-linux-android"),
+                (_, b"x86_64") => Some("x86_64-linux-android"),
                 _ => None,
             };
 


### PR DESCRIPTION
Cherry-picked from #3898.

When compiling for Android, the linter will warn about unreachable branches such as the `(b"Linux", b"i686")` one, since it's already covered by the `(_, b"i686")` case.