### PR TITLE
Upgrade to rustls-platform-verifier 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,9 +2237,9 @@ checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afbb878bdfdf63a336a5e63561b1835e7a8c91524f51621db870169eac84b490"
+checksum = "a4c7dc240fec5517e6c4eab3310438636cfe6391dfc345ba013109909a90d136"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -2252,8 +2252,8 @@ dependencies = [
  "rustls-webpki",
  "security-framework",
  "security-framework-sys",
- "webpki-roots",
- "winapi",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3269,10 +3269,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
+name = "webpki-root-certs"
 version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
+checksum = "e8c6dfa3ac045bc517de14c7b1384298de1dbd229d38e08e169d9ae8c170937c"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/download/Cargo.toml
+++ b/download/Cargo.toml
@@ -21,7 +21,7 @@ curl = { version = "0.4.44", optional = true }
 env_proxy = { version = "0.4.1", optional = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "socks", "stream"], optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "aws_lc_rs", "tls12"] }
-rustls-platform-verifier = { version = "0.3", optional = true }
+rustls-platform-verifier = { version = "0.4", optional = true }
 thiserror.workspace = true
 tokio = { workspace = true, default-features = false, features = ["sync"] }
 tokio-stream.workspace = true

--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -303,6 +303,8 @@ pub mod reqwest_be {
     use reqwest::{header, Client, ClientBuilder, Proxy, Response};
     #[cfg(feature = "reqwest-rustls-tls")]
     use rustls::crypto::aws_lc_rs;
+    #[cfg(feature = "reqwest-rustls-tls")]
+    use rustls_platform_verifier::BuilderVerifierExt;
     use tokio_stream::StreamExt;
     use url::Url;
 
@@ -357,10 +359,13 @@ pub mod reqwest_be {
         let catcher = || {
             client_generic()
                 .use_preconfigured_tls(
-                    rustls_platform_verifier::tls_config_with_provider(Arc::new(
+                    rustls::ClientConfig::builder_with_provider(Arc::new(
                         aws_lc_rs::default_provider(),
                     ))
-                    .expect("failed to initialize pre-configured rustls backend"),
+                    .with_safe_default_protocol_versions()
+                    .unwrap()
+                    .with_platform_verifier()
+                    .with_no_client_auth(),
                 )
                 .user_agent(super::REQWEST_RUSTLS_TLS_USER_AGENT)
                 .build()


### PR DESCRIPTION
Alternative to #4083, fixing the use of deprecated API (which I caused upstream).