### PR TITLE
Switch flate2 to use the zlib-rs backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
+ "libz-rs-sys",
  "miniz_oxide",
 ]
 
@@ -1348,6 +1349,15 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "libz-rs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6489ca9bd760fe9642d7644e827b0c9add07df89857b0416ee15c1cc1a3b8c5a"
+dependencies = [
+ "zlib-rs",
 ]
 
 [[package]]
@@ -3717,6 +3727,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "868b928d7949e09af2f6086dfc1e01936064cc7a819253bce650d4e2a2d63ba8"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ curl = { version = "0.4.44", optional = true }
 effective-limits = "0.5.5"
 enum-map = "2.5.0"
 env_proxy = { version = "0.4.1", optional = true }
-flate2 = "1"
+flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
 fs_at = "0.2.1"
 git-testament = "0.2"
 home = "0.5.4"


### PR DESCRIPTION
This backend is written in Rust, but has substantially higher performance. And, as of the latest version, zlib-rs does not export any C zlib symbols, so it won't conflict with other implementations of zlib in the same process; thus, it doesn't conflict with linking to C libraries that use zlib.
