### PR TITLE
fix(cli/rustup-mode): remove `.num_args()` when `.value_delimiter(',')` is present

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -52,10 +52,10 @@ Options:
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
       --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <COMPONENT>...
-          Component name to also install
-  -t, --target <TARGET>...
-          Target name to also install
+  -c, --component <COMPONENT>
+          Comma-separated list of component names to also install
+  -t, --target <TARGET>
+          Comma-separated list of target names to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install
       --no-modify-path

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -343,12 +343,12 @@ struct UpdateOpts {
     #[arg(long, value_enum)]
     profile: Option<Profile>,
 
-    /// Add specific components on installation
-    #[arg(short, long, value_delimiter = ',', num_args = 1..)]
+    /// Comma-separated list of components to be added on installation
+    #[arg(short, long, value_delimiter = ',')]
     component: Vec<String>,
 
-    /// Add specific targets on installation
-    #[arg(short, long, value_delimiter = ',', num_args = 1..)]
+    /// Comma-separated list of targets to be added on installation
+    #[arg(short, long, value_delimiter = ',')]
     target: Vec<String>,
 
     /// Don't perform self update when running the `rustup toolchain install` command

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -197,7 +197,7 @@ enum RustupSubcmd {
         #[arg(help = RESOLVABLE_LOCAL_TOOLCHAIN_ARG_HELP)]
         toolchain: ResolvableLocalToolchainName,
 
-        #[arg(required = true, num_args = 1.., use_value_delimiter = false)]
+        #[arg(required = true, num_args = 1..)]
         command: Vec<String>,
 
         /// Install the requested toolchain if needed

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -48,12 +48,12 @@ struct RustupInit {
     #[arg(long, value_enum, default_value_t)]
     profile: Profile,
 
-    /// Component name to also install
-    #[arg(short, long, value_delimiter = ',', num_args = 1..)]
+    /// Comma-separated list of component names to also install
+    #[arg(short, long, value_delimiter = ',')]
     component: Vec<String>,
 
-    /// Target name to also install
-    #[arg(short, long, value_delimiter = ',', num_args = 1..)]
+    /// Comma-separated list of target names to also install
+    #[arg(short, long, value_delimiter = ',')]
     target: Vec<String>,
 
     /// Don't update any existing default toolchain after install

--- a/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_help_flag_stdout.toml
@@ -21,10 +21,10 @@ Options:
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
       --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <COMPONENT>...
-          Component name to also install
-  -t, --target <TARGET>...
-          Target name to also install
+  -c, --component <COMPONENT>
+          Comma-separated list of component names to also install
+  -t, --target <TARGET>
+          Comma-separated list of target names to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install
       --no-modify-path

--- a/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup-init/rustup-init_sh_help_flag_stdout.toml
@@ -21,10 +21,10 @@ Options:
           Choose a default toolchain to install. Use 'none' to not install any toolchains at all
       --profile <PROFILE>
           [default: default] [possible values: minimal, default, complete]
-  -c, --component <COMPONENT>...
-          Component name to also install
-  -t, --target <TARGET>...
-          Target name to also install
+  -c, --component <COMPONENT>
+          Comma-separated list of component names to also install
+  -t, --target <TARGET>
+          Comma-separated list of target names to also install
       --no-update-default-toolchain
           Don't update any existing default toolchain after install
       --no-modify-path

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_install_cmd_help_flag_stdout.toml
@@ -10,16 +10,16 @@ Arguments:
                   `rustup help toolchain`
 
 Options:
-      --profile <PROFILE>         [possible values: minimal, default, complete]
-  -c, --component <COMPONENT>...  Add specific components on installation
-  -t, --target <TARGET>...        Add specific targets on installation
-      --no-self-update            Don't perform self update when running the `rustup toolchain
-                                  install` command
-      --force                     Force an update, even if some components are missing
-      --allow-downgrade           Allow rustup to downgrade the toolchain to satisfy your component
-                                  choice
-      --force-non-host            Install toolchains that require an emulator. See
-                                  https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-  -h, --help                      Print help
+      --profile <PROFILE>      [possible values: minimal, default, complete]
+  -c, --component <COMPONENT>  Comma-separated list of components to be added on installation
+  -t, --target <TARGET>        Comma-separated list of targets to be added on installation
+      --no-self-update         Don't perform self update when running the `rustup toolchain install`
+                               command
+      --force                  Force an update, even if some components are missing
+      --allow-downgrade        Allow rustup to downgrade the toolchain to satisfy your component
+                               choice
+      --force-non-host         Install toolchains that require an emulator. See
+                               https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+  -h, --help                   Print help
 """
 stderr = ""

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1212,3 +1212,30 @@ async fn uninstall_self_smart_guess() {
             .contains("if you meant to uninstall rustup itself, use `rustup self uninstall`"))
     }
 }
+
+// https://github.com/rust-lang/rustup/issues/4073
+#[tokio::test]
+async fn toolchain_install_multi_components_comma() {
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let components = ["rls", "rust-docs"];
+    cx.config
+        .expect_ok(&[
+            "rustup",
+            "toolchain",
+            "install",
+            "--profile=minimal",
+            "--component",
+            &components.join(","),
+            "nightly",
+        ])
+        .await;
+    for component in components {
+        cx.config
+            .expect_ok_contains(
+                &["rustup", "+nightly", "component", "list", "--installed"],
+                for_host!("{component}-{}"),
+                "",
+            )
+            .await;
+    }
+}


### PR DESCRIPTION
Closes #4073, as discussed in https://github.com/rust-lang/rustup/issues/4073#issuecomment-2472164680.