### PR TITLE
fix(errors)!: improve error messages for `RustupError::ToolchainNotInstalled`

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -418,7 +418,7 @@ pub(crate) async fn list_toolchains(
         let default_toolchain_name = cfg.get_default()?;
         let active_toolchain_name: Option<ToolchainName> =
             if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
-                cfg.find_active_toolchain(None).await
+                cfg.maybe_ensure_active_toolchain(None).await
             {
                 Some(toolchain)
             } else {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -763,7 +763,7 @@ async fn default_(
             }
         };
 
-        if let Some((toolchain, reason)) = cfg.maybe_ensure_active_toolchain(None).await? {
+        if let Some((toolchain, reason)) = cfg.active_toolchain()? {
             if !matches!(reason, ActiveReason::Default) {
                 info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
             }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -899,9 +899,7 @@ async fn update(
             exit_code &= common::self_update(|| Ok(()), cfg.process).await?;
         }
     } else if ensure_active_toolchain {
-        let (toolchain, reason) = cfg
-            .find_or_install_active_toolchain(force_non_host, true)
-            .await?;
+        let (toolchain, reason) = cfg.ensure_active_toolchain(force_non_host, true).await?;
         info!("the active toolchain `{toolchain}` has been installed");
         info!("it's active because: {reason}");
     } else {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -763,7 +763,7 @@ async fn default_(
             }
         };
 
-        if let Some((toolchain, reason)) = cfg.find_active_toolchain(None).await? {
+        if let Some((toolchain, reason)) = cfg.maybe_ensure_active_toolchain(None).await? {
             if !matches!(reason, ActiveReason::Default) {
                 info!("note that the toolchain '{toolchain}' is currently in use ({reason})");
             }
@@ -974,7 +974,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     let installed_toolchains = cfg.list_toolchains()?;
     let active_toolchain_and_reason: Option<(ToolchainName, ActiveReason)> =
         if let Ok(Some((LocalToolchainName::Named(toolchain_name), reason))) =
-            cfg.find_active_toolchain(None).await
+            cfg.maybe_ensure_active_toolchain(None).await
         {
             Some((toolchain_name, reason))
         } else {
@@ -1094,7 +1094,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
 #[tracing::instrument(level = "trace", skip_all)]
 async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
-    match cfg.find_active_toolchain(None).await? {
+    match cfg.maybe_ensure_active_toolchain(None).await? {
         Some((toolchain_name, reason)) => {
             let toolchain = Toolchain::with_reason(cfg, toolchain_name.clone(), &reason)?;
             if verbose {
@@ -1332,7 +1332,7 @@ async fn toolchain_link(
 async fn toolchain_remove(cfg: &mut Cfg<'_>, opts: UninstallOpts) -> Result<utils::ExitCode> {
     let default_toolchain = cfg.get_default().ok().flatten();
     let active_toolchain = cfg
-        .find_active_toolchain(Some(false))
+        .maybe_ensure_active_toolchain(Some(false))
         .await
         .ok()
         .flatten()

--- a/src/config.rs
+++ b/src/config.rs
@@ -675,17 +675,13 @@ impl<'a> Cfg<'a> {
 
                     // XXX: this awkwardness deals with settings file being locked already
                     let toolchain_name = toolchain_name.resolve(&default_host_triple)?;
-                    match Toolchain::new(self, (&toolchain_name).into()) {
-                        Err(RustupError::ToolchainNotInstalled { .. }) => {
-                            if matches!(toolchain_name, ToolchainName::Custom(_)) {
-                                bail!(
-                                    "custom toolchain specified in override file '{}' is not installed",
-                                    toolchain_file.display()
-                                )
-                            }
-                        }
-                        Ok(_) => {}
-                        Err(e) => Err(e)?,
+                    if !Toolchain::exists(self, &(&toolchain_name).into())?
+                        && matches!(toolchain_name, ToolchainName::Custom(_))
+                    {
+                        bail!(
+                            "custom toolchain specified in override file '{}' is not installed",
+                            toolchain_file.display()
+                        )
                     }
                 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -535,7 +535,7 @@ impl<'a> Cfg<'a> {
             return self.active_toolchain();
         }
 
-        match self.find_or_install_active_toolchain(true, false).await {
+        match self.ensure_active_toolchain(true, false).await {
             Ok(r) => Ok(Some(r)),
             Err(e) => match e.downcast_ref::<RustupError>() {
                 Some(RustupError::ToolchainNotSelected(_)) => Ok(None),
@@ -777,7 +777,7 @@ impl<'a> Cfg<'a> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) async fn find_or_install_active_toolchain(
+    pub(crate) async fn ensure_active_toolchain(
         &self,
         force_non_host: bool,
         verbose: bool,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -98,12 +98,16 @@ pub enum RustupError {
     #[error(
         "toolchain '{name}' is not installed{}",
         if let ToolchainName::Official(t) = name {
-            format!("\nhelp: run `rustup toolchain install {t}` to install it")
+            let t = if *is_active { "" } else { &format!(" {t}") };
+            format!("\nhelp: run `rustup toolchain install{t}` to install it")
         } else {
             String::new()
         },
     )]
-    ToolchainNotInstalled { name: ToolchainName },
+    ToolchainNotInstalled {
+        name: ToolchainName,
+        is_active: bool,
+    },
     #[error("path '{0}' not found")]
     PathToolchainNotInstalled(PathBasedToolchainName),
     #[error(

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -53,6 +53,7 @@ impl<'a> Toolchain<'a> {
             Ok(tc) => Ok(tc),
             Err(RustupError::ToolchainNotInstalled {
                 name: ToolchainName::Official(desc),
+                ..
             }) if install_if_missing => {
                 Ok(
                     DistributableToolchain::install(cfg, &desc, &[], &[], cfg.get_profile()?, true)
@@ -107,7 +108,10 @@ impl<'a> Toolchain<'a> {
         let path = cfg.toolchain_path(&name);
         if !Toolchain::exists(cfg, &name)? {
             return Err(match name {
-                LocalToolchainName::Named(name) => RustupError::ToolchainNotInstalled { name },
+                LocalToolchainName::Named(name) => {
+                    let is_active = matches!(cfg.active_toolchain(), Ok(Some((t, _))) if t == name);
+                    RustupError::ToolchainNotInstalled { name, is_active }
+                }
                 LocalToolchainName::Path(name) => RustupError::PathToolchainNotInstalled(name),
             });
         }


### PR DESCRIPTION
Closes #4212.