### PR TITLE
test(cli-self-upd): migrate to `.expect()` APIs

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -1,6 +1,7 @@
 //! A mock distribution server used by tests/cli-v1.rs and
 //! tests/cli-v2.rs
 use std::{
+    borrow::Cow,
     cell::RefCell,
     collections::HashMap,
     env::{self, consts::EXE_SUFFIX},
@@ -32,6 +33,7 @@ use crate::test::this_host_triple;
 use crate::utils;
 
 use super::{
+    CROSS_ARCH1, CROSS_ARCH2,
     dist::{MockDistServer, MockManifestVersion, Release, RlsStatus, change_channel_date},
     mock::MockFile,
 };
@@ -74,7 +76,15 @@ impl Assert {
     pub fn new(output: SanitizedOutput) -> Self {
         let mut redactions = Redactions::new();
         redactions
-            .extend([("[HOST_TRIPLE]", this_host_triple())])
+            .extend([
+                (
+                    "[CURRENT_VERSION]",
+                    Cow::Borrowed(env!("CARGO_PKG_VERSION")),
+                ),
+                ("[HOST_TRIPLE]", Cow::Owned(this_host_triple())),
+                ("[CROSS_ARCH_I]", Cow::Borrowed(CROSS_ARCH1)),
+                ("[CROSS_ARCH_II]", Cow::Borrowed(CROSS_ARCH2)),
+            ])
             .expect("invalid redactions detected");
         Self { output, redactions }
     }

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -237,10 +237,9 @@ async fn check_updates_self_no_change() {
     cx.config
         .expect(["rustup", "check"])
         .await
-        .extend_redactions([("[VERSION]", current_version)])
         .is_err()
         .with_stdout(snapbox::str![[r#"
-rustup - Up to date : [VERSION]
+rustup - Up to date : [CURRENT_VERSION]
 
 "#]]);
 }


### PR DESCRIPTION
Part of #4359.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4343/commits)

