### PR TITLE
feat(cli)!: set log level to `INFO`/`DEBUG` on `--quiet`/`--verbose` if `RUSTUP_LOG` is unset

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -41,7 +41,7 @@ Usage: rustup-init[EXE] [OPTIONS]
 
 Options:
   -v, --verbose
-          Enable verbose output
+          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
           Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -43,7 +43,7 @@ Options:
   -v, --verbose
           Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
-          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
+          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -93,7 +93,7 @@ async fn run_rustup_inner(
     utils::current_exe()?;
 
     match process.name().as_deref() {
-        Some("rustup") => rustup_mode::main(current_dir, process).await,
+        Some("rustup") => rustup_mode::main(current_dir, process, console_filter).await,
         Some(n) if n.starts_with("rustup-setup") || n.starts_with("rustup-init") => {
             // NB: The above check is only for the prefix of the file
             // name. Browsers rename duplicates to

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -127,15 +127,13 @@ pub(crate) fn read_line(process: &Process) -> Result<String> {
 pub(super) struct Notifier {
     tracker: Mutex<DownloadTracker>,
     ram_notice_shown: RefCell<bool>,
-    verbose: bool,
 }
 
 impl Notifier {
-    pub(super) fn new(verbose: bool, quiet: bool, process: &Process) -> Self {
+    pub(super) fn new(quiet: bool, process: &Process) -> Self {
         Self {
             tracker: Mutex::new(DownloadTracker::new_with_display_progress(!quiet, process)),
             ram_notice_shown: RefCell::new(false),
-            verbose,
         }
     }
 
@@ -158,9 +156,7 @@ impl Notifier {
         for n in format!("{n}").lines() {
             match level {
                 NotificationLevel::Debug => {
-                    if self.verbose {
-                        debug!("{}", n);
-                    }
+                    debug!("{}", n);
                 }
                 NotificationLevel::Info => {
                     info!("{}", n);
@@ -180,13 +176,8 @@ impl Notifier {
 }
 
 #[tracing::instrument(level = "trace")]
-pub(crate) fn set_globals(
-    current_dir: PathBuf,
-    verbose: bool,
-    quiet: bool,
-    process: &Process,
-) -> Result<Cfg<'_>> {
-    let notifier = Notifier::new(verbose, quiet, process);
+pub(crate) fn set_globals(current_dir: PathBuf, quiet: bool, process: &Process) -> Result<Cfg<'_>> {
+    let notifier = Notifier::new(quiet, process);
     Cfg::from_env(current_dir, Arc::new(move |n| notifier.handle(n)), process)
 }
 

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -69,7 +69,7 @@ where
         (logger.compact().with_filter(env_filter).boxed(), handle)
     } else {
         // Receive log lines from Rustup only.
-        let (env_filter, handle) = reload::Layer::new(EnvFilter::new("rustup=DEBUG"));
+        let (env_filter, handle) = reload::Layer::new(EnvFilter::new("rustup=INFO"));
         (
             logger
                 .event_format(EventFormatter)

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -31,7 +31,7 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .skip(1 + toolchain.is_some() as usize)
         .collect();
 
-    let cfg = set_globals(current_dir, false, true, process)?;
+    let cfg = set_globals(current_dir, true, process)?;
     let cmd = cfg.resolve_local_toolchain(toolchain)?.command(arg0)?;
     run_command_for_dir(cmd, arg0, &cmd_args)
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -545,7 +545,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
         Err(err) if err.kind() == DisplayVersion => {
             write!(process.stdout().lock(), "{err}")?;
             info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
-            let mut cfg = common::set_globals(current_dir, false, true, process)?;
+            let mut cfg = common::set_globals(current_dir, true, process)?;
             match cfg.active_rustc_version() {
                 Ok(Some(version)) => info!("The currently active `rustc` version is `{version}`"),
                 Ok(None) => info!("No `rustc` is currently active"),
@@ -570,7 +570,7 @@ pub async fn main(current_dir: PathBuf, process: &Process) -> Result<utils::Exit
         }
     };
 
-    let cfg = &mut common::set_globals(current_dir, matches.verbose, matches.quiet, process)?;
+    let cfg = &mut common::set_globals(current_dir, matches.quiet, process)?;
 
     if let Some(t) = &matches.plus_toolchain {
         cfg.set_toolchain_override(t);

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -491,7 +491,6 @@ fn canonical_cargo_home(process: &Process) -> Result<Cow<'static, str>> {
 pub(crate) async fn install(
     current_dir: PathBuf,
     no_prompt: bool,
-    verbose: bool,
     quiet: bool,
     mut opts: InstallOpts<'_>,
     process: &Process,
@@ -549,7 +548,7 @@ pub(crate) async fn install(
     }
 
     let no_modify_path = opts.no_modify_path;
-    if let Err(e) = maybe_install_rust(current_dir, verbose, quiet, opts, process).await {
+    if let Err(e) = maybe_install_rust(current_dir, quiet, opts, process).await {
         report_error(&e, process);
 
         // On windows, where installation happens in a console
@@ -804,7 +803,6 @@ pub(crate) fn install_proxies(process: &Process) -> Result<()> {
 
 async fn maybe_install_rust(
     current_dir: PathBuf,
-    verbose: bool,
     quiet: bool,
     opts: InstallOpts<'_>,
     process: &Process,
@@ -828,7 +826,7 @@ async fn maybe_install_rust(
         fs::create_dir_all(home).context("unable to create ~/.rustup")?;
     }
 
-    let mut cfg = common::set_globals(current_dir, verbose, quiet, process)?;
+    let mut cfg = common::set_globals(current_dir, quiet, process)?;
 
     let (components, targets) = (opts.components, opts.targets);
     let toolchain = opts.install(&mut cfg)?;
@@ -1230,8 +1228,7 @@ mod tests {
             home.apply(&mut vars);
             let tp = TestProcess::with_vars(vars);
             let mut cfg =
-                common::set_globals(tp.process.current_dir().unwrap(), false, false, &tp.process)
-                    .unwrap();
+                common::set_globals(tp.process.current_dir().unwrap(), false, &tp.process).unwrap();
 
             let opts = InstallOpts {
                 default_host_triple: None,

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -131,5 +131,5 @@ pub async fn main(
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    self_update::install(current_dir, no_prompt, verbose, quiet, opts, process).await
+    self_update::install(current_dir, no_prompt, quiet, opts, process).await
 }

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -29,7 +29,7 @@ struct RustupInit {
     #[arg(short, long, conflicts_with = "quiet")]
     verbose: bool,
 
-    /// Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
+    /// Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
     #[arg(short, long, conflicts_with = "verbose")]
     quiet: bool,
 

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -7,7 +7,7 @@ use tracing_subscriber::{reload::Handle, EnvFilter, Registry};
 
 use crate::{
     cli::{
-        common,
+        common::{self, update_console_filter},
         self_update::{self, InstallOpts},
     },
     dist::Profile,
@@ -115,18 +115,7 @@ pub async fn main(
         warn!("{}", common::WARN_COMPLETE_PROFILE);
     }
 
-    if process.var("RUSTUP_LOG").is_err() {
-        if quiet {
-            console_filter
-                .modify(|it| *it = EnvFilter::new("rustup=WARN"))
-                .expect("error reloading `EnvFilter` for console_logger");
-        }
-        if verbose {
-            console_filter
-                .modify(|it| *it = EnvFilter::new("rustup=DEBUG"))
-                .expect("error reloading `EnvFilter` for console_logger");
-        }
-    }
+    update_console_filter(process, &console_filter, quiet, verbose);
 
     let opts = InstallOpts {
         default_host_triple: default_host,

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -793,7 +793,12 @@ impl Config {
         }
 
         let tp = process::TestProcess::new(&*self.workdir.borrow(), &arg_strings, vars, "");
-        let process_res = rustup_mode::main(tp.process.current_dir().unwrap(), &tp.process).await;
+        let process_res = rustup_mode::main(
+            tp.process.current_dir().unwrap(),
+            &tp.process,
+            tp.console_filter.clone(),
+        )
+        .await;
         // convert Err's into an ec
         let ec = match process_res {
             Ok(process_res) => process_res,

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -10,7 +10,7 @@ Usage: rustup-init[EXE] [OPTIONS]
 
 Options:
   -v, --verbose
-          Enable verbose output
+          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
           Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -12,7 +12,7 @@ Options:
   -v, --verbose
           Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
-          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
+          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -10,7 +10,7 @@ Usage: rustup-init[EXE] [OPTIONS]
 
 Options:
   -v, --verbose
-          Enable verbose output
+          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
           Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
   -y

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -12,7 +12,7 @@ Options:
   -v, --verbose
           Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
-          Disable progress output, limit console logger level to 'WARN' if 'RUSTUP_LOG' is unset
+          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
   -y
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -30,8 +30,8 @@ Arguments:
   [+toolchain]  Release channel (e.g. +stable) or custom toolchain to set override
 
 Options:
-  -v, --verbose  Enable verbose output
-  -q, --quiet    Disable progress output
+  -v, --verbose  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
+  -q, --quiet    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
   -h, --help     Print help
   -V, --version  Print version
 

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -30,8 +30,8 @@ Arguments:
   [+toolchain]  Release channel (e.g. +stable) or custom toolchain to set override
 
 Options:
-  -v, --verbose  Enable verbose output
-  -q, --quiet    Disable progress output
+  -v, --verbose  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
+  -q, --quiet    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
   -h, --help     Print help
   -V, --version  Print version
 

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -32,10 +32,10 @@ Arguments:
 
 Options:
   -v, --verbose
-          Enable verbose output
+          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
 
   -q, --quiet
-          Disable progress output
+          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
 
   -h, --help
           Print help

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -84,24 +84,7 @@ async fn rustup_stable_quiet() {
 
 "
             ),
-            for_host!(
-                r"info: syncing channel updates for 'stable-{0}'
-info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
-info: cleaning up downloads & tmp directories
-"
-            ),
+            "",
         )
         .await;
 }


### PR DESCRIPTION
In the current setting, `debug!()` lines are not printed out even if I use `RUSTUP_LOG=rustup=DEBUG`. This logic used to make sense when we didn't have support for directives, but now it feels a bit awkward.

As a solution, I decided to follow the basic idea of #3911:
- `RUSTUP_LOG` decides ultimately when it's present.
- When `RUSTUP_LOG` is unset, `--quiet` or `--verbose` gets to decide the log verbosity.

Overall, now `--quiet` and `--verbose` behave more like what would be expected from general CLI applications.

This applies to both `rustup-mode` (i.e. `rustup`) and `setup-mode` (i.e. `rustup-init`).