### PR TITLE
dist: update commit shasum in `rustup-init.sh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ The headlines of this release are:
     With the default download backend already switched to reqwest since [2019][pr#1660], the team
     thinks it is time to focus maintenance on the Rust-based stack.
 
-  - The rustup team encourages everyone to switch to the reqwest backend, and would love to hear from
-    you about your use case via [GitHub Issues][issue tracker] if it does not work well with your
-    particular setup.
+  - The rustup team encourages everyone to switch to the reqwest backend with rustls, and would love
+    to hear from you about your use case via [GitHub Issues][issue tracker] if it does not work well
+    with your particular setup.
 
 - The version of `rustup` can be pinned when installing via `rustup-init.sh`, and
   `rustup self update` can be used to upgrade/downgrade rustup v1.28.2+ to a given version.

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -33,7 +33,7 @@ RUSTUP_QUIET=no
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.28.2 (4edd08e3f 2025-04-13)
+rustup-init 1.28.2 (d1f31992a 2025-04-28)
 
 The installer for rustup
 


### PR DESCRIPTION
Following #4313, this is the 2nd PR for the `1.28.2` stable release according to our [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#making-a-release).