### PR TITLE
feat(self_update): add proxy sanity checks

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -141,6 +141,12 @@ pub enum RustupError {
         target: TargetTriple,
         suggestion: Option<String>,
     },
+    #[error(
+        "rustup executable proxies don't seem to work\n\
+        help: this might be a bug in rustup, please open a new issue here:\n\
+        help: https://github.com/rust-lang/rustup/issues/new"
+    )]
+    BrokenProxy,
     #[error("unknown metadata version: '{0}'")]
     UnknownMetadataVersion(String),
     #[error("manifest version '{0}' is not supported")]


### PR DESCRIPTION
Sometimes, proxies can be incorrectly installed for whatever reason. This adds a new check after initial component installation to call all proxies with --version, and to fail if one of them doesn't report success.

Closes #4336 (but there should probably be a followup issue for potentially self-repairing broken proxies?).

~~There are two test failures in my local testing:~~ this has been resolved (for now...?) by limiting to only core components