### PR TITLE
style(test): clarify uses of `snapbox::str![]`

### DIFF
--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -8,7 +8,6 @@ use rustup::test::{
     CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_triple,
 };
 use rustup::utils::raw;
-use snapbox::str;
 
 #[tokio::test]
 async fn update_once() {
@@ -323,7 +322,7 @@ async fn override_again() {
         .extend_redactions([("[CWD]", cx.config.current_dir().display().to_string())])
         .is_ok()
         .with_stdout("")
-        .with_stderr(str![[r#"
+        .with_stderr(snapbox::str![[r#"
 info: override toolchain for '[CWD]' set to 'nightly-[HOST_TRIPLE]'
 
 "#]]);

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -13,7 +13,6 @@ use rustup::test::{
 };
 use rustup::utils;
 use rustup::utils::raw::symlink_dir;
-use snapbox::str;
 
 #[tokio::test]
 async fn smoke_test() {
@@ -119,7 +118,7 @@ async fn update_all_no_update_whitespace() {
         .expect(["rustup", "update", "nightly"])
         .await
         .is_ok()
-        .with_stdout(str![[r#"
+        .with_stdout(snapbox::str![[r#"
 
   nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
 

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -22,7 +22,6 @@ use rustup::test::{
 use rustup::test::{RegistryGuard, RegistryValueId, USER_PATH};
 use rustup::utils::{self, raw};
 use rustup::{DUP_TOOLS, TOOLS, for_host};
-use snapbox::str;
 #[cfg(windows)]
 use windows_registry::Value;
 
@@ -406,12 +405,12 @@ async fn update_precise() {
             ("[TEST_VERSION]", TEST_VERSION),
             ("[VERSION]", env!("CARGO_PKG_VERSION")),
         ])
-        .with_stdout(str![[r#"
+        .with_stdout(snapbox::str![[r#"
   rustup updated - [VERSION] (from [VERSION])
 
 
 "#]])
-        .with_stderr(str![[r#"
+        .with_stderr(snapbox::str![[r#"
 info: checking for self-update (current version: [VERSION])
 info: `RUSTUP_VERSION` has been set to `[TEST_VERSION]`
 info: downloading self-update (new version: [TEST_VERSION])

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -7,7 +7,6 @@ use std::fs;
 
 use rustup::for_host;
 use rustup::test::{CliTestContext, Scenario};
-use snapbox::str;
 
 #[tokio::test]
 async fn rustc_no_default_toolchain() {
@@ -16,7 +15,7 @@ async fn rustc_no_default_toolchain() {
         .expect(["rustc"])
         .await
         .is_err()
-        .with_stderr(str![[r#"
+        .with_stderr(snapbox::str![[r#"
 error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
 help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
 


### PR DESCRIPTION
Part of #4359, addresses https://github.com/rust-lang/rustup/pull/4334#discussion_r2095015455.

To make the origin of the `str![[r#"..."#]]` special syntax clearer, the current implementation qualifies all uses of `snapbox::str![]`.