### PR TITLE
docs(dev-guide/tracing): make "Adding instrumentation" a level-2 title

### DIFF
--- a/doc/dev-guide/src/tracing.md
+++ b/doc/dev-guide/src/tracing.md
@@ -94,18 +94,23 @@ And [look in Jaeger for a trace](http://localhost:16686/search?service=rustup).
 Tracing can also be used in tests to get a trace of the operations taken during the test.
 To use this feature, build the project with `--features=otel,test`.
 
-### Adding instrumentation
+## Adding instrumentation
 
-The `otel` feature uses conditional compilation to only add function instrument
-when enabled. Instrumenting a currently uninstrumented function is mostly simply
-done like so:
+Instrumenting a currently uninstrumented function is mostly simply done like so:
 
 ```rust
 #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
 ```
 
-`skip_all` is not required, but some core structs don't implement Debug yet, and
-others have a lot of output in Debug : tracing adds some overheads, so keeping
+Sometimes you might want to instrument a function only when the `otel` feature is enabled.
+In this case, you will need to use conditional compilation with `cfg_attr`:
+
+```rust
+#[cfg_attr(feature="otel", tracing::instrument(level = "trace", err(level = "trace"), skip_all))]
+```
+
+`skip_all` is not required, but some core structs don't implement `Debug` yet, and
+others have a lot of output in `Debug`: tracing adds some overheads, so keeping
 spans lightweight can help avoid frequency bias in the results - where
 parameters with large debug in frequently called functions show up as much
 slower than they are.


### PR DESCRIPTION
In https://github.com/rust-lang/rustup/pull/3873, mentions of `cfg_attr()` instrumentation under the `otel` flag have been mostly regex-replaced to under no particular flag at all.

However, this also means that "Adding instrumentation" now applies to more cases and should no longer be put under the "Opentelemetry tracing" level-2 title.

This PR has fixed that issue.