### PR TITLE
DON'T MERGE[ci skip]: demonstrate `if_let_rescope` auto migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,8 @@ url = "2.4"
 walkdir = "2"
 
 [workspace.lints.rust]
-rust_2018_idioms = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
+if_let_rescope = { level = "warn", priority = -2 }
 
 [workspace.lints.clippy]
 # `dbg!()` and `todo!()` clearly shouldn't make it to production:

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -417,13 +417,12 @@ pub(crate) fn list_toolchains(
     } else {
         let default_toolchain_name = cfg.get_default()?;
         let active_toolchain_name: Option<ToolchainName> =
-            if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
-                cfg.find_active_toolchain()
-            {
+            match cfg.find_active_toolchain()
+            { Ok(Some((LocalToolchainName::Named(toolchain), _reason))) => {
                 Some(toolchain)
-            } else {
+            } _ => {
                 None
-            };
+            }};
 
         for toolchain in toolchains {
             let is_default_toolchain = default_toolchain_name.as_ref() == Some(&toolchain);

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -727,7 +727,7 @@ async fn default_(
 ) -> Result<utils::ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
-    if let Some(toolchain) = toolchain {
+    match toolchain { Some(toolchain) => {
         match toolchain.to_owned() {
             MaybeResolvableToolchainName::None => {
                 cfg.set_default(None)?;
@@ -756,12 +756,12 @@ async fn default_(
                 info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
             }
         }
-    } else {
+    } _ => {
         let default_toolchain = cfg
             .get_default()?
             .ok_or_else(|| anyhow!("no default toolchain is configured"))?;
         writeln!(cfg.process.stdout().lock(), "{default_toolchain} (default)")?;
-    }
+    }}
 
     Ok(utils::ExitCode(0))
 }
@@ -961,13 +961,12 @@ fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     let installed_toolchains = cfg.list_toolchains()?;
     let active_toolchain_and_reason: Option<(ToolchainName, ActiveReason)> =
-        if let Ok(Some((LocalToolchainName::Named(toolchain_name), reason))) =
-            cfg.find_active_toolchain()
-        {
+        match cfg.find_active_toolchain()
+        { Ok(Some((LocalToolchainName::Named(toolchain_name), reason))) => {
             Some((toolchain_name, reason))
-        } else {
+        } _ => {
             None
-        };
+        }};
 
     let (active_toolchain_name, _active_reason) = active_toolchain_and_reason
         .as_ref()

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -162,14 +162,14 @@ impl<'a> DownloadCfg<'a> {
 
         if let Some(hash_file) = update_hash {
             if utils::is_file(hash_file) {
-                if let Ok(contents) = utils::read_file("update hash", hash_file) {
+                match utils::read_file("update hash", hash_file) { Ok(contents) => {
                     if contents == partial_hash {
                         // Skip download, update hash matches
                         return Ok(None);
                     }
-                } else {
+                } _ => {
                     (self.notify_handler)(Notification::CantReadUpdateHash(hash_file));
-                }
+                }}
             } else {
                 (self.notify_handler)(Notification::NoUpdateHash(hash_file));
             }

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -369,15 +369,15 @@ impl Manifestation {
         // component name plus the target triple.
         let name = component.name_in_manifest();
         let short_name = component.short_name_in_manifest();
-        if let Some(c) = self.installation.find(&name)? {
+        match self.installation.find(&name)? { Some(c) => {
             tx = c.uninstall(tx, process)?;
-        } else if let Some(c) = self.installation.find(short_name)? {
+        } _ => { match self.installation.find(short_name)? { Some(c) => {
             tx = c.uninstall(tx, process)?;
-        } else {
+        } _ => {
             notify_handler(Notification::MissingInstalledComponent(
                 &component.short_name(manifest),
             ));
-        }
+        }}}}
 
         Ok(tx)
     }

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -335,11 +335,7 @@ impl FromStr for ParsedToolchainDesc {
             }
         });
 
-        if let Some(d) = d {
-            Ok(d)
-        } else {
-            Err(RustupError::InvalidToolchainName(desc.to_string()).into())
-        }
+        d.ok_or_else(|| RustupError::InvalidToolchainName(desc.to_string()).into())
     }
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -971,13 +971,13 @@ pub(crate) async fn update_from_dist(
 
         if try_next < last_manifest {
             // Wouldn't be an update if we go further back than the user's current nightly.
-            if let Some(e) = first_err {
+            match first_err { Some(e) => {
                 break Err(e);
-            } else {
+            } _ => {
                 // In this case, all newer nightlies are missing, which means there are no
                 // updates, so the user is already at the latest nightly.
                 break Ok(None);
-            }
+            }}
         }
 
         toolchain.date = Some(try_next.format("%Y-%m-%d").to_string());

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -353,16 +353,16 @@ impl<'a> Toolchain<'a> {
     #[cfg_attr(feature="otel", tracing::instrument(err,fields(binary, recursion=self.cfg.process.var("RUST_RECURSION_COUNT").ok())))]
     fn create_command<T: AsRef<OsStr> + Debug>(&self, binary: T) -> Result<Command, anyhow::Error> {
         // Create the path to this binary within the current toolchain sysroot
-        let binary = if let Some(binary_str) = binary.as_ref().to_str() {
+        let binary = match binary.as_ref().to_str() { Some(binary_str) => {
             if binary_str.to_lowercase().ends_with(EXE_SUFFIX) {
                 binary.as_ref().to_owned()
             } else {
                 OsString::from(format!("{binary_str}{EXE_SUFFIX}"))
             }
-        } else {
+        } _ => {
             // Very weird case. Non-unicode command.
             binary.as_ref().to_owned()
-        };
+        }};
 
         let bin_path = self.path.join("bin").join(&binary);
         let path = if utils::is_file(&bin_path) {

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -231,7 +231,7 @@ impl<'a> DistributableToolchain<'a> {
         const MAX_DISTANCE: usize = 3;
 
         let components = manifest.query_components(&self.desc, config);
-        if let Ok(components) = components {
+        match components { Ok(components) => {
             let short_name_distance = components
                 .iter()
                 .filter(|c| !only_installed || c.installed)
@@ -296,9 +296,9 @@ impl<'a> DistributableToolchain<'a> {
             } else {
                 Some(closest_match)
             }
-        } else {
+        } _ => {
             None
-        }
+        }}
     }
 
     #[tracing::instrument(level = "trace", skip_all)]


### PR DESCRIPTION
Complements https://github.com/rust-lang/rustup/pull/4191 to show the `if-let` migrations that I **didn't** do.

For the sake of simplicity, the first commit of #4191 has also been cherry-picked into this branch. After that, a `cargo clippy --fix` is performed after adjusting the `Cargo.toml` to activate the `if_let_rescope` lint.

Notably, according to https://github.com/rust-lang/rust/issues/133167#issuecomment-2674679030, `if let Some()` and other similar cases **where the `else` drop is not significant** are not affected by the Edition change.

Please feel free to point out if I have missed a significant drop somewhere in #4191.

You can get a clearer version of the PR diff via [_semanticdiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4192).