### PR TITLE
test(cli-exact): migrate to `.expect()` APIs

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -33,7 +33,7 @@ use crate::test::this_host_triple;
 use crate::utils;
 
 use super::{
-    CROSS_ARCH1, CROSS_ARCH2,
+    CROSS_ARCH1, CROSS_ARCH2, MULTI_ARCH1,
     dist::{MockDistServer, MockManifestVersion, Release, RlsStatus, change_channel_date},
     mock::MockFile,
 };
@@ -84,6 +84,7 @@ impl Assert {
                 ("[HOST_TRIPLE]", Cow::Owned(this_host_triple())),
                 ("[CROSS_ARCH_I]", Cow::Borrowed(CROSS_ARCH1)),
                 ("[CROSS_ARCH_II]", Cow::Borrowed(CROSS_ARCH2)),
+                ("[MULTI_ARCH_I]", Cow::Borrowed(MULTI_ARCH1)),
             ])
             .expect("invalid redactions detected");
         Self { output, redactions }

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -1,9 +1,6 @@
 //! Yet more cli test cases. These are testing that the output
 //! is exactly as expected.
 
-#![allow(deprecated)]
-
-use rustup::for_host;
 use rustup::test::{
     CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_triple,
 };
@@ -11,18 +8,19 @@ use rustup::utils::raw;
 
 #[tokio::test]
 async fn update_once() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{0} installed - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'cargo'
 info: downloading component 'rust-docs'
@@ -32,11 +30,9 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
-info: default toolchain set to 'nightly-{0}'
-"
-            ),
-        )
-        .await;
+info: default toolchain set to 'nightly-[HOST_TRIPLE]'
+
+"#]]);
 }
 
 #[tokio::test]
@@ -45,28 +41,28 @@ async fn update_once_and_check_self_update() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let _dist_guard = cx.with_update_server(test_version);
     cx.config
-        .expect_ok(&["rustup-init", "-y", "--no-modify-path"])
-        .await;
+        .expect(["rustup-init", "-y", "--no-modify-path"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "set", "auto-self-update", "check-only"])
-        .await;
-    let current_version = env!("CARGO_PKG_VERSION");
+        .expect(["rustup", "set", "auto-self-update", "check-only"])
+        .await
+        .is_ok();
 
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            &format!(
-                r"
-  nightly-{} installed - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .extend_redactions([("[TEST_VERSION]", test_version)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-rustup - Update available : {} -> {}
-",
-                &this_host_triple(),
-                current_version,
-                test_version
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
+
+rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'cargo'
 info: downloading component 'rust-docs'
@@ -76,35 +72,36 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
-"
-            ),
-        )
-        .await;
+
+"#]]);
 }
 
 #[tokio::test]
 async fn update_once_and_self_update() {
     let test_version = "2.0.0";
-    let current = env!("CARGO_PKG_VERSION");
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let _dist_guard = cx.with_update_server(test_version);
     cx.config
-        .expect_ok(&["rustup-init", "-y", "--no-modify-path"])
-        .await;
+        .expect(["rustup-init", "-y", "--no-modify-path"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "set", "auto-self-update", "enable"])
-        .await;
+        .expect(["rustup", "set", "auto-self-update", "enable"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{0} installed - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .extend_redactions([("[TEST_VERSION]", test_version)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'cargo'
 info: downloading component 'rust-docs'
@@ -114,57 +111,60 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
-info: checking for self-update (current version: {current})
-info: downloading self-update (new version: 2.0.0)
-"
-            ),
-        )
-        .await;
+info: checking for self-update (current version: [CURRENT_VERSION])
+info: downloading self-update (new version: [TEST_VERSION])
+
+"#]]);
 }
 
 #[tokio::test]
 async fn update_again() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
-    cx.config.expect_ok(&["rustup", "upgrade", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{0} unchanged - 1.3.0 (hash-nightly-2)
-
-"
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
-"
-            ),
-        )
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(
-            &["rustup", "upgrade", "nightly"],
-            for_host!(
-                r"
-  nightly-{0} unchanged - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "upgrade", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
-"
-            ),
-        )
-        .await;
+  nightly-[HOST_TRIPLE] unchanged - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
+
+"#]]);
+    cx.config
+        .expect(["rustup", "upgrade", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+
+  nightly-[HOST_TRIPLE] unchanged - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
+
+"#]]);
 }
 
 #[tokio::test]
 async fn check_updates_none() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "add", "stable", "beta", "nightly"])
-        .await;
+        .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+        .await
+        .is_ok();
     cx.config
         .expect(["rustup", "check"])
         .await
@@ -182,22 +182,24 @@ async fn check_updates_some() {
     let mut cx = CliTestContext::new(Scenario::None).await;
 
     {
-        let mut cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
         cx.config
-            .expect_ok(&["rustup", "toolchain", "add", "stable", "beta", "nightly"])
-            .await;
+            .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+            .await
+            .is_ok();
     }
 
     let cx = cx.with_dist_dir(Scenario::SimpleV2);
-    cx.config.expect_stdout_ok(
-        &["rustup", "check"],
-        for_host!(
-            r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
-beta-{0} - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
-nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
-"
-        ),
-    ).await;
+    cx.config
+        .expect(["rustup", "check"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+stable-[HOST_TRIPLE] - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-[HOST_TRIPLE] - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
+nightly-[HOST_TRIPLE] - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
+
+"#]]);
 }
 
 #[tokio::test]
@@ -205,7 +207,6 @@ async fn check_updates_self() {
     let test_version = "2.0.0";
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let _dist_guard = cx.with_update_server(test_version);
-    let current_version = env!("CARGO_PKG_VERSION");
 
     // We are checking an update to rustup itself in this test.
     cx.config
@@ -213,14 +214,14 @@ async fn check_updates_self() {
         .await;
 
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "check"],
-            &format!(
-                r"rustup - Update available : {current_version} -> {test_version}
-"
-            ),
-        )
-        .await;
+        .expect(["rustup", "check"])
+        .await
+        .extend_redactions([("[TEST_VERSION]", test_version)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -249,10 +250,11 @@ async fn check_updates_with_update() {
     let mut cx = CliTestContext::new(Scenario::None).await;
 
     {
-        let mut cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
         cx.config
-            .expect_ok(&["rustup", "toolchain", "add", "stable", "beta", "nightly"])
-            .await;
+            .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+            .await
+            .is_ok();
         cx.config
             .expect(["rustup", "check"])
             .await
@@ -265,42 +267,45 @@ nightly-[HOST_TRIPLE] - Up to date : 1.2.0 (hash-nightly-1)
 "#]]);
     }
 
-    let mut cx = cx.with_dist_dir(Scenario::SimpleV2);
-    cx.config.expect_stdout_ok(
-        &["rustup", "check"],
-        for_host!(
-            r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
-beta-{0} - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
-nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
-"
-        ),
-    ).await;
-    cx.config.expect_ok(&["rustup", "update", "beta"]).await;
-    cx.config.expect_stdout_ok(
-        &["rustup", "check"],
-        for_host!(
-            r"stable-{0} - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
-beta-{0} - Up to date : 1.2.0 (hash-beta-1.2.0)
-nightly-{0} - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
-"
-        ),
-    ).await;
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    cx.config
+        .expect(["rustup", "check"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+stable-[HOST_TRIPLE] - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-[HOST_TRIPLE] - Update available : 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
+nightly-[HOST_TRIPLE] - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
+
+"#]]);
+    cx.config.expect(["rustup", "update", "beta"]).await.is_ok();
+    cx.config
+        .expect(["rustup", "check"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+stable-[HOST_TRIPLE] - Update available : 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
+beta-[HOST_TRIPLE] - Up to date : 1.2.0 (hash-beta-1.2.0)
+nightly-[HOST_TRIPLE] - Update available : 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-nightly-2)
+
+"#]]);
 }
 
 #[tokio::test]
 async fn default() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok_ex(
-            &["rustup", "default", "nightly"],
-            for_host!(
-                r"
-  nightly-{0} installed - 1.3.0 (hash-nightly-2)
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            for_host!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 info: downloading component 'cargo'
 info: downloading component 'rust-docs'
@@ -310,11 +315,9 @@ info: installing component 'cargo'
 info: installing component 'rust-docs'
 info: installing component 'rust-std'
 info: installing component 'rustc'
-info: default toolchain set to 'nightly-{0}'
-"
-            ),
-        )
-        .await;
+info: default toolchain set to 'nightly-[HOST_TRIPLE]'
+
+"#]]);
 }
 
 #[tokio::test]
@@ -329,7 +332,7 @@ async fn override_again() {
         .await
         .extend_redactions([("[CWD]", cx.config.current_dir().display().to_string())])
         .is_ok()
-        .with_stdout("")
+        .with_stdout(snapbox::str![[""]])
         .with_stderr(snapbox::str![[r#"
 info: override toolchain for '[CWD]' set to 'nightly-[HOST_TRIPLE]'
 
@@ -339,37 +342,41 @@ info: override toolchain for '[CWD]' set to 'nightly-[HOST_TRIPLE]'
 #[tokio::test]
 async fn remove_override() {
     for keyword in &["remove", "unset"] {
-        let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+        let cx = CliTestContext::new(Scenario::SimpleV2).await;
         let cwd = cx.config.current_dir();
         cx.config
-            .expect_ok(&["rustup", "override", "add", "nightly"])
-            .await;
+            .expect(["rustup", "override", "add", "nightly"])
+            .await
+            .is_ok();
         cx.config
-            .expect_ok_ex(
-                &["rustup", "override", keyword],
-                r"",
-                &format!("info: override toolchain for '{}' removed\n", cwd.display()),
-            )
-            .await;
+            .expect(["rustup", "override", keyword])
+            .await
+            .extend_redactions([("[CWD]", cwd.display().to_string())])
+            .is_ok()
+            .with_stdout(snapbox::str![[""]])
+            .with_stderr(snapbox::str![[r#"
+info: override toolchain for '[CWD]' removed
+
+"#]]);
     }
 }
 
 #[tokio::test]
 async fn remove_override_none() {
     for keyword in &["remove", "unset"] {
-        let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+        let cx = CliTestContext::new(Scenario::SimpleV2).await;
         let cwd = cx.config.current_dir();
         cx.config
-            .expect_ok_ex(
-                &["rustup", "override", keyword],
-                r"",
-                &format!(
-                    "info: no override toolchain for '{}'
-info: you may use `--path <path>` option to remove override toolchain for a specific path\n",
-                    cwd.display()
-                ),
-            )
-            .await;
+            .expect(["rustup", "override", keyword])
+            .await
+            .extend_redactions([("[CWD]", cwd.display().to_string())])
+            .is_ok()
+            .with_stdout(snapbox::str![[""]])
+            .with_stderr(snapbox::str![[r#"
+info: no override toolchain for '[CWD]'
+info: you may use `--path <path>` option to remove override toolchain for a specific path
+
+"#]]);
     }
 }
 
@@ -383,28 +390,29 @@ async fn remove_override_with_path() {
             .unwrap();
 
         {
-            let mut cx = cx.change_dir(dir.path());
+            let cx = cx.change_dir(dir.path());
             cx.config
-                .expect_ok(&["rustup", "override", "add", "nightly"])
-                .await;
+                .expect(["rustup", "override", "add", "nightly"])
+                .await
+                .is_ok();
         }
 
         cx.config
-            .expect_ok_ex(
-                &[
-                    "rustup",
-                    "override",
-                    keyword,
-                    "--path",
-                    dir.path().to_str().unwrap(),
-                ],
-                r"",
-                &format!(
-                    "info: override toolchain for '{}' removed\n",
-                    dir.path().display()
-                ),
-            )
-            .await;
+            .expect([
+                "rustup",
+                "override",
+                keyword,
+                "--path",
+                dir.path().to_str().unwrap(),
+            ])
+            .await
+            .extend_redactions([("[PATH]", dir.path().display().to_string())])
+            .is_ok()
+            .with_stdout(snapbox::str![[""]])
+            .with_stderr(snapbox::str![[r#"
+info: override toolchain for '[PATH]' removed
+
+"#]]);
     }
 }
 
@@ -418,28 +426,29 @@ async fn remove_override_with_path_deleted() {
                 .tempdir()
                 .unwrap();
             let path = std::fs::canonicalize(dir.path()).unwrap();
-            let mut cx = cx.change_dir(&path);
+            let cx = cx.change_dir(&path);
             cx.config
-                .expect_ok(&["rustup", "override", "add", "nightly"])
-                .await;
+                .expect(["rustup", "override", "add", "nightly"])
+                .await
+                .is_ok();
             path
         };
         cx.config
-            .expect_ok_ex(
-                &[
-                    "rustup",
-                    "override",
-                    keyword,
-                    "--path",
-                    path.to_str().unwrap(),
-                ],
-                r"",
-                &format!(
-                    "info: override toolchain for '{}' removed\n",
-                    path.display()
-                ),
-            )
-            .await;
+            .expect([
+                "rustup",
+                "override",
+                keyword,
+                "--path",
+                path.to_str().unwrap(),
+            ])
+            .await
+            .extend_redactions([("[PATH]", path.display().to_string())])
+            .is_ok()
+            .with_stdout(snapbox::str![[""]])
+            .with_stderr(snapbox::str![[r#"
+info: override toolchain for '[PATH]' removed
+
+"#]]);
     }
 }
 
@@ -454,31 +463,32 @@ async fn remove_override_nonexistent() {
                 .tempdir()
                 .unwrap();
             let path = std::fs::canonicalize(dir.path()).unwrap();
-            let mut cx = cx.change_dir(&path);
+            let cx = cx.change_dir(&path);
             cx.config
-                .expect_ok(&["rustup", "override", "add", "nightly"])
-                .await;
+                .expect(["rustup", "override", "add", "nightly"])
+                .await
+                .is_ok();
             path
         };
         // FIXME TempDir seems to succumb to difficulties removing dirs on windows
         let _ = rustup::utils::raw::remove_dir(&path);
         assert!(!path.exists());
         cx.config
-            .expect_ok_ex(
-                &["rustup", "override", keyword, "--nonexistent"],
-                r"",
-                &format!(
-                    "info: override toolchain for '{}' removed\n",
-                    path.display()
-                ),
-            )
-            .await;
+            .expect(["rustup", "override", keyword, "--nonexistent"])
+            .await
+            .extend_redactions([("[PATH]", path.display().to_string())])
+            .is_ok()
+            .with_stdout(snapbox::str![[""]])
+            .with_stderr(snapbox::str![[r#"
+info: override toolchain for '[PATH]' removed
+
+"#]]);
     }
 }
 
 #[tokio::test]
 async fn list_overrides() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let cwd = std::fs::canonicalize(cx.config.current_dir()).unwrap();
     let mut cwd_formatted = format!("{}", cwd.display());
 
@@ -486,37 +496,36 @@ async fn list_overrides() {
         cwd_formatted.drain(..4);
     }
 
-    let trip = this_host_triple();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "nightly"])
-        .await;
+        .expect(["rustup", "override", "add", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(
-            &["rustup", "override", "list"],
-            &format!(
-                "{:<40}\t{:<20}\n",
-                cwd_formatted,
-                &format!("nightly-{trip}")
-            ),
-            r"",
-        )
-        .await;
+        .expect(["rustup", "override", "list"])
+        .await
+        .extend_redactions([("[CWD]", cwd_formatted)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+[CWD]	nightly-[HOST_TRIPLE]
+
+"#]])
+        .with_stderr(snapbox::str![[""]]);
 }
 
 #[tokio::test]
 async fn list_overrides_with_nonexistent() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let trip = this_host_triple();
 
     let nonexistent_path = {
         let dir = tempfile::Builder::new()
             .prefix("rustup-test")
             .tempdir()
             .unwrap();
-        let mut cx = cx.change_dir(dir.path());
+        let cx = cx.change_dir(dir.path());
         cx.config
-            .expect_ok(&["rustup", "override", "add", "nightly"])
-            .await;
+            .expect(["rustup", "override", "add", "nightly"])
+            .await
+            .is_ok();
         std::fs::canonicalize(dir.path()).unwrap()
     };
     // FIXME TempDir seems to succumb to difficulties removing dirs on windows
@@ -529,33 +538,35 @@ async fn list_overrides_with_nonexistent() {
     }
 
     cx.config
-        .expect_ok_ex(
-            &["rustup", "override", "list"],
-            &format!(
-                "{:<40}\t{:<20}\n\n",
-                path_formatted + " (not a directory)",
-                &format!("nightly-{trip}")
-            ),
-            "info: you may remove overrides for non-existent directories with
-`rustup override unset --nonexistent`\n",
-        )
-        .await;
+        .expect(["rustup", "override", "list"])
+        .await
+        .extend_redactions([("[PATH]", path_formatted + " (not a directory)")])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+[PATH]	nightly-[HOST_TRIPLE]
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: you may remove overrides for non-existent directories with
+`rustup override unset --nonexistent`
+
+"#]]);
 }
 
 #[tokio::test]
 async fn update_no_manifest() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err_ex(
-            &["rustup", "update", "nightly-2016-01-01"],
-            r"",
-            for_host!(
-                r"info: syncing channel updates for 'nightly-2016-01-01-{0}'
+        .expect(["rustup", "update", "nightly-2016-01-01"])
+        .await
+        .is_err()
+        .with_stdout(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-2016-01-01-[HOST_TRIPLE]'
 error: no release found for 'nightly-2016-01-01'
-"
-            ),
-        )
-        .await;
+
+"#]]);
 }
 
 // Issue #111
@@ -565,11 +576,14 @@ async fn update_custom_toolchain() {
     // installable toolchains require 2 digits in the DD and MM fields, so this is
     // treated as a custom toolchain, which can't be used with update.
     cx.config
-        .expect_err(
-            &["rustup", "update", "nightly-2016-03-1"],
-            "invalid toolchain name: 'nightly-2016-03-1'",
-        )
-        .await;
+        .expect(["rustup", "update", "nightly-2016-03-1"])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+...
+error: [..]invalid toolchain name: 'nightly-2016-03-1'
+...
+"#]]);
 }
 
 #[tokio::test]
@@ -578,43 +592,52 @@ async fn default_custom_not_installed_toolchain() {
     // installable toolchains require 2 digits in the DD and MM fields, so this is
     // treated as a custom toolchain, which isn't installed.
     cx.config
-        .expect_err(
-            &["rustup", "default", "nightly-2016-03-1"],
-            "toolchain 'nightly-2016-03-1' is not installed",
-        )
-        .await;
+        .expect(["rustup", "default", "nightly-2016-03-1"])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'nightly-2016-03-1' is not installed
+
+"#]]);
 }
 
 #[tokio::test]
 async fn default_none() {
     let cx = CliTestContext::new(Scenario::None).await;
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "default", "none"],
-            "info: default toolchain unset",
-        )
-        .await;
+        .expect(["rustup", "default", "none"])
+        .await
+        .is_ok()
+        .with_stderr(snapbox::str![[r#"
+info: default toolchain unset
+
+"#]]);
 
     cx.config
-        .expect_err_ex(
-            &["rustup", "default"],
-            "",
-            "error: no default toolchain is configured\n",
-        )
-        .await;
+        .expect(["rustup", "default"])
+        .await
+        .is_err()
+        .with_stdout(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+error: no default toolchain is configured
 
-    cx.config.expect_err_ex(
-            &["rustc", "--version"],
-            "",
-            "error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
+"#]]);
+
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .is_err()
+        .with_stdout(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+error: rustup could not choose a version of rustc to run, because one wasn't specified explicitly, and no default is configured.
 help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
-",
-        ).await;
+
+"#]]);
 }
 
 #[tokio::test]
 async fn list_targets() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let trip = this_host_triple();
     let mut sorted = [
         format!("{} (installed)", &*trip),
@@ -625,70 +648,100 @@ async fn list_targets() {
 
     let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok(&["rustup", "target", "add", CROSS_ARCH1])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(&["rustup", "target", "list"], &expected, r"")
-        .await;
+        .expect(["rustup", "target", "add", CROSS_ARCH1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "target", "list"])
+        .await
+        .extend_redactions([("[EXPECTED]", expected)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+[EXPECTED]"#]])
+        .with_stderr(snapbox::str![[""]]);
 }
 
 #[tokio::test]
 async fn list_targets_quiet() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let trip = this_host_triple();
     let mut sorted = [trip, CROSS_ARCH1.to_string(), CROSS_ARCH2.to_string()];
     sorted.sort();
 
     let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok(&["rustup", "target", "add", CROSS_ARCH1])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(&["rustup", "target", "list", "--quiet"], &expected, r"")
-        .await;
+        .expect(["rustup", "target", "add", CROSS_ARCH1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "target", "list", "--quiet"])
+        .await
+        .extend_redactions([("[EXPECTED]", expected)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+[EXPECTED]"#]])
+        .with_stderr(snapbox::str![[""]]);
 }
 
 #[tokio::test]
 async fn list_installed_targets() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let trip = this_host_triple();
     let mut sorted = [trip, CROSS_ARCH1.to_string(), CROSS_ARCH2.to_string()];
     sorted.sort();
 
     let expected = format!("{}\n{}\n{}\n", sorted[0], sorted[1], sorted[2]);
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok(&["rustup", "target", "add", CROSS_ARCH1])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "target", "add", CROSS_ARCH2])
-        .await;
+        .expect(["rustup", "target", "add", CROSS_ARCH1])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_ex(&["rustup", "target", "list", "--installed"], &expected, r"")
-        .await;
+        .expect(["rustup", "target", "add", CROSS_ARCH2])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "target", "list", "--installed"])
+        .await
+        .extend_redactions([("[EXPECTED]", expected)])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+[EXPECTED]"#]])
+        .with_stderr(snapbox::str![[""]]);
 }
 
 #[tokio::test]
 async fn cross_install_indicates_target() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     // TODO error 'nightly-x86_64-apple-darwin' is not installed
     cx.config
-        .expect_ok_ex(
-            &["rustup", "target", "add", CROSS_ARCH1],
-            r"",
-            &format!(
-                r"info: downloading component 'rust-std' for '{CROSS_ARCH1}'
-info: installing component 'rust-std' for '{CROSS_ARCH1}'
-"
-            ),
-        )
-        .await;
+        .expect(["rustup", "target", "add", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+info: downloading component 'rust-std' for '[CROSS_ARCH_I]'
+info: installing component 'rust-std' for '[CROSS_ARCH_I]'
+
+"#]]);
 }
 
 // issue #3573
@@ -696,16 +749,14 @@ info: installing component 'rust-std' for '{CROSS_ARCH1}'
 async fn show_suggestion_for_missing_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err_env(
-            &["cargo", "+nightly", "fmt"],
-            &[("RUSTUP_AUTO_INSTALL", "0")],
-            for_host!(
-                r"error: toolchain 'nightly-{0}' is not installed
-help: run `rustup toolchain install nightly-{0}` to install it
-"
-            ),
-        )
-        .await;
+        .expect_with_env(["cargo", "+nightly", "fmt"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'nightly-[HOST_TRIPLE]' is not installed
+help: run `rustup toolchain install nightly-[HOST_TRIPLE]` to install it
+
+"#]]);
 }
 
 // issue #4212
@@ -725,16 +776,14 @@ components = [ "rust-src" ]
     )
     .unwrap();
     cx.config
-        .expect_err_env(
-            &["cargo", "fmt"],
-            &[("RUSTUP_AUTO_INSTALL", "0")],
-            for_host!(
-                r"error: toolchain 'stable-{0}' is not installed
+        .expect_with_env(["cargo", "fmt"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'stable-[HOST_TRIPLE]' is not installed
 help: run `rustup toolchain install` to install it
-"
-            ),
-        )
-        .await;
+
+"#]]);
 }
 
 // issue #927
@@ -742,82 +791,84 @@ help: run `rustup toolchain install` to install it
 async fn undefined_linked_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err_ex(
-            &["cargo", "+bogus", "test"],
-            r"",
-            "error: toolchain 'bogus' is not installed\n",
-        )
-        .await;
+        .expect(["cargo", "+bogus", "test"])
+        .await
+        .is_err()
+        .with_stdout(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'bogus' is not installed
+
+"#]]);
 }
 
 #[tokio::test]
 async fn install_by_version_number() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2TwoVersions).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2TwoVersions).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "add", "0.100.99"])
-        .await;
+        .expect(["rustup", "toolchain", "add", "0.100.99"])
+        .await
+        .is_ok();
 }
 
 // issue #2191
 #[tokio::test]
 async fn install_unreleased_component() {
-    let mut cx = CliTestContext::new(Scenario::MissingComponentMulti).await;
+    let cx = CliTestContext::new(Scenario::MissingComponentMulti).await;
     // Initial channel content is host + rls + multiarch-std
     cx.config.set_current_dist_date("2019-09-12");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "target", "add", MULTI_ARCH1])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "target", "add", MULTI_ARCH1])
+        .await
+        .is_ok();
 
     // Next channel variant should have host + rls but not multiarch-std
     cx.config.set_current_dist_date("2019-09-13");
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{} unchanged - 1.37.0 (hash-nightly-1)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            &format!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] unchanged - 1.37.0 (hash-nightly-1)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2019-09-13, rust version 1.37.0 (hash-nightly-2)
-info: skipping nightly which is missing installed component 'rust-std-{1}'
-info: syncing channel updates for 'nightly-2019-09-12-{0}'
-",
-                this_host_triple(),
-                MULTI_ARCH1
-            ),
-        )
-        .await;
+info: skipping nightly which is missing installed component 'rust-std-[MULTI_ARCH_I]'
+info: syncing channel updates for 'nightly-2019-09-12-[HOST_TRIPLE]'
+
+"#]]);
 
     // Next channel variant should have host + multiarch-std but have rls missing
     cx.config.set_current_dist_date("2019-09-14");
     cx.config
-        .expect_ok_ex(
-            &["rustup", "update", "nightly"],
-            for_host!(
-                r"
-  nightly-{} unchanged - 1.37.0 (hash-nightly-1)
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
 
-"
-            ),
-            &format!(
-                r"info: syncing channel updates for 'nightly-{0}'
+  nightly-[HOST_TRIPLE] unchanged - 1.37.0 (hash-nightly-1)
+
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2019-09-14, rust version 1.37.0 (hash-nightly-3)
 info: skipping nightly which is missing installed component 'rls'
-info: syncing channel updates for 'nightly-2019-09-13-{0}'
+info: syncing channel updates for 'nightly-2019-09-13-[HOST_TRIPLE]'
 info: latest update on 2019-09-13, rust version 1.37.0 (hash-nightly-2)
-info: skipping nightly which is missing installed component 'rust-std-{1}'
-info: syncing channel updates for 'nightly-2019-09-12-{0}'
-",
-                this_host_triple(),
-                MULTI_ARCH1,
-            ),
-        )
-        .await;
+info: skipping nightly which is missing installed component 'rust-std-[MULTI_ARCH_I]'
+info: syncing channel updates for 'nightly-2019-09-12-[HOST_TRIPLE]'
+
+"#]]);
 }


### PR DESCRIPTION
Part of #4359.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4352/commits)