### PR TITLE
Correct Nushell source command

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -33,7 +33,7 @@ RUSTUP_QUIET=no
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.28.1 (83ac5d9ec 2025-03-04)
+rustup-init 1.28.1 (bb9441b61 2025-03-05)
 
 The installer for rustup
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -33,7 +33,7 @@ RUSTUP_QUIET=no
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.28.1 (bb9441b61 2025-03-05)
+rustup-init 1.28.1 (83ac5d9ec 2025-03-04)
 
 The installer for rustup
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -382,9 +382,9 @@ macro_rules! post_install_msg_unix_source_env {
 the corresponding `env` file under {cargo_home}.
 
 This is usually done by running one of the following (note the leading DOT):
-    . "{cargo_home}/env"            # For sh/bash/zsh/ash/dash/pdksh
-    source "{cargo_home}/env.fish"  # For fish
-    source "{cargo_home}/env.nu"    # For nushell
+    . "{cargo_home}/env"                       # For sh/bash/zsh/ash/dash/pdksh
+    source "{cargo_home}/env.fish"             # For fish
+    source $"($nu.home-path)/.cargo/env.nu"    # For nushell
 "#
     };
 }

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -299,7 +299,8 @@ impl UnixShell for Nu {
     }
 
     fn source_string(&self, process: &Process) -> Result<String> {
-        Ok(format!(r#"source "{}/env.nu""#, cargo_home_str(process)?))
+        let cargo_home_nushell = (cargo_home_str(process)?).replace("$HOME", "($nu.home-path)");
+        Ok(format!(r#"source $"{}/env.nu""#, cargo_home_nushell))
     }
 }
 


### PR DESCRIPTION
Nushell uses `$env.HOME` instead of `$HOME` syntax for environment variables. However since `source` is a parser keyword it cannot access environment variables which is why it should use `$nu.home-path` instead
Additionally, the original command will cause nushell to error out on next config evaluation