### PR TITLE
Use `read_timeout` for reqwest instead of `timeout`

### DIFF
--- a/download/src/lib.rs
+++ b/download/src/lib.rs
@@ -379,7 +379,7 @@ pub mod reqwest_be {
             .pool_max_idle_per_host(0)
             .gzip(false)
             .proxy(Proxy::custom(env_proxy))
-            .timeout(Duration::from_secs(30))
+            .read_timeout(Duration::from_secs(30))
     }
 
     #[cfg(feature = "reqwest-rustls-tls")]


### PR DESCRIPTION
The [`ClientBuilder::timeout`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.timeout) method applies to the whole download. Having 30s to complete a download seems very wrong so I assume the intent was to only timeout if the download stalls for that long, which is what [`read_timeout`](https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#method.read_timeout) does.

It might also be worth increasing the timeout to a minute or two for people with unreliable internet connections but I'm less sure that's needed.

Fixes #4213