### PR TITLE
feat(cli)!: remove implicit toolchain installation

### DIFF
--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -32,6 +32,9 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .collect();
 
     let cfg = set_globals(current_dir, false, true, process)?;
-    let cmd = cfg.local_toolchain(toolchain).await?.command(arg0)?;
+    let cmd = cfg
+        .resolve_local_toolchain(toolchain)?
+        .await
+        .command(arg0)?;
     run_command_for_dir(cmd, arg0, &cmd_args)
 }

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -32,9 +32,6 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .collect();
 
     let cfg = set_globals(current_dir, false, true, process)?;
-    let cmd = cfg
-        .resolve_local_toolchain(toolchain)?
-        .await
-        .command(arg0)?;
+    let cmd = cfg.resolve_local_toolchain(toolchain)?.command(arg0)?;
     run_command_for_dir(cmd, arg0, &cmd_args)
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -908,7 +908,7 @@ async fn which(
     binary: &str,
     toolchain: Option<ResolvableToolchainName>,
 ) -> Result<utils::ExitCode> {
-    let binary_path = cfg.resolve_toolchain(toolchain).await?.binary_file(binary);
+    let binary_path = cfg.resolve_toolchain(toolchain)?.binary_file(binary);
 
     utils::assert_is_file(&binary_path)?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1097,7 +1097,7 @@ async fn target_list(
     quiet: bool,
 ) -> Result<utils::ExitCode> {
     // downcasting required because the toolchain files can name any toolchain
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
     common::list_items(
         distributable,
         |c| {
@@ -1124,7 +1124,7 @@ async fn target_add(
     // isn't a feature yet.
     // list_components *and* add_component would both be inappropriate for
     // custom toolchains.
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
     let components = distributable.components()?;
 
     if targets.contains(&"all".to_string()) {
@@ -1168,7 +1168,7 @@ async fn target_remove(
     targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
 ) -> Result<utils::ExitCode> {
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
 
     for target in targets {
         let target = TargetTriple::new(target);
@@ -1204,7 +1204,7 @@ async fn component_list(
     quiet: bool,
 ) -> Result<utils::ExitCode> {
     // downcasting required because the toolchain files can name any toolchain
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
     common::list_items(
         distributable,
         |c| Some(&c.name),
@@ -1220,7 +1220,7 @@ async fn component_add(
     toolchain: Option<PartialToolchainDesc>,
     target: Option<String>,
 ) -> Result<utils::ExitCode> {
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
     let target = get_target(target, &distributable);
 
     for component in &components {
@@ -1246,7 +1246,7 @@ async fn component_remove(
     toolchain: Option<PartialToolchainDesc>,
     target: Option<String>,
 ) -> Result<utils::ExitCode> {
-    let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
+    let distributable = DistributableToolchain::from_partial(toolchain, cfg)?;
     let target = get_target(target, &distributable);
 
     for component in &components {
@@ -1447,7 +1447,7 @@ async fn doc(
     mut topic: Option<&str>,
     doc_page: &DocPage,
 ) -> Result<utils::ExitCode> {
-    let toolchain = cfg.toolchain_from_partial(toolchain).await?;
+    let toolchain = cfg.toolchain_from_partial(toolchain)?;
 
     if let Ok(distributable) = DistributableToolchain::try_from(&toolchain) {
         if let [_] = distributable
@@ -1508,7 +1508,7 @@ async fn man(
     command: &str,
     toolchain: Option<PartialToolchainDesc>,
 ) -> Result<utils::ExitCode> {
-    let toolchain = cfg.toolchain_from_partial(toolchain).await?;
+    let toolchain = cfg.toolchain_from_partial(toolchain)?;
     let path = toolchain.man_path();
     utils::assert_is_directory(&path)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -729,7 +729,11 @@ impl<'a> Cfg<'a> {
         let local = name
             .map(|name| name.resolve(&self.get_default_host_triple()?))
             .transpose()?;
-        let toolchain = match local {
+        self.local_toolchain(local)
+    }
+
+    fn local_toolchain(&self, name: Option<LocalToolchainName>) -> Result<Toolchain<'_>> {
+        let toolchain = match name {
             Some(tc) => tc,
             None => {
                 self.find_active_toolchain()?

--- a/src/config.rs
+++ b/src/config.rs
@@ -722,7 +722,7 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    pub(crate) async fn resolve_local_toolchain(
+    pub(crate) fn resolve_local_toolchain(
         &self,
         name: Option<ResolvableLocalToolchainName>,
     ) -> Result<Toolchain<'_>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -498,7 +498,7 @@ impl<'a> Cfg<'a> {
             .transpose()?)
     }
 
-    pub(crate) async fn toolchain_from_partial(
+    pub(crate) fn toolchain_from_partial(
         &self,
         toolchain: Option<PartialToolchainDesc>,
     ) -> anyhow::Result<Toolchain<'_>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -713,13 +713,14 @@ impl<'a> Cfg<'a> {
         &self,
         name: Option<ResolvableToolchainName>,
     ) -> Result<Toolchain<'_>> {
-        Ok(match name {
+        let toolchain = match name {
             Some(name) => {
                 let desc = name.resolve(&self.get_default_host_triple()?)?;
-                Toolchain::new(self, desc.into())?
+                Some(desc.into())
             }
-            None => self.find_or_install_active_toolchain(false).await?.0,
-        })
+            None => None,
+        };
+        self.local_toolchain(toolchain)
     }
 
     pub(crate) fn resolve_local_toolchain(

--- a/src/config.rs
+++ b/src/config.rs
@@ -709,7 +709,7 @@ impl<'a> Cfg<'a> {
         Ok(Some(Toolchain::new(self, name)?.rustc_version()))
     }
 
-    pub(crate) async fn resolve_toolchain(
+    pub(crate) fn resolve_toolchain(
         &self,
         name: Option<ResolvableToolchainName>,
     ) -> Result<Toolchain<'_>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -729,16 +729,15 @@ impl<'a> Cfg<'a> {
         let local = name
             .map(|name| name.resolve(&self.get_default_host_triple()?))
             .transpose()?;
-
-        Ok(match local {
-            Some(tc) => Toolchain::new(self, tc)?,
-            None => Toolchain::new(
-                self,
+        let toolchain = match local {
+            Some(tc) => tc,
+            None => {
                 self.find_active_toolchain()?
                     .ok_or_else(|| no_toolchain_error(self.process))?
-                    .0,
-            )?,
-        })
+                    .0
+            }
+        };
+        Ok(Toolchain::new(self, toolchain)?)
     }
 
     #[tracing::instrument(level = "trace", skip_all)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -502,16 +502,14 @@ impl<'a> Cfg<'a> {
         &self,
         toolchain: Option<PartialToolchainDesc>,
     ) -> anyhow::Result<Toolchain<'_>> {
-        match toolchain {
+        let toolchain = match toolchain {
             Some(toolchain) => {
                 let desc = toolchain.resolve(&self.get_default_host_triple()?)?;
-                Ok(Toolchain::new(
-                    self,
-                    LocalToolchainName::Named(ToolchainName::Official(desc)),
-                )?)
+                Some(LocalToolchainName::Named(ToolchainName::Official(desc)))
             }
-            None => Ok(self.find_or_install_active_toolchain(false).await?.0),
-        }
+            None => None,
+        };
+        self.local_toolchain(toolchain)
     }
 
     pub(crate) fn find_active_toolchain(

--- a/src/config.rs
+++ b/src/config.rs
@@ -731,8 +731,13 @@ impl<'a> Cfg<'a> {
             .transpose()?;
 
         Ok(match local {
-            Some(tc) => Toolchain::from_local(tc, false, self).await?,
-            None => self.find_or_install_active_toolchain(false).await?.0,
+            Some(tc) => Toolchain::new(self, tc)?,
+            None => Toolchain::new(
+                self,
+                self.find_active_toolchain()?
+                    .ok_or_else(|| no_toolchain_error(self.process))?
+                    .0,
+            )?,
         })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -722,7 +722,7 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    pub(crate) async fn local_toolchain(
+    pub(crate) async fn resolve_local_toolchain(
         &self,
         name: Option<ResolvableLocalToolchainName>,
     ) -> Result<Toolchain<'_>> {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -33,13 +33,11 @@ pub(crate) struct DistributableToolchain<'a> {
 }
 
 impl<'a> DistributableToolchain<'a> {
-    pub(crate) async fn from_partial(
+    pub(crate) fn from_partial(
         toolchain: Option<PartialToolchainDesc>,
         cfg: &'a Cfg<'a>,
     ) -> anyhow::Result<Self> {
-        Ok(Self::try_from(
-            &cfg.toolchain_from_partial(toolchain).await?,
-        )?)
+        Ok(Self::try_from(&cfg.toolchain_from_partial(toolchain)?)?)
     }
 
     pub(crate) fn new(cfg: &'a Cfg<'a>, desc: ToolchainDesc) -> Result<Self, RustupError> {

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1099,6 +1099,10 @@ async fn which_asking_uninstalled_toolchain() {
 #[tokio::test]
 async fn override_by_toolchain_on_the_command_line() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect_ok(&["rustup", "toolchain", "install", "stable", "nightly"])
+        .await;
+
     #[cfg(windows)]
     cx.config
         .expect_stdout_ok(

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -933,47 +933,6 @@ async fn list_default_and_override_toolchain() {
 }
 
 #[tokio::test]
-async fn heal_damaged_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config
-        .expect_not_stderr_ok(&["rustup", "which", "rustc"], "syncing channel updates")
-        .await;
-    let manifest_path = format!(
-        "toolchains/nightly-{}/lib/rustlib/multirust-channel-manifest.toml",
-        this_host_triple()
-    );
-
-    let mut rustc_path = cx.config.rustupdir.join(
-        [
-            "toolchains",
-            &format!("nightly-{}", this_host_triple()),
-            "bin",
-            "rustc",
-        ]
-        .iter()
-        .collect::<PathBuf>(),
-    );
-
-    if cfg!(windows) {
-        rustc_path.set_extension("exe");
-    }
-
-    fs::remove_file(cx.config.rustupdir.join(manifest_path)).unwrap();
-    cx.config
-        .expect_ok_ex(
-            &["rustup", "which", "rustc"],
-            &format!("{}\n", rustc_path.to_str().unwrap()),
-            for_host!("info: syncing channel updates for 'nightly-{0}'\n"),
-        )
-        .await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config
-        .expect_stderr_ok(&["rustup", "which", "rustc"], "syncing channel updates")
-        .await;
-}
-
-#[tokio::test]
 #[ignore = "FIXME: Windows shows UNC paths"]
 async fn show_toolchain_override() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2143,6 +2143,12 @@ components = [ "rust-src" ]
     .unwrap();
 
     cx.config
+        .expect_stderr_ok(
+            &["rustup", "toolchain", "install"],
+            "info: installing component 'rust-src'",
+        )
+        .await;
+    cx.config
         .expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)")
         .await;
 }
@@ -2169,6 +2175,12 @@ targets = [ "arm-linux-androideabi" ]
     )
     .unwrap();
 
+    cx.config
+        .expect_stderr_ok(
+            &["rustup", "toolchain", "install"],
+            "info: installing component 'rust-std' for 'arm-linux-androideabi'",
+        )
+        .await;
     cx.config
         .expect_stdout_ok(
             &["rustup", "component", "list"],
@@ -2225,6 +2237,9 @@ channel = "nightly"
 "#,
     )
     .unwrap();
+    cx.config
+        .expect_ok(&["rustup", "toolchain", "install"])
+        .await;
     cx.config
         .expect_not_stdout_ok(
             &["rustup", "component", "list"],

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2133,7 +2133,7 @@ async fn file_override_toml_format_install_both_toolchain_and_components() {
         cx.config.expect_ok(&["rustup", "default", "stable"]).await;
     }
 
-    let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+    let mut cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
     cx.config
         .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
         .await;
@@ -2153,6 +2153,9 @@ components = [ "rust-src" ]
     )
     .unwrap();
 
+    cx.config
+        .expect_ok(&["rustup", "toolchain", "install"])
+        .await;
     cx.config
         .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
         .await;
@@ -2233,7 +2236,7 @@ components = [ "rust-bongo" ]
 
     cx.config
         .expect_stderr_ok(
-            &["rustc", "--version"],
+            &["rustup", "toolchain", "install"],
             "warn: Force-skipping unavailable component 'rust-bongo",
         )
         .await;
@@ -2789,7 +2792,7 @@ async fn dont_warn_on_partial_build() {
 /// Checks that `rust-toolchain.toml` files are considered
 #[tokio::test]
 async fn rust_toolchain_toml() {
-    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect_err(
             &["rustc", "--version"],
@@ -2800,7 +2803,9 @@ async fn rust_toolchain_toml() {
     let cwd = cx.config.current_dir();
     let toolchain_file = cwd.join("rust-toolchain.toml");
     raw::write_file(&toolchain_file, "[toolchain]\nchannel = \"nightly\"").unwrap();
-
+    cx.config
+        .expect_ok(&["rustup", "toolchain", "install"])
+        .await;
     cx.config
         .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
         .await;
@@ -2831,7 +2836,7 @@ async fn warn_on_duplicate_rust_toolchain_file() {
 
     cx.config
         .expect_stderr_ok(
-            &["rustc", "--version"],
+            &["rustup", "toolchain", "install"],
             &format!(
                 "warn: both `{0}` and `{1}` exist. Using `{0}`",
                 toolchain_file_1.canonicalize().unwrap().display(),

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -170,18 +170,6 @@ async fn remove_toolchain() {
 }
 
 #[tokio::test]
-async fn remove_default_toolchain_autoinstalls() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config
-        .expect_ok(&["rustup", "toolchain", "remove", "nightly"])
-        .await;
-    cx.config
-        .expect_stderr_ok(&["rustc", "--version"], "info: installing component")
-        .await;
-}
-
-#[tokio::test]
 async fn remove_override_toolchain_err_handling() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
@@ -194,7 +182,15 @@ async fn remove_override_toolchain_err_handling() {
         .expect_ok(&["rustup", "toolchain", "remove", "beta"])
         .await;
     cx.config
-        .expect_stderr_ok(&["rustc", "--version"], "info: installing component")
+        .expect_err_ex(
+            &["rustc", "--version"],
+            "",
+            for_host!(
+                r"error: toolchain 'beta-{0}' is not installed
+help: run `rustup toolchain install beta-{0}` to install it
+"
+            ),
+        )
         .await;
 }
 


### PR DESCRIPTION
Closes #3943.

As a follow-up of #3983, this PR makes `rustup toolchain install` (or `rustup install`) the only way to ensure the installation of the active toolchain (apart from installing it manually).

When the active toolchain needs to be installed, the existing error messages now come to our rescue:

https://github.com/rust-lang/rustup/blob/e857897d74215c6f33db7b7360fbbb12a89b46b3/tests/suite/cli_v2.rs#L320-L336

This PR also makes it possible to merge `find_or_install_active_toolchain()` and `find_active_toolchain()` by reducing the number of call sites of the former.

~~Given the current state of this PR, the CI will certainly fail, since even the test suite also relies on implicit installation.~~ Fixup commits has been added accordingly, which will of course be squashed onto the original commit respectively before actually merging this PR.