### PR TITLE
fix(component): normalize path separators

### DIFF
--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -198,13 +198,16 @@ impl ComponentPart {
     const PATH_SEP_MAIN: &str = std::path::MAIN_SEPARATOR_STR;
 
     pub(crate) fn encode(&self) -> String {
+        let mut buf = self.kind.to_string();
+        buf.push(':');
         // Lossy conversion is safe here because we assume that `path` comes from
         // `ComponentPart::decode()`, i.e. from calling `Path::from()` on a `&str`.
         let mut path = self.path.to_string_lossy();
         if Self::PATH_SEP_MAIN != Self::PATH_SEP_MANIFEST {
             path = Cow::Owned(path.replace(Self::PATH_SEP_MAIN, Self::PATH_SEP_MANIFEST));
         };
-        format!("{}:{path}", self.kind)
+        buf.push_str(&path);
+        buf
     }
 
     pub(crate) fn decode(line: &str) -> Option<Self> {

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -177,16 +177,14 @@ impl ComponentPart {
     }
 
     pub(crate) fn decode(line: &str) -> Option<Self> {
-        line.find(':').map(|pos| {
-            let mut path_str = Cow::Borrowed(&line[(pos + 1)..]);
-            if Self::PATH_SEP_MANIFEST != Self::PATH_SEP_MAIN {
-                path_str =
-                    Cow::Owned(path_str.replace(Self::PATH_SEP_MANIFEST, Self::PATH_SEP_MAIN));
-            };
-            Self {
-                kind: line[0..pos].to_owned(),
-                path: PathBuf::from(path_str.as_ref()),
-            }
+        let pos = line.find(':')?;
+        let mut path_str = Cow::Borrowed(&line[(pos + 1)..]);
+        if Self::PATH_SEP_MANIFEST != Self::PATH_SEP_MAIN {
+            path_str = Cow::Owned(path_str.replace(Self::PATH_SEP_MANIFEST, Self::PATH_SEP_MAIN));
+        };
+        Some(Self {
+            kind: line[0..pos].to_owned(),
+            path: PathBuf::from(path_str.as_ref()),
         })
     }
 }

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -106,15 +106,15 @@ impl Package for DirectoryPackage {
             let path = part.path;
             let src_path = root.join(&path);
 
-            match &*part.kind {
-                "file" => {
+            match part.kind {
+                ComponentPartKind::File => {
                     if self.copy {
                         builder.copy_file(path.clone(), &src_path)?
                     } else {
                         builder.move_file(path.clone(), &src_path)?
                     }
                 }
-                "dir" => {
+                ComponentPartKind::Dir => {
                     if self.copy {
                         builder.copy_dir(path.clone(), &src_path)?
                     } else {

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -103,10 +103,10 @@ impl Package for DirectoryPackage {
             let part = ComponentPart::decode(l)
                 .ok_or_else(|| RustupError::CorruptComponent(name.to_owned()))?;
 
-            let path = part.1;
+            let path = part.path;
             let src_path = root.join(&path);
 
-            match &*part.0 {
+            match &*part.kind {
                 "file" => {
                     if self.copy {
                         builder.copy_file(path.clone(), &src_path)?

--- a/src/dist/prefix.rs
+++ b/src/dist/prefix.rs
@@ -2,7 +2,14 @@ use std::path::{Path, PathBuf};
 
 use crate::utils;
 
-const REL_MANIFEST_DIR: &str = "lib/rustlib";
+/// The relative path to the manifest directory in a Rust installation,
+/// with path components separated by [`std::path::MAIN_SEPARATOR`].
+const REL_MANIFEST_DIR: &str = match std::path::MAIN_SEPARATOR {
+    '/' => "lib/rustlib",
+    '\\' => r"lib\rustlib",
+    _ => panic!("unknown `std::path::MAIN_SEPARATOR`"),
+};
+
 static V1_COMMON_COMPONENT_LIST: &[&str] = &["cargo", "rustc", "rust-docs"];
 
 #[derive(Clone, Debug)]

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -3,6 +3,7 @@
 
 use std::fs;
 use std::io::Write;
+use std::path::PathBuf;
 
 use rustup::dist::TargetTriple;
 use rustup::for_host;
@@ -392,17 +393,15 @@ async fn bad_manifest() {
     // install some toolchain
     cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
 
-    #[cfg(not(target_os = "windows"))]
-    let path = format!(
-        "toolchains/nightly-{}/lib/rustlib/multirust-channel-manifest.toml",
-        this_host_triple(),
-    );
-
-    #[cfg(target_os = "windows")]
-    let path = format!(
-        r"toolchains\nightly-{}\lib/rustlib\multirust-channel-manifest.toml",
-        this_host_triple(),
-    );
+    let path = [
+        "toolchains",
+        for_host!("nightly-{}"),
+        "lib",
+        "rustlib",
+        "multirust-channel-manifest.toml",
+    ]
+    .into_iter()
+    .collect::<PathBuf>();
 
     assert!(cx.config.rustupdir.has(&path));
     let path = cx.config.rustupdir.join(&path);


### PR DESCRIPTION
Supersedes #3077.

This solution is based on the analysis made in https://github.com/rust-lang/rustup/pull/3077#discussion_r1909829756.

~~PS: Sincerely, I think this `ComponentPart` needs to be changed to something like:~~

```rs
struct ComponentPart {
  pub kind: String,
  pub path: PathBuf,
}
```

~~... I'd like to work on stylistic changes like this once I'm done with updating the test cases (some of them are of course expected to break).~~
Done.