### PR TITLE
feat(toolchain): consider external `rust-analyzer` when calling a proxy

### DIFF
--- a/src/test/mock_bin_src.rs
+++ b/src/test/mock_bin_src.rs
@@ -102,6 +102,10 @@ fn main() {
                 panic!("CARGO environment variable not set");
             }
         }
+        Some("--echo-current-exe") => {
+            let mut out = io::stderr();
+            writeln!(out, "{}", std::env::current_exe().unwrap().display()).unwrap();
+        }
         arg => panic!("bad mock proxy commandline: {:?}", arg),
     }
 }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt as _;
 use std::{
     env::{self, consts::EXE_SUFFIX},
     ffi::{OsStr, OsString},
@@ -12,6 +14,7 @@ use std::{
 
 use anyhow::{Context, anyhow, bail};
 use fs_at::OpenOptions;
+use same_file::is_same_file;
 use tracing::info;
 use url::Url;
 use wait_timeout::ChildExt;
@@ -331,6 +334,8 @@ impl<'a> Toolchain<'a> {
         // perhaps a trait that create command layers on?
         if let Some(cmd) = self.maybe_do_cargo_fallback(binary)? {
             return Ok(cmd);
+        } else if let Some(cmd) = self.maybe_do_rust_analyzer_fallback(binary)? {
+            return Ok(cmd);
         }
 
         self.create_command(binary)
@@ -368,6 +373,52 @@ impl<'a> Toolchain<'a> {
             }
         }
 
+        Ok(None)
+    }
+
+    /// Tries to find `rust-analyzer` on the PATH when the active toolchain does
+    /// not have `rust-analyzer` installed.
+    ///
+    /// This happens from time to time often because the user wants to use a
+    /// more recent build of RA than the one shipped with rustup, or because
+    /// rustup isn't shipping RA on their host platform at all.
+    ///
+    /// See the following issues for more context:
+    /// - <https://github.com/rust-lang/rustup/issues/3299>
+    /// - <https://github.com/rust-lang/rustup/issues/3846>
+    fn maybe_do_rust_analyzer_fallback(&self, binary: &str) -> anyhow::Result<Option<Command>> {
+        if binary != "rust-analyzer" && binary != "rust-analyzer.exe"
+            || self.binary_file("rust-analyzer").exists()
+        {
+            return Ok(None);
+        }
+
+        let proc = self.cfg.process;
+        let Some(path) = proc.var_os("PATH") else {
+            return Ok(None);
+        };
+
+        let me = env::current_exe()?;
+
+        // Try to find the first `rust-analyzer` under the `$PATH` that is both
+        // an existing file and not the same file as `me`, i.e. not a rustup proxy.
+        for mut p in env::split_paths(&path) {
+            p.push(binary);
+            let is_external_ra = p.is_file()
+                // We report `true` on `is_same_file()` error to prevent an invalid `p`
+                // from becoming the candidate.
+                && !is_same_file(&me, &p).unwrap_or(true);
+            // On Unix, we additionally check if the file is executable.
+            #[cfg(unix)]
+            let is_external_ra = is_external_ra
+                && p.metadata()
+                    .is_ok_and(|meta| meta.permissions().mode() & 0o111 != 0);
+            if is_external_ra {
+                let mut ra = Command::new(p);
+                self.set_env(&mut ra);
+                return Ok(Some(ra));
+            }
+        }
         Ok(None)
     }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -333,8 +333,12 @@ impl<'a> Toolchain<'a> {
         // Should push the cargo fallback into a custom toolchain type? And then
         // perhaps a trait that create command layers on?
         if let Some(cmd) = self.maybe_do_cargo_fallback(binary)? {
+            info!("`cargo` is unavailable for the active toolchain");
+            info!("falling back to {:?}", cmd.get_program());
             return Ok(cmd);
         } else if let Some(cmd) = self.maybe_do_rust_analyzer_fallback(binary)? {
+            info!("`rust-analyzer` is unavailable for the active toolchain");
+            info!("falling back to {:?}", cmd.get_program());
             return Ok(cmd);
         }
 

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -343,7 +343,7 @@ impl<'a> Toolchain<'a> {
 
     // Custom toolchains don't have cargo, so here we detect that situation and
     // try to find a different cargo.
-    pub(crate) fn maybe_do_cargo_fallback(&self, binary: &str) -> anyhow::Result<Option<Command>> {
+    fn maybe_do_cargo_fallback(&self, binary: &str) -> anyhow::Result<Option<Command>> {
         if binary != "cargo" && binary != "cargo.exe" {
             return Ok(None);
         }

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -329,13 +329,8 @@ impl<'a> Toolchain<'a> {
     pub(crate) fn command(&self, binary: &str) -> anyhow::Result<Command> {
         // Should push the cargo fallback into a custom toolchain type? And then
         // perhaps a trait that create command layers on?
-        if !matches!(
-            self.name(),
-            LocalToolchainName::Named(ToolchainName::Official(_))
-        ) {
-            if let Some(cmd) = self.maybe_do_cargo_fallback(binary)? {
-                return Ok(cmd);
-            }
+        if let Some(cmd) = self.maybe_do_cargo_fallback(binary)? {
+            return Ok(cmd);
         }
 
         self.create_command(binary)
@@ -344,7 +339,9 @@ impl<'a> Toolchain<'a> {
     // Custom toolchains don't have cargo, so here we detect that situation and
     // try to find a different cargo.
     fn maybe_do_cargo_fallback(&self, binary: &str) -> anyhow::Result<Option<Command>> {
-        if binary != "cargo" && binary != "cargo.exe" {
+        if let LocalToolchainName::Named(ToolchainName::Official(_)) = self.name() {
+            return Ok(None);
+        } else if binary != "cargo" && binary != "cargo.exe" {
             return Ok(None);
         }
 

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1343,7 +1343,10 @@ async fn rust_analyzer_proxy_falls_back_external() {
             &["rust-analyzer", "--echo-current-exe"],
             &[("PATH", &extern_dir.to_string_lossy())],
             "",
-            &format!("{}\n", extern_path.display()),
+            &format!(
+                "info: `rust-analyzer` is unavailable for the active toolchain\ninfo: falling back to {:?}\n{}\n",
+                extern_path.as_os_str(), extern_path.display()
+            ),
         )
         .await;
 }


### PR DESCRIPTION
Closes #3846.

Following the reasoning in https://github.com/rust-lang/rustup/issues/3846#issuecomment-2597469049, this PR make rustup prioritize rustup-hosted RA and only delegates to the outside as a final rescue. This way, it will also close https://github.com/rust-lang/rustup/issues/3299:

```console
> rust-analyzer --version
info: `rust-analyzer` is unavailable for the active toolchain
info: falling back to "~/.local/share/nvim/mason/bin/rust-analyzer"
rust-analyzer 0.3.2449-standalone (3b57c00151 2025-05-04)
```

This approach has also been approved by @davidbarsky in [#t-rustup > More frequent rust-analyzer updates in rustup @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/490103-t-rustup/topic/More.20frequent.20rust-analyzer.20updates.20in.20rustup/near/514149302) as a temporary measure before the new update cadence for RA on our release server is settled.

## Concerns

- [x] ~~Should we emit a log line indicating the fallback is happening? Idem for the pre-existing `cargo` fallback.~~ Added.