### PR TITLE
fix(cli/rustup-mode)!: change `rustup doc --error_codes` to `--error-codes`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1448,8 +1448,6 @@ docs_data![
     (core, "The Rust Core Library", "core/index.html"),
     (edition_guide, "The Rust Edition Guide", "edition-guide/index.html"),
     (embedded_book, "The Embedded Rust Book", "embedded-book/index.html"),
-
-    #[arg(long = "error_codes")]
     (error_codes, "The Rust Error Codes Index", "error_codes/index.html"),
 
     (nomicon, "The Dark Arts of Advanced and Unsafe Rust Programming", "nomicon/index.html"),

--- a/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_doc_cmd_help_flag_stdout.toml
@@ -22,7 +22,7 @@ Options:
       --core                   The Rust Core Library
       --edition-guide          The Rust Edition Guide
       --embedded-book          The Embedded Rust Book
-      --error_codes            The Rust Error Codes Index
+      --error-codes            The Rust Error Codes Index
       --nomicon                The Dark Arts of Advanced and Unsafe Rust Programming
       --proc_macro             A support library for macro authors when defining new macros
       --reference              The Rust Reference


### PR DESCRIPTION
This is a pre-existing upstream issue (the naming of the directory is not following the convention: it should be `error-codes/index.html` instead of `error_codes/index.html`), but I think on our side `--error-codes` should be better.

The only exception here is `--proc_macro`, and I don't think it should ever been changed since it's really an entire Rust idiom instead of several words concatenated by word connectors.

PS: Regarding backwards compatibility, this new flag was introduced in v1.28.0 beta, so it'd be fine to break it.