### PR TITLE
refactor(config)!: simplify logic

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -867,10 +867,7 @@ async fn update(
         }
     } else if ensure_active_toolchain {
         let (toolchain, reason) = cfg.find_or_install_active_toolchain(true).await?;
-        info!(
-            "the active toolchain `{}` has been installed",
-            toolchain.name()
-        );
+        info!("the active toolchain `{toolchain}` has been installed");
         info!("it's active because: {reason}");
     } else {
         exit_code &= common::update_all_channels(cfg, self_update, opts.force).await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -711,13 +711,9 @@ impl<'a> Cfg<'a> {
         &self,
         name: Option<ResolvableToolchainName>,
     ) -> Result<Toolchain<'_>> {
-        let toolchain = match name {
-            Some(name) => {
-                let desc = name.resolve(&self.get_default_host_triple()?)?;
-                Some(desc.into())
-            }
-            None => None,
-        };
+        let toolchain = name
+            .map(|name| anyhow::Ok(name.resolve(&self.get_default_host_triple()?)?.into()))
+            .transpose()?;
         self.local_toolchain(toolchain)
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -741,18 +741,18 @@ impl<'a> Cfg<'a> {
 
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) async fn find_or_install_active_toolchain(
-        &'a self,
+        &self,
         verbose: bool,
-    ) -> Result<(Toolchain<'a>, ActiveReason)> {
+    ) -> Result<(LocalToolchainName, ActiveReason)> {
         match self.find_override_config()? {
             Some((override_config, reason)) => match override_config {
                 OverrideCfg::PathBased(path_based_name) => {
                     let toolchain = Toolchain::with_reason(self, path_based_name.into(), &reason)?;
-                    Ok((toolchain, reason))
+                    Ok((toolchain.name().clone(), reason))
                 }
                 OverrideCfg::Custom(custom_name) => {
                     let toolchain = Toolchain::with_reason(self, custom_name.into(), &reason)?;
-                    Ok((toolchain, reason))
+                    Ok((toolchain.name().clone(), reason))
                 }
                 OverrideCfg::Official {
                     toolchain,
@@ -764,7 +764,7 @@ impl<'a> Cfg<'a> {
                         .ensure_installed(&toolchain, components, targets, profile, verbose)
                         .await?
                         .1;
-                    Ok((toolchain, reason))
+                    Ok((toolchain.name().clone(), reason))
                 }
             },
             None => match self.get_default()? {
@@ -772,7 +772,7 @@ impl<'a> Cfg<'a> {
                 Some(ToolchainName::Custom(custom_name)) => {
                     let reason = ActiveReason::Default;
                     let toolchain = Toolchain::with_reason(self, custom_name.into(), &reason)?;
-                    Ok((toolchain, reason))
+                    Ok((toolchain.name().clone(), reason))
                 }
                 Some(ToolchainName::Official(toolchain_desc)) => {
                     let reason = ActiveReason::Default;
@@ -780,7 +780,7 @@ impl<'a> Cfg<'a> {
                         .ensure_installed(&toolchain_desc, vec![], vec![], None, verbose)
                         .await?
                         .1;
-                    Ok((toolchain, reason))
+                    Ok((toolchain.name().clone(), reason))
                 }
             },
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -502,13 +502,13 @@ impl<'a> Cfg<'a> {
         &self,
         toolchain: Option<PartialToolchainDesc>,
     ) -> anyhow::Result<Toolchain<'_>> {
-        let toolchain = match toolchain {
-            Some(toolchain) => {
-                let desc = toolchain.resolve(&self.get_default_host_triple()?)?;
-                Some(LocalToolchainName::Named(ToolchainName::Official(desc)))
-            }
-            None => None,
-        };
+        let toolchain = toolchain
+            .map(|desc| {
+                anyhow::Ok(LocalToolchainName::Named(ToolchainName::Official(
+                    desc.resolve(&self.get_default_host_triple()?)?,
+                )))
+            })
+            .transpose()?;
         self.local_toolchain(toolchain)
     }
 


### PR DESCRIPTION
Continuation of #3985.

I originally wanted to unify `async fn find_or_install_active_toolchain()` and `fn find_active_toolchain()`, but since this essentially involves plugging an async part in the middle of the latter, I finally backed out on this change. Instead, I rewrote the former to look more like the latter, thanks to the fact that I'm now free to change what the former returns.