### PR TITLE
feat(rustup-init/sh): add env var to print arch detection result

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -857,4 +857,13 @@ get_strong_ciphersuites_for() {
     fi
 }
 
-main "$@" || exit 1
+set +u
+case "$RUSTUP_INIT_SH_PRINT" in
+    arch | architecture)
+        get_architecture || exit 1
+        echo "$RETVAL"
+        ;;
+    *)
+        main "$@" || exit 1
+        ;;
+esac


### PR DESCRIPTION
This PR tries to achieve #3830's goal...

> fetch the rustup script [..] and then source it from the caller script, so I can access/execute the get_architecture function [..]

... but in a more proper way:

```console
> RUSTUP_INIT_SH_PRINT=arch ./rustup-init.sh
aarch64-apple-darwin

> ./rustup-init.sh
# The installer executes normally
```

This is inspired by `rustc`'s own dry-run mode which is controlled by the `--print=<field>` option, but I made it an env var instead because `./rustup-init.sh --help` is always redirected to `./rustup-init --help` as you might have noticed.

In the future we could possibly add support for more info if needed.

cc @onur-ozkan for review, and I'm really sorry for the huge delay! 🙇 