### PR TITLE
Skip manifest loading if there are no components/targets to check

### DIFF
--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -134,6 +134,12 @@ impl<'a> DistributableToolchain<'a> {
         components: &[&str],
         targets: &[&str],
     ) -> anyhow::Result<bool> {
+        // Performance optimization: avoid loading the manifest (which can be expensive)
+        // if there are no components/targets to check.
+        if components.is_empty() && targets.is_empty() {
+            return Ok(true);
+        }
+
         let manifestation = self.get_manifestation()?;
         let manifest = manifestation.load_manifest()?;
         let manifest = match manifest {


### PR DESCRIPTION
While examining the manifest loading issues in https://github.com/rust-lang/rustup/issues/2626, I noticed that for the common case (running just `rustc`), the list of components and targets to check is actually empty. In that case, we parse the manifest for no reason, costing us ~20-30ms on every rustup proxy invocation.

This makes the common case of running `rustc` almost as fast as when the toolchain is specified explicitly using e.g. `+nightly`, where the components/targets weren't checked before.

This does not help the situation where there is a `rust-toolchain.toml` file with custom components and targets, these will be checked as before.

Before:
```
$ cargo build --release && cp target/release/rustup-init rustc
$ hyperfine "./rustc +nightly --version" "./rustc --version"

Benchmark 1: ./rustc +nightly --version
  Time (mean ± σ):      17.3 ms ±   0.4 ms    [User: 5.2 ms, System: 13.3 ms]
  Range (min … max):    16.6 ms …  19.0 ms    173 runs
 
Benchmark 2: ./rustc --version
  Time (mean ± σ):      44.8 ms ±   0.6 ms    [User: 25.5 ms, System: 20.6 ms]
  Range (min … max):    43.7 ms …  46.4 ms    65 runs
 
Summary
  ./rustc +nightly --version ran
    2.59 ± 0.07 times faster than ./rustc --version
```

After:
```
$ cargo build --release && cp target/release/rustup-init rustc
$ hyperfine "./rustc +nightly --version" "./rustc --version"

Benchmark 1: ./rustc +nightly --version
  Time (mean ± σ):      17.3 ms ±   0.4 ms    [User: 5.3 ms, System: 13.1 ms]
  Range (min … max):    16.4 ms …  19.2 ms    170 runs
 
Benchmark 2: ./rustc --version
  Time (mean ± σ):      17.4 ms ±   0.5 ms    [User: 5.3 ms, System: 13.3 ms]
  Range (min … max):    16.5 ms …  18.8 ms    165 runs
 
Summary
  ./rustc +nightly --version ran
    1.01 ± 0.04 times faster than ./rustc --version
```

Alternative to https://github.com/rust-lang/rustup/pull/4344.
Related issue: https://github.com/rust-lang/rustup/issues/2626