### PR TITLE
Fix build script `cargo` instructions

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,8 +13,8 @@ fn from_build() -> Result<String, String> {
 }
 
 fn main() {
-    println!("cargo:rerun-if-env-changed=RUSTUP_OVERRIDE_BUILD_TRIPLE");
-    println!("cargo:rerun-if-env-changed=TARGET");
+    println!("cargo::rerun-if-env-changed=RUSTUP_OVERRIDE_BUILD_TRIPLE");
+    println!("cargo::rerun-if-env-changed=TARGET");
     match from_build() {
         Ok(triple) => eprintln!("Computed build based on target triple: {triple:#?}"),
         Err(s) => {
@@ -26,7 +26,7 @@ fn main() {
         }
     }
     let target = env::var("TARGET").unwrap();
-    println!("cargo:rustc-env=TARGET={target}");
+    println!("cargo::rustc-env=TARGET={target}");
 
     // Set linker options specific to Windows MSVC.
     let target_os = env::var("CARGO_CFG_TARGET_OS");
@@ -40,7 +40,7 @@ fn main() {
     // This applies to DLLs loaded at load time. However, this setting is ignored
     // before Windows 10 RS1 (aka 1601).
     // https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170
-    println!("cargo:cargo:rustc-link-arg-bin=rustup-init=/DEPENDENTLOADFLAG:0x800");
+    println!("cargo::rustc-link-arg-bin=rustup-init=/DEPENDENTLOADFLAG:0x800");
 
     // # Delay load
     //
@@ -55,16 +55,16 @@ fn main() {
     // See also: src/bin/rustup-init.rs
     let delay_load_dlls = ["bcrypt", "api-ms-win-core-synch-l1-2-0"];
     for dll in delay_load_dlls {
-        println!("cargo:rustc-link-arg-bin=rustup-init=/delayload:{dll}.dll");
+        println!("cargo::rustc-link-arg-bin=rustup-init=/delayload:{dll}.dll");
     }
     // When using delayload, it's necessary to also link delayimp.lib
     // https://learn.microsoft.com/en-us/cpp/build/reference/dependentloadflag?view=msvc-170
-    println!("cargo:rustc-link-arg-bin=rustup-init=delayimp.lib");
+    println!("cargo::rustc-link-arg-bin=rustup-init=delayimp.lib");
 
     // # Turn linker warnings into errors
     //
     // Rust hides linker warnings meaning mistakes may go unnoticed.
     // Turning them into errors forces them to be displayed (and the build to fail).
     // If we do want to ignore specific warnings then `/IGNORE:` should be used.
-    println!("cargo:rustc-link-arg-bin=rustup-init=/WX");
+    println!("cargo::rustc-link-arg-bin=rustup-init=/WX");
 }

--- a/build.rs
+++ b/build.rs
@@ -53,7 +53,7 @@ fn main() {
     // This will work on all supported Windows versions but it relies on
     // us using `SetDefaultDllDirectories` before any libraries are loaded.
     // See also: src/bin/rustup-init.rs
-    let delay_load_dlls = ["bcrypt", "secur32"];
+    let delay_load_dlls = ["bcrypt", "api-ms-win-core-synch-l1-2-0"];
     for dll in delay_load_dlls {
         println!("cargo:rustc-link-arg-bin=rustup-init=/delayload:{dll}.dll");
     }


### PR DESCRIPTION
This fixes a stray `cargo:cargo:` copy/paste error. I also took the opportunity to use the modern `::` syntax. While it doesn't matter too much for these commands, we may as well be future proof. Finally I updated the list of delay imports, which helps for older versions of Windows.

Fixes #4234