### PR TITLE
Tweak rustup help output

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -125,7 +125,7 @@ enum RustupSubcmd {
     #[command(hide = true)]
     DumpTestament,
 
-    /// Modify or query the installed toolchains
+    /// Install, uninstall, or list toolchains
     Toolchain {
         #[command(subcommand)]
         subcmd: ToolchainSubcmd,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -125,6 +125,23 @@ enum RustupSubcmd {
     #[command(hide = true)]
     DumpTestament,
 
+    /// Modify or query the installed toolchains
+    Toolchain {
+        #[command(subcommand)]
+        subcmd: ToolchainSubcmd,
+    },
+
+    /// Set the default toolchain
+    #[command(after_help = DEFAULT_HELP)]
+    Default {
+        #[arg(help = MAYBE_RESOLVABLE_TOOLCHAIN_ARG_HELP)]
+        toolchain: Option<MaybeResolvableToolchainName>,
+
+        /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
+        #[arg(long)]
+        force_non_host: bool,
+    },
+
     /// Show the active and installed toolchains or profiles
     #[command(after_help = SHOW_HELP)]
     Show {
@@ -161,23 +178,6 @@ enum RustupSubcmd {
 
     /// Check for updates to Rust toolchains and rustup
     Check,
-
-    /// Set the default toolchain
-    #[command(after_help = DEFAULT_HELP)]
-    Default {
-        #[arg(help = MAYBE_RESOLVABLE_TOOLCHAIN_ARG_HELP)]
-        toolchain: Option<MaybeResolvableToolchainName>,
-
-        /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
-        #[arg(long)]
-        force_non_host: bool,
-    },
-
-    /// Modify or query the installed toolchains
-    Toolchain {
-        #[command(subcommand)]
-        subcmd: ToolchainSubcmd,
-    },
 
     /// Modify a toolchain's supported targets
     Target {

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -9,7 +9,7 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
-  toolchain    Modify or query the installed toolchains
+  toolchain    Install, uninstall, or list toolchains
   default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup

--- a/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_cmd_stdout.toml
@@ -9,11 +9,11 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
+  toolchain    Modify or query the installed toolchains
+  default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup
   check        Check for updates to Rust toolchains and rustup
-  default      Set the default toolchain
-  toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
   override     Modify toolchain overrides for directories

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -9,7 +9,7 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
-  toolchain    Modify or query the installed toolchains
+  toolchain    Install, uninstall, or list toolchains
   default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup

--- a/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_help_flag_stdout.toml
@@ -9,11 +9,11 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
+  toolchain    Modify or query the installed toolchains
+  default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup
   check        Check for updates to Rust toolchains and rustup
-  default      Set the default toolchain
-  toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
   override     Modify toolchain overrides for directories

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -9,7 +9,7 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
-  toolchain    Modify or query the installed toolchains
+  toolchain    Install, uninstall, or list toolchains
   default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup

--- a/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_only_options_stdout.toml
@@ -9,11 +9,11 @@ The Rust toolchain installer
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
+  toolchain    Modify or query the installed toolchains
+  default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup
   check        Check for updates to Rust toolchains and rustup
-  default      Set the default toolchain
-  toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
   override     Modify toolchain overrides for directories

--- a/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_toolchain_cmd_help_flag_stdout.toml
@@ -2,7 +2,7 @@ bin.name = "rustup"
 args = ["toolchain", "--help"]
 stdout = """
 ...
-Modify or query the installed toolchains
+Install, uninstall, or list toolchains
 
 Usage: rustup[EXE] toolchain <COMMAND>
 


### PR DESCRIPTION
```diff
--- old.txt     2025-03-30 10:49:43
+++ new.txt     2025-03-30 10:49:30
@@ -1,15 +1,15 @@
-rustup 1.28.1+35 (626178865 2025-03-25) dirty 1 modification
+rustup 1.28.1+37 (39efc4949 2025-03-30)
 
 The Rust toolchain installer
 
 Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]
 
 Commands:
+  toolchain    Install, uninstall, or list toolchains
+  default      Set the default toolchain
   show         Show the active and installed toolchains or profiles
   update       Update Rust toolchains and rustup
   check        Check for updates to Rust toolchains and rustup
-  default      Set the default toolchain
-  toolchain    Modify or query the installed toolchains
   target       Modify a toolchain's supported targets
   component    Modify a toolchain's installed components
   override     Modify toolchain overrides for directories
```

Fixes #4269.