### PR TITLE
Add `set auto-install disable`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -13,6 +13,7 @@ use itertools::Itertools;
 use tracing::{info, trace, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
+use crate::dist::AutoInstallMode;
 use crate::{
     cli::{
         common::{self, PackageUpdate, update_console_filter},
@@ -539,6 +540,12 @@ enum SetSubcmd {
         #[arg(value_enum, default_value_t)]
         auto_self_update_mode: SelfUpdateMode,
     },
+
+    /// The auto toolchain install mode
+    AutoInstall {
+        #[arg(value_enum, default_value_t)]
+        auto_install_mode: AutoInstallMode,
+    },
 }
 
 #[tracing::instrument(level = "trace", fields(args = format!("{:?}", process.args_os().collect::<Vec<_>>())))]
@@ -715,6 +722,9 @@ pub async fn main(
             SetSubcmd::AutoSelfUpdate {
                 auto_self_update_mode,
             } => set_auto_self_update(cfg, auto_self_update_mode),
+            SetSubcmd::AutoInstall { auto_install_mode } => cfg
+                .set_auto_install(auto_install_mode)
+                .map(|_| utils::ExitCode(0)),
         },
         RustupSubcmd::Completions { shell, command } => {
             output_completion_script(shell, command, process)

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -771,6 +771,59 @@ impl FromStr for Profile {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AutoInstallMode {
+    #[default]
+    Enable,
+    Disable,
+}
+
+impl AutoInstallMode {
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Enable => "enable",
+            Self::Disable => "disable",
+        }
+    }
+}
+
+impl ValueEnum for AutoInstallMode {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Enable, Self::Disable]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue> {
+        Some(PossibleValue::new(self.as_str()))
+    }
+
+    fn from_str(input: &str, _: bool) -> Result<Self, String> {
+        <Self as FromStr>::from_str(input).map_err(|e| e.to_string())
+    }
+}
+
+impl FromStr for AutoInstallMode {
+    type Err = anyhow::Error;
+
+    fn from_str(mode: &str) -> Result<Self> {
+        match mode {
+            "enable" => Ok(Self::Enable),
+            "disable" => Ok(Self::Disable),
+            _ => Err(anyhow!(format!(
+                "unknown auto install mode: '{}'; valid modes are {}",
+                mode,
+                Self::value_variants().iter().join(", ")
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for AutoInstallMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl fmt::Display for TargetTriple {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)

--- a/src/notifications.rs
+++ b/src/notifications.rs
@@ -14,6 +14,7 @@ pub(crate) enum Notification<'a> {
     Utils(crate::utils::Notification<'a>),
     Temp(temp::Notification<'a>),
 
+    SetAutoInstall(&'a str),
     SetDefaultToolchain(Option<&'a ToolchainName>),
     SetOverrideToolchain(&'a Path, &'a str),
     SetProfile(&'a str),
@@ -69,7 +70,8 @@ impl Notification<'_> {
             | ReadMetadataVersion(_)
             | InstalledToolchain(_)
             | UpdateHashMatches => NotificationLevel::Debug,
-            SetDefaultToolchain(_)
+            SetAutoInstall(_)
+            | SetDefaultToolchain(_)
             | SetOverrideToolchain(_, _)
             | SetProfile(_)
             | SetSelfUpdate(_)
@@ -91,6 +93,7 @@ impl Display for Notification<'_> {
             Install(n) => n.fmt(f),
             Utils(n) => n.fmt(f),
             Temp(n) => n.fmt(f),
+            SetAutoInstall(auto) => write!(f, "auto install set to '{auto}'"),
             SetDefaultToolchain(None) => write!(f, "default toolchain unset"),
             SetDefaultToolchain(Some(name)) => write!(f, "default toolchain set to '{name}'"),
             SetOverrideToolchain(path, name) => write!(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::cli::self_update::SelfUpdateMode;
-use crate::dist::Profile;
+use crate::dist::{AutoInstallMode, Profile};
 use crate::errors::*;
 use crate::notifications::*;
 use crate::utils;
@@ -93,6 +93,8 @@ pub struct Settings {
     pub pgp_keys: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_self_update: Option<SelfUpdateMode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_install: Option<AutoInstallMode>,
 }
 
 impl Settings {

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -137,7 +137,12 @@ impl Config {
 
     /// Expect an ok status
     pub async fn expect_ok(&mut self, args: &[&str]) {
-        let out = self.run(args[0], &args[1..], &[]).await;
+        self.expect_ok_env(args, &[]).await
+    }
+
+    /// Expect an ok status with extra environment variables
+    pub async fn expect_ok_env(&self, args: &[&str], env: &[(&str, &str)]) {
+        let out = self.run(args[0], &args[1..], env).await;
         if !out.ok {
             print_command(args, &out);
             println!("expected.ok: true");

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-install_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_auto-install_cmd_help_flag_stdout.toml
@@ -1,0 +1,15 @@
+bin.name = "rustup"
+args = ["set", "auto-install", "--help"]
+stdout = """
+...
+The auto toolchain install mode
+
+Usage: rustup[EXE] set auto-install [AUTO_INSTALL_MODE]
+
+Arguments:
+  [AUTO_INSTALL_MODE]  [default: enable] [possible values: enable, disable]
+
+Options:
+  -h, --help  Print help
+"""
+stderr = ""

--- a/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_set_cmd_help_flag_stdout.toml
@@ -10,6 +10,7 @@ Commands:
   default-host      The triple used to identify toolchains when not specified
   profile           The default components installed with a toolchain
   auto-self-update  The rustup auto self update mode
+  auto-install      The auto toolchain install mode
   help              Print this message or the help of the given subcommand(s)
 
 Options:


### PR DESCRIPTION
The rustup setting equivalent to the environment variable `RUSTUP_AUTO_INSTALL`.

The environment variable will take precedence if it's set, otherwise the global setting will be used.