### PR TITLE
Show toolchain paths in `rustup show -v` output

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1007,7 +1007,6 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
         print_header::<Error>(&mut t, "installed toolchains")?;
 
         let default_toolchain_name = cfg.get_default()?;
-
         let last_index = installed_toolchains.len().wrapping_sub(1);
         for (n, toolchain_name) in installed_toolchains.into_iter().enumerate() {
             let is_default_toolchain = default_toolchain_name.as_ref() == Some(&toolchain_name);
@@ -1026,11 +1025,10 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
                 let toolchain = Toolchain::new(cfg, toolchain_name.into())?;
                 writeln!(
                     cfg.process.stdout().lock(),
-                    "  {}",
-                    toolchain.rustc_version()
+                    "  {}\n  path: {}",
+                    toolchain.rustc_version(),
+                    toolchain.path().display()
                 )?;
-                // To make it easy to see which rustc belongs to which
-                // toolchain, we separate each pair with an extra newline.
                 if n != last_index {
                     writeln!(cfg.process.stdout().lock())?;
                 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1197,9 +1197,11 @@ installed toolchains
 --------------------
 nightly-{0} (active, default)
   1.3.0 (hash-nightly-2)
+  path: {2}
 
 nightly-2015-01-01-{0}
   1.2.0 (hash-nightly-1)
+  path: {3}
 
 active toolchain
 ----------------
@@ -1214,6 +1216,11 @@ installed targets:
                     .rustupdir
                     .join("toolchains")
                     .join(for_host!("nightly-{0}"))
+                    .display(),
+                config
+                    .rustupdir
+                    .join("toolchains")
+                    .join(for_host!("nightly-2015-01-01-{0}"))
                     .display()
             ),
             r"",


### PR DESCRIPTION
## This PR implements the feature requested in issue #3408 by adding path information for each installed toolchain when using the `-v` verbose flag with `rustup show`.

### Changes
1. Modified the `show` function in `src/cli/rustup_mode.rs` to display the path for each installed toolchain in verbose mode
2. Now all toolchains show their paths in the detailed output, not just the active toolchain

### Before
```
installed toolchains
--------------------
stable-x86_64-pc-windows-msvc (active, default)
  rustc 1.85.1 (4eb161250 2025-03-15)

1.81-x86_64-pc-windows-msvc
  rustc 1.81.0 (eeb90cda1 2024-09-04)
```

### After
```
installed toolchains
--------------------
stable-x86_64-pc-windows-msvc (active, default)
  rustc 1.85.1 (4eb161250 2025-03-15)
  path: C:\Users\laysh\.rustup\toolchains\stable-x86_64-pc-windows-msvc

1.81-x86_64-pc-windows-msvc
  rustc 1.81.0 (eeb90cda1 2024-09-04)
  path: C:\Users\laysh\.rustup\toolchains\1.81-x86_64-pc-windows-msvc
```
Fixes #3408
---