### PR TITLE
fix(ci/doc): fix typo in renovate `datasource`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1527,7 +1527,7 @@ jobs:
       - name: Install mdbook
         uses: taiki-e/install-action@v2
         env:
-          # renovate: datasource=crates depName=mdbook
+          # renovate: datasource=crate depName=mdbook
           MDBOOK_VERSION: "0.4.43"
         with:
           tool: mdbook@${{ env.MDBOOK_VERSION }}

--- a/ci/actions-templates/test-docs-template.yaml
+++ b/ci/actions-templates/test-docs-template.yaml
@@ -14,7 +14,7 @@ jobs: # skip-all
       - name: Install mdbook
         uses: taiki-e/install-action@v2
         env:
-          # renovate: datasource=crates depName=mdbook
+          # renovate: datasource=crate depName=mdbook
           MDBOOK_VERSION: "0.4.43"
         with:
           tool: mdbook@${{ env.MDBOOK_VERSION }}


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/rustup/pull/4162.

It's very weird to me, but the `datasource` of `crates.io` is actually named `crate`.
See: <https://docs.renovatebot.com/modules/datasource/crate>