### PR TITLE
fix!(config): re-enable implicit toolchain installation in `Cfg::local_toolchain()` with optional opt-out

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -147,7 +147,12 @@ impl Config {
 
     /// Expect an err status and a string in stderr
     pub async fn expect_err(&self, args: &[&str], expected: &str) {
-        let out = self.run(args[0], &args[1..], &[]).await;
+        self.expect_err_env(args, &[], expected).await
+    }
+
+    /// Expect an err status and a string in stderr, with extra environment variables
+    pub async fn expect_err_env(&self, args: &[&str], env: &[(&str, &str)], expected: &str) {
+        let out = self.run(args[0], &args[1..], env).await;
         if out.ok || !out.stderr.contains(expected) {
             print_command(args, &out);
             println!("expected.ok: false");

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -687,9 +687,9 @@ info: installing component 'rust-std' for '{0}'
 async fn show_suggestion_for_missing_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err_ex(
+        .expect_err_env(
             &["cargo", "+nightly", "fmt"],
-            r"",
+            &[("RUSTUP_AUTO_INSTALL", "0")],
             for_host!(
                 r"error: toolchain 'nightly-{0}' is not installed
 help: run `rustup toolchain install nightly-{0}` to install it

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1073,24 +1073,17 @@ async fn which_asking_uninstalled_toolchain() {
     cx.config
         .expect_ok(&["rustup", "default", "custom-1"])
         .await;
-    #[cfg(windows)]
     cx.config
         .expect_stdout_ok(
             &["rustup", "which", "rustc"],
-            "\\toolchains\\custom-1\\bin\\rustc",
+            &["", "toolchains", "custom-1", "bin", "rustc"].join(std::path::MAIN_SEPARATOR_STR),
         )
         .await;
-    #[cfg(not(windows))]
     cx.config
         .expect_stdout_ok(
-            &["rustup", "which", "rustc"],
-            "/toolchains/custom-1/bin/rustc",
-        )
-        .await;
-    cx.config
-        .expect_err(
             &["rustup", "which", "--toolchain=nightly", "rustc"],
-            for_host!("toolchain 'nightly-{}' is not installed"),
+            &["", "toolchains", for_host!("nightly-{0}"), "bin", "rustc"]
+                .join(std::path::MAIN_SEPARATOR_STR),
         )
         .await;
 }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -354,9 +354,17 @@ async fn file_override_toolchain_err_handling() {
 async fn plus_override_toolchain_err_handling() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustc", "+beta"],
+        .expect_err_env(
+            &["rustc", "+beta", "--version"],
+            &[("RUSTUP_AUTO_INSTALL", "0")],
             for_host!("toolchain 'beta-{0}' is not installed"),
+        )
+        .await;
+    cx.config
+        .expect_ok_contains(
+            &["rustc", "+beta", "--version"],
+            "1.2.0 (hash-beta-1.2.0)",
+            "",
         )
         .await;
 }
@@ -776,8 +784,9 @@ async fn upgrade_v2_to_v1() {
 async fn list_targets_no_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
+        .expect_err_env(
             &["rustup", "target", "list", "--toolchain=nightly"],
+            &[("RUSTUP_AUTO_INSTALL", "0")],
             for_host!("toolchain 'nightly-{0}' is not installed"),
         )
         .await;
@@ -962,7 +971,7 @@ async fn remove_target_by_component_remove() {
 async fn add_target_no_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
+        .expect_err_env(
             &[
                 "rustup",
                 "target",
@@ -970,10 +979,12 @@ async fn add_target_no_toolchain() {
                 CROSS_ARCH1,
                 "--toolchain=nightly",
             ],
+            &[("RUSTUP_AUTO_INSTALL", "0")],
             for_host!("toolchain 'nightly-{0}' is not installed"),
         )
         .await;
 }
+
 #[tokio::test]
 async fn add_target_bogus() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
@@ -1120,7 +1131,7 @@ async fn remove_target_not_installed() {
 async fn remove_target_no_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
+        .expect_err_env(
             &[
                 "rustup",
                 "target",
@@ -1128,6 +1139,7 @@ async fn remove_target_no_toolchain() {
                 CROSS_ARCH1,
                 "--toolchain=nightly",
             ],
+            &[("RUSTUP_AUTO_INSTALL", "0")],
             for_host!("toolchain 'nightly-{0}' is not installed"),
         )
         .await;


### PR DESCRIPTION
> [!NOTE]
> Following @djc's previous statement at https://github.com/rust-lang/rustup/issues/4211#issuecomment-2695620307, I sincerely apologize for all the previous issues related to the abrupt breaking change without enough clarity and transparency, and, if a well-organized public discussion allows this change to happen, a potential experimental stage with a properly-extended migration period.

Complements #4214.

This fixes the case of `cargo +nightly --version` not implicitly installing `nightly` when it's not installed.
I did a minimal test locally and this PR seems to be working.

@rust-lang/rustup Please feel free to modify this PR as you see fit.