### PR TITLE
style(edition): migrate the codebase to the 2024 Style Edition

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -327,8 +327,8 @@ pub mod reqwest_be {
     use std::sync::LazyLock;
     use std::time::Duration;
 
-    use anyhow::{anyhow, Context, Result};
-    use reqwest::{header, Client, ClientBuilder, Proxy, Response};
+    use anyhow::{Context, Result, anyhow};
+    use reqwest::{Client, ClientBuilder, Proxy, Response, header};
     #[cfg(feature = "reqwest-rustls-tls")]
     use rustls::crypto::aws_lc_rs;
     #[cfg(feature = "reqwest-rustls-tls")]

--- a/download/tests/download-curl-resume.rs
+++ b/download/tests/download-curl-resume.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "curl-backend")]
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use url::Url;
 

--- a/download/tests/download-reqwest-resume.rs
+++ b/download/tests/download-reqwest-resume.rs
@@ -1,7 +1,7 @@
 #![cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
 
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use url::Url;
 

--- a/download/tests/read-proxy-env.rs
+++ b/download/tests/read-proxy-env.rs
@@ -3,8 +3,8 @@
 use std::env::{remove_var, set_var};
 use std::error::Error;
 use std::net::TcpListener;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::LazyLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::thread;
 use std::time::Duration;
 

--- a/download/tests/support/mod.rs
+++ b/download/tests/support/mod.rs
@@ -3,14 +3,14 @@ use std::fs;
 use std::io;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::sync::mpsc::{channel, Sender};
+use std::sync::mpsc::{Sender, channel};
 use std::thread;
 
 use http_body_util::Full;
+use hyper::Request;
 use hyper::body::Bytes;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
-use hyper::Request;
 use tempfile::TempDir;
 
 pub fn tmp_dir() -> TempDir {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+style_edition = "2024"

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -15,13 +15,13 @@
 
 use std::process::ExitCode;
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use cfg_if::cfg_if;
 // Public macros require availability of the internal symbols
 use rs_tracing::{
     close_trace_file, close_trace_file_internal, open_trace_file, trace_to_file_internal,
 };
-use tracing_subscriber::{reload::Handle, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 use rustup::cli::common;
 use rustup::cli::proxy_mode;
@@ -145,7 +145,7 @@ fn do_recursion_guard(process: &Process) -> Result<()> {
 #[cfg(windows)]
 pub fn pre_rustup_main_init() {
     use windows_sys::Win32::System::LibraryLoader::{
-        SetDefaultDllDirectories, LOAD_LIBRARY_SEARCH_SYSTEM32,
+        LOAD_LIBRARY_SEARCH_SYSTEM32, SetDefaultDllDirectories,
     };
     // Default to loading delay loaded DLLs from the system directory.
     // For DLLs loaded at load time, this relies on the `delayload` linker flag.

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -10,22 +10,22 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, LazyLock, Mutex};
 use std::{cmp, env};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use git_testament::{git_testament, render_testament};
 use tracing::{debug, error, info, trace, warn};
-use tracing_subscriber::{reload::Handle, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 use super::self_update;
 use crate::{
     cli::download_tracker::DownloadTracker,
     config::Cfg,
     dist::{
-        manifest::ComponentStatus, notifications as dist_notifications, TargetTriple, ToolchainDesc,
+        TargetTriple, ToolchainDesc, manifest::ComponentStatus, notifications as dist_notifications,
     },
     errors::RustupError,
     install::UpdateStatus,
     notifications::Notification,
-    process::{terminalsource, Process},
+    process::{Process, terminalsource},
     toolchain::{DistributableToolchain, LocalToolchainName, Toolchain, ToolchainName},
     utils::{self, notifications as util_notifications, notify::NotificationLevel},
 };
@@ -654,7 +654,9 @@ pub(crate) fn warn_if_host_is_emulated(process: &Process) {
             "Rustup is not running natively. It's running under emulation of {}.",
             TargetTriple::from_host_or_build(process)
         );
-        warn!("For best compatibility and performance you should reinstall rustup for your native CPU.");
+        warn!(
+            "For best compatibility and performance you should reinstall rustup for your native CPU."
+        );
     }
 }
 

--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -5,9 +5,9 @@ use std::time::{Duration, Instant};
 
 use crate::dist::Notification as In;
 use crate::notifications::Notification;
-use crate::process::{terminalsource, Process};
-use crate::utils::units::{Size, Unit, UnitMode};
+use crate::process::{Process, terminalsource};
 use crate::utils::Notification as Un;
+use crate::utils::units::{Size, Unit, UnitMode};
 
 /// Keep track of this many past download amounts
 const DOWNLOAD_TRACK_COUNT: usize = 5;

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -278,8 +278,7 @@ pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
 
         $ rustup completions zsh cargo > ~/.zfunc/_cargo";
 
-pub(crate) static OFFICIAL_TOOLCHAIN_ARG_HELP: &str =
-    "Toolchain name, such as 'stable', 'nightly', \
+pub(crate) static OFFICIAL_TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \
                                        or '1.8.0'. For more information see `rustup \
                                        help toolchain`";
 pub(crate) static RESOLVABLE_LOCAL_TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -3,15 +3,16 @@ use std::{fmt, io::Write};
 #[cfg(feature = "otel")]
 use opentelemetry_sdk::trace::Tracer;
 use termcolor::{Color, ColorSpec, WriteColor};
-use tracing::{level_filters::LevelFilter, Event, Subscriber};
+use tracing::{Event, Subscriber, level_filters::LevelFilter};
 use tracing_subscriber::{
+    EnvFilter, Layer, Registry,
     fmt::{
-        format::{self, FormatEvent, FormatFields},
         FmtContext,
+        format::{self, FormatEvent, FormatFields},
     },
     layer::SubscriberExt,
     registry::LookupSpan,
-    reload, EnvFilter, Layer, Registry,
+    reload,
 };
 
 use crate::{process::Process, utils::notify::NotificationLevel};
@@ -152,12 +153,12 @@ where
 fn telemetry_default_tracer() -> Tracer {
     use std::time::Duration;
 
-    use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
+    use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_sdk::{
+        Resource,
         runtime::Tokio,
         trace::{Sampler, TracerProvider},
-        Resource,
     };
 
     let exporter = opentelemetry_otlp::SpanExporter::builder()

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -195,8 +195,8 @@ impl<'a> LineFormatter<'a> {
             }
             TagEnd::Strong => {}
             TagEnd::Strikethrough => {}
-            TagEnd::Link { .. } => {}
-            TagEnd::Image { .. } => {} // shouldn't happen, handled in start
+            TagEnd::Link => {}
+            TagEnd::Image => {} // shouldn't happen, handled in start
             TagEnd::FootnoteDefinition => {}
             TagEnd::MetadataBlock(_) => {}
             TagEnd::Superscript => {}

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1048,13 +1048,8 @@ fn get_and_parse_new_rustup_version(path: &Path) -> Option<String> {
 }
 
 fn get_new_rustup_version(path: &Path) -> Option<String> {
-    match Command::new(path).arg("--version").output() {
-        Err(_) => None,
-        Ok(output) => match String::from_utf8(output.stdout) {
-            Ok(version) => Some(version),
-            Err(_) => None,
-        },
-    }
+    let output = Command::new(path).arg("--version").output().ok()?;
+    String::from_utf8(output.stdout).ok()
 }
 
 fn parse_new_rustup_version(version: String) -> String {

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -26,7 +26,7 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use super::utils;
 use crate::process::Process;

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use tracing::{error, warn};
 
 use super::install_bins;

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -9,20 +9,20 @@ use std::sync::{Arc, Mutex};
 #[cfg(any(test, feature = "test"))]
 use std::sync::{LockResult, MutexGuard};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use tracing::{info, warn};
 #[cfg(any(test, feature = "test"))]
 use windows_registry::Value;
-use windows_registry::{Key, CURRENT_USER, HSTRING};
+use windows_registry::{CURRENT_USER, HSTRING, Key};
 use windows_result::HRESULT;
 use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_INVALID_DATA};
 
 use super::super::errors::*;
 use super::common;
-use super::{install_bins, report_error, InstallOpts};
+use super::{InstallOpts, install_bins, report_error};
 use crate::cli::{download_tracker::DownloadTracker, markdown::md};
 use crate::dist::TargetTriple;
-use crate::process::{terminalsource::ColorableTerminal, Process};
+use crate::process::{Process, terminalsource::ColorableTerminal};
 use crate::utils::{self, Notification};
 
 pub(crate) fn ensure_prompt(process: &Process) -> Result<()> {
@@ -223,7 +223,9 @@ impl fmt::Display for VsInstallError {
             1602 => "operation was canceled",
             1618 => "another installation running",
             1641 => "operation completed successfully, and reboot was initiated",
-            3010 => "operation completed successfully, but install requires reboot before it can be used",
+            3010 => {
+                "operation completed successfully, but install requires reboot before it can be used"
+            }
             5003 => "bootstrapper failed to download installer",
             5004 => "operation was canceled",
             5005 => "bootstrapper command-line parse error",
@@ -236,7 +238,7 @@ impl fmt::Display for VsInstallError {
             8006 => "Visual Studio processes running",
             -1073720687 => "connectivity failure",
             -1073741510 => "Microsoft Visual Studio Installer was terminated",
-            _ => "error installing Visual Studio"
+            _ => "error installing Visual Studio",
         };
         write!(f, "{} (exit code {})", message, self.0)
     }
@@ -391,10 +393,10 @@ pub(crate) fn wait_for_parent() -> Result<()> {
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, WAIT_OBJECT_0};
     use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
     use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-        CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS,
+        CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
     };
     use windows_sys::Win32::System::Threading::{
-        GetCurrentProcessId, OpenProcess, WaitForSingleObject, INFINITE,
+        GetCurrentProcessId, INFINITE, OpenProcess, WaitForSingleObject,
     };
 
     unsafe {
@@ -467,7 +469,7 @@ fn _apply_new_path(new_path: Option<HSTRING>) -> Result<()> {
     use std::ptr;
     use windows_sys::Win32::Foundation::*;
     use windows_sys::Win32::UI::WindowsAndMessaging::{
-        SendMessageTimeoutA, HWND_BROADCAST, SMTO_ABORTIFHUNG, WM_SETTINGCHANGE,
+        HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutA, WM_SETTINGCHANGE,
     };
 
     let new_path = match new_path {

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use tracing::warn;
-use tracing_subscriber::{reload::Handle, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 use crate::{
     cli::{

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 struct DocData<'a> {
     topic: &'a str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::{env, io};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use thiserror::Error as ThisError;
 use tokio_stream::StreamExt;
@@ -13,8 +13,8 @@ use tracing::trace;
 use crate::{
     cli::{common, self_update::SelfUpdateMode},
     dist::{
-        self, download::DownloadCfg, temp, PartialToolchainDesc, Profile, TargetTriple,
-        ToolchainDesc,
+        self, PartialToolchainDesc, Profile, TargetTriple, ToolchainDesc, download::DownloadCfg,
+        temp,
     },
     errors::RustupError,
     fallback_settings::FallbackSettings,
@@ -31,7 +31,9 @@ use crate::{
 
 #[derive(Debug, ThisError)]
 enum OverrideFileConfigError {
-    #[error("empty toolchain override file detected. Please remove it, or else specify the desired toolchain properties in the file")]
+    #[error(
+        "empty toolchain override file detected. Please remove it, or else specify the desired toolchain properties in the file"
+    )]
     Empty,
     #[error("missing toolchain properties in toolchain override file")]
     Invalid,

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 
-use super::{get_executor, Executor, Item, Kind};
+use super::{Executor, Item, Kind, get_executor};
 use crate::process::TestProcess;
 use crate::test::test_dir;
 

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -6,15 +6,15 @@
 /// will cause minutes of wall clock time.
 use std::cell::{Cell, RefCell};
 use std::fmt;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, Sender, channel};
 
-use enum_map::{enum_map, Enum, EnumMap};
+use enum_map::{Enum, EnumMap, enum_map};
 use sharded_slab::pool::{OwnedRef, OwnedRefMut};
 use tracing::debug;
 
-use super::{perform, CompletedIo, Executor, Item};
+use super::{CompletedIo, Executor, Item, perform};
 use crate::utils::notifications::Notification;
 use crate::utils::units::Unit;
 

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -9,7 +9,7 @@ use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 
 use crate::dist::component::package::{INSTALLER_VERSION, VERSION_FILE};
 use crate::dist::component::transaction::Transaction;
@@ -272,8 +272,8 @@ impl Component {
         // and the version file.
 
         // Track visited directories
-        use std::collections::hash_set::IntoIter;
         use std::collections::HashSet;
+        use std::collections::hash_set::IntoIter;
         use std::fs::read_dir;
 
         // dirs will contain the set of longest disjoint directory paths seen

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -8,11 +8,11 @@ use std::io::{self, ErrorKind as IOErrorKind, Read};
 use std::mem;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use tar::EntryType;
 use tracing::warn;
 
-use crate::diskio::{get_executor, CompletedIo, Executor, FileBuffer, Item, Kind, IO_CHUNK_SIZE};
+use crate::diskio::{CompletedIo, Executor, FileBuffer, IO_CHUNK_SIZE, Item, Kind, get_executor};
 use crate::dist::component::components::*;
 use crate::dist::component::transaction::*;
 use crate::dist::temp;

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -2,11 +2,11 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::dist::DEFAULT_DIST_SERVER;
+use crate::dist::Notification;
 use crate::dist::component::Transaction;
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
-use crate::dist::Notification;
-use crate::dist::DEFAULT_DIST_SERVER;
 use crate::errors::RustupError;
 use crate::process::TestProcess;
 use crate::utils::{self, raw as utils_raw};

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -12,7 +12,7 @@
 use std::fs::File;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 
 use crate::dist::notifications::*;
 use crate::dist::prefix::InstallPrefix;

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::ops;
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use sha2::{Digest, Sha256};
 use url::Url;
 

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -12,17 +12,17 @@
 //!
 //! Docs: <https://forge.rust-lang.org/infra/channel-layout.html>
 
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::collections::hash_map::Entry;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dist::{config::Config, Profile, TargetTriple, ToolchainDesc},
+    dist::{Profile, TargetTriple, ToolchainDesc, config::Config},
     errors::*,
     toolchain::DistributableToolchain,
 };
@@ -620,9 +620,9 @@ impl fmt::Display for ManifestVersion {
 
 #[cfg(test)]
 mod tests {
-    use crate::dist::manifest::Manifest;
-    use crate::dist::TargetTriple;
     use crate::RustupError;
+    use crate::dist::TargetTriple;
+    use crate::dist::manifest::Manifest;
 
     // Example manifest from https://public.etherpad-mozilla.org/p/Rust-infra-work-week
     static EXAMPLE: &str = include_str!("manifest/tests/channel-rust-nightly-example.toml");

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -6,8 +6,8 @@ mod tests;
 
 use std::path::Path;
 
-use anyhow::{anyhow, bail, Context, Result};
-use tokio_retry::{strategy::FixedInterval, RetryIf};
+use anyhow::{Context, Result, anyhow, bail};
+use tokio_retry::{RetryIf, strategy::FixedInterval};
 
 use crate::dist::component::{
     Components, Package, TarGzPackage, TarXzPackage, TarZStdPackage, Transaction,
@@ -18,7 +18,7 @@ use crate::dist::manifest::{Component, CompressionKind, Manifest, TargetedPackag
 use crate::dist::notifications::*;
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
-use crate::dist::{Profile, TargetTriple, DEFAULT_DIST_SERVER};
+use crate::dist::{DEFAULT_DIST_SERVER, Profile, TargetTriple};
 use crate::errors::RustupError;
 use crate::process::Process;
 use crate::utils;

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -11,20 +11,21 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use url::Url;
 
 use crate::{
     dist::{
+        DEFAULT_DIST_SERVER, Notification, Profile, TargetTriple, ToolchainDesc,
         download::DownloadCfg,
         manifest::{Component, Manifest},
         manifestation::{Changes, Manifestation, UpdateStatus},
         prefix::InstallPrefix,
-        temp, Notification, Profile, TargetTriple, ToolchainDesc, DEFAULT_DIST_SERVER,
+        temp,
     },
     errors::RustupError,
     process::TestProcess,
-    test::mock::{dist::*, MockComponentBuilder, MockFile, MockInstallerBuilder},
+    test::mock::{MockComponentBuilder, MockFile, MockInstallerBuilder, dist::*},
     utils::{self, raw as utils_raw},
 };
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -4,9 +4,9 @@ use std::{
     collections::HashSet, env, fmt, io::Write, ops::Deref, path::Path, str::FromStr, sync::LazyLock,
 };
 
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use chrono::NaiveDate;
-use clap::{builder::PossibleValue, ValueEnum};
+use clap::{ValueEnum, builder::PossibleValue};
 use itertools::Itertools;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ use thiserror::Error as ThisError;
 use tracing::{info, warn};
 
 use crate::{
-    config::{dist_root_server, Cfg},
+    config::{Cfg, dist_root_server},
     errors::RustupError,
     process::Process,
     toolchain::ToolchainName,
@@ -57,7 +57,9 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
     let mut buf = vec![];
 
     match cs {
-        [] => panic!("`components_missing_msg` should not be called with an empty collection of unavailable components"),
+        [] => panic!(
+            "`components_missing_msg` should not be called with an empty collection of unavailable components"
+        ),
         [c] => {
             let _ = writeln!(
                 buf,
@@ -416,10 +418,10 @@ impl TargetTriple {
             /// it is only available on Windows 10 1511+, so we use `GetProcAddress`
             /// to maintain backward compatibility with older Windows versions.
             fn arch_primary() -> Option<&'static str> {
-                use windows_sys::core::s;
                 use windows_sys::Win32::Foundation::{BOOL, HANDLE};
                 use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
                 use windows_sys::Win32::System::Threading::GetCurrentProcess;
+                use windows_sys::core::s;
 
                 const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
                 const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
@@ -1195,10 +1197,14 @@ pub(crate) async fn dl_v2_manifest(
 
                 let server = dist_root_server(download.process)?;
                 if server == DEFAULT_DIST_SERVER {
-                    info!("this is likely due to an ongoing update of the official release server, please try again later");
+                    info!(
+                        "this is likely due to an ongoing update of the official release server, please try again later"
+                    );
                     info!("see <https://github.com/rust-lang/rustup/issues/3390> for more details");
                 } else {
-                    info!("this might indicate an issue with the third-party release server '{server}'");
+                    info!(
+                        "this might indicate an issue with the third-party release server '{server}'"
+                    );
                     info!("see <https://github.com/rust-lang/rustup/issues/3885> for more details");
                 }
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,8 +12,8 @@ use url::Url;
 
 use crate::{
     dist::{
-        manifest::{Component, Manifest},
         Channel, TargetTriple, ToolchainDesc,
+        manifest::{Component, Manifest},
     },
     toolchain::{PathBasedToolchainName, ToolchainName},
 };
@@ -165,7 +165,9 @@ fn suggest_message(suggestion: &Option<String>) -> String {
 fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &str) -> String {
     let mut buf = vec![];
     match cs {
-        [] => panic!("`component_unavailable_msg` should not be called with an empty collection of unavailable components"),
+        [] => panic!(
+            "`component_unavailable_msg` should not be called with an empty collection of unavailable components"
+        ),
         [c] => {
             let _ = writeln!(
                 buf,

--- a/src/install.rs
+++ b/src/install.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 
 use crate::{
     config::Cfg,
-    dist::{self, prefix::InstallPrefix, DistOptions, Notification},
+    dist::{self, DistOptions, Notification, prefix::InstallPrefix},
     errors::RustupError,
     notifications::Notification as RootNotification,
     toolchain::{CustomToolchainName, LocalToolchainName, Toolchain},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 ))]
 #![recursion_limit = "1024"]
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use errors::RustupError;
-use itertools::{chain, Itertools};
+use itertools::{Itertools, chain};
 
 #[macro_use]
 extern crate rs_tracing;
@@ -92,7 +92,7 @@ pub mod utils;
 
 #[cfg(test)]
 mod tests {
-    use crate::{is_proxyable_tools, DUP_TOOLS, TOOLS};
+    use crate::{DUP_TOOLS, TOOLS, is_proxyable_tools};
 
     #[test]
     fn test_is_proxyable_tools() {

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::settings::MetadataVersion;
 use crate::{
-    dist::{temp, ToolchainDesc},
+    dist::{ToolchainDesc, temp},
     toolchain::ToolchainName,
     utils::notify::NotificationLevel,
 };

--- a/src/process.rs
+++ b/src/process.rs
@@ -18,7 +18,7 @@ use tracing::subscriber::DefaultGuard;
 #[cfg(feature = "test")]
 use tracing_subscriber::util::SubscriberInitExt;
 #[cfg(feature = "test")]
-use tracing_subscriber::{reload::Handle, EnvFilter, Registry};
+use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 pub mod filesource;
 pub mod terminalsource;

--- a/src/process/terminalsource.rs
+++ b/src/process/terminalsource.rs
@@ -9,9 +9,9 @@ use std::{
 pub(crate) use termcolor::Color;
 use termcolor::{ColorChoice, ColorSpec, StandardStream, StandardStreamLock, WriteColor};
 
+use super::Process;
 #[cfg(feature = "test")]
 use super::filesource::{TestWriter, TestWriterLock};
-use super::Process;
 
 /// Select what stream to make a terminal on
 pub(super) enum StreamSelector {

--- a/src/test.rs
+++ b/src/test.rs
@@ -24,7 +24,7 @@ use crate::dist::TargetTriple;
 use crate::process::TestProcess;
 
 #[cfg(windows)]
-pub use crate::cli::self_update::{get_path, RegistryGuard, RegistryValueId, USER_PATH};
+pub use crate::cli::self_update::{RegistryGuard, RegistryValueId, USER_PATH, get_path};
 
 // Things that can have environment variables applied to them.
 pub trait Env {

--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -16,7 +16,7 @@ use std::{
     time::Instant,
 };
 
-use enum_map::{enum_map, Enum, EnumMap};
+use enum_map::{Enum, EnumMap, enum_map};
 use tempfile::TempDir;
 use url::Url;
 
@@ -28,11 +28,12 @@ use crate::test::this_host_triple;
 use crate::utils;
 
 use super::{
+    MockComponentBuilder, MockFile, MockInstallerBuilder,
     dist::{
-        change_channel_date, MockChannel, MockComponent, MockDistServer, MockManifestVersion,
-        MockPackage, MockTargetedPackage,
+        MockChannel, MockComponent, MockDistServer, MockManifestVersion, MockPackage,
+        MockTargetedPackage, change_channel_date,
     },
-    topical_doc_data, MockComponentBuilder, MockFile, MockInstallerBuilder,
+    topical_doc_data,
 };
 
 /// The configuration used by the tests in this module

--- a/src/test/mock/dist.rs
+++ b/src/test/mock/dist.rs
@@ -11,15 +11,15 @@ use sha2::{Digest, Sha256};
 use url::Url;
 
 use crate::dist::{
+    Profile, TargetTriple,
     manifest::{
         Component, CompressionKind, HashedBinary, Manifest, ManifestVersion, Package,
         PackageTargets, Renamed, TargetedPackage,
     },
-    Profile, TargetTriple,
 };
 
-use super::clitools::hard_link;
 use super::MockInstallerBuilder;
+use super::clitools::hard_link;
 
 // This function changes the mock manifest for a given channel to that
 // of a particular date. For advancing the build from e.g. 2016-02-1

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -204,7 +204,7 @@ impl<'a> Toolchain<'a> {
             .cfg
             .process
             .var_os(sysenv::LOADER_PATH)
-            .filter(|x| x.len() > 0)
+            .filter(|x| !x.is_empty())
             .is_none()
         {
             // These are the defaults when DYLD_FALLBACK_LIBRARY_PATH isn't

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -10,19 +10,19 @@ use std::{
     time::Duration,
 };
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::{Context, anyhow, bail};
 use fs_at::OpenOptions;
 use tracing::info;
 use url::Url;
 use wait_timeout::ChildExt;
 
 use crate::{
+    RustupError,
     config::{ActiveReason, Cfg, InstalledPath},
     dist::PartialToolchainDesc,
     env_var, install,
     notifications::Notification,
     utils::{self, raw::open_dir_following_links},
-    RustupError,
 };
 
 mod distributable;

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -476,8 +476,8 @@ mod tests {
 
     use crate::{
         dist::{
-            triple::known::{LIST_ARCHS, LIST_ENVS, LIST_OSES},
             PartialToolchainDesc,
+            triple::known::{LIST_ARCHS, LIST_ENVS, LIST_OSES},
         },
         toolchain::names::{CustomToolchainName, ResolvableToolchainName, ToolchainName},
     };

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,9 +8,9 @@ use std::ops::{BitAnd, BitAndAssign};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
-use anyhow::{anyhow, bail, Context, Result};
-use retry::delay::{jitter, Fibonacci};
-use retry::{retry, OperationResult};
+use anyhow::{Context, Result, anyhow, bail};
+use retry::delay::{Fibonacci, jitter};
+use retry::{OperationResult, retry};
 use sha2::Sha256;
 #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
 use tracing::info;
@@ -279,7 +279,9 @@ async fn download_file_(
         #[cfg(feature = "reqwest-native-tls")]
         (_, Some(false)) => {
             if use_curl_backend == Some(true) {
-                info!("RUSTUP_USE_CURL is set and RUSTUP_USE_RUSTLS is set to off, using reqwest with native-tls");
+                info!(
+                    "RUSTUP_USE_CURL is set and RUSTUP_USE_RUSTLS is set to off, using reqwest with native-tls"
+                );
             }
             Backend::Reqwest(TlsBackend::NativeTls)
         }

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -150,9 +150,9 @@ fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
     use std::ptr;
     use windows_sys::Win32::Foundation::*;
     use windows_sys::Win32::Storage::FileSystem::*;
+    use windows_sys::Win32::System::IO::*;
     use windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT;
     use windows_sys::Win32::System::SystemServices::*;
-    use windows_sys::Win32::System::IO::*;
 
     const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
 

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -3,7 +3,7 @@
 
 use rustup::for_host;
 use rustup::test::{
-    mock::clitools::{self, set_current_dist_date, CliTestContext, Scenario},
+    mock::clitools::{self, CliTestContext, Scenario, set_current_dist_date},
     this_host_triple,
 };
 

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -6,12 +6,12 @@ use std::process::Stdio;
 
 use rustup::for_host;
 use rustup::test::mock::clitools::CliTestContext;
-use rustup::test::{
-    mock::clitools::{self, set_current_dist_date, Config, SanitizedOutput, Scenario},
-    this_host_triple,
-};
 #[cfg(windows)]
 use rustup::test::{RegistryGuard, USER_PATH};
+use rustup::test::{
+    mock::clitools::{self, Config, SanitizedOutput, Scenario, set_current_dist_date},
+    this_host_triple,
+};
 use rustup::utils::raw;
 
 fn run_input(config: &Config, args: &[&str], input: &str) -> SanitizedOutput {
@@ -121,9 +121,10 @@ async fn smoke_case_install_with_path_install() {
 
     let out = run_input(&cx.config, &["rustup-init"], "\n\n");
     assert!(out.ok);
-    assert!(!out
-        .stdout
-        .contains("This path needs to be in your PATH environment variable"));
+    assert!(
+        !out.stdout
+            .contains("This path needs to be in your PATH environment variable")
+    );
 }
 
 #[tokio::test]
@@ -437,9 +438,10 @@ async fn install_forces_and_skips_rls() {
         "\n\n",
     );
     assert!(out.ok);
-    assert!(out
-        .stderr
-        .contains("warn: Force-skipping unavailable component"));
+    assert!(
+        out.stderr
+            .contains("warn: Force-skipping unavailable component")
+    );
 }
 
 #[tokio::test]
@@ -467,9 +469,10 @@ async fn installing_when_already_installed_updates_toolchain() {
         .await;
     let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "\n\n");
     println!("stdout:\n{}\n...\n", out.stdout);
-    assert!(out
-        .stdout
-        .contains(for_host!("stable-{} unchanged - 1.1.0 (hash-stable-1.1.0)")));
+    assert!(
+        out.stdout
+            .contains(for_host!("stable-{} unchanged - 1.1.0 (hash-stable-1.1.0)"))
+    );
 }
 
 #[tokio::test]
@@ -496,12 +499,14 @@ async fn install_stops_if_rustc_exists() {
         )
         .await;
     assert!(!out.ok);
-    assert!(out
-        .stderr
-        .contains("It looks like you have an existing installation of Rust at:"));
-    assert!(out
-        .stderr
-        .contains("If you are sure that you want both rustup and your already installed Rust"));
+    assert!(
+        out.stderr
+            .contains("It looks like you have an existing installation of Rust at:")
+    );
+    assert!(
+        out.stderr
+            .contains("If you are sure that you want both rustup and your already installed Rust")
+    );
 }
 
 #[tokio::test]
@@ -528,12 +533,14 @@ async fn install_stops_if_cargo_exists() {
         )
         .await;
     assert!(!out.ok);
-    assert!(out
-        .stderr
-        .contains("It looks like you have an existing installation of Rust at:"));
-    assert!(out
-        .stderr
-        .contains("If you are sure that you want both rustup and your already installed Rust"));
+    assert!(
+        out.stderr
+            .contains("It looks like you have an existing installation of Rust at:")
+    );
+    assert!(
+        out.stderr
+            .contains("If you are sure that you want both rustup and your already installed Rust")
+    );
 }
 
 #[tokio::test]
@@ -612,7 +619,8 @@ version = "12""#
         )
         .await;
     assert!(out.ok);
-    assert!(out
-        .stderr
-        .contains("It looks like you have an existing rustup settings file at:"));
+    assert!(
+        out.stderr
+            .contains("It looks like you have an existing rustup settings file at:")
+    );
 }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -7,7 +7,7 @@ use std::{env::consts::EXE_SUFFIX, path::Path};
 
 use rustup::for_host;
 use rustup::test::{
-    mock::clitools::{self, set_current_dist_date, CliTestContext, Config, Scenario},
+    mock::clitools::{self, CliTestContext, Config, Scenario, set_current_dist_date},
     this_host_triple,
 };
 use rustup::utils;
@@ -1195,9 +1195,10 @@ async fn update_self_smart_guess() {
     let out = cx.config.run("rustup", &["update", "self"], &[]).await;
     let invalid_toolchain = out.stderr.contains("invalid toolchain name");
     if !out.ok && invalid_toolchain {
-        assert!(out
-            .stderr
-            .contains("if you meant to update rustup itself, use `rustup self update`"))
+        assert!(
+            out.stderr
+                .contains("if you meant to update rustup itself, use `rustup self update`")
+        )
     }
 }
 
@@ -1207,9 +1208,10 @@ async fn uninstall_self_smart_guess() {
     let out = cx.config.run("rustup", &["uninstall", "self"], &[]).await;
     let no_toolchain_installed = out.stdout.contains("no toolchain installed");
     if out.ok && no_toolchain_installed {
-        assert!(out
-            .stdout
-            .contains("if you meant to uninstall rustup itself, use `rustup self uninstall`"))
+        assert!(
+            out.stdout
+                .contains("if you meant to uninstall rustup itself, use `rustup self uninstall`")
+        )
     }
 }
 

--- a/tests/suite/cli_paths.rs
+++ b/tests/suite/cli_paths.rs
@@ -381,9 +381,9 @@ export PATH="$HOME/apple/bin"
 mod windows {
     use super::INIT_NONE;
     use rustup::test::mock::clitools::{CliTestContext, Scenario};
-    use rustup::test::{get_path, RegistryGuard, USER_PATH};
+    use rustup::test::{RegistryGuard, USER_PATH, get_path};
 
-    use windows_registry::{Value, HSTRING};
+    use windows_registry::{HSTRING, Value};
 
     #[tokio::test]
     /// Smoke test for end-to-end code connectivity of the installer path mgmt on windows.
@@ -416,7 +416,7 @@ mod windows {
     async fn install_uninstall_affect_path_with_non_unicode() {
         use std::os::windows::ffi::OsStrExt;
 
-        use windows_registry::{Type, CURRENT_USER};
+        use windows_registry::{CURRENT_USER, Type};
 
         let mut cx = CliTestContext::new(Scenario::Empty).await;
         let _guard = RegistryGuard::new(&USER_PATH).unwrap();

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1,7 +1,7 @@
 //! Test cases for new rustup UI
 
 use std::fs;
-use std::path::{PathBuf, MAIN_SEPARATOR};
+use std::path::{MAIN_SEPARATOR, PathBuf};
 use std::{env::consts::EXE_SUFFIX, path::Path};
 
 use rustup::for_host;
@@ -1068,9 +1068,10 @@ async fn show_toolchain_override_not_installed() {
         .await;
     let out = cx.config.run("rustup", ["show"], &[]).await;
     assert!(!out.ok);
-    assert!(out
-        .stderr
-        .contains("is not installed: the directory override for"));
+    assert!(
+        out.stderr
+            .contains("is not installed: the directory override for")
+    );
     assert!(!out.stderr.contains("info: installing component 'rustc'"));
 }
 
@@ -2462,9 +2463,11 @@ async fn env_override_beats_file_override() {
     cmd.env("RUSTUP_TOOLCHAIN", "beta");
 
     let out = cmd.output().unwrap();
-    assert!(String::from_utf8(out.stdout)
-        .unwrap()
-        .contains("hash-beta-1.2.0"));
+    assert!(
+        String::from_utf8(out.stdout)
+            .unwrap()
+            .contains("hash-beta-1.2.0")
+    );
 }
 
 #[tokio::test]

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -9,20 +9,20 @@ use std::process::Command;
 use remove_dir_all::remove_dir_all;
 
 use retry::{
-    delay::{jitter, Fibonacci},
+    delay::{Fibonacci, jitter},
     retry,
 };
+#[cfg(windows)]
+use rustup::test::{RegistryGuard, RegistryValueId, USER_PATH};
 use rustup::test::{
     mock::{
-        clitools::{self, output_release_file, CliTestContext, Scenario, SelfUpdateTestContext},
+        clitools::{self, CliTestContext, Scenario, SelfUpdateTestContext, output_release_file},
         dist::calc_hash,
     },
     this_host_triple,
 };
-#[cfg(windows)]
-use rustup::test::{RegistryGuard, RegistryValueId, USER_PATH};
 use rustup::utils::{self, raw};
-use rustup::{for_host, DUP_TOOLS, TOOLS};
+use rustup::{DUP_TOOLS, TOOLS, for_host};
 #[cfg(windows)]
 use windows_registry::Value;
 

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -4,7 +4,7 @@
 use std::fs;
 
 use rustup::for_host;
-use rustup::test::mock::clitools::{set_current_dist_date, CliTestContext, Scenario};
+use rustup::test::mock::clitools::{CliTestContext, Scenario, set_current_dist_date};
 
 #[tokio::test]
 async fn rustc_no_default_toolchain() {

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use rustup::dist::TargetTriple;
 use rustup::for_host;
-use rustup::test::mock::clitools::{self, set_current_dist_date, CliTestContext, Config, Scenario};
+use rustup::test::mock::clitools::{self, CliTestContext, Config, Scenario, set_current_dist_date};
 use rustup::test::this_host_triple;
 
 #[tokio::test]
@@ -1434,8 +1434,8 @@ async fn update_unavailable_force() {
         .expect_err(
             &["rustup", "update", "nightly"],
             for_host!(
-            "component 'rls' for target '{0}' is unavailable for download for channel 'nightly'"
-        ),
+                "component 'rls' for target '{0}' is unavailable for download for channel 'nightly'"
+            ),
         )
         .await;
     cx.config

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,13 +1,13 @@
 use std::fs::File;
 use std::io::Write;
 
+use rustup::dist::DEFAULT_DIST_SERVER;
+use rustup::dist::Notification;
 use rustup::dist::component::Components;
 use rustup::dist::component::Transaction;
 use rustup::dist::component::{DirectoryPackage, Package};
 use rustup::dist::prefix::InstallPrefix;
 use rustup::dist::temp;
-use rustup::dist::Notification;
-use rustup::dist::DEFAULT_DIST_SERVER;
 use rustup::process::TestProcess;
 use rustup::utils;
 

--- a/tests/suite/known_triples.rs
+++ b/tests/suite/known_triples.rs
@@ -89,6 +89,8 @@ fn parse_triple(triple: &str) -> (&str, &str, &str) {
             &triple[(arch.len() + 1)..(triple.len() - env.len() - 1)],
             env,
         ),
-        _ => panic!("Internal error while parsing target triple `{triple}`, please file an issue at https://github.com/rust-lang/rustup/issues"),
+        _ => panic!(
+            "Internal error while parsing target triple `{triple}`, please file an issue at https://github.com/rust-lang/rustup/issues"
+        ),
     }
 }


### PR DESCRIPTION
This PR is the first part of rustup's migration to Rust 2024, which contains style-related changes only. Notably, macro invocations are now correctly formatted by `rustfmt`.

A second PR will follow shortly once this one gets merged, which will perform a semi-auto migration based on  #4061's plan:

> ```toml
> [workspace.lints.rust]
> rust_2018_idioms = { level = "deny", priority = -1 }
> rust-2024-compatibility = { level = "warn", priority = -2 }
> ```

PS: The newly-added `rustfmt` config is here for migration purposes. It should be deleted by the end of the second PR.

PPS: The CI should pass once the 2024 Edition lands in stable in a few hours.