### PR TITLE
chore(deps): update opentelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1711,32 +1711,48 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+checksum = "236e667b670a5cdf90c258f5a55794ec5ac5027e960c224bff8367a59e1e6426"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8863faf2910030d139fb48715ad5ff2f35029fc5f244f6d5f689ddcf4d26253"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
  "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+checksum = "5bef114c6d41bea83d6dc60eb41720eedd0261a67af57b66dd2b84ac46c01d91"
 dependencies = [
  "async-trait",
  "futures-core",
  "http",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.69",
+ "reqwest",
+ "thiserror 2.0.11",
  "tokio",
  "tonic",
  "tracing",
@@ -1744,9 +1760,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+checksum = "56f8870d3024727e99212eb3bb1762ec16e255e3e6f58eeb3dc8db1aa226746d"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1756,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+checksum = "84dfad6042089c7fc1f6118b7040dc2eb4ab520abbf410b79dc481032af39570"
 dependencies = [
  "async-trait",
  "futures-channel",
@@ -1769,7 +1785,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.8.5",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.11",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3042,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "721f2d2569dce9f3dfbbddee5906941e953bfcdf736a62da3377f5751650cc36"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,9 +137,9 @@ license = "MIT OR Apache-2.0"
 [workspace.dependencies]
 anyhow = "1.0.69"
 fs_at = "0.2.1"
-opentelemetry = "0.27"
-opentelemetry-otlp = "0.27"
-opentelemetry_sdk = { version = "0.27", features = ["rt-tokio"] }
+opentelemetry = "0.28"
+opentelemetry-otlp = { version = "0.28", features = ["grpc-tonic"] }
+opentelemetry_sdk = { version = "0.28", features = ["rt-tokio"] }
 platforms = "3.4"
 proptest = "1.1.0"
 tempfile = "3.8"
@@ -149,7 +149,7 @@ tokio = { version = "1.26.0", default-features = false, features = ["macros", "r
 tokio-retry = { version = "0.3.0" }
 tokio-stream = { version = "0.1.14" }
 tracing = "0.1"
-tracing-opentelemetry = "0.28"
+tracing-opentelemetry = "0.29"
 tracing-subscriber = "0.3.16"
 url = "2.4"
 walkdir = "2"

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -24,6 +24,7 @@ use rs_tracing::{
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 use rustup::cli::common;
+use rustup::cli::log;
 use rustup::cli::proxy_mode;
 use rustup::cli::rustup_mode;
 #[cfg(windows)]
@@ -43,9 +44,9 @@ async fn main() -> Result<ExitCode> {
     let process = Process::os();
     let result = {
         #[cfg(feature = "otel")]
-        let _telemetry_guard = rustup::cli::log::set_global_telemetry();
+        let _telemetry_guard = log::set_global_telemetry();
 
-        let (subscriber, console_filter) = rustup::cli::log::tracing_subscriber(&process);
+        let (subscriber, console_filter) = log::tracing_subscriber(&process);
         tracing::subscriber::set_global_default(subscriber)?;
         run_rustup(&process, console_filter).await
     };

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -50,7 +50,9 @@ async fn main() -> Result<ExitCode> {
     let result = run_rustup(&process, console_filter).await;
     // We're tracing, so block until all spans are exported.
     #[cfg(feature = "otel")]
-    opentelemetry::global::shutdown_tracer_provider();
+    opentelemetry::global::set_tracer_provider(
+        opentelemetry::trace::noop::NoopTracerProvider::new(),
+    );
 
     match result {
         Err(e) => {

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -153,12 +153,11 @@ where
 fn telemetry_default_tracer() -> Tracer {
     use std::time::Duration;
 
-    use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
+    use opentelemetry::{global, trace::TracerProvider as _};
     use opentelemetry_otlp::WithExportConfig;
     use opentelemetry_sdk::{
         Resource,
-        runtime::Tokio,
-        trace::{Sampler, TracerProvider},
+        trace::{Sampler, SdkTracerProvider},
     };
 
     let exporter = opentelemetry_otlp::SpanExporter::builder()
@@ -167,10 +166,10 @@ fn telemetry_default_tracer() -> Tracer {
         .build()
         .unwrap();
 
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_sampler(Sampler::AlwaysOn)
-        .with_resource(Resource::new(vec![KeyValue::new("service.name", "rustup")]))
-        .with_batch_exporter(exporter, Tokio)
+        .with_resource(Resource::builder().with_service_name("rustup").build())
+        .with_batch_exporter(exporter)
         .build();
 
     global::set_tracer_provider(provider.clone());

--- a/src/process.rs
+++ b/src/process.rs
@@ -180,7 +180,7 @@ impl Default for OsProcess {
 pub struct TestProcess {
     pub process: Process,
     pub console_filter: Handle<EnvFilter, Registry>,
-    _guard: DefaultGuard, // guard is dropped at the end of the test
+    _tracing_guard: DefaultGuard, // guard is dropped at the end of the test
 }
 
 #[cfg(feature = "test")]
@@ -237,7 +237,7 @@ impl From<TestContext> for TestProcess {
         Self {
             process: inner,
             console_filter,
-            _guard: tracing_subscriber.set_default(),
+            _tracing_guard: tracing_subscriber.set_default(),
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -20,6 +20,9 @@ use tracing_subscriber::util::SubscriberInitExt;
 #[cfg(feature = "test")]
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
+#[cfg(all(feature = "test", feature = "otel"))]
+use crate::cli::log;
+
 pub mod filesource;
 pub mod terminalsource;
 
@@ -180,7 +183,10 @@ impl Default for OsProcess {
 pub struct TestProcess {
     pub process: Process,
     pub console_filter: Handle<EnvFilter, Registry>,
-    _tracing_guard: DefaultGuard, // guard is dropped at the end of the test
+    // These guards are dropped _in order_ at the end of the test.
+    #[cfg(feature = "otel")]
+    _telemetry_guard: log::GlobalTelemetryGuard,
+    _tracing_guard: DefaultGuard,
 }
 
 #[cfg(feature = "test")]
@@ -237,6 +243,8 @@ impl From<TestContext> for TestProcess {
         Self {
             process: inner,
             console_filter,
+            #[cfg(feature = "otel")]
+            _telemetry_guard: log::set_global_telemetry(),
             _tracing_guard: tracing_subscriber.set_default(),
         }
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -245,6 +245,8 @@ pub async fn after_test_async() {
     #[cfg(feature = "otel")]
     {
         // We're tracing, so block until all spans are exported.
-        opentelemetry::global::shutdown_tracer_provider();
+        opentelemetry::global::set_tracer_provider(
+            opentelemetry::trace::noop::NoopTracerProvider::new(),
+        );
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -231,22 +231,3 @@ where
     let rustup_home = RustupHome::new_in(test_dir)?;
     f(&rustup_home)
 }
-
-pub async fn before_test_async() {
-    #[cfg(feature = "otel")]
-    {
-        opentelemetry::global::set_text_map_propagator(
-            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
-        );
-    }
-}
-
-pub async fn after_test_async() {
-    #[cfg(feature = "otel")]
-    {
-        // We're tracing, so block until all spans are exported.
-        opentelemetry::global::set_tracer_provider(
-            opentelemetry::trace::noop::NoopTracerProvider::new(),
-        );
-    }
-}


### PR DESCRIPTION
Supersedes #4182.

Following https://github.com/rust-lang/rustup/pull/4182#issuecomment-2663126604, I realized that since `otel` is not an essential part of our project (it's used in benchmarks for the timeline view only), the following change has brought us no benefits:

> `opentelemetry::global::shutdown_tracer_provider()` is removed.
> Now, you should explicitly call shutdown() on the created tracer provider.
> [..]
> This now makes shutdown consistent across signals.
_https://github.com/open-telemetry/opentelemetry-rust/blob/main/docs/migration_0.28.md#tracing-shutdown-changes_

... so it'd be nice to just stick to the original behavior of `shutdown_tracer_provider()`, which is simply replacing the global tracer provider with `NoopTracerProvider::new()` and dropping the replaced provider immediately:

```rs
pub fn set_tracer_provider<P, T, S>(new_provider: P) -> GlobalTracerProvider
where
    S: trace::Span + Send + Sync + 'static,
    T: trace::Tracer<Span = S> + Send + Sync + 'static,
    P: trace::TracerProvider<Tracer = T> + Send + Sync + 'static,
{
    let mut tracer_provider = GLOBAL_TRACER_PROVIDER
        .write()
        .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned");
    mem::replace(
        &mut *tracer_provider,
        GlobalTracerProvider::new(new_provider),
    )
}

pub fn shutdown_tracer_provider() {
    let mut tracer_provider = GLOBAL_TRACER_PROVIDER
        .write()
        .expect("GLOBAL_TRACER_PROVIDER RwLock poisoned");
    let _ = mem::replace(
        &mut *tracer_provider,
        GlobalTracerProvider::new(NoopTracerProvider::new()),
    );
}
```
_https://github.com/open-telemetry/opentelemetry-rust/blob/99d24b7b8ca25652b955678a1109af0f9d65e242/opentelemetry/src/global/trace.rs#L398-L430_

Regarding the setup/shutdown ergonomics, I've made a simple guard to bring back `(before|after)_test_async()` with minimal efforts, so this has also addressed the test-related part of https://github.com/rust-lang/rustup/issues/4195, although it'd probably still be nice to be able to fetch e.g. logger filter levels directly from within `Process`, so the remainder of that issue stays valid.