### PR TITLE
Add component path feature

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -64,6 +64,21 @@ impl Config {
     pub fn current_dir(&self) -> PathBuf {
         self.workdir.borrow().clone()
     }
+    pub async fn expect_stdout_contains(&self, args: &[&str], expected: &str) {
+            let out = self.run(args[0], &args[1..], &[]).await;
+            if !out.ok {
+                print_command(args, &out);
+                println!("expected.ok: true");
+                print_indented("expected.stdout.contains", expected);
+                panic!();
+            }
+            if !out.stdout.contains(expected) {
+                print_command(args, &out);
+                println!("expected.ok: true");
+                print_indented("expected.stdout.contains", expected);
+                panic!();
+            }
+        }
 
     pub fn cmd<I, A>(&self, name: &str, args: I) -> Command
     where


### PR DESCRIPTION
## Description
This PR adds several new features to Rustup to display the file paths of components and toolchains:

1. **`rustup which --prefix`**: Displays the binary directory path of the active or specified toolchain
   - Example: `rustup which --prefix` outputs `C:\Users\user\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin`
   - Works with `--toolchain` flag: `rustup which --prefix --toolchain nightly`

2. **`rustup component list --verbose`**: Shows installation paths for all components
   - Displays the file system path next to each component
   - Makes it easy to locate where specific components are installed
   - Example output: `rustc-x86_64-pc-windows-msvc (installed) - C:\Users\user\.rustup\toolchains\stable-x86_64-pc-windows-msvc\bin/rustc`

3. **`rustup show active-toolchain --verbose`**: Shows detailed information about the active toolchain including:
   - Why it's active (default or override)
   - Compiler version
   - Toolchain path
   - Complete list of installed components with their filesystem paths
