### PR TITLE
ci(windows): don't install `awscli` via `choco`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,10 +146,11 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
-      - name: Acquire the AWS tooling
+      - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
-          choco upgrade awscli
+          Get-Command aws
+          aws --version
       - name: Prepare the dist
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
@@ -309,10 +310,11 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
-      - name: Acquire the AWS tooling
+      - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
-          choco upgrade awscli
+          Get-Command aws
+          aws --version
       - name: Prepare the dist
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
@@ -478,10 +480,11 @@ jobs:
           path: |
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
-      - name: Acquire the AWS tooling
+      - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
-          choco upgrade awscli
+          Get-Command aws
+          aws --version
       - name: Prepare the dist
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |

--- a/ci/actions-templates/windows-builds-template.yaml
+++ b/ci/actions-templates/windows-builds-template.yaml
@@ -139,10 +139,11 @@ jobs: # skip-master skip-pr skip-stable
           path: |
             target/${{ matrix.target }}/release/rustup-init.exe
           retention-days: 7
-      - name: Acquire the AWS tooling
+      - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |
-          choco upgrade awscli
+          Get-Command aws
+          aws --version
       - name: Prepare the dist
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/master')
         run: |


### PR DESCRIPTION
TLDR: Addresses https://github.com/rust-lang/rustup/pull/4105#issuecomment-2537797422.

It's not our problem, but `choco upgrade awscli` has been causing our `master` CI to fail since a few days ago:

```console
Progress: 100% - Completed download of C:\Users\runneradmin\AppData\Local\Temp\chocolatey\awscli\2.22.13\AWSCLIV2-2.22.13.msi (40.56 MB).
Download of AWSCLIV2-2.22.13.msi (40.56 MB) completed.
Hashes match.
Installing awscli...
WARNING: Generic MSI Error. This is a local environment error, not an issue with a package or the MSI itself - it could mean a pending reboot is necessary prior to install or something else (like the same version is already installed). Please see MSI log if available. If not, try again adding '--install-arguments="'/l*v c:\awscli_msi_install.log'"'. Then search the MSI Log for "Return Value 3" and look above that for the error.
ERROR: Running ["C:\Windows\System32\msiexec.exe" /i "C:\Users\runneradmin\AppData\Local\Temp\chocolatey\awscli\2.22.13\AWSCLIV2-2.22.13.msi" /qn /norestart /l*v "C:\Users\runneradmin\AppData\Local\Temp\chocolatey\awscli.2.22.13.MsiInstall.log"] was not successful. Exit code was '1603'. Exit code indicates the following: Generic MSI Error. This is a local environment error, not an issue with a package or the MSI itself - it could mean a pending reboot is necessary prior to install or something else (like the same version is already installed). Please see MSI log if available. If not, try again adding '--install-arguments="'/l*v c:\awscli_msi_install.log'"'. Then search the MSI Log for "Return Value 3" and look above that for the error..
The upgrade of awscli was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\awscli\tools\chocolateyinstall.ps1'.
 See log for details.
Chocolatey upgraded 0/1 packages. 1 packages failed.
 See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).
Failures
 - awscli (exited 1603) - Error while running 'C:\ProgramData\chocolatey\lib\awscli\tools\chocolateyinstall.ps1'.
 See log for details.
Error: Process completed with exit code 1.
```

... and I guess the only reasonable thing to do now is stop using that command. Instead, we should just check whether `awscli` is already installed, like we currently do on Linux.