### PR TITLE
docs: update channel toolchain syntax

### DIFF
--- a/doc/user-guide/src/concepts/toolchains.md
+++ b/doc/user-guide/src/concepts/toolchains.md
@@ -15,7 +15,9 @@ Standard release channel toolchain names have the following form:
 ```
 <channel>[-<date>][-<host>]
 
-<channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
+<channel>       = stable|beta|nightly|<versioned>[-<prerelease>]
+<versioned>     = <major.minor>|<major.minor.patch>
+<prerelease>    = beta[.<number>]
 <date>          = YYYY-MM-DD
 <host>          = <target-triple>
 ```

--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -122,7 +122,9 @@ string in the following form:
 ```
 (<channel>[-<date>])|<custom toolchain name>
 
-<channel>       = stable|beta|nightly|<major.minor.patch>
+<channel>       = stable|beta|nightly|<versioned>[-<prerelease>]
+<versioned>     = <major.minor>|<major.minor.patch>
+<prerelease>    = beta[.<number>]
 <date>          = YYYY-MM-DD
 ```
 

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -55,7 +55,9 @@ pub(crate) static TOOLCHAIN_HELP: &str = r"Discussion:
 
         <channel>[-<date>][-<host>]
 
-        <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
+        <channel>       = stable|beta|nightly|<versioned>[-<prerelease>]
+        <versioned>     = <major.minor>|<major.minor.patch>
+        <prerelease>    = beta[.<number>]
         <date>          = YYYY-MM-DD
         <host>          = <target-triple>
 

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -28,7 +28,9 @@ Discussion:
 
         <channel>[-<date>][-<host>]
 
-        <channel>       = stable|beta|nightly|<major.minor>|<major.minor.patch>
+        <channel>       = stable|beta|nightly|<versioned>[-<prerelease>]
+        <versioned>     = <major.minor>|<major.minor.patch>
+        <prerelease>    = beta[.<number>]
         <date>          = YYYY-MM-DD
         <host>          = <target-triple>
 


### PR DESCRIPTION
Update documentation to match https://rust-lang.github.io/rustup/concepts/toolchains.html