### PR TITLE
fix!(config): re-enable active toolchain installation in `Cfg::find_active_toolchain()` with optional opt-out

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -406,7 +406,7 @@ pub(super) fn list_items(
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn list_toolchains(
+pub(crate) async fn list_toolchains(
     cfg: &Cfg<'_>,
     verbose: bool,
     quiet: bool,
@@ -418,7 +418,7 @@ pub(crate) fn list_toolchains(
         let default_toolchain_name = cfg.get_default()?;
         let active_toolchain_name: Option<ToolchainName> =
             if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
-                cfg.find_active_toolchain()
+                cfg.find_active_toolchain().await
             {
                 Some(toolchain)
             } else {

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -418,7 +418,7 @@ pub(crate) async fn list_toolchains(
         let default_toolchain_name = cfg.get_default()?;
         let active_toolchain_name: Option<ToolchainName> =
             if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
-                cfg.find_active_toolchain().await
+                cfg.find_active_toolchain(None).await
             {
                 Some(toolchain)
             } else {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -32,6 +32,9 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .collect();
 
     let cfg = set_globals(current_dir, true, process)?;
-    let cmd = cfg.resolve_local_toolchain(toolchain)?.command(arg0)?;
+    let cmd = cfg
+        .resolve_local_toolchain(toolchain)
+        .await?
+        .command(arg0)?;
     run_command_for_dir(cmd, arg0, &cmd_args)
 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -753,7 +753,7 @@ async fn default_(
             }
         };
 
-        if let Some((toolchain, reason)) = cfg.find_active_toolchain().await? {
+        if let Some((toolchain, reason)) = cfg.find_active_toolchain(None).await? {
             if !matches!(reason, ActiveReason::Default) {
                 info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
             }
@@ -964,7 +964,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     let installed_toolchains = cfg.list_toolchains()?;
     let active_toolchain_and_reason: Option<(ToolchainName, ActiveReason)> =
         if let Ok(Some((LocalToolchainName::Named(toolchain_name), reason))) =
-            cfg.find_active_toolchain().await
+            cfg.find_active_toolchain(None).await
         {
             Some((toolchain_name, reason))
         } else {
@@ -1084,7 +1084,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
 #[tracing::instrument(level = "trace", skip_all)]
 async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
-    match cfg.find_active_toolchain().await? {
+    match cfg.find_active_toolchain(None).await? {
         Some((toolchain_name, reason)) => {
             let toolchain = Toolchain::with_reason(cfg, toolchain_name.clone(), &reason)?;
             writeln!(
@@ -1316,7 +1316,7 @@ async fn toolchain_link(
 async fn toolchain_remove(cfg: &mut Cfg<'_>, opts: UninstallOpts) -> Result<utils::ExitCode> {
     let default_toolchain = cfg.get_default().ok().flatten();
     let active_toolchain = cfg
-        .find_active_toolchain()
+        .find_active_toolchain(Some(false))
         .await
         .ok()
         .flatten()

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -32,11 +32,13 @@ pub(crate) struct DistributableToolchain<'a> {
 }
 
 impl<'a> DistributableToolchain<'a> {
-    pub(crate) fn from_partial(
+    pub(crate) async fn from_partial(
         toolchain: Option<PartialToolchainDesc>,
         cfg: &'a Cfg<'a>,
     ) -> anyhow::Result<Self> {
-        Ok(Self::try_from(&cfg.toolchain_from_partial(toolchain)?)?)
+        Ok(Self::try_from(
+            &cfg.toolchain_from_partial(toolchain).await?,
+        )?)
     }
 
     pub(crate) fn new(cfg: &'a Cfg<'a>, desc: ToolchainDesc) -> Result<Self, RustupError> {

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1052,12 +1052,12 @@ async fn show_toolchain_override_not_installed() {
         .expect_ok(&["rustup", "toolchain", "remove", "nightly"])
         .await;
     let out = cx.config.run("rustup", ["show"], &[]).await;
-    assert!(!out.ok);
+    assert!(out.ok);
     assert!(
-        out.stderr
+        !out.stderr
             .contains("is not installed: the directory override for")
     );
-    assert!(!out.stderr.contains("info: installing component 'rustc'"));
+    assert!(out.stderr.contains("info: installing component 'rustc'"));
 }
 
 #[tokio::test]
@@ -1137,7 +1137,7 @@ async fn show_toolchain_env_not_installed() {
         .run("rustup", ["show"], &[("RUSTUP_TOOLCHAIN", "nightly")])
         .await;
 
-    assert!(!out.ok);
+    assert!(out.ok);
 
     let expected_out = for_host_and_home!(
         cx.config,
@@ -1149,17 +1149,13 @@ installed toolchains
 
 active toolchain
 ----------------
+name: nightly-{0}
+active because: overridden by environment variable RUSTUP_TOOLCHAIN
+installed targets:
+  {0}
 "
     );
     assert!(&out.stdout == expected_out);
-    assert!(
-        out.stderr
-            == format!(
-                "error: override toolchain 'nightly-{}' is not installed: \
-                the RUSTUP_TOOLCHAIN environment variable specifies an uninstalled toolchain\n",
-                this_host_triple()
-            )
-    );
 }
 
 #[tokio::test]

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -182,14 +182,10 @@ async fn remove_override_toolchain_err_handling() {
         .expect_ok(&["rustup", "toolchain", "remove", "beta"])
         .await;
     cx.config
-        .expect_err_ex(
+        .expect_ok_contains(
             &["rustc", "--version"],
-            "",
-            for_host!(
-                r"error: toolchain 'beta-{0}' is not installed
-help: run `rustup toolchain install beta-{0}` to install it
-"
-            ),
+            "1.2.0 (hash-beta-1.2.0)",
+            "info: downloading component 'rust'",
         )
         .await;
 }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -327,14 +327,10 @@ async fn remove_override_toolchain_err_handling() {
         .expect_ok(&["rustup", "toolchain", "remove", "beta"])
         .await;
     cx.config
-        .expect_err_ex(
+        .expect_ok_contains(
             &["rustc", "--version"],
-            "",
-            for_host!(
-                r"error: toolchain 'beta-{0}' is not installed
-help: run `rustup toolchain install beta-{0}` to install it
-"
-            ),
+            "1.2.0 (hash-beta-1.2.0)",
+            "info: downloading component 'rustc'",
         )
         .await;
 }
@@ -346,9 +342,10 @@ async fn file_override_toolchain_err_handling() {
     let toolchain_file = cwd.join("rust-toolchain");
     rustup::utils::raw::write_file(&toolchain_file, "beta").unwrap();
     cx.config
-        .expect_err(
+        .expect_ok_contains(
             &["rustc", "--version"],
-            for_host!("toolchain 'beta-{0}' is not installed"),
+            "1.2.0 (hash-beta-1.2.0)",
+            "info: downloading component 'rustc'",
         )
         .await;
 }


### PR DESCRIPTION
> [!NOTE]
> Following @djc's previous statement at https://github.com/rust-lang/rustup/issues/4211#issuecomment-2695620307, I sincerely apologize for all the previous issues related to the abrupt breaking change without enough clarity and transparency, and, if a well-organized public discussion allows this change to happen, a potential experimental stage with a properly-extended migration period.

This PR tries to mitigate #4211 by introducing a new environment variable `RUSTUP_AUTO_INSTALL` that defaults to `1` ~~and is subsumed under `CI`~~. This environment variable, when evaluated to `true`, will try to install the active toolchain in `Cfg::find_active_toolchain()`.

@rust-lang/rustup please feel free to change this PR as you see fit so that we can land the fix as promptly as possible.

## Concerns

Remaining work around this PR might include:
- [ ] Introducing a proper warning message about the originally-planned change in behavior;
- [x] Making sure that the tests pass properly;
- [ ] Ensuring that both the old way and the new way are working as intended.