### PR TITLE
fix(ci): fix installation of `cargo-all-features`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1487,7 +1487,8 @@ jobs:
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-all-features
-        run: cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
+        shell: bash
+        run: which cargo-check-all-features || cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
       - name: Ensure we have our goal target installed
         run: |
           rustup target install ${{ matrix.target }}

--- a/ci/actions-templates/all-features-template.yaml
+++ b/ci/actions-templates/all-features-template.yaml
@@ -50,7 +50,8 @@ jobs: # skip-all
       - name: Cache Cargo
         uses: Swatinem/rust-cache@v2
       - name: Install cargo-all-features
-        run: cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
+        shell: bash
+        run: which cargo-check-all-features || cargo install cargo-all-features --git https://github.com/rbtcollins/cargo-all-features.git
       - name: Ensure we have our goal target installed
         run: |
           rustup target install ${{ matrix.target }}


### PR DESCRIPTION
Fixes `cargo install` failure when the binary already exists (such as recovered from a backup).

See: https://github.com/rust-lang/rustup/actions/runs/12532031025/job/34952022473