### PR TITLE
fix(rustup-init/sh): fix incorrect TLS warning with curl v8.10

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -706,7 +706,7 @@ check_help_for() {
     shift
 
     local _category
-    if "$_cmd" --help | grep -q 'For all options use the manual or "--help all".'; then
+    if "$_cmd" --help | grep -q '"--help all"'; then
       _category="all"
     else
       _category=""


### PR DESCRIPTION
Closes #4045, as discussed in https://github.com/rust-lang/rustup/issues/4045#issuecomment-2406387405.

Tested locally on Alpine Linux v3.20 aarch64 with the following cURL distribution:

```console
> curl --version
curl 8.10.1 (aarch64-alpine-linux-musl) libcurl/8.10.1 OpenSSL/3.3.2 zlib/1.3.1 brotli/1.1.0 zstd/1.5.6 c-ares/1.33.1 libidn2/2.3.7 libpsl/0.21.5 nghttp2/1.62.1
Release-Date: 2024-09-18
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTPS-proxy IDN IPv6 Largefile libz NTLM PSL SSL threadsafe TLS-SRP UnixSockets zstd
```