### PR TITLE
refactor(cli/common)!: deny installing a host-incompatible toolchain w/o `--force-non-host`

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -629,7 +629,7 @@ pub(crate) fn ignorable_error(
 /// Warns if rustup is trying to install a toolchain that might not be
 /// able to run on the host system.
 pub(crate) fn warn_if_host_is_incompatible(
-    toolchain: impl Display,
+    toolchain: String,
     host_arch: &TargetTriple,
     target_triple: &TargetTriple,
     force_non_host: bool,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -725,7 +725,7 @@ async fn default_(
             MaybeResolvableToolchainName::Some(ResolvableToolchainName::Official(toolchain)) => {
                 let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
                 let status = cfg
-                    .ensure_installed(&desc, vec![], vec![], None, true)
+                    .ensure_installed(&desc, vec![], vec![], None, false, true)
                     .await?
                     .0;
 
@@ -878,7 +878,9 @@ async fn update(
             exit_code &= common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else if ensure_active_toolchain {
-        let (toolchain, reason) = cfg.find_or_install_active_toolchain(true).await?;
+        let (toolchain, reason) = cfg
+            .find_or_install_active_toolchain(force_non_host, true)
+            .await?;
         info!("the active toolchain `{toolchain}` has been installed");
         info!("it's active because: {reason}");
     } else {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -814,7 +814,7 @@ async fn update(
     let self_update = !self_update::NEVER_SELF_UPDATE
         && self_update_mode == SelfUpdateMode::Enable
         && !opts.no_self_update;
-    let forced = opts.force_non_host;
+    let force_non_host = opts.force_non_host;
     if let Some(p) = opts.profile {
         cfg.set_profile_override(p);
     }
@@ -829,7 +829,12 @@ async fn update(
             if name.has_triple() {
                 let host_arch = TargetTriple::from_host_or_build(cfg.process);
                 let target_triple = name.clone().resolve(&host_arch)?.target;
-                common::warn_if_host_is_incompatible(&name, &host_arch, &target_triple, forced)?;
+                common::warn_if_host_is_incompatible(
+                    &name,
+                    &host_arch,
+                    &target_triple,
+                    force_non_host,
+                )?;
             }
             let desc = name.resolve(&cfg.get_default_host_triple()?)?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -838,7 +838,7 @@ async fn update(
                 let host_arch = TargetTriple::from_host_or_build(cfg.process);
                 let target_triple = name.clone().resolve(&host_arch)?.target;
                 common::warn_if_host_is_incompatible(
-                    &name,
+                    name.to_string(),
                     &host_arch,
                     &target_triple,
                     force_non_host,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -837,7 +837,7 @@ async fn update(
             if name.has_triple() {
                 let host_arch = TargetTriple::from_host_or_build(cfg.process);
                 let target_triple = name.clone().resolve(&host_arch)?.target;
-                common::warn_if_host_is_incompatible(
+                common::check_non_host_toolchain(
                     name.to_string(),
                     &host_arch,
                     &target_triple,

--- a/src/config.rs
+++ b/src/config.rs
@@ -793,7 +793,7 @@ impl<'a> Cfg<'a> {
         force_non_host: bool,
         verbose: bool,
     ) -> Result<(UpdateStatus, Toolchain<'_>)> {
-        common::warn_if_host_is_incompatible(
+        common::check_non_host_toolchain(
             toolchain.to_string(),
             &TargetTriple::from_host_or_build(self.process),
             &toolchain.target,

--- a/src/config.rs
+++ b/src/config.rs
@@ -794,7 +794,7 @@ impl<'a> Cfg<'a> {
         verbose: bool,
     ) -> Result<(UpdateStatus, Toolchain<'_>)> {
         common::warn_if_host_is_incompatible(
-            toolchain,
+            toolchain.to_string(),
             &TargetTriple::from_host_or_build(self.process),
             &toolchain.target,
             force_non_host,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -84,6 +84,15 @@ pub enum RustupError {
     },
     #[error("command failed: '{}'", PathBuf::from(.name).display())]
     RunningCommand { name: OsString },
+    #[error(
+        "toolchain '{toolchain}' may not be able to run on this system\n\
+        note: to build software for that platform, try `rustup target add {target_triple}` instead\n\
+        note: add the `--force-non-host` flag to install the toolchain anyway"
+    )]
+    ToolchainIncompatible {
+        toolchain: String,
+        target_triple: TargetTriple,
+    },
     #[error("toolchain '{0}' is not installable")]
     ToolchainNotInstallable(String),
     #[error(

--- a/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_default_cmd_help_flag_stdout.toml
@@ -4,14 +4,16 @@ stdout = """
 ...
 Set the default toolchain
 
-Usage: rustup[EXE] default [TOOLCHAIN]
+Usage: rustup[EXE] default [OPTIONS] [TOOLCHAIN]
 
 Arguments:
   [TOOLCHAIN]  'none', a toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain
                name. For more information see `rustup help toolchain`
 
 Options:
-  -h, --help  Print help
+      --force-non-host  Install toolchains that require an emulator. See
+                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help            Print help
 
 Discussion:
     Sets the default toolchain to the one specified. If the toolchain

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -210,7 +210,7 @@ async fn multi_host_smoke_test() {
     let mut cx = CliTestContext::new(Scenario::MultiHost).await;
     let toolchain = format!("nightly-{}", clitools::MULTI_ARCH1);
     cx.config
-        .expect_ok(&["rustup", "default", &toolchain])
+        .expect_ok(&["rustup", "default", &toolchain, "--force-non-host"])
         .await;
     cx.config
         .expect_stdout_ok(&["rustc", "--version"], "xxxx-nightly-2")

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -754,6 +754,7 @@ async fn show_multiple_targets() {
             "rustup",
             "default",
             &format!("nightly-{}", clitools::MULTI_ARCH1),
+            "--force-non-host",
         ])
         .await;
     cx.config
@@ -801,6 +802,7 @@ async fn show_multiple_toolchains_and_targets() {
             "rustup",
             "default",
             &format!("nightly-{}", clitools::MULTI_ARCH1),
+            "--force-non-host",
         ])
         .await;
     cx.config
@@ -810,6 +812,7 @@ async fn show_multiple_toolchains_and_targets() {
         .expect_ok(&[
             "rustup",
             "update",
+            "--force-non-host",
             &format!("stable-{}", clitools::MULTI_ARCH1),
         ])
         .await;
@@ -2731,29 +2734,33 @@ async fn check_unix_settings_fallback() {
 }
 
 #[tokio::test]
-async fn warn_on_unmatch_build() {
+async fn deny_incompatible_toolchain_install() {
     let cx = CliTestContext::new(Scenario::MultiHost).await;
     let arch = clitools::MULTI_ARCH1;
-    cx.config.expect_stderr_ok(
-        &["rustup", "toolchain", "install", &format!("nightly-{arch}")],
-        &format!(
-            r"warn: toolchain 'nightly-{arch}' may not be able to run on this system.
-warn: If you meant to build software to target that platform, perhaps try `rustup target add {arch}` instead?",
-        ),
-    ).await;
+    cx.config
+        .expect_err(
+            &["rustup", "toolchain", "install", &format!("nightly-{arch}")],
+            &format!(
+                "error: toolchain 'nightly-{arch}' may not be able to run on this system
+note: to build software for that platform, try `rustup target add {arch}` instead",
+            ),
+        )
+        .await;
 }
 
 #[tokio::test]
-async fn warn_on_unmatch_build_default() {
+async fn deny_incompatible_toolchain_default() {
     let cx = CliTestContext::new(Scenario::MultiHost).await;
     let arch = clitools::MULTI_ARCH1;
-    cx.config.expect_stderr_ok(
-        &["rustup", "default", &format!("nightly-{arch}")],
-        &format!(
-            r"warn: toolchain 'nightly-{arch}' may not be able to run on this system.
-warn: If you meant to build software to target that platform, perhaps try `rustup target add {arch}` instead?",
-        ),
-    ).await;
+    cx.config
+        .expect_err(
+            &["rustup", "default", &format!("nightly-{arch}")],
+            &format!(
+                "error: toolchain 'nightly-{arch}' may not be able to run on this system
+note: to build software for that platform, try `rustup target add {arch}` instead",
+            ),
+        )
+        .await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #3982, as discussed in https://github.com/rust-lang/rustup/issues/3982#issuecomment-2360847988.