### PR TITLE
feat(rustup-mode): install the active toolchain by default on `rustup toolchain install`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -107,7 +107,7 @@ enum RustupSubcmd {
         opts: UpdateOpts,
     },
 
-    /// Uninstall Rust toolchains
+    /// Uninstall the given toolchains
     #[command(hide = true)]
     Uninstall {
         #[command(flatten)]
@@ -309,7 +309,7 @@ enum ToolchainSubcmd {
         opts: UpdateOpts,
     },
 
-    /// Uninstall a toolchain
+    /// Uninstall the given toolchains
     #[command(alias = "remove")]
     Uninstall {
         #[command(flatten)]

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -584,7 +584,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
 
     match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
-        RustupSubcmd::Install { opts } => update(cfg, opts).await,
+        RustupSubcmd::Install { opts } => update(cfg, opts, false).await,
         RustupSubcmd::Uninstall { opts } => toolchain_remove(cfg, opts),
         RustupSubcmd::Show { verbose, subcmd } => handle_epipe(match subcmd {
             None => show(cfg, verbose),
@@ -610,11 +610,12 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
                     force_non_host,
                     ..UpdateOpts::default()
                 },
+                false,
             )
             .await
         }
         RustupSubcmd::Toolchain { subcmd } => match subcmd {
-            ToolchainSubcmd::Install { opts } => update(cfg, opts).await,
+            ToolchainSubcmd::Install { opts } => update(cfg, opts, false).await,
             ToolchainSubcmd::List { verbose, quiet } => {
                 handle_epipe(common::list_toolchains(cfg, verbose, quiet))
             }
@@ -791,7 +792,11 @@ async fn check_updates(cfg: &Cfg<'_>) -> Result<utils::ExitCode> {
     Ok(utils::ExitCode(0))
 }
 
-async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> {
+async fn update(
+    cfg: &mut Cfg<'_>,
+    opts: UpdateOpts,
+    ensure_active_toolchain: bool,
+) -> Result<utils::ExitCode> {
     let mut exit_code = utils::ExitCode(0);
 
     common::warn_if_host_is_emulated(cfg.process);
@@ -861,6 +866,13 @@ async fn update(cfg: &mut Cfg<'_>, opts: UpdateOpts) -> Result<utils::ExitCode> 
         if self_update {
             exit_code &= common::self_update(|| Ok(()), cfg.process).await?;
         }
+    } else if ensure_active_toolchain {
+        let (toolchain, reason) = cfg.find_or_install_active_toolchain(true).await?;
+        info!(
+            "the active toolchain `{}` has been installed",
+            toolchain.name()
+        );
+        info!("it's active because: {reason}");
     } else {
         exit_code &= common::update_all_channels(cfg, self_update, opts.force).await?;
         info!("cleaning up downloads & tmp directories");

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -100,7 +100,7 @@ fn plus_toolchain_value_parser(s: &str) -> clap::error::Result<ResolvableToolcha
 #[derive(Debug, Subcommand)]
 #[command(name = "rustup", bin_name = "rustup[EXE]")]
 enum RustupSubcmd {
-    /// Update Rust toolchains
+    /// Install or update the given toolchains, or by default the active toolchain
     #[command(hide = true, after_help = INSTALL_HELP)]
     Install {
         #[command(flatten)]
@@ -302,7 +302,7 @@ enum ToolchainSubcmd {
         quiet: bool,
     },
 
-    /// Install or update a given toolchain
+    /// Install or update the given toolchains, or by default the active toolchain
     #[command(aliases = ["update", "add"] )]
     Install {
         #[command(flatten)]
@@ -330,7 +330,6 @@ enum ToolchainSubcmd {
 #[derive(Debug, Default, Args)]
 struct UpdateOpts {
     #[arg(
-        required = true,
         help = OFFICIAL_TOOLCHAIN_ARG_HELP,
         num_args = 1..,
     )]
@@ -584,7 +583,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
 
     match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
-        RustupSubcmd::Install { opts } => update(cfg, opts, false).await,
+        RustupSubcmd::Install { opts } => update(cfg, opts, true).await,
         RustupSubcmd::Uninstall { opts } => toolchain_remove(cfg, opts),
         RustupSubcmd::Show { verbose, subcmd } => handle_epipe(match subcmd {
             None => show(cfg, verbose),
@@ -615,7 +614,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
             .await
         }
         RustupSubcmd::Toolchain { subcmd } => match subcmd {
-            ToolchainSubcmd::Install { opts } => update(cfg, opts, false).await,
+            ToolchainSubcmd::Install { opts } => update(cfg, opts, true).await,
             ToolchainSubcmd::List { verbose, quiet } => {
                 handle_epipe(common::list_toolchains(cfg, verbose, quiet))
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -737,7 +737,7 @@ impl<'a> Cfg<'a> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn find_or_install_active_toolchain(
+    pub(crate) async fn find_or_install_active_toolchain(
         &'a self,
         verbose: bool,
     ) -> Result<(Toolchain<'a>, ActiveReason)> {

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -8,7 +8,7 @@ Usage: rustup[EXE] toolchain <COMMAND>
 
 Commands:
   list       List installed toolchains
-  install    Install or update a given toolchain
+  install    Install or update the given toolchains, or by default the active toolchain
   uninstall  Uninstall the given toolchains
   link       Create a custom toolchain by symlinking to a directory
   help       Print this message or the help of the given subcommand(s)

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -9,7 +9,7 @@ Usage: rustup[EXE] toolchain <COMMAND>
 Commands:
   list       List installed toolchains
   install    Install or update a given toolchain
-  uninstall  Uninstall a toolchain
+  uninstall  Uninstall the given toolchains
   link       Create a custom toolchain by symlinking to a directory
   help       Print this message or the help of the given subcommand(s)
 

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -1,13 +1,12 @@
 bin.name = "rustup"
 args = ["toolchain", "install", "--help"]
 stdout = """
-...
-Install or update a given toolchain
+Install or update the given toolchains, or by default the active toolchain
 
-Usage: rustup[EXE] toolchain install [OPTIONS] <TOOLCHAIN>...
+Usage: rustup[EXE] toolchain install [OPTIONS] [TOOLCHAIN]...
 
 Arguments:
-  <TOOLCHAIN>...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
+  [TOOLCHAIN]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see
                   `rustup help toolchain`
 
 Options:

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_uninstall_cmd_help_flag_stdout.toml
@@ -1,8 +1,7 @@
 bin.name = "rustup"
 args = ["toolchain", "uninstall", "--help"]
 stdout = """
-...
-Uninstall a toolchain
+Uninstall the given toolchains
 
 Usage: rustup[EXE] toolchain uninstall <TOOLCHAIN>...
 


### PR DESCRIPTION
Closes #2686 by extending the existing `rustup toolchain install` and `rustup install` commands, as discussed in https://github.com/rust-lang/rustup/issues/3635#issuecomment-2260336594:

> > What would be the semantics here? Would it only install if there is a `rust-toolchain.toml` file or would it install any missing default toolchain?
> 
> My understanding is that it is expected to do anything `rustc --version` currently does before actually running that command on the corresponding `rustc`, it's just that everything will become explicit now. So yes, this includes (and isn't limited to) installing the toolchain specified in the `rust-toolchain.toml` file.
> 
> > And presumably the `rustup install` alias.
> 
> Yes! As the two subcommands has been unified with #3596, that looks like a less painful move indeed. A single change for these two places!

TLDR: This PR makes `rustup toolchain install` and `rustup install` install the active toolchain, i.e. behave like the hypothetical `rustup toolchain ensure` command, when no toolchain is specified.