### PR TITLE
docs(README): Point out where to find nightly/master docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ And it runs on all platforms Rust supports, including Windows.
 See [**The Rustup book**](https://rust-lang.github.io/rustup/) for
 documentation on installing and using Rustup.
 
+The latest documentation for the master branch can be found
+under [devel](https://rust-lang.github.io/rustup/devel/).
+
 ## Contributing
 
 See [**The Rustup dev guide**](https://rust-lang.github.io/rustup/dev-guide) for information on contributing to Rustup.


### PR DESCRIPTION
Change was briefly discussed with @rami3l over Discord.

I'm not sure if this is the most clear wording, and whether the book itself should point out where to find the nightly/master version. Can adjust both if needed.