### PR TITLE
refactor(diskio): replace `eprintln!()` with `debug!()`

### DIFF
--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -12,6 +12,7 @@ use std::sync::Arc;
 
 use enum_map::{enum_map, Enum, EnumMap};
 use sharded_slab::pool::{OwnedRef, OwnedRefMut};
+use tracing::debug;
 
 use super::{perform, CompletedIo, Executor, Item};
 use crate::utils::notifications::Notification;
@@ -268,9 +269,8 @@ impl<'a> Executor for Threaded<'a> {
                 prev_files as u64,
             ));
         }
-        #[allow(clippy::print_stderr)]
         if prev_files > 50 {
-            eprintln!("{prev_files} deferred IO operations");
+            debug!("{prev_files} deferred IO operations");
         }
         let buf: Vec<u8> = vec![0; prev_files];
         // Cheap wrap-around correctness check - we have 20k files, more than

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,9 @@
-#![allow(clippy::box_default, clippy::print_stdout, clippy::print_stderr)]
+#![allow(
+    clippy::box_default,
+    clippy::print_stdout,
+    clippy::print_stderr,
+    clippy::dbg_macro
+)]
 //! Test support module; public to permit use from integration tests.
 
 pub mod mock;

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -668,11 +668,8 @@ impl Config {
             println!("expected.ok: true");
             print_indented("expected.stdout", stdout);
             print_indented("expected.stderr", stderr);
-            #[allow(clippy::dbg_macro)]
-            {
-                dbg!(out.stdout == stdout);
-                dbg!(out.stderr == stderr);
-            }
+            dbg!(out.stdout == stdout);
+            dbg!(out.stderr == stderr);
             panic!();
         }
     }


### PR DESCRIPTION
Addresses @djc's concerns in reviewing https://github.com/rust-lang/rustup/pull/4061. See https://github.com/rust-lang/rustup/pull/4061#discussion_r1816147157 and https://github.com/rust-lang/rustup/pull/4061#discussion_r1816145584.