### PR TITLE
ci(freebsd): fix build failure related to `aws-lc`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1302,7 +1302,9 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo ca_root_nss
+          pkg install -y git gmake bash sudo \
+            `# The following packages are required by 'aws-lc-rs':` \
+            cmake-core llvm-devel-lite rust-bindgen-cli
         run: |
           echo "========="
           echo "create non-root user and log into it"
@@ -1332,7 +1334,9 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo ca_root_nss
+          pkg install -y git gmake bash sudo \
+            `# The following packages are required by 'aws-lc-rs':` \
+            cmake-core llvm-devel-lite rust-bindgen-cli
         run: |
           echo "========="
           echo "create non-root user and log into it"

--- a/ci/actions-templates/freebsd-builds-template.yaml
+++ b/ci/actions-templates/freebsd-builds-template.yaml
@@ -22,7 +22,9 @@ jobs: # skip-master skip-stable
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo ca_root_nss
+          pkg install -y git gmake bash sudo \
+            `# The following packages are required by 'aws-lc-rs':` \
+            cmake-core llvm-devel-lite rust-bindgen-cli
         run: |
           echo "========="
           echo "create non-root user and log into it"

--- a/ci/freebsd/script.bash
+++ b/ci/freebsd/script.bash
@@ -40,4 +40,9 @@ export CARGO_BUILD_JOBS=1
 export TARGET="x86_64-unknown-freebsd"
 # TODO: This should be split into two as the other jobs are.
 export BUILD_PROFILE="release"
+
+# HACK: Works around `aws-lc-rs`' issue with internal bindgen on FreeBSD.
+# See: https://github.com/aws/aws-lc-rs/issues/476#issuecomment-2263118015
+export AWS_LC_SYS_EXTERNAL_BINDGEN=1
+
 bash ci/run.bash


### PR DESCRIPTION
Follow-up of #3898.

This PR works around the build failure by opting for external bindgen, as suggested in https://github.com/aws/aws-lc-rs/issues/476#issuecomment-2263118015.

Upstream issue:
- https://github.com/aws/aws-lc-rs/issues/476

Tested in:
- https://github.com/rust-lang/rustup/actions/runs/10208075599/job/28243947424