### PR TITLE
docs(user-guide/components): add deprecation notice for `wasm32-wasi`

### DIFF
--- a/doc/user-guide/src/concepts/components.md
+++ b/doc/user-guide/src/concepts/components.md
@@ -71,6 +71,9 @@ These components have been deprecated and are not published in new Rust releases
 * `rls` --- [RLS] is a language server that is deprecated and has been replaced
   by rust-analyzer.
 * `rust-analysis` --- Metadata about the standard library, used by [RLS].
+* The `wasm32-wasi` target --- It has been
+  [renamed](https://blog.rust-lang.org/2024/04/09/updates-to-rusts-wasi-targets.html)
+  to `wasm32-wasip1`.
 
 ## Component availability
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -246,7 +246,7 @@ impl<'a> Toolchain<'a> {
             .cfg
             .process
             .var_os("RUSTUP_WINDOWS_PATH_ADD_BIN")
-            .map_or(false, |s| s == "1")
+            .is_some_and(|s| s == "1")
         {
             path_entries.push(self.path.join("bin"));
         }


### PR DESCRIPTION
Partially addresses https://github.com/rust-lang/rustup/issues/4099.