### PR TITLE
feat(cli/rustup-mode): support more books in `rustup doc`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1445,6 +1445,7 @@ docs_data![
     (cargo, "The Cargo Book", "cargo/index.html"),
     (core, "The Rust Core Library", "core/index.html"),
     (edition_guide, "The Rust Edition Guide", "edition-guide/index.html"),
+    (embedded_book, "The Embedded Rust Book", "embedded-book/index.html"),
     (nomicon, "The Dark Arts of Advanced and Unsafe Rust Programming", "nomicon/index.html"),
 
     #[arg(long = "proc_macro")]
@@ -1457,7 +1458,6 @@ docs_data![
     (std, "Standard library API documentation", "std/index.html"),
     (test, "Support code for rustc's built in unit-test and micro-benchmarking framework", "test/index.html"),
     (unstable_book, "The Unstable Book", "unstable-book/index.html"),
-    (embedded_book, "The Embedded Rust Book", "embedded-book/index.html"),
 ];
 
 async fn doc(

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1443,9 +1443,14 @@ docs_data![
     (alloc, "The Rust core allocation and collections library", "alloc/index.html"),
     (book, "The Rust Programming Language book", "book/index.html"),
     (cargo, "The Cargo Book", "cargo/index.html"),
+    (clippy, "The Clippy Documentation", "clippy/index.html"),
     (core, "The Rust Core Library", "core/index.html"),
     (edition_guide, "The Rust Edition Guide", "edition-guide/index.html"),
     (embedded_book, "The Embedded Rust Book", "embedded-book/index.html"),
+
+    #[arg(long = "error_codes")]
+    (error_codes, "The Rust Error Codes Index", "error_codes/index.html"),
+
     (nomicon, "The Dark Arts of Advanced and Unsafe Rust Programming", "nomicon/index.html"),
 
     #[arg(long = "proc_macro")]
@@ -1456,6 +1461,7 @@ docs_data![
     (rustc, "The compiler for the Rust programming language", "rustc/index.html"),
     (rustdoc, "Documentation generator for Rust projects", "rustdoc/index.html"),
     (std, "Standard library API documentation", "std/index.html"),
+    (style_guide, "The Rust Style Guide", "style-guide/index.html"),
     (test, "Support code for rustc's built in unit-test and micro-benchmarking framework", "test/index.html"),
     (unstable_book, "The Unstable Book", "unstable-book/index.html"),
 ];

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -20,6 +20,7 @@ Options:
       --cargo                  The Cargo Book
       --core                   The Rust Core Library
       --edition-guide          The Rust Edition Guide
+      --embedded-book          The Embedded Rust Book
       --nomicon                The Dark Arts of Advanced and Unsafe Rust Programming
       --proc_macro             A support library for macro authors when defining new macros
       --reference              The Rust Reference
@@ -31,7 +32,6 @@ Options:
       --test                   Support code for rustc's built in unit-test and micro-benchmarking
                                framework
       --unstable-book          The Unstable Book
-      --embedded-book          The Embedded Rust Book
   -h, --help                   Print help
 
 Discussion:

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -18,9 +18,11 @@ Options:
       --alloc                  The Rust core allocation and collections library
       --book                   The Rust Programming Language book
       --cargo                  The Cargo Book
+      --clippy                 The Clippy Documentation
       --core                   The Rust Core Library
       --edition-guide          The Rust Edition Guide
       --embedded-book          The Embedded Rust Book
+      --error_codes            The Rust Error Codes Index
       --nomicon                The Dark Arts of Advanced and Unsafe Rust Programming
       --proc_macro             A support library for macro authors when defining new macros
       --reference              The Rust Reference
@@ -29,6 +31,7 @@ Options:
       --rustc                  The compiler for the Rust programming language
       --rustdoc                Documentation generator for Rust projects
       --std                    Standard library API documentation
+      --style-guide            The Rust Style Guide
       --test                   Support code for rustc's built in unit-test and micro-benchmarking
                                framework
       --unstable-book          The Unstable Book


### PR DESCRIPTION
Cherry-picked from https://github.com/rust-lang/rustup/pull/4070.