### PR TITLE
Note that selecting VS lang packs is optional

### DIFF
--- a/doc/user-guide/src/installation/windows-msvc.md
+++ b/doc/user-guide/src/installation/windows-msvc.md
@@ -52,11 +52,16 @@ Note that the specific version of the Windows SDK doesn't matter for pure Rust c
 ![Select the latest MSVC component](images/component-msvc.png)
 ![Select the Windows 11 SDK component](images/component-sdk.png)
 
-### Completing the install
+### Adding Language Packs (optional)
 
-After choosing the components, switch to the "Language Packs" tab and add the English language pack in addition to your preferred language.
+After choosing the components, you may also want to select the language packs to install.
+Switch to the "Language Packs" tab and add the languages.
+It is recommended that you add the English language pack in addition to your preferred language.
+This will provide English language error messages, which may help when reporting errors.
 
 ![Add the English language](images/step4.png)
+
+### Completing the install
 
 Finally click the install button and wait for everything to be installed.
 


### PR DESCRIPTION
Rust used to mangle linker output for non-ascii error messages. The workaround was to install the Visual Studio English Language Pack so that most error messages would be mostly ascii (file names aside). However this was [fixed](https://github.com/rust-lang/rust/pull/110586) in Rust 1.71 (released July 2023) so it's no longer required. We should still recommend installing the English pack both for the sake of compatibility and because rustc's output is itself still in English unless a nightly feature is used.