### PR TITLE
ci(macos): install `awscli` from `brew`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1114,6 +1114,7 @@ jobs:
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
+          brew install --overwrite awscli
           which aws
           aws --version
       - name: Prepare the dist
@@ -1245,6 +1246,7 @@ jobs:
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
+          brew install --overwrite awscli
           which aws
           aws --version
       - name: Prepare the dist

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -99,6 +99,7 @@ jobs: # skip-x86_64 skip-aarch64
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
+          brew install --overwrite awscli
           which aws
           aws --version
       - name: Prepare the dist


### PR DESCRIPTION
Coming from https://github.com/aws/aws-cli/issues/8858 and https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Strange.20error.20with.20Rustup's.20release.20process.20on.20macOS.20ARM64, it looks like GitHub Actions is installing the x64 version of `awscli` on macOS ARM64, causing weird segfaults on upload.

This PR tries to install the native `awscli` from `brew` instead. It's not guaranteed to work, but AWS might no accept reports running x64 `awscli` on ARM64 in the first place, so this should be a reasonable move forward.

---

Tested with [d696700](https://github.com/rust-lang/rustup/commit/d696700bb39920a8577a05db73beb35ff4a7279d):

```console
> brew install --overwrite awscli
  which aws
  aws --version
  shell: /bin/bash -e {0}
  env:
    MACOSX_DEPLOYMENT_TARGET: 11
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/manifests/2.17.22
==> Fetching awscli
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/blobs/sha256:5e99263aa00c6f2dfb113b929e40f9c412e7ac7c000fc98d0a231c08b5782c71
==> Pouring awscli--2.17.22.arm64_sonoma.bottle.tar.gz
==> Caveats
The "examples" directory has been installed to:
  /opt/homebrew/share/awscli/examples

Bash completion has been installed to:
  /opt/homebrew/etc/bash_completion.d
==> Summary
🍺  /opt/homebrew/Cellar/awscli/2.17.22: 14,541 files, 127.9MB
/opt/homebrew/bin/aws
aws-cli/2.17.22 Python/3.11.9 Darwin/23.6.0 source/arm64
```
_https://github.com/rust-lang/rustup/actions/runs/10351189934/job/28649168983_

```console
> brew install --overwrite awscli
  which aws
  aws --version
  shell: /bin/bash -e {0}
  env:
    MACOSX_DEPLOYMENT_TARGET: 10.12
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/manifests/2.17.27
==> Fetching dependencies for awscli: cffi
==> Downloading https://ghcr.io/v2/homebrew/core/cffi/manifests/1.17.0
==> Fetching cffi
==> Downloading https://ghcr.io/v2/homebrew/core/cffi/blobs/sha256:02f428835ad5ca182e3a336574b63da07ad91f47f634d475376585a31d321c27
==> Fetching awscli
==> Downloading https://ghcr.io/v2/homebrew/core/awscli/blobs/sha256:c6358f1eb00c7ecc080256cdfd4ea67992a4c579eda46473f843a01f2a3e8727
==> Installing dependencies for awscli: cffi
==> Installing awscli dependency: cffi
==> Downloading https://ghcr.io/v2/homebrew/core/cffi/manifests/1.17.0
Already downloaded: /Users/runner/Library/Caches/Homebrew/downloads/7ceab5a46d67fed71a7c5c52fb74da10c3f08bea94026224b4823cd03d783552--cffi-1.17.0.bottle_manifest.json
==> Pouring cffi--1.17.0.ventura.bottle.tar.gz
🍺  /usr/local/Cellar/cffi/1.17.0: 66 files, 1.1MB
==> Installing awscli
==> Pouring awscli--2.17.27.ventura.bottle.tar.gz
==> Caveats
The "examples" directory has been installed to:
  /usr/local/share/awscli/examples

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
==> Summary
🍺  /usr/local/Cellar/awscli/2.17.27: 14,541 files, 128MB
==> Caveats
==> awscli
The "examples" directory has been installed to:
  /usr/local/share/awscli/examples

Bash completion has been installed to:
  /usr/local/etc/bash_completion.d
/usr/local/bin/aws
aws-cli/2.17.27 Python/3.11.9 Darwin/22.6.0 source/x86_64
```
_https://github.com/rust-lang/rustup/actions/runs/10351189934/job/28649170320_