### PR TITLE
fix: add missing close body tag

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -240,3 +240,4 @@
 </p>
 
 <script src="rustup.js"></script>
+</body>


### PR DESCRIPTION
Split from https://github.com/rust-lang/rustup/pull/4080

This PR just added the missing close body tag.