### PR TITLE
fix(rustup-init/sh): don't emit "unknown macOS major version" for macOS v11+

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -733,14 +733,13 @@ check_help_for() {
                         return 1
                     fi
                     ;;
-                11)
-                    # We assume Big Sur will be OK for now
-                    ;;
                 *)
-                    # Unknown product version, warn and continue
-                    warn "Detected unknown macOS major version: $_os_version"
-                    warn "TLS capabilities detection may fail"
-                    ;;
+                    if ! { [ "$_os_major" -eq "$_os_major" ] 2>/dev/null && [ "$_os_major" -ge 11 ]; }; then
+                        # Unknown product version, warn and continue
+                        warn "Detected unknown macOS major version: $_os_version"
+                        warn "TLS capabilities detection may fail"
+                    fi
+                    ;; # We assume that macOS v11+ will always be okay.
             esac
         fi
         ;;

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -719,11 +719,13 @@ check_help_for() {
 
         *darwin*)
         if check_cmd sw_vers; then
-            case $(sw_vers -productVersion) in
+            local _os_version
+            _os_version=$(sw_vers -productVersion)
+            case $_os_version in
                 10.*)
                     # If we're running on macOS, older than 10.13, then we always
                     # fail to find these options to force fallback
-                    if [ "$(sw_vers -productVersion | cut -d. -f2)" -lt 13 ]; then
+                    if [ "$(echo "$_os_version" | cut -d. -f2)" -lt 13 ]; then
                         # Older than 10.13
                         warn "Detected macOS platform older than 10.13"
                         return 1
@@ -734,7 +736,7 @@ check_help_for() {
                     ;;
                 *)
                     # Unknown product version, warn and continue
-                    warn "Detected unknown macOS major version: $(sw_vers -productVersion)"
+                    warn "Detected unknown macOS major version: $_os_version"
                     warn "TLS capabilities detection may fail"
                     ;;
             esac

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -720,9 +720,11 @@ check_help_for() {
         *darwin*)
         if check_cmd sw_vers; then
             local _os_version
+            local _os_major
             _os_version=$(sw_vers -productVersion)
-            case $_os_version in
-                10.*)
+            _os_major=$(echo "$_os_version" | cut -d. -f1)
+            case $_os_major in
+                10)
                     # If we're running on macOS, older than 10.13, then we always
                     # fail to find these options to force fallback
                     if [ "$(echo "$_os_version" | cut -d. -f2)" -lt 13 ]; then
@@ -731,7 +733,7 @@ check_help_for() {
                         return 1
                     fi
                     ;;
-                11.*)
+                11)
                     # We assume Big Sur will be OK for now
                     ;;
                 *)


### PR DESCRIPTION
Closes #4119.