### PR TITLE
Remove validation for custom toolchains when reading rust-toolchain.toml

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -181,18 +181,7 @@ impl OverrideCfg {
                         .transpose()?,
                 }
             }
-            ToolchainName::Custom(name) => {
-                if file.toolchain.targets.is_some()
-                    || file.toolchain.components.is_some()
-                    || file.toolchain.profile.is_some()
-                {
-                    bail!(
-                        "toolchain options are ignored for a custom toolchain ({})",
-                        name
-                    )
-                }
-                Self::Custom(name)
-            }
+            ToolchainName::Custom(name) => Self::Custom(name),
         })
     }
 


### PR DESCRIPTION
This validation was introduced in e1306b390820826d967f3bf367cb8b83ab1b16cd However, it breaks a number of scenarios that previously worked without issue such as #4248. As requested by rustup maintainers in that thread, I'm taking out the extra validation added in that commit, leaving the rest of the code as-is.

Testing confirms this fixes #4248.