### PR TITLE
test(cli-inst-interactive): migrate to `.expect()` APIs

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -28,8 +28,8 @@ pub use crate::cli::self_update::{RegistryGuard, RegistryValueId, USER_PATH, get
 
 mod clitools;
 pub use clitools::{
-    CliTestContext, Config, SanitizedOutput, Scenario, SelfUpdateTestContext, output_release_file,
-    print_command, print_indented,
+    Assert, CliTestContext, Config, SanitizedOutput, Scenario, SelfUpdateTestContext,
+    output_release_file, print_command, print_indented,
 };
 pub(crate) mod dist;
 pub(crate) mod mock;

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -1,27 +1,19 @@
 //! Tests of the interactive console installer
 
-#![allow(deprecated)]
-
 use std::env::consts::EXE_SUFFIX;
 use std::io::Write;
 use std::process::Stdio;
 
-use rustup::for_host;
-use rustup::test::{CliTestContext, Config, SanitizedOutput, Scenario, this_host_triple};
+use rustup::test::{Assert, CliTestContext, Config, SanitizedOutput, Scenario, this_host_triple};
 #[cfg(windows)]
 use rustup::test::{RegistryGuard, USER_PATH};
 use rustup::utils::raw;
 
-fn run_input(config: &Config, args: &[&str], input: &str) -> SanitizedOutput {
+fn run_input(config: &Config, args: &[&str], input: &str) -> Assert {
     run_input_with_env(config, args, input, &[])
 }
 
-fn run_input_with_env(
-    config: &Config,
-    args: &[&str],
-    input: &str,
-    env: &[(&str, &str)],
-) -> SanitizedOutput {
+fn run_input_with_env(config: &Config, args: &[&str], input: &str, env: &[(&str, &str)]) -> Assert {
     let mut cmd = config.cmd(args[0], &args[1..]);
     config.env(&mut cmd);
 
@@ -42,11 +34,11 @@ fn run_input_with_env(
         .unwrap();
     let out = child.wait_with_output().unwrap();
 
-    SanitizedOutput {
+    Assert::new(SanitizedOutput {
         ok: out.status.success(),
         stdout: String::from_utf8(out.stdout).unwrap(),
         stderr: String::from_utf8(out.stderr).unwrap(),
-    }
+    })
 }
 
 #[tokio::test]
@@ -56,8 +48,7 @@ async fn update() {
     let _path_guard = RegistryGuard::new(&USER_PATH).unwrap();
 
     run_input(&cx.config, &["rustup-init"], "\n\n");
-    let out = run_input(&cx.config, &["rustup-init"], "\n\n");
-    assert!(out.ok, "stdout:\n{}\nstderr:\n{}", out.stdout, out.stderr);
+    run_input(&cx.config, &["rustup-init"], "\n\n").is_ok();
 }
 
 // Testing that the right number of blank lines are printed after the
@@ -66,16 +57,14 @@ async fn update() {
 #[tokio::test]
 async fn smoke_case_install_no_modify_path() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "\n\n");
-    assert!(out.ok);
     // During an interactive session, after "Press the Enter
     // key..."  the UI emits a blank line, then there is a blank
     // line that comes from the user pressing enter, then log
     // output on stderr, then an explicit blank line on stdout
     // before printing $toolchain installed
-    assert!(
-        out.stdout.contains(for_host!(
-            r"
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "\n\n")
+        .with_stdout(snapbox::str![[r#"
+...
 This path needs to be in your PATH environment variable,
 but will not be added automatically.
 
@@ -85,7 +74,7 @@ these changes will be reverted.
 Current installation options:
 
 
-   default host triple: {0}
+   default host triple: [HOST_TRIPLE]
      default toolchain: stable (default)
                profile: default
   modify PATH variable: no
@@ -95,16 +84,13 @@ Current installation options:
 3) Cancel installation
 >
 
-  stable-{0} installed - 1.1.0 (hash-stable-1.1.0)
+  stable-[HOST_TRIPLE] installed - 1.1.0 (hash-stable-1.1.0)
 
 
 Rust is installed now. Great!
-
-"
-        )),
-        "pattern not found in \"\"\"{}\"\"\"",
-        out.stdout
-    );
+...
+"#]])
+        .is_ok();
     if cfg!(unix) {
         assert!(!cx.config.homedir.join(".profile").exists());
         assert!(cx.config.cargodir.join("env").exists());
@@ -117,21 +103,19 @@ async fn smoke_case_install_with_path_install() {
     #[cfg(windows)]
     let _path_guard = RegistryGuard::new(&USER_PATH).unwrap();
 
-    let out = run_input(&cx.config, &["rustup-init"], "\n\n");
-    assert!(out.ok);
-    assert!(
-        !out.stdout
-            .contains("This path needs to be in your PATH environment variable")
-    );
+    run_input(&cx.config, &["rustup-init"], "\n\n")
+        .is_ok()
+        .without_stdout("This path needs to be in your PATH environment variable");
 }
 
 #[tokio::test]
 async fn blank_lines_around_stderr_log_output_update() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup-init", "-y", "--no-modify-path"])
-        .await;
-    let out = run_input(
+        .expect(["rustup-init", "-y", "--no-modify-path"])
+        .await
+        .is_ok();
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -139,53 +123,46 @@ async fn blank_lines_around_stderr_log_output_update() {
             "--no-modify-path",
         ],
         "\n\n",
-    );
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-
-    assert!(out.stdout.contains(
-        r"
+    )
+    .with_stdout(snapbox::str![[r#"
+...
 3) Cancel installation
 >
 
 
 Rust is installed now. Great!
-"
-    ));
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn installer_shows_default_host_triple() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n");
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(for_host!(
-        r"
-Default host triple? [{0}]
-"
-    )));
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n").with_stdout(snapbox::str![
+        [r#"
+...
+Default host triple? [[HOST_TRIPLE]]
+...
+"#]
+    ]);
 }
 
 #[tokio::test]
 async fn installer_shows_default_toolchain_as_stable() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n\n");
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n\n").with_stdout(
+        snapbox::str![[r#"
+...
 Default toolchain? (stable/beta/nightly/none) [stable]
-"
-    ));
+...
+"#]],
+    );
 }
 
 #[tokio::test]
 async fn installer_shows_default_toolchain_when_set_in_args() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -193,93 +170,77 @@ async fn installer_shows_default_toolchain_when_set_in_args() {
             "--default-toolchain=nightly",
         ],
         "2\n\n",
-    );
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    )
+    .with_stdout(snapbox::str![[r#"
+...
 Default toolchain? (stable/beta/nightly/none) [nightly]
-"
-    ));
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn installer_shows_default_profile() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n\n\n");
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "2\n\n\n").with_stdout(
+        snapbox::str![[r#"
+...
 Profile (which tools and data to install)? (minimal/default/complete) [default]
-"
-    ));
+...
+"#]],
+    );
 }
 
 #[tokio::test]
 async fn installer_shows_default_profile_when_set_in_args() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path", "--profile=minimal"],
         "2\n\n\n",
-    );
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    )
+    .with_stdout(snapbox::str![[r#"
+...
 Profile (which tools and data to install)? (minimal/default/complete) [minimal]
-"
-    ));
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn installer_shows_default_for_modify_path() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init"], "2\n\n\n\n");
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    run_input(&cx.config, &["rustup-init"], "2\n\n\n\n").with_stdout(snapbox::str![[r#"
+...
 Modify PATH variable? (Y/n)
-"
-    ));
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn installer_shows_default_for_modify_path_when_set_with_args() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path"],
         "2\n\n\n\n",
-    );
-
-    println!("-- stdout --\n {}", out.stdout);
-    println!("-- stderr --\n {}", out.stderr);
-    assert!(out.stdout.contains(
-        r"
+    )
+    .with_stdout(snapbox::str![[r#"
+...
 Modify PATH variable? (y/N)
-"
-    ));
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn user_says_nope() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "n\n\n");
-    assert!(out.ok);
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "n\n\n").is_ok();
     assert!(!cx.config.cargodir.join("bin").exists());
 }
 
 #[tokio::test]
 async fn with_no_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -287,18 +248,24 @@ async fn with_no_toolchain() {
             "--default-toolchain=none",
         ],
         "\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustup", "show"], "no active toolchain")
-        .await;
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+no active toolchain
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn with_non_default_toolchain_still_prompts() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -306,18 +273,26 @@ async fn with_non_default_toolchain_still_prompts() {
             "--default-toolchain=nightly",
         ],
         "\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustup", "show"], "nightly")
-        .await;
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+installed toolchains
+--------------------
+nightly-[HOST_TRIPLE] (active, default)
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn with_non_release_channel_non_default_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -325,41 +300,54 @@ async fn with_non_release_channel_non_default_toolchain() {
             "--default-toolchain=nightly-2015-01-02",
         ],
         "\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustup", "show"], "nightly")
-        .await;
-    cx.config
-        .expect_stdout_ok(&["rustup", "show"], "2015-01-02")
-        .await;
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+installed toolchains
+--------------------
+nightly-2015-01-02-[HOST_TRIPLE] (active, default)
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn set_nightly_toolchain() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path"],
         "2\n\nnightly\n\n\n\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustup", "show"], "nightly")
-        .await;
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+installed toolchains
+--------------------
+nightly-[HOST_TRIPLE] (active, default)
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn set_no_modify_path() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path"],
         "2\n\n\n\nno\n\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
 
     if cfg!(unix) {
         assert!(!cx.config.homedir.join(".profile").exists());
@@ -369,29 +357,35 @@ async fn set_no_modify_path() {
 #[tokio::test]
 async fn set_nightly_toolchain_and_unset() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path"],
         "2\n\nnightly\n\n\n2\n\nbeta\n\n\n\n\n",
-    );
-    println!("{:?}", out.stderr);
-    println!("{:?}", out.stdout);
-    assert!(out.ok);
+    )
+    .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustup", "show"], "beta")
-        .await;
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+installed toolchains
+--------------------
+beta-[HOST_TRIPLE] (active, default)
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn user_says_nope_after_advanced_install() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = run_input(
+    run_input(
         &cx.config,
         &["rustup-init", "--no-modify-path"],
         "2\n\n\n\n\nn\n\n\n",
-    );
-    assert!(out.ok);
+    )
+    .is_ok();
     assert!(!cx.config.cargodir.join("bin").exists());
 }
 
@@ -401,17 +395,26 @@ async fn install_with_components() {
         let mut args = vec!["rustup-init", "-y", "--no-modify-path"];
         args.extend_from_slice(comp_args);
 
-        let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-        cx.config.expect_ok(&args).await;
+        let cx = CliTestContext::new(Scenario::SimpleV2).await;
+        cx.config.expect(&args).await.is_ok();
         cx.config
-            .expect_stdout_ok(&["rustup", "component", "list"], "rust-src (installed)")
-            .await;
+            .expect(["rustup", "component", "list"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+...
+rust-src (installed)
+...
+"#]])
+            .is_ok();
         cx.config
-            .expect_stdout_ok(
-                &["rustup", "component", "list"],
-                &format!("rust-analysis-{} (installed)", this_host_triple()),
-            )
-            .await;
+            .expect(["rustup", "component", "list"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+...
+rust-analysis-[HOST_TRIPLE] (installed)
+...
+"#]])
+            .is_ok();
     }
 
     go(&["-c", "rust-src", "-c", "rust-analysis"]).await;
@@ -423,7 +426,7 @@ async fn install_forces_and_skips_rls() {
     let cx = CliTestContext::new(Scenario::UnavailableRls).await;
     cx.config.set_current_dist_date("2015-01-01");
 
-    let out = run_input(
+    run_input(
         &cx.config,
         &[
             "rustup-init",
@@ -434,43 +437,49 @@ async fn install_forces_and_skips_rls() {
             "--no-modify-path",
         ],
         "\n\n",
-    );
-    assert!(out.ok);
-    assert!(
-        out.stderr
-            .contains("warn: Force-skipping unavailable component")
-    );
+    )
+    .is_ok()
+    .with_stderr(snapbox::str![[r#"
+...
+warn: Force-skipping unavailable component 'rls-[HOST_TRIPLE]'
+...
+"#]]);
 }
 
 #[tokio::test]
 async fn test_warn_if_complete_profile_is_used() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_stderr_ok(
-            &[
-                "rustup-init",
-                "-y",
-                "--profile",
-                "complete",
-                "--no-modify-path",
-            ],
-            "warn: downloading with complete profile",
-        )
-        .await;
+        .expect([
+            "rustup-init",
+            "-y",
+            "--profile",
+            "complete",
+            "--no-modify-path",
+        ])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+warn: downloading with complete profile isn't recommended unless you are a developer of the rust language
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn installing_when_already_installed_updates_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup-init", "-y", "--no-modify-path"])
-        .await;
-    let out = run_input(&cx.config, &["rustup-init", "--no-modify-path"], "\n\n");
-    println!("stdout:\n{}\n...\n", out.stdout);
-    assert!(
-        out.stdout
-            .contains(for_host!("stable-{} unchanged - 1.1.0 (hash-stable-1.1.0)"))
-    );
+        .expect(["rustup-init", "-y", "--no-modify-path"])
+        .await
+        .is_ok();
+    run_input(&cx.config, &["rustup-init", "--no-modify-path"], "\n\n").with_stdout(snapbox::str![
+        [r#"
+...
+[..]stable-[HOST_TRIPLE] unchanged - 1.1.0 (hash-stable-1.1.0)
+...
+"#]
+    ]);
 }
 
 #[tokio::test]
@@ -485,26 +494,23 @@ async fn install_stops_if_rustc_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = cx
-        .config
-        .run(
-            "rustup-init",
-            ["--no-modify-path"],
-            &[
+    cx.config
+        .expect_with_env(
+            ["rustup-init", "--no-modify-path"],
+            [
                 ("RUSTUP_INIT_SKIP_PATH_CHECK", "no"),
                 ("PATH", temp_dir_path),
             ],
         )
-        .await;
-    assert!(!out.ok);
-    assert!(
-        out.stderr
-            .contains("It looks like you have an existing installation of Rust at:")
-    );
-    assert!(
-        out.stderr
-            .contains("If you are sure that you want both rustup and your already installed Rust")
-    );
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+...
+warn: It looks like you have an existing installation of Rust at:
+...
+warn: If you are sure that you want both rustup and your already installed Rust
+...
+"#]]);
 }
 
 #[tokio::test]
@@ -519,26 +525,23 @@ async fn install_stops_if_cargo_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = cx
-        .config
-        .run(
-            "rustup-init",
-            ["--no-modify-path"],
-            &[
+    cx.config
+        .expect_with_env(
+            ["rustup-init", "--no-modify-path"],
+            [
                 ("RUSTUP_INIT_SKIP_PATH_CHECK", "no"),
                 ("PATH", temp_dir_path),
             ],
         )
-        .await;
-    assert!(!out.ok);
-    assert!(
-        out.stderr
-            .contains("It looks like you have an existing installation of Rust at:")
-    );
-    assert!(
-        out.stderr
-            .contains("If you are sure that you want both rustup and your already installed Rust")
-    );
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+...
+warn: It looks like you have an existing installation of Rust at:
+...
+warn: If you are sure that you want both rustup and your already installed Rust
+...
+"#]]);
 }
 
 #[tokio::test]
@@ -553,18 +556,16 @@ async fn with_no_prompt_install_succeeds_if_rustc_exists() {
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = cx
-        .config
-        .run(
-            "rustup-init",
-            ["-y", "--no-modify-path"],
-            &[
+    cx.config
+        .expect_with_env(
+            ["rustup-init", "-y", "--no-modify-path"],
+            [
                 ("RUSTUP_INIT_SKIP_PATH_CHECK", "no"),
                 ("PATH", temp_dir_path),
             ],
         )
-        .await;
-    assert!(out.ok);
+        .await
+        .is_ok();
 }
 
 // Issue 2547
@@ -572,17 +573,20 @@ async fn with_no_prompt_install_succeeds_if_rustc_exists() {
 async fn install_non_installable_toolchain() {
     let cx = CliTestContext::new(Scenario::Unavailable).await;
     cx.config
-        .expect_err(
-            &[
-                "rustup-init",
-                "-y",
-                "--no-modify-path",
-                "--default-toolchain",
-                "nightly",
-            ],
-            "is not installable",
-        )
-        .await;
+        .expect([
+            "rustup-init",
+            "-y",
+            "--no-modify-path",
+            "--default-toolchain",
+            "nightly",
+        ])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: toolchain 'nightly-[HOST_TRIPLE]' is not installable
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
@@ -595,30 +599,30 @@ async fn install_warns_about_existing_settings_file() {
     let settings_file = temp_dir.path().join("settings.toml");
     raw::write_file(
         &settings_file,
-        for_host!(
+        &format!(
             r#"default_toolchain = "{}"
 profile = "default"
-version = "12""#
+version = "12""#,
+            this_host_triple()
         ),
     )
     .unwrap();
     let temp_dir_path = temp_dir.path().to_str().unwrap();
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let out = cx
-        .config
-        .run(
-            "rustup-init",
-            ["-y", "--no-modify-path"],
-            &[
+    cx.config
+        .expect_with_env(
+            ["rustup-init", "-y", "--no-modify-path"],
+            [
                 ("RUSTUP_INIT_SKIP_PATH_CHECK", "no"),
                 ("RUSTUP_HOME", temp_dir_path),
             ],
         )
-        .await;
-    assert!(out.ok);
-    assert!(
-        out.stderr
-            .contains("It looks like you have an existing rustup settings file at:")
-    );
+        .await
+        .is_ok()
+        .with_stderr(snapbox::str![[r#"
+...
+warn: It looks like you have an existing rustup settings file at:
+...
+"#]]);
 }


### PR DESCRIPTION
Part of #4359.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4353/commits)