### PR TITLE
fix(config): don't show toolchain names from `rust-toolchain.toml` in error message

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -619,7 +619,13 @@ impl<'a> Cfg<'a> {
                         }
                     })?;
                 if let Some(toolchain_name_str) = &override_file.toolchain.channel {
-                    let toolchain_name = ResolvableToolchainName::try_from(toolchain_name_str)?;
+                    let toolchain_name = ResolvableToolchainName::try_from(toolchain_name_str)
+                        .map_err(|_| {
+                            anyhow!(
+                                "invalid toolchain name detected in override file '{}'",
+                                toolchain_file.display()
+                            )
+                        })?;
                     let default_host_triple = get_default_host_triple(settings, self.process);
                     // Do not permit architecture/os selection in channels as
                     // these are host specific and toolchain files are portable.

--- a/src/config.rs
+++ b/src/config.rs
@@ -649,7 +649,7 @@ impl<'a> Cfg<'a> {
                         Err(RustupError::ToolchainNotInstalled(_)) => {
                             if matches!(toolchain_name, ToolchainName::Custom(_)) {
                                 bail!(
-                                    "Toolchain {toolchain_name} in {} is custom and not installed",
+                                    "custom toolchain specified in override file '{}' is not installed",
                                     toolchain_file.display()
                                 )
                             }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2487,7 +2487,37 @@ async fn file_override_not_installed_custom() {
     raw::write_file(&toolchain_file, "gumbo").unwrap();
 
     cx.config
-        .expect_err(&["rustc", "--version"], "custom and not installed")
+        .expect_err(
+            &["rustup", "show", "active-toolchain"],
+            "custom toolchain specified in override file",
+        )
+        .await;
+    cx.config
+        .expect_err(
+            &["rustc", "--version"],
+            "custom toolchain specified in override file",
+        )
+        .await;
+}
+
+#[tokio::test]
+async fn file_override_not_installed_custom_toml() {
+    let cx = CliTestContext::new(Scenario::None).await;
+    let cwd = cx.config.current_dir();
+    let toolchain_file = cwd.join("rust-toolchain.toml");
+    raw::write_file(&toolchain_file, r#"toolchain.channel = "i-am-the-walrus""#).unwrap();
+
+    cx.config
+        .expect_err(
+            &["rustup", "show", "active-toolchain"],
+            "custom toolchain specified in override file",
+        )
+        .await;
+    cx.config
+        .expect_err(
+            &["rustc", "--version"],
+            "custom toolchain specified in override file",
+        )
         .await;
 }
 


### PR DESCRIPTION
Closes #4053.