### PR TITLE
Add `Config::run_subprocess_cmd`

### DIFF
--- a/src/test/mock/clitools.rs
+++ b/src/test/mock/clitools.rs
@@ -839,7 +839,10 @@ impl Config {
         for env in env {
             cmd.env(env.0, env.1);
         }
+        self.run_subprocess_cmd(cmd)
+    }
 
+    pub fn run_subprocess_cmd(&self, mut cmd: Command) -> Output {
         let mut retries = 8;
         let out = loop {
             let lock = CMD_LOCK.read().unwrap();


### PR DESCRIPTION
The function `Config::run_subprocess` takes a program name and a list of arguments, constructs a command from them, and then runs the command.

The function this commit adds is similar, but it accepts an already constructed command.

Extracted from #4175