### PR TITLE
Allow copy&paste of documented registry keys into Regedit

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -360,8 +360,8 @@ modifying the profile file{plural} located at:
 macro_rules! pre_install_msg_win {
     () => {
         pre_install_msg_template!(
-            "This path will then be added to your `PATH` environment variable by
-modifying the `HKEY_CURRENT_USER/Environment/PATH` registry key."
+            r#"This path will then be added to your `PATH` environment variable by
+modifying the `PATH` registry key at `HKEY_CURRENT_USER\Environment`."#
         )
     };
 }


### PR DESCRIPTION
Current documented registry path can't be easily used as a lookup in the default Windows Regedit registry editing tool
  - Forward slashes are not accepted by Regedit
  - nor do the full paths that include registry keys, only their parent address

This edits the message format so you could copy&paste