### PR TITLE
Deprecate native-tls as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@ This new patch release has brought even more tiny fixes and improvements over th
 
 The headlines of this release are:
 
-- The cURL download backend is now officially deprecated and a warning will start to show up when it is used. [pr#4277]
+- The cURL download backend and the native-tls TLS backend are now officially deprecated and a warning will start to show up when they are used. [pr#4277]
 
   - While rustup predates reqwest and rustls, the rustup team has long wanted to standardize on
     an HTTP + TLS stack in Rust, which should increase security, potentially improve performance, and
     simplify maintenance of the project.
-    With the default download backend already switched to reqwest since [2019](https://github.com/rust-lang/rustup/pull/1660),
-    the team thinks it is time to start removing the cURL backend and focus on maintaining the Rust-based stack.
+    With the default download backend already switched to reqwest since [2019](https://github.com/rust-lang/rustup/pull/1660)
+    the team thinks it is time to focus maintenance on the Rust-based stack.
 
   - The rustup team encourages everyone to switch to the reqwest backend, and would love to hear from
     you about your use case via GitHub Issues if it does work against your particular setup.

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -127,12 +127,19 @@ async fn download_file_(
     let use_curl_backend = process.var_os("RUSTUP_USE_CURL").map(|it| it != "0");
     if use_curl_backend == Some(true) {
         warn!(
-            "RUSTUP_USE_CURL is set; the curl backend is deprecated, please file an issue if the \
-            default download backend does not work for your use case"
+            "RUSTUP_USE_CURL is set; the curl backend is deprecated,
+            please file an issue if the default download backend does not work for your use case"
         );
     }
 
     let use_rustls = process.var_os("RUSTUP_USE_RUSTLS").map(|it| it != "0");
+    if use_rustls == Some(false) {
+        warn!(
+            "RUSTUP_USE_RUSTLS is set to `0`; the native-tls backend is deprecated,
+            please file an issue if the default download backend does not work for your use case"
+        );
+    }
+
     let backend = match (use_curl_backend, use_rustls) {
         // If environment specifies a backend that's unavailable, error out
         #[cfg(not(feature = "reqwest-rustls-tls"))]


### PR DESCRIPTION
@shepmaster suggested in https://github.com/rust-lang/blog.rust-lang.org/pull/1593#discussion_r2063547165 that we should avoid people jumping from cURL to native-tls. I think we haven't seen a case where native-tls was better than rustls since we made rustls the default in 1.28.0, so I think it might make sense to deprecate this at the same time.