### PR TITLE
Add toolchain_name to not installed bail msg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -679,7 +679,8 @@ impl<'a> Cfg<'a> {
                         && matches!(toolchain_name, ToolchainName::Custom(_))
                     {
                         bail!(
-                            "custom toolchain specified in override file '{}' is not installed",
+                            "custom toolchain '{}' specified in override file '{}' is not installed",
+                            toolchain_name,
                             toolchain_file.display()
                         )
                     }


### PR DESCRIPTION
Regularly working with local custom toolchains that have reasonably high cardinality, having this extra info in this diagnostic would've saved me a good chunk of time.