### PR TITLE
docs(changelog): update for v1.28.2 release, pt. 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ The headlines of this release are:
 - Log original download errors immediately by @djc in https://github.com/rust-lang/rustup/pull/4307
 - download: show Debug representation for errors by @djc in https://github.com/rust-lang/rustup/pull/4309
 - Emit tracing events from log facade calls by @djc in https://github.com/rust-lang/rustup/pull/4310
+- Take rustls-platform-verifier 0.5.2 by @ctz in https://github.com/rust-lang/rustup/pull/4314
+- Set ALPN protocols for rustls backend by @djc in https://github.com/rust-lang/rustup/pull/4312
+- Deprecate native-tls as well by @djc in https://github.com/rust-lang/rustup/pull/4317
 
 [1.28.2]: https://github.com/rust-lang/rustup/releases/tag/1.28.2
 [pr#4254]: https://github.com/rust-lang/rustup/pull/4254

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,23 +6,26 @@ This new patch release has brought even more tiny fixes and improvements over th
 
 The headlines of this release are:
 
-- The cURL download backend and the native-tls TLS backend are now officially deprecated and a warning will start to show up when they are used. [pr#4277]
+- The cURL download backend and the native-tls TLS backend are now officially deprecated and
+  a warning will start to show up when they are used. [pr#4277]
 
   - While rustup predates reqwest and rustls, the rustup team has long wanted to standardize on
     an HTTP + TLS stack in Rust, which should increase security, potentially improve performance, and
     simplify maintenance of the project.
-    With the default download backend already switched to reqwest since [2019](https://github.com/rust-lang/rustup/pull/1660)
-    the team thinks it is time to focus maintenance on the Rust-based stack.
+    With the default download backend already switched to reqwest since [2019][pr#1660], the team
+    thinks it is time to focus maintenance on the Rust-based stack.
 
   - The rustup team encourages everyone to switch to the reqwest backend, and would love to hear from
-    you about your use case via GitHub Issues if it does work against your particular setup.
+    you about your use case via [GitHub Issues][issue tracker] if it does not work well with your
+    particular setup.
 
-- Version pinning of `rustup` is now supported when installing it via `rustup-init.sh` with the `RUSTUP_VERSION`
-  environment variable set to e.g. `1.28.2`; the same configuration will be respected when performing
-  `rustup self update` from this version on, enabling arbitrary downgrades in the meantime. [pr#4259]
+- The version of `rustup` can be pinned when installing via `rustup-init.sh`, and
+  `rustup self update` can be used to upgrade/downgrade rustup v1.28.2+ to a given version.
+  To do so, set the `RUSTUP_VERSION` environment variable to the desired version (for example `1.28.2`).
 
 - `rustup set auto-install disable` can now be used to disable automatic installation of the toolchain.
-  This is similar to the `RUSTUP_AUTO_INSTALL` environment variable but with a lower priority. [pr#4254]
+  This is similar to the `RUSTUP_AUTO_INSTALL` environment variable introduced in v1.28.1 but with a
+  lower priority. [pr#4254]
 
 - Fixed a bug in Nushell integration that might generate invalid commands in the shell configuration.
   Reinstalling rustup might be required for the fix to work. [pr#4265]
@@ -63,6 +66,7 @@ The headlines of this release are:
 [pr#4259]: https://github.com/rust-lang/rustup/pull/4259
 [pr#4265]: https://github.com/rust-lang/rustup/pull/4265
 [pr#4277]: https://github.com/rust-lang/rustup/pull/4277
+[issue tracker]: https://github.com/rust-lang/rustup/issues/
 
 ## [1.28.1] - 2025-03-05
 


### PR DESCRIPTION
Continuation of #4303.

The very constructive feedback from https://github.com/rust-lang/blog.rust-lang.org/pull/1593 combined with the potentially upcoming PRs regarding #4305 makes tonight probably not a very good time to conclude the release anyway, so I'm leaving this PR here to mark my progress.

cc @rust-lang/rustup Please feel free to update it to include more fixes/PRs if needed.