### PR TITLE
docs: update CHANGELOG for v1.28.1 release and bump the version in Cargo.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [1.28.1] - 2025-03-05
+
+This is a patch release to restore the automatic install behavior by default.
+
+This release contains the following fixes:
+
+- Automatic install is enabled by default but can be opted out by setting `RUSTUP_AUTO_INSTALL`
+  environment variable to `0`. [pr#4214]
+- `rustup show active-toolchain` will only print a single line, as it did in 1.27. [pr#4221]
+- Fixed a bug in the reqwest backend that would erroneously timeout downloads after 30s. [pr#4218]
+
+[1.28.1]: https://github.com/rust-lang/rustup/releases/tag/1.28.1
+[pr#4214]: https://github.com/rust-lang/rustup/pull/4214
+[pr#4221]: https://github.com/rust-lang/rustup/pull/4221
+[pr#4218]: https://github.com/rust-lang/rustup/pull/4218
+
 ## [1.28.0] - 2025-03-04
 
 This new release of rustup has been a long time in the making and comes with substantial changes.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
 
 [[package]]
 name = "download"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "anyhow",
  "curl",
@@ -2313,7 +2313,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.28.0"
+version = "1.28.1"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ workspace = true
 members = ["download"]
 
 [workspace.package]
-version = "1.28.0"
+version = "1.28.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 


### PR DESCRIPTION
This is the first PR in the **stable** release process of rustup v1.28.1, as per https://rust-lang.github.io/rustup/dev-guide/release-process.html.

Once this PR is merged, **two** actual release PRs will follow: the first will update the commit shasum in `rustup-init.sh`, and the second will announce our release on the Rust Blog.