### PR TITLE
refactor(test): add new APIs for easier snapshot testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
  "sha2",
  "sharded-slab",
  "similar-asserts",
+ "snapbox",
  "strsim",
  "tar",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ otel = [
 ]
 
 # Exports code dependent on private interfaces for the integration test suite
-test = ["dep:similar-asserts", "dep:walkdir"]
+test = ["dep:similar-asserts", "dep:snapbox", "dep:walkdir"]
 
 # Sorted by alphabetic order
 [dependencies]
@@ -77,8 +77,6 @@ semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 sharded-slab = "0.1.1"
-# test only (depends on `test` feature)
-similar-asserts = { version = "1.7", optional = true }
 strsim = "0.11"
 tar = "0.4.26"
 tempfile = "3.8"
@@ -95,9 +93,13 @@ tracing-opentelemetry = { version = "0.30", optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "2.4"
 wait-timeout = "0.2"
-walkdir = { version = "2", optional = true }
 xz2 = "0.1.3"
 zstd = "0.13"
+
+# test only (depends on `test` feature)
+similar-asserts = { version = "1.7", optional = true }
+snapbox = { version = "0.6.21", optional = true }
+walkdir = { version = "2", optional = true }
 
 [target."cfg(windows)".dependencies]
 cc = "1"

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -231,11 +231,14 @@ impl Config {
     }
 
     /// Expect an ok status
+    #[deprecated(note = "use `.expect().await.is_ok()` instead")]
+    #[allow(deprecated)]
     pub async fn expect_ok(&mut self, args: &[&str]) {
         self.expect_ok_env(args, &[]).await
     }
 
     /// Expect an ok status with extra environment variables
+    #[deprecated(note = "use `.expect_with_env().await.is_ok()` instead")]
     pub async fn expect_ok_env(&self, args: &[&str], env: &[(&str, &str)]) {
         let out = self.run(args[0], &args[1..], env).await;
         if !out.ok {
@@ -246,11 +249,14 @@ impl Config {
     }
 
     /// Expect an err status and a string in stderr
+    #[deprecated(note = "use `.expect().await.is_err()` instead")]
+    #[allow(deprecated)]
     pub async fn expect_err(&self, args: &[&str], expected: &str) {
         self.expect_err_env(args, &[], expected).await
     }
 
     /// Expect an err status and a string in stderr, with extra environment variables
+    #[deprecated(note = "use `.expect_with_env().await.is_err()` instead")]
     pub async fn expect_err_env(&self, args: &[&str], env: &[(&str, &str)], expected: &str) {
         let out = self.run(args[0], &args[1..], env).await;
         if out.ok || !out.stderr.contains(expected) {
@@ -262,6 +268,7 @@ impl Config {
     }
 
     /// Expect an ok status and a string in stdout
+    #[deprecated(note = "use `.expect().await.is_ok().with_stdout()` instead")]
     pub async fn expect_stdout_ok(&self, args: &[&str], expected: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if !out.ok || !out.stdout.contains(expected) {
@@ -272,6 +279,7 @@ impl Config {
         }
     }
 
+    #[deprecated(note = "use `.expect().await.is_ok().without_stdout()` instead")]
     pub async fn expect_not_stdout_ok(&self, args: &[&str], expected: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if !out.ok || out.stdout.contains(expected) {
@@ -282,6 +290,7 @@ impl Config {
         }
     }
 
+    #[deprecated(note = "use `.expect().await.is_ok().without_stderr()` instead")]
     pub async fn expect_not_stderr_ok(&self, args: &[&str], expected: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if !out.ok || out.stderr.contains(expected) {
@@ -292,6 +301,7 @@ impl Config {
         }
     }
 
+    #[deprecated(note = "use `.expect().await.is_err().without_stderr()` instead")]
     pub async fn expect_not_stderr_err(&self, args: &[&str], expected: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if out.ok || out.stderr.contains(expected) {
@@ -303,6 +313,7 @@ impl Config {
     }
 
     /// Expect an ok status and a string in stderr
+    #[deprecated(note = "use `.expect().await.is_ok().with_stderr()` instead")]
     pub async fn expect_stderr_ok(&self, args: &[&str], expected: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if !out.ok || !out.stderr.contains(expected) {
@@ -314,12 +325,17 @@ impl Config {
     }
 
     /// Expect an exact strings on stdout/stderr with an ok status code
+    #[deprecated(note = "use `.expect().await.is_ok().with_stdout().with_stderr()` instead")]
+    #[allow(deprecated)]
     pub async fn expect_ok_ex(&mut self, args: &[&str], stdout: &str, stderr: &str) {
         self.expect_ok_ex_env(args, &[], stdout, stderr).await;
     }
 
     /// Expect an exact strings on stdout/stderr with an ok status code,
     /// with extra environment variables
+    #[deprecated(
+        note = "use `.expect_with_env().await.is_ok().with_stdout().with_stderr()` instead"
+    )]
     pub async fn expect_ok_ex_env(
         &mut self,
         args: &[&str],
@@ -342,6 +358,7 @@ impl Config {
     }
 
     /// Expect an exact strings on stdout/stderr with an error status code
+    #[deprecated(note = "use `.expect().await.is_err().with_stdout().with_stderr()` instead")]
     pub async fn expect_err_ex(&self, args: &[&str], stdout: &str, stderr: &str) {
         let out = self.run(args[0], &args[1..], &[]).await;
         if out.ok || out.stdout != stdout || out.stderr != stderr {

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -1,6 +1,8 @@
 //! Yet more cli test cases. These are testing that the output
 //! is exactly as expected.
 
+#![allow(deprecated)]
+
 use rustup::for_host;
 use rustup::test::{
     CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_triple,

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -1,5 +1,7 @@
 //! Tests of the interactive console installer
 
+#![allow(deprecated)]
+
 use std::env::consts::EXE_SUFFIX;
 use std::io::Write;
 use std::process::Stdio;

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -13,6 +13,7 @@ use rustup::test::{
 };
 use rustup::utils;
 use rustup::utils::raw::symlink_dir;
+use snapbox::str;
 
 #[tokio::test]
 async fn smoke_test() {
@@ -115,16 +116,15 @@ async fn custom_invalid_names_with_archive_dates() {
 async fn update_all_no_update_whitespace() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{} installed - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(str![[r#"
 
-"
-            ),
-        )
-        .await;
+  nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
+
+
+"#]]);
 }
 
 // Issue #145

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1,6 +1,8 @@
 //! Test cases of the rustup command that do not depend on the
 //! dist server, mostly derived from multirust/test-v2.sh
 
+#![allow(deprecated)]
+
 use std::fs;
 use std::str;
 use std::{env::consts::EXE_SUFFIX, path::Path};

--- a/tests/suite/cli_paths.rs
+++ b/tests/suite/cli_paths.rs
@@ -2,6 +2,8 @@
 //! It depends on self-update working, so if absolutely everything here breaks,
 //! check those tests as well.
 
+#![allow(deprecated)]
+
 // Prefer omitting actually unpacking content while just testing paths.
 const INIT_NONE: [&str; 4] = ["rustup-init", "-y", "--default-toolchain", "none"];
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1,5 +1,7 @@
 //! Test cases for new rustup UI
 
+#![allow(deprecated)]
+
 use std::fs;
 use std::path::{MAIN_SEPARATOR, PathBuf};
 use std::{env::consts::EXE_SUFFIX, path::Path};

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -22,6 +22,7 @@ use rustup::test::{
 use rustup::test::{RegistryGuard, RegistryValueId, USER_PATH};
 use rustup::utils::{self, raw};
 use rustup::{DUP_TOOLS, TOOLS, for_host};
+use snapbox::str;
 #[cfg(windows)]
 use windows_registry::Value;
 
@@ -390,26 +391,32 @@ info: downloading self-update (new version: {TEST_VERSION})
 
 #[tokio::test]
 async fn update_precise() {
-    let version = env!("CARGO_PKG_VERSION");
-    let expected_output = format!(
-        "info: checking for self-update (current version: {version})
-info: `RUSTUP_VERSION` has been set to `{TEST_VERSION}`
-info: downloading self-update (new version: {TEST_VERSION})
-"
-    );
-
-    let mut cx = SelfUpdateTestContext::new(TEST_VERSION).await;
+    let cx = SelfUpdateTestContext::new(TEST_VERSION).await;
     cx.config
-        .expect_ok(&["rustup-init", "-y", "--no-modify-path"])
-        .await;
+        .expect(["rustup-init", "-y", "--no-modify-path"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex_env(
-            &["rustup", "self", "update"],
-            &[("RUSTUP_VERSION", TEST_VERSION)],
-            &format!("  rustup updated - {version} (from {version})\n\n",),
-            &expected_output,
+        .expect_with_env(
+            ["rustup", "self", "update"],
+            [("RUSTUP_VERSION", TEST_VERSION)],
         )
-        .await;
+        .await
+        .extend_redactions([
+            ("[TEST_VERSION]", TEST_VERSION),
+            ("[VERSION]", env!("CARGO_PKG_VERSION")),
+        ])
+        .with_stdout(str![[r#"
+  rustup updated - [VERSION] (from [VERSION])
+
+
+"#]])
+        .with_stderr(str![[r#"
+info: checking for self-update (current version: [VERSION])
+info: `RUSTUP_VERSION` has been set to `[TEST_VERSION]`
+info: downloading self-update (new version: [TEST_VERSION])
+
+"#]]);
 }
 
 #[cfg(windows)]

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -1,5 +1,7 @@
 //! Testing self install, uninstall and update
 
+#![allow(deprecated)]
+
 use std::env;
 use std::env::consts::EXE_SUFFIX;
 use std::fs;

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -7,16 +7,20 @@ use std::fs;
 
 use rustup::for_host;
 use rustup::test::{CliTestContext, Scenario};
+use snapbox::str;
 
 #[tokio::test]
 async fn rustc_no_default_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_err(
-            &["rustc"],
-            "rustup could not choose a version of rustc to run",
-        )
-        .await;
+        .expect(["rustc"])
+        .await
+        .is_err()
+        .with_stderr(str![[r#"
+error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
+
+"#]]);
 }
 
 #[tokio::test]

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -1,6 +1,8 @@
 //! Test cases of the rustup command, using v1 manifests, mostly
 //! derived from multirust/test-v2.sh
 
+#![allow(deprecated)]
+
 use std::fs;
 
 use rustup::for_host;

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1,6 +1,8 @@
 //! Test cases of the rustup command, using v2 manifests, mostly
 //! derived from multirust/test-v2.sh
 
+#![allow(deprecated)]
+
 use std::fs;
 use std::io::Write;
 use std::path::PathBuf;


### PR DESCRIPTION
This PR is the foundation of #4359.

RA-powered inline snapshot updates seem to work without issues in VSCode with the given demo (thanks @roife!):

<img width="529" alt="image" src="https://github.com/user-attachments/assets/6fa7bc62-6fa8-4efd-9670-107e25af5c76" />

## Concerns

- [ ] Could the API design use some improvements (naming, signature, ...)?
- [x] Should we start to mark the old APIs as deprecated as Cargo once did with theirs?
- [x] What redactions should we include by default (`this_host_triple`, `tempdir`, ...)?
  - This can be added as we go; it does look like `this_host_triple` is a good inclusion at the start; and I've made it so that each test can add their own redactions.