### PR TITLE
chore(triage): allow transferring issues to other org repos

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -15,3 +15,7 @@ allow-unauthenticated = [
 ]
 
 [assign]
+
+# Enable issue transfers within the org
+# Documentation at: https://forge.rust-lang.org/triagebot/transfer.html
+[transfer]


### PR DESCRIPTION
As suggested in https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Transferring.20Rustup's.20issues.20via.20rustbot/near/463700430.

Addresses the following error:

> **Error**: The feature `transfer` is not enabled in this repository. To enable it add its section in the `triagebot.toml` in the root of the repository.
> 
> Please file an issue on GitHub at [triagebot](https://github.com/rust-lang/triagebot) if there's a problem with this bot, or reach out on [#t-infra](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra) on Zulip.
_https://github.com/rust-lang/rustup/issues/4001#issuecomment-2298814183_