### PR TITLE
docs: update changelog for 1.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,17 @@ This is a patch release to restore the automatic install behavior by default.
 This release contains the following fixes:
 
 - Automatic install is enabled by default but can be opted out by setting `RUSTUP_AUTO_INSTALL`
-  environment variable to `0`. [pr#4214]
+  environment variable to `0`. [pr#4214] [pr#4227]
 - `rustup show active-toolchain` will only print a single line, as it did in 1.27. [pr#4221]
 - Fixed a bug in the reqwest backend that would erroneously timeout downloads after 30s. [pr#4218]
+- Use relative symlinks for proxies. [pr#4226]
 
 [1.28.1]: https://github.com/rust-lang/rustup/releases/tag/1.28.1
 [pr#4214]: https://github.com/rust-lang/rustup/pull/4214
 [pr#4221]: https://github.com/rust-lang/rustup/pull/4221
 [pr#4218]: https://github.com/rust-lang/rustup/pull/4218
+[pr#4226]: https://github.com/rust-lang/rustup/pull/4226
+[pr#4227]: https://github.com/rust-lang/rustup/pull/4227
 
 ## [1.28.0] - 2025-03-04
 


### PR DESCRIPTION
Let's see if we can start the release process again.

---

This is the first PR in the **stable** release process of rustup v1.28.1, as per https://rust-lang.github.io/rustup/dev-guide/release-process.html.

Once this PR is merged, **two** actual release PRs will follow: the first will update the commit shasum in `rustup-init.sh`, and the second will announce our release on the Rust Blog.