### PR TITLE
ci(linux): use public ARM64 Linux runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -543,6 +543,7 @@ jobs:
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            run_tests: YES
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
     steps:
@@ -711,6 +712,7 @@ jobs:
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            run_tests: YES
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
     steps:
@@ -897,6 +899,7 @@ jobs:
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            run_tests: YES
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
           - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -542,7 +542,7 @@ jobs:
             # We need to do that because rust's CI uses ARM-based runners
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm64-4core-16gb
+            os: ubuntu-24.04-arm
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
     steps:
@@ -710,7 +710,7 @@ jobs:
             # We need to do that because rust's CI uses ARM-based runners
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm64-4core-16gb
+            os: ubuntu-24.04-arm
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
     steps:
@@ -896,7 +896,7 @@ jobs:
             # We need to do that because rust's CI uses ARM-based runners
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm64-4core-16gb
+            os: ubuntu-24.04-arm
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
           - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -52,6 +52,7 @@ jobs: # skip-master skip-pr skip-stable
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-24.04-arm
+            run_tests: YES
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
           - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -51,7 +51,7 @@ jobs: # skip-master skip-pr skip-stable
             # We need to do that because rust's CI uses ARM-based runners
             # to generate their Dockerfiles.
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm64-4core-16gb
+            os: ubuntu-24.04-arm
           - target: armv7-unknown-linux-gnueabihf
             #snap_arch: armhf
           - target: powerpc64le-unknown-linux-gnu # skip-pr skip-master


### PR DESCRIPTION
Continuation of #4154.

After reading https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Free.20Linux.20ARM64.20runners.20on.20GHA.20now.20in.20beta, it looks like our upstream (https://github.com/rust-lang/rust) has some issues WRT the new runner's virtual environment.

However, this shouldn't affect us in theory because we don't use that environment :)

**Update:** The new runners are blazingly ⚡ fast! They can complete the full test suite *within 6 minutes* where it usually will take our ARM64 Mac runners ~12 minutes to finish.