### PR TITLE
fix(cli/rustup-mode): err when trying to show the default/active toolchain but there is none

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -753,15 +753,10 @@ async fn default_(
             }
         }
     } else {
-        match cfg.get_default()? {
-            Some(default_toolchain) => {
-                writeln!(cfg.process.stdout().lock(), "{default_toolchain} (default)")?;
-            }
-            None => writeln!(
-                cfg.process.stdout().lock(),
-                "no default toolchain is configured"
-            )?,
-        }
+        let default_toolchain = cfg
+            .get_default()?
+            .ok_or_else(|| anyhow!("no default toolchain is configured"))?;
+        writeln!(cfg.process.stdout().lock(), "{default_toolchain} (default)")?;
     }
 
     Ok(utils::ExitCode(0))

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1096,7 +1096,7 @@ fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode
                 )?;
             }
         }
-        None => return Err(anyhow!("there isn't an active toolchain")),
+        None => return Err(anyhow!("no active toolchain")),
     }
     Ok(utils::ExitCode(0))
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1096,10 +1096,7 @@ fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode
                 )?;
             }
         }
-        None => writeln!(
-            cfg.process.stdout().lock(),
-            "There isn't an active toolchain"
-        )?,
+        None => return Err(anyhow!("there isn't an active toolchain")),
     }
     Ok(utils::ExitCode(0))
 }

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -578,7 +578,7 @@ async fn default_custom_not_installed_toolchain() {
 
 #[tokio::test]
 async fn default_none() {
-    let mut cx = CliTestContext::new(Scenario::None).await;
+    let cx = CliTestContext::new(Scenario::None).await;
     cx.config
         .expect_stderr_ok(
             &["rustup", "default", "none"],
@@ -587,10 +587,10 @@ async fn default_none() {
         .await;
 
     cx.config
-        .expect_ok_ex(
+        .expect_err_ex(
             &["rustup", "default"],
-            "no default toolchain is configured\n",
             "",
+            "error: no default toolchain is configured\n",
         )
         .await;
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1281,12 +1281,12 @@ async fn show_active_toolchain_with_override() {
 
 #[tokio::test]
 async fn show_active_toolchain_none() {
-    let mut cx = CliTestContext::new(Scenario::None).await;
+    let cx = CliTestContext::new(Scenario::None).await;
     cx.config
-        .expect_ok_ex(
+        .expect_err_ex(
             &["rustup", "show", "active-toolchain"],
-            "There isn't an active toolchain\n",
             "",
+            "error: there isn't an active toolchain\n",
         )
         .await;
 }
@@ -2358,9 +2358,10 @@ async fn override_order() {
     // No default
     cx.config.expect_ok(&["rustup", "default", "none"]).await;
     cx.config
-        .expect_stdout_ok(
+        .expect_err_ex(
             &["rustup", "show", "active-toolchain"],
-            "There isn't an active toolchain\n",
+            "",
+            "error: there isn't an active toolchain\n",
         )
         .await;
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2802,7 +2802,11 @@ async fn check_unix_settings_fallback() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     // No default toolchain specified yet
     cx.config
-        .expect_stdout_ok(&["rustup", "default"], "no default toolchain is configured")
+        .expect_err_ex(
+            &["rustup", "default"],
+            "",
+            "error: no default toolchain is configured\n",
+        )
         .await;
 
     // Default toolchain specified in fallback settings file

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1286,7 +1286,7 @@ async fn show_active_toolchain_none() {
         .expect_err_ex(
             &["rustup", "show", "active-toolchain"],
             "",
-            "error: there isn't an active toolchain\n",
+            "error: no active toolchain\n",
         )
         .await;
 }
@@ -2361,7 +2361,7 @@ async fn override_order() {
         .expect_err_ex(
             &["rustup", "show", "active-toolchain"],
             "",
-            "error: there isn't an active toolchain\n",
+            "error: no active toolchain\n",
         )
         .await;
 


### PR DESCRIPTION
Closes #4140.

## Concerns

- [ ] When should `rustup show` exit with `1` (https://github.com/rust-lang/rustup/issues/4140#issuecomment-2570016612)?