### PR TITLE
Warn about `CARGO` environment variable in cargo proxy

### DIFF
--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -821,7 +821,10 @@ impl Config {
         for env in env {
             cmd.env(env.0, env.1);
         }
+        self.run_subprocess_cmd(cmd)
+    }
 
+    pub fn run_subprocess_cmd(&self, mut cmd: Command) -> Output {
         let mut retries = 8;
         let out = loop {
             let lock = CMD_LOCK.read().unwrap();

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -522,7 +522,7 @@ impl Config {
         I: IntoIterator<Item = A>,
         A: AsRef<OsStr>,
     {
-        let exe_path = self.exedir.join(format!("{name}{EXE_SUFFIX}"));
+        let exe_path = self.exedir.join(name);
         let mut cmd = Command::new(exe_path);
         cmd.args(args);
         cmd.current_dir(&*self.workdir.borrow());

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -748,15 +748,12 @@ impl Config {
             self.run_subprocess(name, args.clone(), env)
         };
         let duration = Instant::now() - start;
-        let output = SanitizedOutput {
-            ok: matches!(out.status, Some(0)),
-            stdout: String::from_utf8(out.stdout).unwrap(),
-            stderr: String::from_utf8(out.stderr).unwrap(),
-        };
+        let status = out.status;
+        let output: SanitizedOutput = out.try_into().unwrap();
 
         println!("ran: {} {:?}", name, args);
         println!("inprocess: {inprocess}");
-        println!("status: {:?}", out.status);
+        println!("status: {:?}", status);
         println!("duration: {:.3}s", duration.as_secs_f32());
         println!("stdout:\n====\n{}\n====\n", output.stdout);
         println!("stderr:\n====\n{}\n====\n", output.stderr);
@@ -903,6 +900,18 @@ pub struct SanitizedOutput {
     pub ok: bool,
     pub stdout: String,
     pub stderr: String,
+}
+
+impl TryFrom<Output> for SanitizedOutput {
+    type Error = std::string::FromUtf8Error;
+    fn try_from(out: Output) -> Result<Self, Self::Error> {
+        let sanitized_output = Self {
+            ok: matches!(out.status, Some(0)),
+            stdout: String::from_utf8(out.stdout)?,
+            stderr: String::from_utf8(out.stderr)?,
+        };
+        Ok(sanitized_output)
+    }
 }
 
 pub fn cmd<I, A>(config: &Config, name: &str, args: I) -> Command

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -1678,3 +1678,19 @@ where
     }
     inner(original.as_ref(), link.as_ref())
 }
+
+// We need an intermediary to run cargo itself.
+// The "mock" cargo can't do that because on Windows it will check
+// for a `cargo.exe` in the current directory before checking PATH.
+//
+// The solution here is to copy from the "mock" `cargo.exe` into
+// `~/.cargo/bin/cargo-foo`. This is just for convenience to avoid
+// needing to build another executable.
+pub async fn create_cargo_foo(cx: &CliTestContext) {
+    let output = cx.config.run("rustup", ["which", "cargo"], &[]).await;
+    let real_mock_cargo = output.stdout.trim();
+    let cargo_bin_path = cx.config.cargodir.join("bin");
+    let cargo_subcommand = cargo_bin_path.join(format!("cargo-foo{}", EXE_SUFFIX));
+    fs::create_dir_all(&cargo_bin_path).unwrap();
+    fs::copy(real_mock_cargo, cargo_subcommand).unwrap();
+}

--- a/src/test/mock/mock_bin_src.rs
+++ b/src/test/mock/mock_bin_src.rs
@@ -5,7 +5,16 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    let mut args = env::args_os().skip(1);
+    let mut args = env::args_os();
+    let arg0 = args.next().unwrap();
+    if let Some(cargo_subcommand) = PathBuf::from(arg0)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .and_then(|s| s.strip_prefix("cargo-"))
+    {
+        let arg1 = args.next().unwrap();
+        assert_eq!(arg1, cargo_subcommand);
+    }
     match args.next().as_ref().and_then(|s| s.to_str()) {
         Some("--version") => {
             let me = env::current_exe().unwrap();
@@ -63,7 +72,7 @@ fn main() {
         }
         Some("--recursive-cargo-subcommand") => {
             let status = Command::new("cargo-foo")
-                .arg("--recursive-cargo")
+                .args(["foo", "--recursive-cargo"])
                 .status()
                 .unwrap();
             assert!(status.success());

--- a/src/test/mock/mock_bin_src.rs
+++ b/src/test/mock/mock_bin_src.rs
@@ -84,6 +84,10 @@ fn main() {
                 .unwrap();
             assert!(status.success());
         }
+        Some("--recursive-cargo-without-toolchain") => {
+            let status = Command::new("cargo").arg("--version").status().unwrap();
+            assert!(status.success());
+        }
         Some("--echo-args") => {
             let mut out = io::stderr();
             for arg in args {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -163,12 +163,15 @@ impl<'a> Toolchain<'a> {
         if path.file_stem() == Some(OsStr::new("cargo")) {
             if let Some(value) = self.cfg.process.var_os("CARGO") {
                 if value != path {
-                    warn!(
-                        "clearing 'CARGO' as it is not the path of the binary about to be executed"
-                    );
+                    warn!("'CARGO' is not the path of the binary about to be executed");
                     warn!("     'CARGO' value: {}", value.to_string_lossy());
                     warn!("    to be executed: {}", path.to_string_lossy());
-                    cmd.env_remove("CARGO");
+                    warn!("in a future version of the cargo proxy, 'CARGO' may be cleared");
+                    // The `CARGO` environment can be cleared here if there is
+                    // consensus that that is the right approach. See the
+                    // following issue for discussion:
+                    // https://github.com/rust-lang/cargo/issues/15099
+                    // cmd.env_remove("CARGO");
                 }
             }
         }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1269,9 +1269,9 @@ async fn clear_cargo_environment_variable() {
         let out: SanitizedOutput = cx.config.run_subprocess_cmd(cmd).try_into().unwrap();
         assert!(out.ok);
         if should_warn {
-            assert!(out.stderr.contains(
-                "warn: clearing 'CARGO' as it is not the path of the binary about to be executed"
-            ));
+            assert!(out
+                .stderr
+                .contains("warn: 'CARGO' is not the path of the binary about to be executed"));
         } else {
             assert!(!out.stderr.contains("warn"));
         }


### PR DESCRIPTION
Addresses rust-lang/clippy#15099

To recount the problem (copied from https://github.com/rust-lang/cargo/issues/15099#issuecomment-2621296667):
- The `cargo` proxy runs, selects the default `cargo`, and sets the `CARGO` environment variable to default toolchain's `cargo`.
- That `cargo` invocations runs some other code, which invokes `cargo +<toolchain> <subcommand>`.
- `<subcommand>` reads the `CARGO` environment variable and runs the default toolchain's `cargo` rather than `<toolchain>`'s `cargo`.

This PR addresses the problem by warning when the  `CARGO` environment variable does not match what `cargo +<toolchain> <subcommand>` will run.

This PR is currently organized as eight commits:
- The first commit applies the fix.
- The next five commits add infrastructure to support the seventh commit.
- The seventh commit adds a test to address all scenarios in https://github.com/rust-lang/cargo/issues/15099#issuecomment-2624230906.
- The eighth commit is a small bug fix to `Config::cmd`.
- The ninth commit incorporates feedback from https://github.com/rust-lang/cargo/issues/15099#issuecomment-2632618041 and onward.

Nits are welcome.