### PR TITLE
Add toolchain_name to not installed bail msg

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -679,7 +679,8 @@ impl<'a> Cfg<'a> {
                         && matches!(toolchain_name, ToolchainName::Custom(_))
                     {
                         bail!(
-                            "custom toolchain specified in override file '{}' is not installed",
+                            "custom toolchain '{}' specified in override file '{}' is not installed",
+                            toolchain_name,
                             toolchain_file.display()
                         )
                     }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -2517,13 +2517,13 @@ async fn file_override_not_installed_custom() {
     cx.config
         .expect_err(
             &["rustup", "show", "active-toolchain"],
-            "custom toolchain specified in override file",
+            "custom toolchain 'gumbo' specified in override file",
         )
         .await;
     cx.config
         .expect_err(
             &["rustc", "--version"],
-            "custom toolchain specified in override file",
+            "custom toolchain 'gumbo' specified in override file",
         )
         .await;
 }
@@ -2538,13 +2538,13 @@ async fn file_override_not_installed_custom_toml() {
     cx.config
         .expect_err(
             &["rustup", "show", "active-toolchain"],
-            "custom toolchain specified in override file",
+            "custom toolchain 'i-am-the-walrus' specified in override file",
         )
         .await;
     cx.config
         .expect_err(
             &["rustc", "--version"],
-            "custom toolchain specified in override file",
+            "custom toolchain 'i-am-the-walrus' specified in override file",
         )
         .await;
 }


### PR DESCRIPTION
Regularly working with local custom toolchains that have reasonably high cardinality, having this diagnostic would've saved me a good chunk of time.