### PR TITLE
chore: use more workspace-wide configurations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "rustup"
-version = "1.27.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Manage multiple rust installations with ease"
 homepage = "https://github.com/rust-lang/rustup"
 keywords = ["rustup", "multirust", "install", "proxy"]
-license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/rustup"
 build = "build.rs"
@@ -132,6 +132,11 @@ regex = "1"
 
 [workspace]
 members = ["download"]
+
+[workspace.package]
+version = "1.27.1"
+edition = "2021"
+license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
 anyhow = "1.0.69"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,9 @@ trycmd = "0.15.0"
 platforms.workspace = true
 regex = "1"
 
+[lints]
+workspace = true
+
 [workspace]
 members = ["download"]
 
@@ -157,6 +160,9 @@ tracing-opentelemetry = "0.27"
 tracing-subscriber = "0.3.16"
 url = "2.4"
 walkdir = "2"
+
+[workspace.lints.rust]
+rust_2018_idioms = "deny"
 
 [lib]
 name = "rustup"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,6 +164,11 @@ walkdir = "2"
 [workspace.lints.rust]
 rust_2018_idioms = "deny"
 
+[workspace.lints.clippy]
+# `dbg!()` and `todo!()` clearly shouldn't make it to production:
+dbg_macro = "warn"
+todo = "warn"
+
 [lib]
 name = "rustup"
 path = "src/lib.rs"

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -32,3 +32,6 @@ http-body-util = "0.1.0"
 hyper = { version = "1.0", default-features = false, features = ["server", "http1"] }
 hyper-util = { version = "0.1.1", features = ["tokio"] }
 tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "download"
-version = "1.27.1"
-edition = "2021"
-license = "MIT OR Apache-2.0"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [features]
 default = ["reqwest-backend", "reqwest-rustls-tls", "reqwest-native-tls"]

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -1,5 +1,4 @@
 //! Easy file downloading
-#![deny(rust_2018_idioms)]
 
 use std::fs::remove_file;
 use std::path::Path;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -588,7 +588,8 @@ pub async fn main(
     }
 
     let Some(subcmd) = matches.subcmd else {
-        eprintln!("{}", Rustup::command().render_long_help());
+        let help = Rustup::command().render_long_help();
+        writeln!(process.stderr().lock(), "{help}")?;
         return Ok(utils::ExitCode(1));
     };
 

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -268,6 +268,7 @@ impl<'a> Executor for Threaded<'a> {
                 prev_files as u64,
             ));
         }
+        #[allow(clippy::print_stderr)]
         if prev_files > 50 {
             eprintln!("{prev_files} deferred IO operations");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(rust_2018_idioms)]
 #![allow(
     clippy::type_complexity,
     clippy::result_large_err, // 288 bytes is our 'large' variant today, which is unlikely to be a performance problem

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,11 @@
     clippy::result_large_err, // 288 bytes is our 'large' variant today, which is unlikely to be a performance problem
     clippy::arc_with_non_send_sync, // will get resolved as we move further into async
 )]
+#![cfg_attr(not(test), warn(
+    // We use the logging system instead of printing directly.
+    clippy::print_stdout,
+    clippy::print_stderr,
+))]
 #![recursion_limit = "1024"]
 
 use anyhow::{anyhow, Result};

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::box_default)]
+#![allow(clippy::box_default, clippy::print_stdout, clippy::print_stderr)]
 //! Test support module; public to permit use from integration tests.
 
 pub mod mock;

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -668,8 +668,11 @@ impl Config {
             println!("expected.ok: true");
             print_indented("expected.stdout", stdout);
             print_indented("expected.stderr", stderr);
-            dbg!(out.stdout == stdout);
-            dbg!(out.stderr == stderr);
+            #[allow(clippy::dbg_macro)]
+            {
+                dbg!(out.stdout == stdout);
+                dbg!(out.stderr == stderr);
+            }
             panic!();
         }
     }


### PR DESCRIPTION
This PR does the following cleanup WRT `Cargo.toml`:

* Updated `Cargo.toml` to use workspace settings for `version`, `edition`, and `license` fields (cherry-picked from #4041) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-L8) [[2]](diffhunk://#diff-96c60da7e4be39230f90e0d59f4bc52cbbc12cb8330c5df73313c4e63dd3e014L3-R5)
* Added workspace linting configurations for Rust idioms and clippy lints. (`Cargo.toml`, `download/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R164-R171) [[2]](diffhunk://#diff-96c60da7e4be39230f90e0d59f4bc52cbbc12cb8330c5df73313c4e63dd3e014R35-R37)

This also prepares the repo for its upcoming migration to Rust 2024 by making it easier to enable `rust-2024-compatibility` across the project. With this change, that will look like:

```toml
[workspace.lints.rust]
rust_2018_idioms = { level = "deny", priority = -1 }
rust-2024-compatibility = { level = "warn", priority = -2 }
```