### PR TITLE
Allow `rustup doc` to search for unions

### DIFF
--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -47,7 +47,7 @@ pub(crate) fn local_path(root: &Path, topic: &str) -> Result<PathBuf> {
     // be changed.
     // https://github.com/rust-lang/rustup/issues/2076#issuecomment-546613036
     let keywords_top = vec!["keyword", "primitive", "macro"];
-    let keywords_mod = ["fn", "struct", "trait", "enum", "type", "constant"];
+    let keywords_mod = ["fn", "struct", "trait", "enum", "type", "constant", "union"];
 
     let topic_vec: Vec<&str> = topic.split("::").collect();
     let work_path = topic_vec.iter().fold(PathBuf::new(), |acc, e| acc.join(e));

--- a/src/test/mock/topical_doc_data.rs
+++ b/src/test/mock/topical_doc_data.rs
@@ -19,6 +19,7 @@ static TEST_CASES: &[&[&str]] = &[
     &["usize", "std/primitive.usize.html"],
     &["eprintln", "std/macro.eprintln.html"],
     &["alloc::format", "alloc/macro.format.html"],
+    &["std::mem::MaybeUninit", "std/mem/union.MaybeUninit.html"],
 ];
 
 fn repath(origin: &str) -> String {


### PR DESCRIPTION
Add "union" to the list of prefixes used when searching for documentation.

Fixes #4002, where `rustup doc` fails to find the documentation for `std::mem::MaybeUninit`.