### PR TITLE
Remove unnecessary methods

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -809,11 +809,7 @@ pub struct RegistryValueId {
 
 #[cfg(any(test, feature = "test"))]
 impl RegistryValueId {
-    pub fn get_value(&self) -> Result<Option<Value>> {
-        self.get()
-    }
-
-    fn get(&self) -> Result<Option<Value>> {
+    pub fn get(&self) -> Result<Option<Value>> {
         let sub_key = CURRENT_USER.create(self.sub_key)?;
         match sub_key.get_value(self.value_name) {
             Ok(val) => Ok(Some(val)),
@@ -822,11 +818,7 @@ impl RegistryValueId {
         }
     }
 
-    pub fn set_value(&self, new: Option<&Value>) -> Result<()> {
-        self.set(new)
-    }
-
-    fn set(&self, new: Option<&Value>) -> Result<()> {
+    pub fn set(&self, new: Option<&Value>) -> Result<()> {
         let sub_key = CURRENT_USER.create(self.sub_key)?;
         match new {
             Some(new) => Ok(sub_key.set_value(self.value_name, new)?),

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -352,11 +352,11 @@ async fn update_overwrites_programs_display_version() {
         .await;
 
     USER_RUSTUP_VERSION
-        .set_value(Some(&Value::from(PLACEHOLDER_VERSION)))
+        .set(Some(&Value::from(PLACEHOLDER_VERSION)))
         .unwrap();
     cx.config.expect_ok(&["rustup", "self", "update"]).await;
     assert_eq!(
-        USER_RUSTUP_VERSION.get_value().unwrap().unwrap(),
+        USER_RUSTUP_VERSION.get().unwrap().unwrap(),
         Value::from(version)
     );
 }


### PR DESCRIPTION
Coming from this: https://github.com/rust-lang/rustup/pull/3896#discussion_r1704153219. The `get/set_value()` are actually the alias of `get/set()`. So, it should be removed.