### PR TITLE
Restore old behaviour for `rustup show active-toolchain`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1085,18 +1085,24 @@ fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode
     match cfg.find_active_toolchain()? {
         Some((toolchain_name, reason)) => {
             let toolchain = Toolchain::with_reason(cfg, toolchain_name.clone(), &reason)?;
-            writeln!(
-                cfg.process.stdout().lock(),
-                "{}\nactive because: {}",
-                toolchain.name(),
-                reason
-            )?;
             if verbose {
                 writeln!(
                     cfg.process.stdout().lock(),
-                    "compiler: {}\npath: {}",
+                    "{}\nactive because: {}\ncompiler: {}\npath: {}",
+                    toolchain.name(),
+                    reason,
                     toolchain.rustc_version(),
-                    toolchain.path().display(),
+                    toolchain.path().display()
+                )?;
+            } else {
+                writeln!(
+                    cfg.process.stdout().lock(),
+                    "{} ({})",
+                    toolchain.name(),
+                    match reason {
+                        ActiveReason::Default => &"default" as &dyn fmt::Display,
+                        _ => &reason,
+                    }
                 )?;
             }
         }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1169,7 +1169,7 @@ async fn show_active_toolchain() {
     cx.config
         .expect_ok_ex(
             &["rustup", "show", "active-toolchain"],
-            for_host!("nightly-{0}\nactive because: it's the default toolchain\n"),
+            for_host!("nightly-{0} (default)\n"),
             r"",
         )
         .await;
@@ -1260,7 +1260,36 @@ async fn show_active_toolchain_with_override() {
     cx.config
         .expect_stdout_ok(
             &["rustup", "show", "active-toolchain"],
-            for_host!("stable-{0}\nactive because: directory override for"),
+            for_host!("stable-{0}"),
+        )
+        .await;
+}
+
+#[tokio::test]
+async fn show_active_toolchain_with_override_verbose() {
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect_ok(&["rustup", "override", "set", "stable"])
+        .await;
+    cx.config
+        .expect_ok_ex(
+            &["rustup", "show", "active-toolchain", "--verbose"],
+            for_host!(
+                r"stable-{0}
+active because: directory override for '{1}'
+compiler: 1.1.0 (hash-stable-1.1.0)
+path: {2}
+",
+                cx.config.current_dir().display(),
+                cx.config
+                    .rustupdir
+                    .join("toolchains")
+                    .join(for_host!("stable-{0}"))
+                    .display(),
+            ),
+            r"",
         )
         .await;
 }


### PR DESCRIPTION
Fixes #4217

This is a very partial revert of #3225. It only restores the output of `rustup show active-toolchain` and doesn't change `--verbose` or the output of any other commands.