### PR TITLE
ci(stable): fix build issues to prepare for v1.28.0 release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -874,6 +874,7 @@ jobs:
           - x86_64-linux-android           # skip-pr skip-master
           - riscv64gc-unknown-linux-gnu    # skip-pr skip-master
           - loongarch64-unknown-linux-gnu  # skip-pr skip-master
+          - loongarch64-unknown-linux-musl # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -621,6 +621,7 @@ jobs:
             --env LIBZ_SYS_STATIC=1 \
             --env SKIP_TESTS="${SKIP_TESTS}" \
             --env TARGET="${TARGET}" \
+            --env INSTALL_BINDGEN=1 \
             --init \
             --rm \
             --tty \
@@ -785,6 +786,7 @@ jobs:
             --env LIBZ_SYS_STATIC=1 \
             --env SKIP_TESTS="${SKIP_TESTS}" \
             --env TARGET="${TARGET}" \
+            --env INSTALL_BINDGEN=1 \
             --init \
             --rm \
             --tty \
@@ -971,6 +973,7 @@ jobs:
             --env LIBZ_SYS_STATIC=1 \
             --env SKIP_TESTS="${SKIP_TESTS}" \
             --env TARGET="${TARGET}" \
+            --env INSTALL_BINDGEN=1 \
             --init \
             --rm \
             --tty \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47bb8cc16b669d267eeccf585aea077d0882f4777b1c1f740217885d6e6e5a3"
+checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
 dependencies = [
  "aws-lc-sys",
  "paste",
@@ -181,9 +181,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2101df3813227bbaaaa0b04cd61c534c7954b22bd68d399b440be937dc63ff7"
+checksum = "8478a5c29ead3f3be14aff8a202ad965cf7da6856860041bfca271becf8ba48b"
 dependencies = [
  "bindgen",
  "cc",

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -40,7 +40,7 @@ jobs: # skip-master skip-pr skip-stable
           - x86_64-linux-android           # skip-pr skip-master
           - riscv64gc-unknown-linux-gnu    # skip-pr skip-master
           - loongarch64-unknown-linux-gnu  # skip-pr skip-master
-          - loongarch64-unknown-linux-musl # skip-pr skip-master skip-stable
+          - loongarch64-unknown-linux-musl # skip-pr skip-master
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -137,6 +137,7 @@ jobs: # skip-master skip-pr skip-stable
             --env LIBZ_SYS_STATIC=1 \
             --env SKIP_TESTS="${SKIP_TESTS}" \
             --env TARGET="${TARGET}" \
+            --env INSTALL_BINDGEN=1 \
             --init \
             --rm \
             --tty \

--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-aarch64-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_aarch64_unknown_linux_gnu=aarch64-unknown-linux-gnu-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-unknown-linux-gnu-gcc

--- a/ci/docker/aarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-musl/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-aarch64-unknown-linux-musl
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc \

--- a/ci/docker/android/Dockerfile
+++ b/ci/docker/android/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-android
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV PATH=$PATH:/android/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin \
     ANDROID_NDK=/android/ndk/ \

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-arm-unknown-linux-gnueabi
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_arm_unknown_linux_gnueabi=arm-unknown-linux-gnueabi-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER=arm-unknown-linux-gnueabi-gcc

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-arm-unknown-linux-gnueabihf
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_arm_unknown_linux_gnueabihf=arm-unknown-linux-gnueabihf-gcc \
     CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-unknown-linux-gnueabihf-gcc

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-armv7-unknown-linux-gnueabihf
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_armv7_unknown_linux_gnueabihf=armv7-unknown-linux-gnueabihf-gcc \
     CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=armv7-unknown-linux-gnueabihf-gcc

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,12 +1,9 @@
 FROM rust-i686-unknown-linux-gnu
 
-# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
-# See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
-
- # Install `perl-IPC-Cmd` to make OpenSSL v3 happy.
- # See: <https://github.com/sfackler/rust-openssl/issues/1550>
- RUN yum upgrade -y && \
-     yum install -y perl-IPC-Cmd
+# Install `perl-IPC-Cmd` to make OpenSSL v3 happy.
+# See: <https://github.com/sfackler/rust-openssl/issues/1550>
+RUN yum upgrade -y && \
+    yum install -y perl-IPC-Cmd \
+    # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+    # See: https://aws.github.io/aws-lc-rs/requirements/linux
+    glibc-devel.i686 clang-libs

--- a/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-loongarch64-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_loongarch64_unknown_linux_gnu=loongarch64-unknown-linux-gnu-gcc \
     CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_GNU_LINKER=loongarch64-unknown-linux-gnu-gcc

--- a/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/loongarch64-unknown-linux-musl/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-loongarch64-unknown-linux-musl
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_loongarch64_unknown_linux_musl=loongarch64-unknown-linux-musl-gcc \
     CARGO_TARGET_LOONGARCH64_UNKNOWN_LINUX_MUSL_LINKER=loongarch64-unknown-linux-musl-gcc

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-powerpc-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_powerpc_unknown_linux_gnu=powerpc-unknown-linux-gnu-gcc \
     CARGO_TARGET_POWERPC_UNKNOWN_LINUX_GNU_LINKER=powerpc-unknown-linux-gnu-gcc

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-powerpc64-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_powerpc64_unknown_linux_gnu=powerpc64-unknown-linux-gnu-gcc \
     CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_GNU_LINKER=powerpc64-unknown-linux-gnu-gcc

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-powerpc64le-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
     CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc

--- a/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/riscv64gc-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-riscv64gc-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_riscv64gc_unknown_linux_gnu=riscv64-unknown-linux-gnu-gcc \
     CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-unknown-linux-gnu-gcc

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -2,9 +2,7 @@ FROM rust-s390x-unknown-linux-gnu
 
 # Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
-RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev \
-  && curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh \
-  && mv $HOME/.cargo/bin/bindgen /usr/bin
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
 ENV CC_s390x_unknown_linux_gnu=s390x-ibm-linux-gnu-gcc \
     CARGO_TARGET_S390X_UNKNOWN_LINUX_GNU_LINKER=s390x-ibm-linux-gnu-gcc

--- a/ci/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/ci/docker/x86_64-unknown-freebsd/Dockerfile
@@ -1,4 +1,8 @@
 FROM rust-x86_64-unknown-freebsd
 
+# Building `aws-lc-rs` for FreeBSD on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
 ENV CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-clang \
     CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-clang

--- a/ci/docker/x86_64-unknown-illumos/Dockerfile
+++ b/ci/docker/x86_64-unknown-illumos/Dockerfile
@@ -1,5 +1,9 @@
 FROM rust-x86_64-unknown-illumos
 
+# Building `aws-lc-rs` for Illumos on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
 ENV \
   AR_x86_64_unknown_illumos="x86_64-illumos-ar" \
   RANLIB_x86_64_unknown_illumos="x86_64-illumos-ranlib" \

--- a/ci/docker/x86_64-unknown-netbsd/Dockerfile
+++ b/ci/docker/x86_64-unknown-netbsd/Dockerfile
@@ -1,3 +1,7 @@
 FROM rust-x86_64-unknown-netbsd
 
+# Building `aws-lc-rs` for NetBSD on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
 ENV CARGO_TARGET_X86_64_UNKNOWN_NETBSD_LINKER=x86_64--netbsd-gcc-sysroot

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -7,6 +7,18 @@ export RUST_BACKTRACE=1
 rustc -vV
 cargo -vV
 
+if [ -n "$INSTALL_BINDGEN" ]; then
+  if ! curl --proto '=https' --tlsv1.2 -LsSf https://github.com/rust-lang/rust-bindgen/releases/latest/download/bindgen-cli-installer.sh | sh -s -- --no-modify-path \
+    | grep "everything's installed!";
+    # Ignoring exit code since the script might fail to write the receipt after a successful installation.
+  then
+    cargo install --force --locked bindgen-cli
+  fi
+  mkdir "$CARGO_HOME"/bin/bindgen-cli
+  mv "$CARGO_HOME"/bin/bindgen "$CARGO_HOME"/bin/bindgen-cli/
+  export PATH="$CARGO_HOME/bin/bindgen-cli:$PATH"
+fi
+
 
 FEATURES=('--no-default-features' '--features' 'curl-backend,reqwest-native-tls')
 case "$(uname -s)" in

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -15,11 +15,12 @@ case "$(uname -s)" in
 esac
 
 case "$TARGET" in
-  # these platforms aren't supported by ring:
-  powerpc* ) ;;
+  # these platforms aren't supported by aws-lc-rs:
+  powerpc64* ) ;;
   mips* ) ;;
-  riscv* ) ;;
-  s390x* ) ;;
+  loongarch* ) ;;
+  *netbsd* ) ;;
+  *illumos* ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
 esac


### PR DESCRIPTION
Before merging, we should also:

- [x] Wait for https://github.com/aws/aws-lc-rs/issues/620 to land in a new release.
- [x] Drop the `DROP ME` commit.

---

FWIW, because of `rustls`'s migration to `aws-lc-rs`, with this PR:
- The `reqwest/rustls/aws-lc-rs` combo has become the default download backend on Linux for `riscv*`, `s390x*` and `ppc32` platforms.
- `netbsd` and `illumos` builds have switched to `reqwest/rustls/native-tls` by default.