### PR TITLE
fix(manifest): consider possible renames in `Component::try_new()`

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -498,19 +498,11 @@ impl Component {
         distributable: &DistributableToolchain<'_>,
         fallback_target: Option<&TargetTriple>,
     ) -> Result<Self> {
+        let manifest = distributable.get_manifest()?;
         for component_status in distributable.components()? {
-            let short_name = component_status.component.short_name_in_manifest();
-            let target = component_status.component.target.as_ref();
-
-            if name.starts_with(short_name)
-                && target.is_some()
-                && name == format!("{}-{}", short_name, target.unwrap())
-            {
-                return Ok(Component::new(
-                    short_name.to_string(),
-                    target.cloned(),
-                    false,
-                ));
+            let component = component_status.component;
+            if name == component.name_in_manifest() || name == component.name(&manifest) {
+                return Ok(component);
             }
         }
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1543,6 +1543,38 @@ async fn add_component_by_target_triple() {
 }
 
 #[tokio::test]
+async fn add_component_by_target_triple_renamed_from() {
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect_ok(&["rustup", "component", "add", for_host!("rls-{}")])
+        .await;
+    cx.config
+        .expect_ok_contains(
+            &["rustup", "component", "list", "--installed"],
+            for_host!("rls-{}"),
+            "",
+        )
+        .await;
+}
+
+#[tokio::test]
+async fn add_component_by_target_triple_renamed_to() {
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect_ok(&["rustup", "component", "add", for_host!("rls-preview-{}")])
+        .await;
+    cx.config
+        .expect_ok_contains(
+            &["rustup", "component", "list", "--installed"],
+            for_host!("rls-{}"),
+            "",
+        )
+        .await;
+}
+
+#[tokio::test]
 async fn fail_invalid_component_name() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config.expect_ok(&["rustup", "default", "stable"]).await;


### PR DESCRIPTION
Continuation of #3601. Addresses the following concern:

> I saw the fix of this issue was added into milestone 1.27.1.
> But I still met this bug with rustup 1.27.1.
> 
> Execute:
> ```
> rustup component remove llvm-tools-x86_64-unknown-linux-gnu
> ```
> 
> Output:
> ```
> error: toolchain 'stable-x86_64-unknown-linux-gnu' does not contain component 'llvm-tools-x86_64-unknown-linux-gnu' for target 'x86_64-unknown-linux-gnu'
> ```
> 
> But the following command works well:
> ```
> rustup component remove --target x86_64-unknown-linux-gnu llvm-tools
> ```

_by @yangby-cryptape in https://github.com/rust-lang/rustup/issues/3166#issuecomment-2285774658_
            