### PR TITLE
feat(cli): show the toolchain path with `rustup show [active-toolchain] --verbose`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1045,8 +1045,11 @@ fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
                     &active_reason,
                 )?;
                 writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-                writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
                 writeln!(t.lock(), "active because: {}", active_reason)?;
+                if verbose {
+                    writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
+                    writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
+                }
 
                 // show installed targets for the active toolchain
                 writeln!(t.lock(), "installed targets:")?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1092,8 +1092,9 @@ fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode
             if verbose {
                 writeln!(
                     cfg.process.stdout().lock(),
-                    "compiler: {}",
-                    toolchain.rustc_version()
+                    "compiler: {}\npath: {}",
+                    toolchain.rustc_version(),
+                    toolchain.path().display(),
                 )?;
             }
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -178,8 +178,8 @@ pub fn this_host_triple() -> String {
 // Format a string with this host triple.
 #[macro_export]
 macro_rules! for_host {
-    ($s: expr) => {
-        &format!($s, $crate::test::this_host_triple())
+    ($s:tt $($arg:tt)*) => {
+        &format!($s, $crate::test::this_host_triple() $($arg)*)
     };
 }
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -661,7 +661,6 @@ nightly-{0} (active, default)
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (hash-nightly-2)
 active because: it's the default toolchain
 installed targets:
   {0}
@@ -735,7 +734,6 @@ nightly-{0} (active, default)
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (hash-nightly-2)
 active because: it's the default toolchain
 installed targets:
   {0}
@@ -774,7 +772,6 @@ nightly-{0} (active, default)
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (xxxx-nightly-2)
 active because: it's the default toolchain
 installed targets:
   {1}
@@ -831,7 +828,6 @@ nightly-{0} (active, default)
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (xxxx-nightly-2)
 active because: it's the default toolchain
 installed targets:
   {1}
@@ -1139,7 +1135,6 @@ nightly-{0} (active, default)
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (hash-nightly-2)
 active because: overridden by environment variable RUSTUP_TOOLCHAIN
 installed targets:
   {0}
@@ -1227,11 +1222,17 @@ nightly-2015-01-01-{0}
 active toolchain
 ----------------
 name: nightly-{0}
-compiler: 1.3.0 (hash-nightly-2)
 active because: it's the default toolchain
+compiler: 1.3.0 (hash-nightly-2)
+path: {2}
 installed targets:
   {0}
-"
+",
+                config
+                    .rustupdir
+                    .join("toolchains")
+                    .join(for_host!("nightly-{0}"))
+                    .display()
             ),
             r"",
         )

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1249,7 +1249,13 @@ async fn show_active_toolchain_with_verbose() {
                 r"nightly-{0}
 active because: it's the default toolchain
 compiler: 1.3.0 (hash-nightly-2)
-"
+path: {1}
+",
+                cx.config
+                    .rustupdir
+                    .join("toolchains")
+                    .join(for_host!("nightly-{0}"))
+                    .display()
             ),
             r"",
         )

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -15,8 +15,8 @@ use rustup::test::{
 use rustup::utils::raw;
 
 macro_rules! for_host_and_home {
-    ($config:expr, $s: expr) => {
-        &format!($s, this_host_triple(), $config.rustupdir)
+    ($config:expr, $s:tt $($arg:tt)*) => {
+        &format!($s, this_host_triple(), $config.rustupdir $($arg)*)
     };
 }
 


### PR DESCRIPTION
Closes #4129.

This PR also tries to make `--verbose`'s effect on `rustup show`'s output more like that of `rustup show active-toolchain`.