### PR TITLE
test(cli-misc): migrate to `.expect()` APIs

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -339,13 +339,19 @@ impl<'a> Toolchain<'a> {
         if let "cargo" | "cargo.exe" = binary {
             if let Some(cmd) = self.maybe_do_cargo_fallback()? {
                 info!("`cargo` is unavailable for the active toolchain");
-                info!("falling back to {:?}", cmd.get_program());
+                info!(
+                    r#"falling back to "{}""#,
+                    Path::new(cmd.get_program()).display()
+                );
                 return Ok(cmd);
             }
         } else if let "rust-analyzer" | "rust-analyzer.exe" = binary {
             if let Some(cmd) = self.maybe_do_rust_analyzer_fallback(binary)? {
                 info!("`rust-analyzer` is unavailable for the active toolchain");
-                info!("falling back to {:?}", cmd.get_program());
+                info!(
+                    r#"falling back to "{}""#,
+                    Path::new(cmd.get_program()).display()
+                );
                 return Ok(cmd);
             }
         }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1,13 +1,10 @@
 //! Test cases of the rustup command that do not depend on the
 //! dist server, mostly derived from multirust/test-v2.sh
 
-#![allow(deprecated)]
-
 use std::fs;
 use std::str;
 use std::{env::consts::EXE_SUFFIX, path::Path};
 
-use rustup::for_host;
 use rustup::test::{
     CliTestContext, Config, MULTI_ARCH1, Scenario, print_command, print_indented, this_host_triple,
 };
@@ -16,31 +13,38 @@ use rustup::utils::raw::symlink_dir;
 
 #[tokio::test]
 async fn smoke_test() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "--version"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config.expect(["rustup", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn version_mentions_rustc_version_confusion() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
 
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "--version"],
-            "This is the version for the rustup toolchain manager",
-        )
-        .await;
+        .expect(["rustup", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: This is the version for the rustup toolchain manager, not the rustc compiler.
+...
+"#]])
+        .is_ok();
 
     cx.config
-        .expect_ok(&["rustup", "toolchain", "install", "nightly"])
-        .await;
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .is_ok();
 
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "+nightly", "--version"],
-            "The currently active `rustc` version is `1.3.0",
-        )
-        .await;
+        .expect(["rustup", "+nightly", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: The currently active `rustc` version is `1.3.0 (hash-nightly-2)`
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
@@ -68,46 +72,64 @@ async fn rustc_with_bad_rustup_toolchain_env_var() {
 async fn custom_invalid_names() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "nightly", "foo"],
-            "invalid custom toolchain name 'nightly'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "nightly", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'nightly'
+...
+"#]])
+        .is_err();
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "beta", "foo"],
-            "invalid custom toolchain name 'beta'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "beta", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'beta'
+...
+"#]])
+        .is_err();
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "stable", "foo"],
-            "invalid custom toolchain name 'stable'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "stable", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'stable'
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn custom_invalid_names_with_archive_dates() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "nightly-2015-01-01", "foo"],
-            "invalid custom toolchain name 'nightly-2015-01-01'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "nightly-2015-01-01", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'nightly-2015-01-01'
+...
+"#]])
+        .is_err();
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "beta-2015-01-01", "foo"],
-            "invalid custom toolchain name 'beta-2015-01-01'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "beta-2015-01-01", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'beta-2015-01-01'
+...
+"#]])
+        .is_err();
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "link", "stable-2015-01-01", "foo"],
-            "invalid custom toolchain name 'stable-2015-01-01'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "link", "stable-2015-01-01", "foo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error:[..] invalid custom toolchain name 'stable-2015-01-01'
+...
+"#]])
+        .is_err();
 }
 
 // Regression test for newline placement
@@ -207,109 +229,165 @@ async fn multi_host_smoke_test() {
     // to be sure.
     assert_ne!(this_host_triple(), MULTI_ARCH1);
 
-    let mut cx = CliTestContext::new(Scenario::MultiHost).await;
+    let cx = CliTestContext::new(Scenario::MultiHost).await;
     let toolchain = format!("nightly-{MULTI_ARCH1}");
     cx.config
-        .expect_ok(&["rustup", "default", &toolchain, "--force-non-host"])
-        .await;
+        .expect(["rustup", "default", &toolchain, "--force-non-host"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "xxxx-nightly-2")
-        .await; // cross-host mocks have their own versions
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (xxxx-nightly-2)
+
+"#]])
+        .is_ok(); // cross-host mocks have their own versions
 }
 
 #[tokio::test]
 async fn custom_toolchain_cargo_fallback_proxy() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let path = cx.config.customdir.join("custom-1");
 
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "link",
             "mytoolchain",
             &path.to_string_lossy(),
         ])
-        .await;
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "mytoolchain"])
-        .await;
+        .expect(["rustup", "default", "mytoolchain"])
+        .await
+        .is_ok();
 
-    cx.config.expect_ok(&["rustup", "update", "stable"]).await;
     cx.config
-        .expect_stdout_ok(&["cargo", "--version"], "hash-stable-1.1.0")
-        .await;
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
 
-    cx.config.expect_ok(&["rustup", "update", "beta"]).await;
-    cx.config
-        .expect_stdout_ok(&["cargo", "--version"], "hash-beta-1.2.0")
-        .await;
+"#]])
+        .is_ok();
 
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    cx.config.expect(["rustup", "update", "beta"]).await.is_ok();
     cx.config
-        .expect_stdout_ok(&["cargo", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn custom_toolchain_cargo_fallback_run() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let path = cx.config.customdir.join("custom-1");
 
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "link",
             "mytoolchain",
             &path.to_string_lossy(),
         ])
-        .await;
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "mytoolchain"])
-        .await;
+        .expect(["rustup", "default", "mytoolchain"])
+        .await
+        .is_ok();
 
-    cx.config.expect_ok(&["rustup", "update", "stable"]).await;
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-stable-1.1.0",
-        )
-        .await;
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "run", "mytoolchain", "cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
 
-    cx.config.expect_ok(&["rustup", "update", "beta"]).await;
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-beta-1.2.0",
-        )
-        .await;
+"#]])
+        .is_ok();
 
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    cx.config.expect(["rustup", "update", "beta"]).await.is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "run", "mytoolchain", "cargo", "--version"],
-            "hash-nightly-2",
-        )
-        .await;
+        .expect(["rustup", "run", "mytoolchain", "cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "run", "mytoolchain", "cargo", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn rustup_run_searches_path() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     #[cfg(windows)]
     let hello_cmd = &["rustup", "run", "nightly", "cmd", "/C", "echo hello"];
     #[cfg(not(windows))]
     let hello_cmd = &["rustup", "run", "nightly", "sh", "-c", "echo hello"];
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config.expect_stdout_ok(hello_cmd, "hello").await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(hello_cmd)
+        .await
+        .with_stdout(snapbox::str![[r#"
+hello
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn rustup_doesnt_prepend_path_unnecessarily() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     async fn expect_stderr_ok_env_first_then(
         config: &Config,
@@ -369,7 +447,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
     .await;
 
     // Check that CARGO_HOME/bin is prepended to path.
-    let config = &mut cx.config;
+    let config = &cx.config;
     expect_stderr_ok_env_first_then(
         config,
         &["cargo", "--echo-path"],
@@ -399,7 +477,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
 
 #[tokio::test]
 async fn rustup_failed_path_search() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     use std::env::consts::EXE_SUFFIX;
 
     let rustup_path = cx.config.exedir.join(format!("rustup{EXE_SUFFIX}"));
@@ -407,34 +485,38 @@ async fn rustup_failed_path_search() {
     utils::hardlink_file(&rustup_path, &tool_path).expect("Failed to create fake proxy for test");
 
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "link",
             "custom",
             &cx.config.customdir.join("custom-1").to_string_lossy(),
         ])
-        .await;
+        .await
+        .is_ok();
 
-    cx.config.expect_ok(&["rustup", "default", "custom"]).await;
+    cx.config
+        .expect(["rustup", "default", "custom"])
+        .await
+        .is_ok();
 
     let broken = &["rustup", "run", "custom", "fake_proxy"];
     cx.config
-        .expect_err(
-            broken,
-            "unknown proxy name: 'fake_proxy'; valid proxy names are \
-             'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', \
-             'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', \
-             'rust-analyzer', 'rustfmt', 'cargo-fmt'",
-        )
-        .await;
+        .expect(broken)
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: unknown proxy name: 'fake_proxy'; valid proxy names are 'rustc', 'rustdoc', 'cargo', 'rust-lldb', 'rust-gdb', 'rust-gdbgui', 'rls', 'cargo-clippy', 'clippy-driver', 'cargo-miri', 'rust-analyzer', 'rustfmt', 'cargo-fmt'
+...
+"#]])
+        .is_err();
 
     // Hardlink will be automatically cleaned up by test setup code
 }
 
 #[tokio::test]
 async fn rustup_failed_path_search_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     use std::env::consts::EXE_SUFFIX;
 
     let rustup_path = cx.config.exedir.join(format!("rustup{EXE_SUFFIX}"));
@@ -443,237 +525,312 @@ async fn rustup_failed_path_search_toolchain() {
         .expect("Failed to create fake cargo-miri for test");
 
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "link",
             "custom-1",
             &cx.config.customdir.join("custom-1").to_string_lossy(),
         ])
-        .await;
+        .await
+        .is_ok();
 
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "link",
             "custom-2",
             &cx.config.customdir.join("custom-2").to_string_lossy(),
         ])
-        .await;
+        .await
+        .is_ok();
 
     cx.config
-        .expect_ok(&["rustup", "default", "custom-2"])
-        .await;
+        .expect(["rustup", "default", "custom-2"])
+        .await
+        .is_ok();
 
     let broken = &["rustup", "run", "custom-1", "cargo-miri"];
     cx.config
-        .expect_err(broken, "cannot use `rustup component add`")
-        .await;
+        .expect(broken)
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+note: this is a custom toolchain, which cannot use `rustup component add`
+help: if you built this toolchain from source, and used `rustup toolchain link`, then you may be able to build the component with `x.py`
+...
+"#]])
+        .is_err();
 
     let broken = &["rustup", "run", "custom-2", "cargo-miri"];
     cx.config
-        .expect_err(broken, "cannot use `rustup component add`")
-        .await;
+        .expect(broken)
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+note: this is a custom toolchain, which cannot use `rustup component add`
+help: if you built this toolchain from source, and used `rustup toolchain link`, then you may be able to build the component with `x.py`
+...
+"#]])
+        .is_err();
 
     // Hardlink will be automatically cleaned up by test setup code
 }
 
 #[tokio::test]
 async fn rustup_run_not_installed() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "install", "stable"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "run", "nightly", "rustc", "--version"],
-            for_host!("toolchain 'nightly-{0}' is not installed"),
-        )
-        .await;
+        .expect(["rustup", "install", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "run", "nightly", "rustc", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'nightly-[HOST_TRIPLE]' is not installed
+help: run `rustup toolchain install nightly-[HOST_TRIPLE]` to install it
+
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn rustup_run_install() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "install", "stable"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_stderr_ok(
-            &[
-                "rustup",
-                "run",
-                "--install",
-                "nightly",
-                "cargo",
-                "--version",
-            ],
-            "info: installing component 'rustc'",
-        )
-        .await;
+        .expect(["rustup", "install", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect([
+            "rustup",
+            "run",
+            "--install",
+            "nightly",
+            "cargo",
+            "--version",
+        ])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: installing component 'rustc'
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn toolchains_are_resolved_early() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     let full_toolchain = format!("nightly-{}", this_host_triple());
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "default", &full_toolchain],
-            &format!("info: using existing install for '{full_toolchain}'"),
-        )
-        .await;
+        .expect(["rustup", "default", &full_toolchain])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: using existing install for 'nightly-[HOST_TRIPLE]'
+...
+"#]])
+        .is_ok();
 }
 
 // #190
 #[tokio::test]
 async fn proxies_pass_empty_args() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "run", "nightly", "rustc", "--empty-arg-test", ""])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "run", "nightly", "rustc", "--empty-arg-test", ""])
+        .await
+        .is_ok();
 }
 
 #[tokio::test]
 async fn rls_exists_in_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
 
     assert!(cx.config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
-    cx.config.expect_ok(&["rls", "--version"]).await;
+    cx.config.expect(["rls", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn run_rls_when_not_available_in_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::UnavailableRls).await;
+    let cx = CliTestContext::new(Scenario::UnavailableRls).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config.expect_err(
-        &["rls", "--version"],
-        &format!(
-            "the 'rls' component which provides the command 'rls{}' is not available for the 'nightly-{}' toolchain",
-            EXE_SUFFIX,
-            this_host_triple(),
-        ),
-    ).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rls", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: the 'rls' component which provides the command 'rls[EXE]' is not available for the 'nightly-[HOST_TRIPLE]' toolchain
+
+"#]])
+        .is_err();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
 
-    cx.config.expect_ok(&["rls", "--version"]).await;
+    cx.config.expect(["rls", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn run_rls_when_not_installed() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
-    cx.config.expect_err(
-        &["rls", "--version"],
-        &format!(
-            "'rls{}' is not installed for the toolchain 'stable-{}'.\nTo install, run `rustup component add rls`",
-            EXE_SUFFIX,
-            this_host_triple(),
-        ),
-    ).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rls", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: 'rls[EXE]' is not installed for the toolchain 'stable-[HOST_TRIPLE]'.
+To install, run `rustup component add rls`
+
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn run_rls_when_not_installed_for_nightly() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "install", "nightly"])
-        .await;
-    cx.config.expect_err(
-        &["rls", "+nightly", "--version"],
-        &format!(
-            "'rls{}' is not installed for the toolchain 'nightly-{}'.\nTo install, run `rustup component add --toolchain nightly-{1} rls`",
-            EXE_SUFFIX,
-            this_host_triple(),
-        ),
-    ).await;
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rls", "+nightly", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: 'rls[EXE]' is not installed for the toolchain 'nightly-[HOST_TRIPLE]'.
+To install, run `rustup component add --toolchain nightly-[HOST_TRIPLE] rls`
+
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn run_rust_lldb_when_not_in_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::UnavailableRls).await;
+    let cx = CliTestContext::new(Scenario::UnavailableRls).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    cx.config.expect_err(
-        &["rust-lldb", "--version"],
-        &format!(
-            "the 'rust-lldb{}' binary, normally provided by the 'rustc' component, is not applicable to the 'nightly-{}' toolchain",
-            EXE_SUFFIX,
-            this_host_triple(),
-        ),
-    ).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rust-lldb", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: the 'rust-lldb[EXE]' binary, normally provided by the 'rustc' component, is not applicable to the 'nightly-[HOST_TRIPLE]' toolchain
+
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn rename_rls_before() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
 
     assert!(cx.config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
-    cx.config.expect_ok(&["rls", "--version"]).await;
+    cx.config.expect(["rls", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn rename_rls_after() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls-preview"])
-        .await;
+        .expect(["rustup", "component", "add", "rls-preview"])
+        .await
+        .is_ok();
 
     assert!(cx.config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
-    cx.config.expect_ok(&["rls", "--version"]).await;
+    cx.config.expect(["rls", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn rename_rls_add_old_name() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
 
     assert!(cx.config.exedir.join(format!("rls{EXE_SUFFIX}")).exists());
-    cx.config.expect_ok(&["rls", "--version"]).await;
+    cx.config.expect(["rls", "--version"]).await.is_ok();
 }
 
 #[tokio::test]
 async fn rename_rls_list() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
 
     let out = cx.config.run("rustup", ["component", "list"], &[]).await;
     assert!(out.ok);
@@ -682,15 +839,19 @@ async fn rename_rls_list() {
 
 #[tokio::test]
 async fn rename_rls_preview_list() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls-preview"])
-        .await;
+        .expect(["rustup", "component", "add", "rls-preview"])
+        .await
+        .is_ok();
 
     let out = cx.config.run("rustup", ["component", "list"], &[]).await;
     assert!(out.ok);
@@ -699,40 +860,53 @@ async fn rename_rls_preview_list() {
 
 #[tokio::test]
 async fn rename_rls_remove() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
 
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
-    cx.config.expect_ok(&["rls", "--version"]).await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
+    cx.config.expect(["rls", "--version"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "remove", "rls"])
-        .await;
+        .expect(["rustup", "component", "remove", "rls"])
+        .await
+        .is_ok();
     cx.config
-        .expect_err(
-            &["rls", "--version"],
-            &format!("'rls{EXE_SUFFIX}' is not installed"),
-        )
-        .await;
+        .expect(["rls", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: 'rls[EXE]' is not installed for the toolchain 'nightly-[HOST_TRIPLE]'.
+...
+"#]])
+        .is_err();
 
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
-    cx.config.expect_ok(&["rls", "--version"]).await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
+    cx.config.expect(["rls", "--version"]).await.is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "remove", "rls-preview"])
-        .await;
+        .expect(["rustup", "component", "remove", "rls-preview"])
+        .await
+        .is_ok();
     cx.config
-        .expect_err(
-            &["rls", "--version"],
-            &format!("'rls{EXE_SUFFIX}' is not installed"),
-        )
-        .await;
+        .expect(["rls", "--version"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: 'rls[EXE]' is not installed for the toolchain 'nightly-[HOST_TRIPLE]'.
+...
+"#]])
+        .is_err();
 }
 
 // issue #3737
@@ -740,28 +914,45 @@ async fn rename_rls_remove() {
 #[tokio::test]
 #[cfg(any(unix, windows))]
 async fn toolchains_symlink() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let cwd = cx.config.current_dir();
     let test_toolchains = cwd.join("toolchains-test");
     fs::create_dir(&test_toolchains).unwrap();
     symlink_dir(&test_toolchains, &cx.config.rustupdir.join("toolchains")).unwrap();
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_ok_contains(&["rustup", "toolchain", "list"], "nightly", "")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_contains(&["rustc", "--version"], "hash-nightly-2", "")
-        .await;
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+nightly[..]
+...
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "uninstall", "nightly"])
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "toolchain", "list"],
-            "no installed toolchains\n",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "uninstall", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+no installed toolchains
+
+"#]])
+        .is_ok();
 }
 
 // issue #3344
@@ -769,7 +960,7 @@ async fn toolchains_symlink() {
 #[tokio::test]
 #[cfg(any(unix, windows))]
 async fn tmp_downloads_symlink() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
     let cwd = cx.config.current_dir();
 
     let test_tmp = cwd.join("tmp-test");
@@ -781,10 +972,13 @@ async fn tmp_downloads_symlink() {
     symlink_dir(&test_downloads, &cx.config.rustupdir.join("downloads")).unwrap();
 
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update"]).await;
+    cx.config.expect(["rustup", "update"]).await.is_ok();
 
     assert!(cx.config.rustupdir.join("tmp").exists());
     assert!(cx.config.rustupdir.join("downloads").exists());
@@ -795,7 +989,7 @@ async fn tmp_downloads_symlink() {
 #[tokio::test]
 #[cfg(any(unix, windows))]
 async fn toolchain_broken_symlink() {
-    let mut cx = CliTestContext::new(Scenario::None).await;
+    let cx = CliTestContext::new(Scenario::None).await;
     // We artificially create a broken symlink toolchain -- but this can also happen "legitimately"
     // by having a proper toolchain there, using "toolchain link", and later removing the directory.
     fs::create_dir(cx.config.rustupdir.join("toolchains")).unwrap();
@@ -809,44 +1003,68 @@ async fn toolchain_broken_symlink() {
 
     // Make sure this "fake install" actually worked
     cx.config
-        .expect_ok_ex(&["rustup", "toolchain", "list"], "test\n", "")
-        .await;
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+test
+
+"#]])
+        .is_ok();
     // Now try to uninstall it.  That should work only once.
     cx.config
-        .expect_ok_ex(
-            &["rustup", "toolchain", "uninstall", "test"],
-            "",
-            r"info: uninstalling toolchain 'test'
+        .expect(["rustup", "toolchain", "uninstall", "test"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+info: uninstalling toolchain 'test'
 info: toolchain 'test' uninstalled
-",
-        )
-        .await;
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "toolchain", "uninstall", "test"],
-            "no toolchain installed for 'test'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "uninstall", "test"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: no toolchain installed for 'test'
+...
+"#]])
+        .is_ok();
 }
 
 // issue #1297
 #[tokio::test]
 async fn update_unavailable_rustc() {
-    let mut cx = CliTestContext::new(Scenario::Unavailable).await;
+    let cx = CliTestContext::new(Scenario::Unavailable).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
 
     // latest nightly is unavailable
     cx.config.set_current_dist_date("2015-01-02");
     // update should do nothing
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
 }
 
 // issue 2562
@@ -856,48 +1074,78 @@ async fn install_unavailable_platform() {
     cx.config.set_current_dist_date("2015-01-02");
     // explicit attempt to install should fail
     cx.config
-        .expect_err(
-            &["rustup", "toolchain", "install", "nightly"],
-            "is not installable",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: toolchain 'nightly-[HOST_TRIPLE]' is not installable
+...
+"#]])
+        .is_err();
     // implicit attempt to install should fail
     cx.config
-        .expect_err(&["rustup", "default", "nightly"], "is not installable")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: toolchain 'nightly-[HOST_TRIPLE]' is not installable
+...
+"#]])
+        .is_err();
 }
 
 // issue #1329
 #[tokio::test]
 async fn install_beta_with_tag() {
-    let mut cx = CliTestContext::new(Scenario::BetaTag).await;
+    let cx = CliTestContext::new(Scenario::BetaTag).await;
     cx.config
-        .expect_ok(&["rustup", "default", "1.78.0-beta"])
-        .await;
+        .expect(["rustup", "default", "1.78.0-beta"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "1.78.0-beta")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.78.0 (hash-1.78.0-beta-1.78.0)
+
+"#]])
+        .is_ok();
 
     cx.config
-        .expect_ok(&["rustup", "default", "1.79.0-beta.2"])
-        .await;
+        .expect(["rustup", "default", "1.79.0-beta.2"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "1.79.0-beta.2")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.79.0 (hash-1.79.0-beta.2-1.79.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn update_nightly_even_with_incompat() {
-    let mut cx = CliTestContext::new(Scenario::MissingComponent).await;
+    let cx = CliTestContext::new(Scenario::MissingComponent).await;
     cx.config.set_current_dist_date("2019-09-12");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
     cx.config.expect_component_executable("rls").await;
 
     // latest nightly is now one that does not have RLS
@@ -905,51 +1153,78 @@ async fn update_nightly_even_with_incompat() {
 
     cx.config.expect_component_executable("rls").await;
     // update should bring us to latest nightly that does
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
     cx.config.expect_component_executable("rls").await;
 }
 
 #[tokio::test]
 async fn nightly_backtrack_skips_missing() {
-    let mut cx = CliTestContext::new(Scenario::MissingNightly).await;
+    let cx = CliTestContext::new(Scenario::MissingNightly).await;
     cx.config.set_current_dist_date("2019-09-16");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rls"])
-        .await;
+        .expect(["rustup", "component", "add", "rls"])
+        .await
+        .is_ok();
     cx.config.expect_component_executable("rls").await;
 
     // rls is missing on latest, nightly is missing on second-to-latest
     cx.config.set_current_dist_date("2019-09-18");
 
     // update should not change nightly, and should not error
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn completion_rustup() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "completions", "bash", "rustup"])
-        .await;
+        .expect(["rustup", "completions", "bash", "rustup"])
+        .await
+        .is_ok();
 }
 
 #[tokio::test]
 async fn completion_cargo() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "completions", "bash", "cargo"])
-        .await;
+        .expect(["rustup", "completions", "bash", "cargo"])
+        .await
+        .is_ok();
 }
 
 #[tokio::test]
@@ -967,219 +1242,221 @@ async fn completion_default() {
 async fn completion_bad_shell() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "completions", "fake"],
-            r#"error: invalid value 'fake' for '<SHELL>'"#,
-        )
-        .await;
+        .expect(["rustup", "completions", "fake"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: invalid value 'fake' for '<SHELL>'[..]
+...
+"#]])
+        .is_err();
     cx.config
-        .expect_err(
-            &["rustup", "completions", "fake", "cargo"],
-            r#"error: invalid value 'fake' for '<SHELL>'"#,
-        )
-        .await;
+        .expect(["rustup", "completions", "fake", "cargo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: invalid value 'fake' for '<SHELL>'[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn completion_bad_tool() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "completions", "bash", "fake"],
-            r#"error: invalid value 'fake' for '[COMMAND]'"#,
-        )
-        .await;
+        .expect(["rustup", "completions", "bash", "fake"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: invalid value 'fake' for '[COMMAND]'[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn completion_cargo_unsupported_shell() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_err(
-            &["rustup", "completions", "fish", "cargo"],
-            "error: cargo does not currently support completions for ",
-        )
-        .await;
+        .expect(["rustup", "completions", "fish", "cargo"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: cargo does not currently support completions for[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn add_remove_component() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config.expect_component_executable("rustc").await;
     cx.config
-        .expect_ok(&["rustup", "component", "remove", "rustc"])
-        .await;
+        .expect(["rustup", "component", "remove", "rustc"])
+        .await
+        .is_ok();
     cx.config.expect_component_not_executable("rustc").await;
     cx.config
-        .expect_ok(&["rustup", "component", "add", "rustc"])
-        .await;
+        .expect(["rustup", "component", "add", "rustc"])
+        .await
+        .is_ok();
     cx.config.expect_component_executable("rustc").await;
 }
 
 #[tokio::test]
 async fn which() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let path_1 = cx.config.customdir.join("custom-1");
     let path_1 = path_1.to_string_lossy();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "link", "custom-1", &path_1])
-        .await;
+        .expect(["rustup", "toolchain", "link", "custom-1", &path_1])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "custom-1"])
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "default", "custom-1"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "rustc"],
-            "\\toolchains\\custom-1\\bin\\rustc",
-        )
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "rustc"],
-            "/toolchains/custom-1/bin/rustc",
-        )
-        .await;
+        .expect(["rustup", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/custom-1/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
     let path_2 = cx.config.customdir.join("custom-2");
     let path_2 = path_2.to_string_lossy();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "link", "custom-2", &path_2])
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "toolchain", "link", "custom-2", &path_2])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "--toolchain=custom-2", "rustc"],
-            "\\toolchains\\custom-2\\bin\\rustc",
-        )
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "--toolchain=custom-2", "rustc"],
-            "/toolchains/custom-2/bin/rustc",
-        )
-        .await;
+        .expect(["rustup", "which", "--toolchain=custom-2", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/custom-2/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn which_asking_uninstalled_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let path_1 = cx.config.customdir.join("custom-1");
     let path_1 = path_1.to_string_lossy();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "link", "custom-1", &path_1])
-        .await;
+        .expect(["rustup", "toolchain", "link", "custom-1", &path_1])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "custom-1"])
-        .await;
+        .expect(["rustup", "default", "custom-1"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "rustc"],
-            &["", "toolchains", "custom-1", "bin", "rustc"].join(std::path::MAIN_SEPARATOR_STR),
-        )
-        .await;
+        .expect(["rustup", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/custom-1/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "which", "--toolchain=nightly", "rustc"],
-            &["", "toolchains", for_host!("nightly-{0}"), "bin", "rustc"]
-                .join(std::path::MAIN_SEPARATOR_STR),
-        )
-        .await;
+        .expect(["rustup", "which", "--toolchain=nightly", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/nightly-[HOST_TRIPLE]/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn override_by_toolchain_on_the_command_line() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "install", "stable", "nightly"])
-        .await;
+        .expect(["rustup", "toolchain", "install", "stable", "nightly"])
+        .await
+        .is_ok();
 
-    #[cfg(windows)]
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "+stable", "which", "rustc"],
-            for_host!("\\toolchains\\stable-{}"),
-        )
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "+stable", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/stable-[HOST_TRIPLE]/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "+stable", "which", "rustc"], "\\bin\\rustc")
-        .await;
-    #[cfg(not(windows))]
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "+stable", "which", "rustc"],
-            for_host!("/toolchains/stable-{}"),
-        )
-        .await;
-    #[cfg(not(windows))]
+        .expect(["rustup", "+nightly", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/nightly-[HOST_TRIPLE]/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "+stable", "which", "rustc"], "/bin/rustc")
-        .await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    #[cfg(windows)]
+        .expect(["rustup", "+nightly", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+active because: overridden by +toolchain on the command line
+...
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "+nightly", "which", "rustc"],
-            for_host!("\\toolchains\\nightly-{}"),
-        )
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "+foo", "which", "rustc"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: override toolchain 'foo' is not installed: the +toolchain on the command line specifies an uninstalled toolchain
+
+"#]])
+        .is_err();
     cx.config
-        .expect_stdout_ok(&["rustup", "+nightly", "which", "rustc"], "\\bin\\rustc")
-        .await;
-    #[cfg(not(windows))]
+        .expect(["rustup", "+stable", "set", "profile", "minimal"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+info: profile set to 'minimal'
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "+nightly", "which", "rustc"],
-            for_host!("/toolchains/nightly-{}"),
-        )
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(&["rustup", "+nightly", "which", "rustc"], "/bin/rustc")
-        .await;
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "+nightly", "show"],
-            "active because: overridden by +toolchain on the command line",
-        )
-        .await;
-    cx.config
-        .expect_err(
-            &["rustup", "+foo", "which", "rustc"],
-            "toolchain 'foo' is not installed",
-        )
-        .await;
-    cx.config
-        .expect_stderr_ok(
-            &["rustup", "+stable", "set", "profile", "minimal"],
-            "profile set to 'minimal'",
-        )
-        .await;
-    cx.config
-        .expect_stdout_ok(&["rustup", "default"], for_host!("nightly-{}"))
-        .await;
+        .expect(["rustup", "default"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+nightly-[HOST_TRIPLE][..]
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn toolchain_link_then_list_verbose() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let path_1 = cx.config.customdir.join("custom-1");
     let path_1 = path_1.to_string_lossy();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "link", "custom-1", &path_1])
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "toolchain", "link", "custom-1", &path_1])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "\\custom-1")
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "/custom-1")
-        .await;
+        .expect(["rustup", "toolchain", "list", "-v"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+custom-1 [..]/custom-1
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
@@ -1211,10 +1488,10 @@ async fn uninstall_self_smart_guess() {
 // https://github.com/rust-lang/rustup/issues/4073
 #[tokio::test]
 async fn toolchain_install_multi_components_comma() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let components = ["rls", "rust-docs"];
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "install",
@@ -1223,22 +1500,28 @@ async fn toolchain_install_multi_components_comma() {
             &components.join(","),
             "nightly",
         ])
-        .await;
-    for component in components {
-        cx.config
-            .expect_ok_contains(
-                &["rustup", "+nightly", "component", "list", "--installed"],
-                for_host!("{component}-{}"),
-                "",
-            )
-            .await;
-    }
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+rls-[HOST_TRIPLE][..]
+...
+rust-docs-[HOST_TRIPLE][..]
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn rustup_updates_cargo_env_if_proxy() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
 
     use std::env::consts::EXE_SUFFIX;
     let proxy_path = cx
@@ -1262,28 +1545,34 @@ async fn rustup_updates_cargo_env_if_proxy() {
 
     // If CARGO isn't set then we should not set it.
     cx.config
-        .expect_err(
-            &["cargo", "--echo-cargo-env"],
-            "CARGO environment variable not set",
-        )
-        .await;
+        .expect(["cargo", "--echo-cargo-env"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+CARGO environment variable not set[..]
+...
+"#]])
+        .is_err();
 
     // If CARGO is set to a proxy then change it to the real CARGO path
     cx.config
-        .expect_ok_ex_env(
-            &["cargo", "--echo-cargo-env"],
-            &[("CARGO", proxy_path.to_str().unwrap())],
-            "",
-            &real_path,
+        .expect_with_env(
+            ["cargo", "--echo-cargo-env"],
+            [("CARGO", &*proxy_path.display().to_string())],
         )
-        .await;
+        .await
+        .extend_redactions([("[REAL_PATH]", real_path)])
+        .with_stderr(snapbox::str![[r#"
+[REAL_PATH]
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn rust_analyzer_proxy_falls_back_external() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_ok(&[
+        .expect([
             "rustup",
             "toolchain",
             "install",
@@ -1291,8 +1580,12 @@ async fn rust_analyzer_proxy_falls_back_external() {
             "--profile=minimal",
             "--component=rls",
         ])
-        .await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
 
     // We pretend to have a `rust-analyzer` installation by reusing the `rls`
     // proxy and mock binary.
@@ -1303,7 +1596,7 @@ async fn rust_analyzer_proxy_falls_back_external() {
         .config
         .rustupdir
         .join("toolchains")
-        .join(for_host!("stable-{0}"))
+        .join(format!("stable-{}", this_host_triple()))
         .join("bin");
     for dir in [exedir, bindir] {
         fs::rename(dir.join(&rls), dir.join(&ra)).unwrap();
@@ -1316,8 +1609,7 @@ async fn rust_analyzer_proxy_falls_back_external() {
         .run("rust-analyzer", &["--echo-current-exe"], &[])
         .await;
     assert!(real_path.ok);
-    let real_path_str = real_path.stderr.lines().next().unwrap();
-    let real_path = Path::new(real_path_str);
+    let real_path = Path::new(real_path.stderr.trim());
 
     assert!(real_path.is_file());
 
@@ -1329,25 +1621,32 @@ async fn rust_analyzer_proxy_falls_back_external() {
     // First case: rustup-hosted and external RA both installed,
     // prioritize the former.
     cx.config
-        .expect_ok_ex_env(
-            &["rust-analyzer", "--echo-current-exe"],
-            &[("PATH", &extern_dir.to_string_lossy())],
-            "",
-            &format!("{real_path_str}\n"),
+        .expect_with_env(
+            ["rust-analyzer", "--echo-current-exe"],
+            [("PATH", &*extern_dir.display().to_string())],
         )
-        .await;
+        .await
+        .extend_redactions([("[REAL_PATH]", real_path.display().to_string())])
+        .with_stderr(snapbox::str![[r#"
+[REAL_PATH]
+
+"#]])
+        .is_ok();
 
     // Second case: rustup-hosted RA unavailable, fallback on the external RA.
     fs::remove_file(bindir.join(&ra)).unwrap();
     cx.config
-        .expect_ok_ex_env(
-            &["rust-analyzer", "--echo-current-exe"],
-            &[("PATH", &extern_dir.to_string_lossy())],
-            "",
-            &format!(
-                "info: `rust-analyzer` is unavailable for the active toolchain\ninfo: falling back to {:?}\n{}\n",
-                extern_path.as_os_str(), extern_path.display()
-            ),
+        .expect_with_env(
+            ["rust-analyzer", "--echo-current-exe"],
+            [("PATH", &*extern_dir.display().to_string())],
         )
-        .await;
+        .await
+        .extend_redactions([("[EXTERN_PATH]", &extern_path.display().to_string())])
+        .with_stderr(snapbox::str![[r#"
+info: `rust-analyzer` is unavailable for the active toolchain
+info: falling back to "[EXTERN_PATH]"
+[EXTERN_PATH]
+
+"#]])
+        .is_ok();
 }


### PR DESCRIPTION
Part of #4359.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4363/commits)