### PR TITLE
Fix cargo lints on Windows

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1053,7 +1053,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
                     &active_reason,
                 )?;
                 writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-                writeln!(t.lock(), "active because: {}", active_reason)?;
+                writeln!(t.lock(), "active because: {active_reason}")?;
                 if verbose {
                     writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
                     writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
@@ -1063,7 +1063,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
                 writeln!(t.lock(), "installed targets:")?;
 
                 for target in active_toolchain_targets {
-                    writeln!(t.lock(), "  {}", target)?;
+                    writeln!(t.lock(), "  {target}")?;
                 }
             }
             None => {

--- a/src/command.rs
+++ b/src/command.rs
@@ -44,10 +44,7 @@ pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
         }
         unsafe {
             if SetConsoleCtrlHandler(Some(ctrlc_handler), TRUE) == FALSE {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "Unable to set console handler",
-                ));
+                return Err(io::Error::other("Unable to set console handler"));
             }
         }
 

--- a/src/download/tests.rs
+++ b/src/download/tests.rs
@@ -308,7 +308,7 @@ async fn run_server(addr_tx: Sender<SocketAddr>, addr: SocketAddr, contents: Vec
         let svc = svc.clone();
         tokio::spawn(async move {
             if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
-                eprintln!("failed to serve connection: {:?}", err);
+                eprintln!("failed to serve connection: {err:?}");
             }
         });
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -153,7 +153,7 @@ pub enum RustupError {
 
 fn suggest_message(suggestion: &Option<String>) -> String {
     if let Some(suggestion) = suggestion {
-        format!("; did you mean '{}'?", suggestion)
+        format!("; did you mean '{suggestion}'?")
     } else {
         String::new()
     }

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -322,9 +322,9 @@ impl Config {
         let status = out.status;
         let output = SanitizedOutput::try_from(out).unwrap();
 
-        println!("ran: {} {:?}", name, args);
+        println!("ran: {name} {args:?}");
         println!("inprocess: {inprocess}");
-        println!("status: {:?}", status);
+        println!("status: {status:?}");
         println!("duration: {:.3}s", duration.as_secs_f32());
         println!("stdout:\n====\n{}\n====\n", output.stdout);
         println!("stderr:\n====\n{}\n====\n", output.stderr);

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -284,7 +284,7 @@ pub(crate) mod windows {
     pub(crate) fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
         fn inner(s: &OsStr) -> io::Result<Vec<u16>> {
             let mut maybe_result: Vec<u16> = s.encode_wide().collect();
-            if maybe_result.iter().any(|&u| u == 0) {
+            if maybe_result.contains(&0) {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "strings passed to WinAPI cannot contain NULs",

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -609,7 +609,7 @@ async fn list_targets() {
     let trip = this_host_triple();
     let mut sorted = [
         format!("{} (installed)", &*trip),
-        format!("{} (installed)", CROSS_ARCH1),
+        format!("{CROSS_ARCH1} (installed)"),
         CROSS_ARCH2.to_string(),
     ];
     sorted.sort();
@@ -674,10 +674,9 @@ async fn cross_install_indicates_target() {
             &["rustup", "target", "add", CROSS_ARCH1],
             r"",
             &format!(
-                r"info: downloading component 'rust-std' for '{0}'
-info: installing component 'rust-std' for '{0}'
-",
-                CROSS_ARCH1
+                r"info: downloading component 'rust-std' for '{CROSS_ARCH1}'
+info: installing component 'rust-std' for '{CROSS_ARCH1}'
+"
             ),
         )
         .await;

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -207,7 +207,7 @@ async fn multi_host_smoke_test() {
     assert_ne!(this_host_triple(), MULTI_ARCH1);
 
     let mut cx = CliTestContext::new(Scenario::MultiHost).await;
-    let toolchain = format!("nightly-{}", MULTI_ARCH1);
+    let toolchain = format!("nightly-{MULTI_ARCH1}");
     cx.config
         .expect_ok(&["rustup", "default", &toolchain, "--force-non-host"])
         .await;

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -578,7 +578,7 @@ async fn recursive_cargo() {
     let output = cx.config.run("rustup", ["which", "cargo"], &[]).await;
     let real_mock_cargo = output.stdout.trim();
     let cargo_bin_path = cx.config.cargodir.join("bin");
-    let cargo_subcommand = cargo_bin_path.join(format!("cargo-foo{}", EXE_SUFFIX));
+    let cargo_subcommand = cargo_bin_path.join(format!("cargo-foo{EXE_SUFFIX}"));
     fs::create_dir_all(&cargo_bin_path).unwrap();
     fs::copy(real_mock_cargo, cargo_subcommand).unwrap();
 
@@ -736,7 +736,7 @@ async fn show_multiple_targets() {
         .expect_ok(&[
             "rustup",
             "default",
-            &format!("nightly-{}", MULTI_ARCH1),
+            &format!("nightly-{MULTI_ARCH1}"),
             "--force-non-host",
         ])
         .await;
@@ -783,7 +783,7 @@ async fn show_multiple_toolchains_and_targets() {
         .expect_ok(&[
             "rustup",
             "default",
-            &format!("nightly-{}", MULTI_ARCH1),
+            &format!("nightly-{MULTI_ARCH1}"),
             "--force-non-host",
         ])
         .await;
@@ -795,7 +795,7 @@ async fn show_multiple_toolchains_and_targets() {
             "rustup",
             "update",
             "--force-non-host",
-            &format!("stable-{}", MULTI_ARCH1),
+            &format!("stable-{MULTI_ARCH1}"),
         ])
         .await;
     cx.config
@@ -1542,7 +1542,7 @@ async fn add_component_by_target_triple() {
             "rustup",
             "component",
             "add",
-            &format!("rust-std-{}", CROSS_ARCH1),
+            &format!("rust-std-{CROSS_ARCH1}"),
         ])
         .await;
     let path = format!(
@@ -1595,7 +1595,7 @@ async fn fail_invalid_component_name() {
                 "rustup",
                 "component",
                 "add",
-                &format!("dummy-{}", CROSS_ARCH1),
+                &format!("dummy-{CROSS_ARCH1}"),
             ],
             &format!(
             "error: toolchain 'stable-{}' does not contain component 'dummy-{}' for target '{}'",
@@ -1642,7 +1642,7 @@ async fn remove_component() {
 
 #[tokio::test]
 async fn remove_component_by_target_triple() {
-    let component_with_triple = format!("rust-std-{}", CROSS_ARCH1);
+    let component_with_triple = format!("rust-std-{CROSS_ARCH1}");
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config.expect_ok(&["rustup", "default", "stable"]).await;
     cx.config
@@ -1665,11 +1665,11 @@ async fn add_remove_multiple_components() {
     let files = [
         "lib/rustlib/src/rust-src/foo.rs".to_owned(),
         format!("lib/rustlib/{}/analysis/libfoo.json", this_host_triple()),
-        format!("lib/rustlib/{}/lib/libstd.rlib", CROSS_ARCH1),
-        format!("lib/rustlib/{}/lib/libstd.rlib", CROSS_ARCH2),
+        format!("lib/rustlib/{CROSS_ARCH1}/lib/libstd.rlib"),
+        format!("lib/rustlib/{CROSS_ARCH2}/lib/libstd.rlib"),
     ];
-    let component_with_triple1 = format!("rust-std-{}", CROSS_ARCH1);
-    let component_with_triple2 = format!("rust-std-{}", CROSS_ARCH2);
+    let component_with_triple1 = format!("rust-std-{CROSS_ARCH1}");
+    let component_with_triple2 = format!("rust-std-{CROSS_ARCH2}");
 
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
@@ -2358,11 +2358,11 @@ async fn override_order() {
     let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
     let host = this_host_triple();
     // give each override type a different toolchain
-    let default_tc = &format!("beta-2015-01-01-{}", host);
-    let env_tc = &format!("stable-2015-01-01-{}", host);
-    let dir_tc = &format!("beta-2015-01-02-{}", host);
-    let file_tc = &format!("stable-2015-01-02-{}", host);
-    let command_tc = &format!("nightly-2015-01-01-{}", host);
+    let default_tc = &format!("beta-2015-01-01-{host}");
+    let env_tc = &format!("stable-2015-01-01-{host}");
+    let dir_tc = &format!("beta-2015-01-02-{host}");
+    let file_tc = &format!("stable-2015-01-02-{host}");
+    let command_tc = &format!("nightly-2015-01-01-{host}");
     cx.config
         .expect_ok(&["rustup", "install", default_tc])
         .await;
@@ -2395,7 +2395,7 @@ async fn override_order() {
     let toolchain_file = cx.config.current_dir().join("rust-toolchain.toml");
     raw::write_file(
         &toolchain_file,
-        &format!("[toolchain]\nchannel='{}'", file_tc),
+        &format!("[toolchain]\nchannel='{file_tc}'"),
     )
     .unwrap();
     cx.config
@@ -2427,7 +2427,7 @@ async fn override_order() {
         .config
         .run(
             "rustup",
-            [&format!("+{}", command_tc), "show", "active-toolchain"],
+            [&format!("+{command_tc}"), "show", "active-toolchain"],
             &[("RUSTUP_TOOLCHAIN", env_tc)],
         )
         .await;

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -994,7 +994,7 @@ async fn install_with_components_and_targets() {
     cx.config
         .expect_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
     cx.config

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -932,10 +932,7 @@ async fn add_all_targets_fail() {
     cx.config
         .expect_err(
             &["rustup", "target", "add", CROSS_ARCH1, "all", CROSS_ARCH2],
-            &format!(
-                "`rustup target add {} all {}` includes `all`",
-                CROSS_ARCH1, CROSS_ARCH2
-            ),
+            &format!("`rustup target add {CROSS_ARCH1} all {CROSS_ARCH2}` includes `all`"),
         )
         .await;
 }
@@ -947,7 +944,7 @@ async fn add_target_by_component_add() {
     cx.config
         .expect_not_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
     cx.config
@@ -955,13 +952,13 @@ async fn add_target_by_component_add() {
             "rustup",
             "component",
             "add",
-            &format!("rust-std-{}", CROSS_ARCH1),
+            &format!("rust-std-{CROSS_ARCH1}"),
         ])
         .await;
     cx.config
         .expect_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
 }
@@ -976,7 +973,7 @@ async fn remove_target_by_component_remove() {
     cx.config
         .expect_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
     cx.config
@@ -984,13 +981,13 @@ async fn remove_target_by_component_remove() {
             "rustup",
             "component",
             "remove",
-            &format!("rust-std-{}", CROSS_ARCH1),
+            &format!("rust-std-{CROSS_ARCH1}"),
         ])
         .await;
     cx.config
         .expect_not_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
 }
@@ -1085,10 +1082,7 @@ async fn add_target_again() {
     cx.config
         .expect_stderr_ok(
             &["rustup", "target", "add", CROSS_ARCH1],
-            &format!(
-                "component 'rust-std' for target '{}' is up to date",
-                CROSS_ARCH1
-            ),
+            &format!("component 'rust-std' for target '{CROSS_ARCH1}' is up to date"),
         )
         .await;
     let path = format!(
@@ -1540,8 +1534,8 @@ async fn add_target_suggest_best_match() {
     cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
         .expect_err(
-            &["rustup", "target", "add", &format!("{}a", CROSS_ARCH1)[..]],
-            &format!("did you mean '{}'", CROSS_ARCH1),
+            &["rustup", "target", "add", &format!("{CROSS_ARCH1}a")[..]],
+            &format!("did you mean '{CROSS_ARCH1}'"),
         )
         .await;
     cx.config
@@ -1555,13 +1549,8 @@ async fn remove_target_suggest_best_match() {
     cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
         .expect_not_stderr_err(
-            &[
-                "rustup",
-                "target",
-                "remove",
-                &format!("{}a", CROSS_ARCH1)[..],
-            ],
-            &format!("did you mean '{}'", CROSS_ARCH1),
+            &["rustup", "target", "remove", &format!("{CROSS_ARCH1}a")[..]],
+            &format!("did you mean '{CROSS_ARCH1}'"),
         )
         .await;
     cx.config
@@ -1569,13 +1558,8 @@ async fn remove_target_suggest_best_match() {
         .await;
     cx.config
         .expect_err(
-            &[
-                "rustup",
-                "target",
-                "remove",
-                &format!("{}a", CROSS_ARCH1)[..],
-            ],
-            &format!("did you mean '{}'", CROSS_ARCH1),
+            &["rustup", "target", "remove", &format!("{CROSS_ARCH1}a")[..]],
+            &format!("did you mean '{CROSS_ARCH1}'"),
         )
         .await;
 }
@@ -1629,19 +1613,19 @@ async fn install_with_targets() {
         cx.config
             .expect_stdout_ok(
                 &["rustup", "target", "list"],
-                &format!("{} (installed)", CROSS_ARCH1),
+                &format!("{CROSS_ARCH1} (installed)"),
             )
             .await;
         cx.config
             .expect_stdout_ok(
                 &["rustup", "target", "list"],
-                &format!("{} (installed)", CROSS_ARCH2),
+                &format!("{CROSS_ARCH2} (installed)"),
             )
             .await;
     }
 
     go(&["-t", CROSS_ARCH1, "-t", CROSS_ARCH2]).await;
-    go(&["-t", &format!("{},{}", CROSS_ARCH1, CROSS_ARCH2)]).await;
+    go(&["-t", &format!("{CROSS_ARCH1},{CROSS_ARCH2}")]).await;
 }
 
 #[tokio::test]
@@ -1669,7 +1653,7 @@ async fn install_with_component_and_target() {
     cx.config
         .expect_stdout_ok(
             &["rustup", "target", "list"],
-            &format!("{} (installed)", CROSS_ARCH1),
+            &format!("{CROSS_ARCH1} (installed)"),
         )
         .await;
 }


### PR DESCRIPTION
Produced by running:

```
cargo clippy --fix --all-targets --all-features
```

Mostly it's just moving variables inside the format string but there are a couple of other changes:

- using `contains()` instead of `iter().any()` is more efficient
- `io::Error::new(io::ErrorKind::Other, ...)` can be `std::io::Error::other(_)`
