### PR TITLE
Add powerpc64le-unknown-linux-musl support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -905,6 +905,7 @@ jobs:
           - x86_64-unknown-illumos         # skip-pr skip-master
           - powerpc-unknown-linux-gnu      # skip-pr skip-master
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-master
+          - powerpc64le-unknown-linux-musl # skip-pr skip-master
           - s390x-unknown-linux-gnu        # skip-pr skip-master
           - arm-linux-androideabi          # skip-pr skip-master
           - armv7-linux-androideabi        # skip-pr skip-master

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -34,6 +34,7 @@ jobs: # skip-master skip-pr skip-stable
           - x86_64-unknown-illumos         # skip-pr skip-master
           - powerpc-unknown-linux-gnu      # skip-pr skip-master
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-master
+          - powerpc64le-unknown-linux-musl # skip-pr skip-master
           - s390x-unknown-linux-gnu        # skip-pr skip-master
           - arm-linux-androideabi          # skip-pr skip-master
           - armv7-linux-androideabi        # skip-pr skip-master

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -49,6 +49,8 @@ rustup/dist/powerpc64-unknown-linux-gnu/rustup-init
 rustup/dist/powerpc64-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init
 rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init.sha256
+rustup/dist/powerpc64le-unknown-linux-musl/rustup-init
+rustup/dist/powerpc64le-unknown-linux-musl/rustup-init.sha256
 rustup/dist/s390x-unknown-linux-gnu/rustup-init
 rustup/dist/s390x-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/x86_64-apple-darwin/rustup-init

--- a/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-musl/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust-powerpc64le-unknown-linux-musl
+
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
+ENV CC_powerpc64le_unknown_linux_musl=powerpc64le-unknown-linux-musl-gcc \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_MUSL_LINKER=powerpc64le-unknown-linux-musl-gcc \
+    RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-lgcc"

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -35,6 +35,7 @@ case "$TARGET" in
   powerpc-unknown-linux-gnu)       image=dist-powerpc-linux ;;
   powerpc64-unknown-linux-gnu)     image=dist-powerpc64-linux ;;
   powerpc64le-unknown-linux-gnu)   image=dist-powerpc64le-linux ;;
+  powerpc64le-unknown-linux-musl)  image=dist-powerpc64le-linux ;;
   s390x-unknown-linux-gnu)         image=dist-s390x-linux ;;
   x86_64-unknown-freebsd)          image=dist-x86_64-freebsd ;;
   x86_64-unknown-illumos)          image=dist-x86_64-illumos ;;

--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -155,6 +155,8 @@ You can manually download `rustup-init` for a given target from
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64-unknown-linux-gnu/rustup-init.sha256)
 - [powerpc64le-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init.sha256)
+- [powerpc64le-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-musl/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-musl/rustup-init.sha256)
 - [s390x-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/s390x-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/s390x-unknown-linux-gnu/rustup-init.sha256)
 - [x86_64-apple-darwin](https://static.rust-lang.org/rustup/dist/x86_64-apple-darwin/rustup-init)

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -267,6 +267,10 @@ const TRIPLE_AARCH64_UNKNOWN_LINUX: &str = "aarch64-unknown-linux-musl";
 const TRIPLE_LOONGARCH64_UNKNOWN_LINUX: &str = "loongarch64-unknown-linux-gnu";
 #[cfg(all(not(windows), target_env = "musl"))]
 const TRIPLE_LOONGARCH64_UNKNOWN_LINUX: &str = "loongarch64-unknown-linux-musl";
+#[cfg(all(not(windows), not(target_env = "musl")))]
+const TRIPLE_POWERPC64LE_UNKNOWN_LINUX: &str = "powerpc64le-unknown-linux-gnu";
+#[cfg(all(not(windows), target_env = "musl"))]
+const TRIPLE_POWERPC64LE_UNKNOWN_LINUX: &str = "powerpc64le-unknown-linux-musl";
 
 // MIPS platforms don't indicate endianness in uname, however binaries only
 // run on boxes with the same endianness, as expected.
@@ -518,6 +522,7 @@ impl TargetTriple {
                     TRIPLE_AARCH64_UNKNOWN_LINUX
                 }),
                 (b"Linux", b"loongarch64") => Some(TRIPLE_LOONGARCH64_UNKNOWN_LINUX),
+                (b"Linux", b"ppc64le") => Some(TRIPLE_POWERPC64LE_UNKNOWN_LINUX),
                 (b"Darwin", b"x86_64") => Some("x86_64-apple-darwin"),
                 (b"Darwin", b"i686") => Some("i686-apple-darwin"),
                 (b"FreeBSD", b"x86_64") => Some("x86_64-unknown-freebsd"),


### PR DESCRIPTION
~~Still trying to figure out how to get this to be tested in CI.~~ Was able to test the Docker image locally, works fine.

<details>
<summary>Cross-compiled using the Docker image, ran on native target:</summary>

```
aludra:~$ ./rustup-init

Welcome to Rust!

This will download and install the official compiler for the Rust
programming language, and its package manager, Cargo.

Rustup metadata and toolchains will be installed into the Rustup
home directory, located at:

  /home/adrian/.rustup

This can be modified with the RUSTUP_HOME environment variable.

The Cargo home directory is located at:

  /home/adrian/.cargo

This can be modified with the CARGO_HOME environment variable.

The cargo, rustc, rustup and other commands will be added to
Cargo's bin directory, located at:

  /home/adrian/.cargo/bin

This path will then be added to your PATH environment variable by
modifying the profile file located at:

  /home/adrian/.profile

You can uninstall at any time with rustup self uninstall and
these changes will be reverted.

Current installation options:


   default host triple: powerpc64le-unknown-linux-musl
     default toolchain: stable (default)
               profile: default
  modify PATH variable: yes

1) Proceed with standard installation (default - just press enter)
2) Customize installation
3) Cancel installation
>1

info: profile set to 'default'
info: default host triple is powerpc64le-unknown-linux-musl
info: syncing channel updates for 'stable-powerpc64le-unknown-linux-musl'
info: latest update on 2025-04-03, rust version 1.86.0 (05f9846f8 2025-03-31)
info: downloading component 'cargo'
  9.4 MiB /   9.4 MiB (100 %)   2.6 MiB/s in  2s
info: downloading component 'clippy'
  3.2 MiB /   3.2 MiB (100 %)   2.6 MiB/s in  1s
info: downloading component 'rust-docs'
info: downloading component 'rust-std'
 25.6 MiB /  25.6 MiB (100 %)   4.8 MiB/s in  6s
info: downloading component 'rustc'
 99.1 MiB /  99.1 MiB (100 %)   6.7 MiB/s in 19s
info: downloading component 'rustfmt'
info: installing component 'cargo'
info: installing component 'clippy'
info: installing component 'rust-docs'
 21.2 MiB /  21.2 MiB (100 %)   6.3 MiB/s in  3s
info: installing component 'rust-std'
 25.6 MiB /  25.6 MiB (100 %)  11.4 MiB/s in  2s
info: installing component 'rustc'
 99.1 MiB /  99.1 MiB (100 %)  11.5 MiB/s in  8s
info: installing component 'rustfmt'
info: default toolchain set to 'stable-powerpc64le-unknown-linux-musl'

  stable-powerpc64le-unknown-linux-musl installed - rustc 1.86.0 (05f9846f8 2025-03-31)


Rust is installed now. Great!

To get started you may need to restart your current shell.
This would reload your PATH environment variable to include
Cargo's bin directory ($HOME/.cargo/bin).

To configure your current shell, you need to source
the corresponding env file under $HOME/.cargo.

This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
source $"($nu.home-path)/.cargo/env.nu"  # For nushell
```

</details>

Successful runs:
https://github.com/rust-lang/rustup/actions/runs/14528297588/job/40763746894
https://github.com/rust-lang/rustup/actions/runs/14528297588/job/40763744397