### PR TITLE
build: migrate the codebase to the 2024 Language Edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,7 +131,7 @@ members = ["download"]
 
 [workspace.package]
 version = "1.28.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-style_edition = "2024"

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -20,7 +20,7 @@ use crate::{process::Process, utils::notify::NotificationLevel};
 pub fn tracing_subscriber(
     process: &Process,
 ) -> (
-    impl tracing::Subscriber,
+    impl tracing::Subscriber + use<>,
     reload::Handle<EnvFilter, Registry>,
 ) {
     #[cfg(feature = "otel")]
@@ -45,7 +45,7 @@ pub fn tracing_subscriber(
 /// When the `RUSTUP_LOG` environment variable is present, a standard [`tracing_subscriber`]
 /// formatter will be used according to the filtering directives set in its value.
 /// Otherwise, this logger will use [`EventFormatter`] to mimic "classic" Rustup `stderr` output.
-fn console_logger<S>(process: &Process) -> (impl Layer<S>, reload::Handle<EnvFilter, S>)
+fn console_logger<S>(process: &Process) -> (impl Layer<S> + use<S>, reload::Handle<EnvFilter, S>)
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
@@ -129,7 +129,7 @@ impl NotificationLevel {
 /// A [`tracing::Subscriber`] [`Layer`][`tracing_subscriber::Layer`] that corresponds to Rustup's
 /// optional `opentelemetry` (a.k.a. `otel`) feature.
 #[cfg(feature = "otel")]
-fn telemetry<S>(process: &Process) -> impl Layer<S>
+fn telemetry<S>(process: &Process) -> impl Layer<S> + use<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {

--- a/src/diskio/immediate.rs
+++ b/src/diskio/immediate.rs
@@ -81,21 +81,20 @@ impl Executor for ImmediateUnpacker {
                     // If there is a pending error, return it, otherwise stash the
                     // Item for eventual return when the file is finished.
                     let mut guard = self.incremental_state.lock().unwrap();
-                    if let Some(ref mut state) = *guard {
-                        if state.err.is_some() {
-                            let err = state.err.take().unwrap();
-                            item.result = err;
-                            item.finish = item
-                                .start
-                                .map(|s| Instant::now().saturating_duration_since(s));
-                            *guard = None;
-                            Box::new(Some(CompletedIo::Item(item)).into_iter())
-                        } else {
-                            state.item = Some(item);
-                            Box::new(None.into_iter())
-                        }
+                    let Some(ref mut state) = *guard else {
+                        unreachable!()
+                    };
+                    if state.err.is_some() {
+                        let err = state.err.take().unwrap();
+                        item.result = err;
+                        item.finish = item
+                            .start
+                            .map(|s| Instant::now().saturating_duration_since(s));
+                        *guard = None;
+                        Box::new(Some(CompletedIo::Item(item)).into_iter())
                     } else {
-                        unreachable!();
+                        state.item = Some(item);
+                        Box::new(None.into_iter())
                     }
                 };
             }
@@ -181,9 +180,7 @@ impl IncrementalFileWriter {
         if (self.state.lock().unwrap()).is_none() {
             return false;
         }
-        let chunk = if let FileBuffer::Immediate(v) = chunk {
-            v
-        } else {
+        let FileBuffer::Immediate(chunk) = chunk else {
             unreachable!()
         };
         match self.write(chunk) {
@@ -203,25 +200,23 @@ impl IncrementalFileWriter {
 
     fn write(&mut self, chunk: Vec<u8>) -> std::result::Result<bool, io::Error> {
         let mut state = self.state.lock().unwrap();
-        if let Some(ref mut state) = *state {
-            if let Some(ref mut file) = self.file.as_mut() {
-                // Length 0 vector is used for clean EOF signalling.
-                if chunk.is_empty() {
-                    trace_scoped!("close", "name:": self.path_display);
-                    drop(std::mem::take(&mut self.file));
-                    state.finished = true;
-                } else {
-                    trace_scoped!("write_segment", "name": self.path_display, "len": chunk.len());
-                    file.write_all(&chunk)?;
-
-                    state.completed_chunks.push(chunk.len());
-                }
-                Ok(true)
-            } else {
-                Ok(false)
-            }
+        let Some(ref mut state) = *state else {
+            unreachable!()
+        };
+        let Some(ref mut file) = self.file.as_mut() else {
+            return Ok(false);
+        };
+        // Length 0 vector is used for clean EOF signalling.
+        if chunk.is_empty() {
+            trace_scoped!("close", "name:": self.path_display);
+            drop(std::mem::take(&mut self.file));
+            state.finished = true;
         } else {
-            unreachable!();
+            trace_scoped!("write_segment", "name": self.path_display, "len": chunk.len());
+            file.write_all(&chunk)?;
+
+            state.completed_chunks.push(chunk.len());
         }
+        Ok(true)
     }
 }

--- a/src/diskio/immediate.rs
+++ b/src/diskio/immediate.rs
@@ -69,8 +69,8 @@ impl Executor for ImmediateUnpacker {
     fn dispatch(&self, mut item: Item) -> Box<dyn Iterator<Item = CompletedIo> + '_> {
         item.result = match &mut item.kind {
             super::Kind::Directory => super::create_dir(&item.full_path),
-            super::Kind::File(ref contents) => {
-                if let super::FileBuffer::Immediate(ref contents) = &contents {
+            super::Kind::File(contents) => {
+                if let super::FileBuffer::Immediate(contents) = &contents {
                     super::write_file(&item.full_path, contents, item.mode)
                 } else {
                     unreachable!()

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -335,10 +335,9 @@ impl FromStr for ParsedToolchainDesc {
             }
         });
 
-        if let Some(d) = d {
-            Ok(d)
-        } else {
-            Err(RustupError::InvalidToolchainName(desc.to_string()).into())
+        match d {
+            Some(d) => Ok(d),
+            None => Err(RustupError::InvalidToolchainName(desc.to_string()).into()),
         }
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -87,11 +87,11 @@ impl<'a> Toolchain<'a> {
             ActiveReason::CommandLine => {
                 "the +toolchain on the command line specifies an uninstalled toolchain".to_string()
             }
-            ActiveReason::OverrideDB(ref path) => format!(
+            ActiveReason::OverrideDB(path) => format!(
                 "the directory override for '{}' specifies an uninstalled toolchain",
                 utils::canonicalize_path(path, cfg.notify_handler.as_ref()).display(),
             ),
-            ActiveReason::ToolchainFile(ref path) => format!(
+            ActiveReason::ToolchainFile(path) => format!(
                 "the toolchain file at '{}' specifies an uninstalled toolchain",
                 utils::canonicalize_path(path, cfg.notify_handler.as_ref()).display(),
             ),


### PR DESCRIPTION
Continuation of #4190.

This is a semi-automatic migration due to the sheer amount of false positives in the `rust-2024-compatibility` lint group and the `if_let_rescope` lint in particular. Some steps have more details in the corresponding commit messages.

You can get a clearer version of the PR diff via [_semanticdiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4191).

## Concerns

- [ ] Did I get all the `if-let` correctly migrated?
  - To make the review easier, I've made #4192 to include all the suggestions made by `clippy` where there are a lot of false positives.
  -  Please feel free to point out if I have missed a significant drop somewhere.