### PR TITLE
ci(run): accelerate workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1456,7 +1456,6 @@ jobs:
       - name: Install OpenSSL
         if: ${{ contains(matrix.os, 'windows') }}
         run: |
-          choco install openssl -y --no-progress
           Get-Command openssl
           openssl version
           echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV

--- a/ci/actions-templates/all-features-template.yaml
+++ b/ci/actions-templates/all-features-template.yaml
@@ -32,7 +32,6 @@ jobs: # skip-all
       - name: Install OpenSSL
         if: ${{ contains(matrix.os, 'windows') }}
         run: |
-          choco install openssl -y --no-progress
           Get-Command openssl
           openssl version
           echo "OPENSSL_LIB_DIR=C:/Program Files/OpenSSL/lib" >> $env:GITHUB_ENV

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -65,12 +65,8 @@ build_test() {
     target_cargo "${cmd}" --workspace --all-targets --features test
   else
     target_cargo "${cmd}" --workspace --features test --tests
-  fi
-
-  if [ "build" != "${cmd}" ]; then
     target_cargo "${cmd}" --doc --workspace --features test
   fi
-
 }
 
 if [ -z "$SKIP_TESTS" ]; then

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -64,8 +64,7 @@ build_test() {
   if [ "build" = "${cmd}" ]; then
     target_cargo "${cmd}" --workspace --all-targets --features test
   else
-    #  free runners have 2 or 3(mac) cores
-    target_cargo "${cmd}" --workspace --features test --tests -- --test-threads 2
+    target_cargo "${cmd}" --workspace --features test --tests
   fi
 
   if [ "build" != "${cmd}" ]; then


### PR DESCRIPTION
This PR does two things essentially:

- Remove `--test-threads=2`. GitHub Actions [is no longer providing 2-core VMs for its public runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories), so it looks like a waste of resources.
- Stop installing OpenSSL from `choco` on Windows. Instead, we use the bundled OpenSSL installation from the image. This gives a not so up-to-date version of OpenSSL, but it doesn't matter that much for our purpose of checking `all-features`, and will also allow us to save up to 2 minutes of wall time for the installation.

It turns out that the improvement is quite significant! Now a fully cached CI run can finish **within 10 minutes**.

The following is a comparison WRT test threads-related speedups:

| Task \ Test Wall Time | Before (https://github.com/rust-lang/rustup/commit/8fdc61316891cdb72acf406b2ac929227ceb0068)  | After (https://github.com/rust-lang/rustup/commit/35fd52691bc17294496ed24727833ee4f51d18c8)   |
|-------------------------------------------------|---------|---------|
| build-windows-pr (dev, x86_64-pc-windows-msvc)  | 309.14s | 190.87s |
| build-linux-pr (dev, x86_64-unknown-linux-gnu)  | 272.28s | 192.98s |
| build-macos-x86_64 (dev, x86_64-apple-darwin)   | 565.54s | 340.47s |
| build-macos-aarch64 (dev, aarch64-apple-darwin) | 593.02s | 458.74s |