### PR TITLE
fix: add powerpc64 and s390x to known target_arch values for tests

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -144,6 +144,10 @@ pub fn this_host_triple() -> String {
         "aarch64"
     } else if cfg!(target_arch = "loongarch64") {
         "loongarch64"
+    } else if cfg!(target_arch = "powerpc64") && cfg!(target_endian = "little") {
+        "powerpc64le"
+    } else if cfg!(target_arch = "s390x") {
+        "s390x"
     } else {
         unimplemented!()
     };


### PR DESCRIPTION
This fixes running tests on the ppc64le-unknown-linux-gnu and s390x-unknown-linux-gnu targets. Tested and verified to work on both of these architectures on Fedora Linux.
