### PR TITLE
style(taplo): enable `reorder_keys` for `*dependencies` in `Cargo.toml`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1395,7 +1395,7 @@ jobs:
       - name: Install taplo
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli@0.8
+          tool: taplo-cli
       - name: Run TOML formatting checks
         run: |
           taplo fmt

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -11,3 +11,4 @@ keys = [
 
 [rule.formatting]
 column_width = 160
+reorder_keys = true

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -68,7 +68,7 @@ jobs: # skip-all
       - name: Install taplo
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli@0.8
+          tool: taplo-cli
       - name: Run TOML formatting checks
         run: |
           taplo fmt


### PR DESCRIPTION
Closes #3945 by unlocking `taplo-cli` from v0.8, as the upstream issue has been addressed with `taplo-cli` v0.9.3:
- https://github.com/tamasfe/taplo/issues/634