### PR TITLE
feat(cli/rustup-mode): allow `rustup doc` with both a flag and a topic

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1513,19 +1513,19 @@ async fn doc(
     if path_only {
         let doc_path = toolchain.doc_path(doc_url)?;
         writeln!(cfg.process.stdout().lock(), "{}", doc_path.display())?;
-        Ok(utils::ExitCode(0))
-    } else {
-        if let Some(name) = topic {
-            writeln!(
-                cfg.process.stderr().lock(),
-                "Opening docs named `{name}` in your browser"
-            )?;
-        } else {
-            writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
-        }
-        toolchain.open_docs(doc_url)?;
-        Ok(utils::ExitCode(0))
+        return Ok(utils::ExitCode(0));
     }
+
+    if let Some(name) = topic {
+        writeln!(
+            cfg.process.stderr().lock(),
+            "Opening docs named `{name}` in your browser"
+        )?;
+    } else {
+        writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
+    }
+    toolchain.open_docs(doc_url)?;
+    Ok(utils::ExitCode(0))
 }
 
 #[cfg(not(windows))]

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1531,7 +1531,7 @@ async fn doc(
     } else {
         writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
     }
-    toolchain.open_docs(&doc_path)?;
+    toolchain.open_docs(&doc_path, None)?;
     Ok(utils::ExitCode(0))
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1507,7 +1507,7 @@ async fn doc(
         }
     };
 
-    let doc_url = if let Some(topic) = topic {
+    let doc_path = if let Some(topic) = topic {
         Cow::Owned(topical_doc::local_path(
             &toolchain.doc_path("").unwrap(),
             topic,
@@ -1518,7 +1518,7 @@ async fn doc(
     };
 
     if path_only {
-        let doc_path = toolchain.doc_path(&doc_url)?;
+        let doc_path = toolchain.doc_path(&doc_path)?;
         writeln!(cfg.process.stdout().lock(), "{}", doc_path.display())?;
         return Ok(utils::ExitCode(0));
     }
@@ -1531,7 +1531,7 @@ async fn doc(
     } else {
         writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
     }
-    toolchain.open_docs(&doc_url)?;
+    toolchain.open_docs(&doc_path)?;
     Ok(utils::ExitCode(0))
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1425,10 +1425,6 @@ macro_rules! docs_data {
         }
 
         impl DocPage {
-            fn name(&self) -> Option<&'static str> {
-                Some(self.path()?.rsplit_once('/')?.0)
-            }
-
             fn path(&self) -> Option<&'static str> {
                 $( if self.$ident { return Some($path); } )+
                 None
@@ -1465,6 +1461,12 @@ docs_data![
     (test, "Support code for rustc's built in unit-test and micro-benchmarking framework", "test/index.html"),
     (unstable_book, "The Unstable Book", "unstable-book/index.html"),
 ];
+
+impl DocPage {
+    fn name(&self) -> Option<&'static str> {
+        Some(self.path()?.rsplit_once('/')?.0)
+    }
+}
 
 async fn doc(
     cfg: &Cfg<'_>,

--- a/src/test/mock/topical_doc_data.rs
+++ b/src/test/mock/topical_doc_data.rs
@@ -3,23 +3,23 @@ use std::path::PathBuf;
 
 // Paths are written as a string in the UNIX format to make it easy
 // to maintain.
-static TEST_CASES: &[&[&str]] = &[
-    &["core", "core/index.html"],
-    &["core::arch", "core/arch/index.html"],
-    &["fn", "std/keyword.fn.html"],
-    &["keyword:fn", "std/keyword.fn.html"],
-    &["primitive:fn", "std/primitive.fn.html"],
-    &["macro:file!", "std/macro.file!.html"],
-    &["macro:file", "std/macro.file.html"],
-    &["std::fs", "std/fs/index.html"],
-    &["std::fs::read_dir", "std/fs/fn.read_dir.html"],
-    &["std::io::Bytes", "std/io/struct.Bytes.html"],
-    &["std::iter::Sum", "std/iter/trait.Sum.html"],
-    &["std::io::error::Result", "std/io/error/type.Result.html"],
-    &["usize", "std/primitive.usize.html"],
-    &["eprintln", "std/macro.eprintln.html"],
-    &["alloc::format", "alloc/macro.format.html"],
-    &["std::mem::MaybeUninit", "std/mem/union.MaybeUninit.html"],
+static TEST_CASES: &[(&[&str], &str)] = &[
+    (&["core"], "core/index.html"),
+    (&["core::arch"], "core/arch/index.html"),
+    (&["fn"], "std/keyword.fn.html"),
+    (&["keyword:fn"], "std/keyword.fn.html"),
+    (&["primitive:fn"], "std/primitive.fn.html"),
+    (&["macro:file!"], "std/macro.file!.html"),
+    (&["macro:file"], "std/macro.file.html"),
+    (&["std::fs"], "std/fs/index.html"),
+    (&["std::fs::read_dir"], "std/fs/fn.read_dir.html"),
+    (&["std::io::Bytes"], "std/io/struct.Bytes.html"),
+    (&["std::iter::Sum"], "std/iter/trait.Sum.html"),
+    (&["std::io::error::Result"], "std/io/error/type.Result.html"),
+    (&["usize"], "std/primitive.usize.html"),
+    (&["eprintln"], "std/macro.eprintln.html"),
+    (&["alloc::format"], "alloc/macro.format.html"),
+    (&["std::mem::MaybeUninit"], "std/mem/union.MaybeUninit.html"),
 ];
 
 fn repath(origin: &str) -> String {
@@ -30,8 +30,8 @@ fn repath(origin: &str) -> String {
     repathed.into_os_string().into_string().unwrap()
 }
 
-pub fn test_cases<'a>() -> impl Iterator<Item = (&'a str, String)> {
-    TEST_CASES.iter().map(|x| (x[0], repath(x[1])))
+pub fn test_cases<'a>() -> impl Iterator<Item = (&'a [&'a str], String)> {
+    TEST_CASES.iter().map(|(args, path)| (*args, repath(path)))
 }
 
 pub fn unique_paths() -> impl Iterator<Item = String> {
@@ -39,6 +39,6 @@ pub fn unique_paths() -> impl Iterator<Item = String> {
     let mut unique_paths = HashSet::new();
     TEST_CASES
         .iter()
-        .filter(move |e| unique_paths.insert(e[1]))
-        .map(|e| repath(e[1]))
+        .filter(move |(_, p)| unique_paths.insert(p))
+        .map(|(_, p)| repath(p))
 }

--- a/src/test/mock/topical_doc_data.rs
+++ b/src/test/mock/topical_doc_data.rs
@@ -20,6 +20,12 @@ static TEST_CASES: &[(&[&str], &str)] = &[
     (&["eprintln"], "std/macro.eprintln.html"),
     (&["alloc::format"], "alloc/macro.format.html"),
     (&["std::mem::MaybeUninit"], "std/mem/union.MaybeUninit.html"),
+    (&["--rustc", "lints"], "rustc/lints/index.html"),
+    (&["--rustdoc", "lints"], "rustdoc/lints.html"),
+    (
+        &["lints::broken_intra_doc_links", "--rustdoc"],
+        "rustdoc/lints.html",
+    ),
 ];
 
 fn repath(origin: &str) -> String {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -409,6 +409,11 @@ impl<'a> Toolchain<'a> {
     }
 
     pub fn doc_path(&self, relative: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
+        let relative = relative.as_ref();
+        if relative.is_absolute() {
+            return Ok(relative.to_owned());
+        }
+
         let mut doc_dir = self.path.clone();
         doc_dir.extend(["share", "doc", "rust", "html"]);
         doc_dir.push(relative);

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -408,7 +408,7 @@ impl<'a> Toolchain<'a> {
         buf
     }
 
-    pub fn doc_path(&self, relative: &str) -> anyhow::Result<PathBuf> {
+    pub fn doc_path(&self, relative: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
         let parts = vec!["share", "doc", "rust", "html"];
         let mut doc_dir = self.path.clone();
         for part in parts {
@@ -419,7 +419,7 @@ impl<'a> Toolchain<'a> {
         Ok(doc_dir)
     }
 
-    pub fn open_docs(&self, relative: &str) -> anyhow::Result<()> {
+    pub fn open_docs(&self, relative: impl AsRef<Path>) -> anyhow::Result<()> {
         utils::open_browser(&self.doc_path(relative)?)
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -409,11 +409,8 @@ impl<'a> Toolchain<'a> {
     }
 
     pub fn doc_path(&self, relative: impl AsRef<Path>) -> anyhow::Result<PathBuf> {
-        let parts = vec!["share", "doc", "rust", "html"];
         let mut doc_dir = self.path.clone();
-        for part in parts {
-            doc_dir.push(part);
-        }
+        doc_dir.extend(["share", "doc", "rust", "html"]);
         doc_dir.push(relative);
 
         Ok(doc_dir)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,6 +1,7 @@
 //!  Utility functions for Rustup
 
 use std::env;
+use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::{self, BufReader, Write};
 use std::ops::{BitAnd, BitAndAssign};
@@ -459,7 +460,7 @@ pub(crate) fn read_dir(name: &'static str, path: &Path) -> Result<fs::ReadDir> {
     })
 }
 
-pub(crate) fn open_browser(path: &Path) -> Result<()> {
+pub(crate) fn open_browser(path: impl AsRef<OsStr>) -> Result<()> {
     opener::open_browser(path).context("couldn't open browser")
 }
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2640,8 +2640,12 @@ async fn docs_topical_with_path() {
         .expect_ok(&["rustup", "toolchain", "install", "nightly"])
         .await;
 
-    for (topic, path) in mock::topical_doc_data::test_cases() {
-        let mut cmd = clitools::cmd(&cx.config, "rustup", ["doc", "--path", topic]);
+    for (args, path) in mock::topical_doc_data::test_cases() {
+        let mut cmd = clitools::cmd(
+            &cx.config,
+            "rustup",
+            ["doc", "--path"].iter().chain(args.iter()),
+        );
         clitools::env(&cx.config, &mut cmd);
 
         let out = cmd.output().unwrap();
@@ -2649,7 +2653,7 @@ async fn docs_topical_with_path() {
         let out_str = String::from_utf8(out.stdout).unwrap();
         assert!(
             out_str.contains(&path),
-            "comparing path\ntopic: '{topic}'\nexpected path: '{path}'\noutput: {out_str}\n\n\n",
+            "comparing path\nargs: '{args:?}'\nexpected path: '{path}'\noutput: {out_str}\n\n\n",
         );
     }
 }


### PR DESCRIPTION
This PR is my stab at the concern in https://github.com/rust-lang/rustup/issues/4069.

However, I think `rustup` should not magically detect and acknowledge lints, so I've made a more neutral solution that might apply to more topics:

> Does `rustup doc --rustdoc lints::broken_intra_doc_links` look okay to you?
> 
> I mean, we can try with the following semantics with `lints::broken_intra_doc_links`:
> 
> 1. Look for `lints/broken_intra_doc_links/index.html`.
> 2. Look for `lints/broken_intra_doc_links.html`.
> 3. Look for `lints.html`. If it exists, resolve to `lints.html#broken_intra_doc_links`.
> 4. Throw an error.
> 
> PS: I have manually verified that this algorithm, if implemented correctly, will work with `rustc`, `rustdoc` and `clippy` books.
_https://github.com/rust-lang/rustup/issues/4069#issuecomment-2466043060_

## Example

```console
> rustup doc --rustc platform-support::armv6k-nintendo-3ds::building-the-target
```

## Concerns

- [x] ~~Should we add test cases for this PR, and how may we add them?~~ Added `--path` tests to ensure that we can get the doc paths right.
- [ ] Due to a restriction with our upstream [Seeker14491/opener](https://github.com/Seeker14491/opener) and/or the underlying macOS `open` command, anchors (such as `#building-the-target` in this case) are unfortunately ignored when using this syntax on macOS.