### PR TITLE
Update `CARGO` environment variable if it is set to a rustup proxy

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -684,6 +684,7 @@ async fn setup_test_state(test_dist_dir: tempfile::TempDir) -> (tempfile::TempDi
     //   **in this process** when the tests are still running.
     unsafe {
         // Unset env variables that will break our testing
+        env::remove_var("CARGO");
         env::remove_var("RUSTUP_UPDATE_ROOT");
         env::remove_var("RUSTUP_TOOLCHAIN");
         env::remove_var("SHELL");

--- a/src/test/mock_bin_src.rs
+++ b/src/test/mock_bin_src.rs
@@ -94,6 +94,14 @@ fn main() {
             let mut out = io::stderr();
             writeln!(out, "{}", std::env::var("PATH").unwrap()).unwrap();
         }
+        Some("--echo-cargo-env") => {
+            let mut out = io::stderr();
+            if let Ok(cargo) = std::env::var("CARGO") {
+                writeln!(out, "{cargo}").unwrap();
+            } else {
+                panic!("CARGO environment variable not set");
+            }
+        }
         arg => panic!("bad mock proxy commandline: {:?}", arg),
     }
 }


### PR DESCRIPTION
This is done only if we know the absolute path to the real `cargo` and only if we're sure that `CARGO` points to a proxy.

Fixes #4274