### PR TITLE
Do not append `EXE_SUFFIX` in `Config::cmd`

### DIFF
--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -537,7 +537,7 @@ impl Config {
         I: IntoIterator<Item = A>,
         A: AsRef<OsStr>,
     {
-        let exe_path = self.exedir.join(format!("{name}{EXE_SUFFIX}"));
+        let exe_path = self.exedir.join(name);
         let mut cmd = Command::new(exe_path);
         cmd.args(args);
         cmd.current_dir(&*self.workdir.borrow());


### PR DESCRIPTION
Previously, `Config::cmd` would always append an `EXE_SUFFIX`. However, this would produce an invalid path if the suffix was already present.

Extracted from #4175