### PR TITLE
test(cli-v1): migrate to `.expect()` APIs

### DIFF
--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -1,11 +1,8 @@
 //! Test cases of the rustup command, using v1 manifests, mostly
 //! derived from multirust/test-v2.sh
 
-#![allow(deprecated)]
-
 use std::fs;
 
-use rustup::for_host;
 use rustup::test::{CliTestContext, Scenario};
 
 #[tokio::test]
@@ -24,175 +21,268 @@ help: run 'rustup default stable' to download the latest stable release of Rust 
 
 #[tokio::test]
 async fn expected_bins_exist() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "1.3.0")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn install_toolchain_from_channel() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
-    cx.config.expect_ok(&["rustup", "default", "beta"]).await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0")
-        .await;
-    cx.config.expect_ok(&["rustup", "default", "stable"]).await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-        .await;
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn install_toolchain_from_archive() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV1).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV1).await;
     cx.config
-        .expect_ok(&["rustup", "default", "nightly-2015-01-01"])
-        .await;
+        .expect(["rustup", "default", "nightly-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "beta-2015-01-01"])
-        .await;
+        .expect(["rustup", "default", "beta-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-beta-1.1.0)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "default", "stable-2015-01-01"])
-        .await;
+        .expect(["rustup", "default", "stable-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.0.0 (hash-stable-1.0.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn install_toolchain_from_version() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "default", "1.1.0"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-        .await;
+        .expect(["rustup", "default", "1.1.0"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn default_existing_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stderr_ok(
-            &["rustup", "default", "nightly"],
-            for_host!("using existing install for 'nightly-{0}'"),
-        )
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+info: using existing install for 'nightly-[HOST_TRIPLE]'
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn update_channel() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV1).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV1).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn list_toolchains() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV1).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV1).await;
     cx.config
-        .expect_ok(&["rustup", "update", "beta-2015-01-01"])
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list"], "nightly")
-        .await;
+        .expect(["rustup", "update", "beta-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list", "-v"], "(active, default) ")
-        .await;
-    #[cfg(windows)]
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+beta-2015-01-01-[HOST_TRIPLE]
+nightly-[HOST_TRIPLE] (active, default)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "toolchain", "list", "-v"],
-            for_host!(r"\toolchains\nightly-{}"),
-        )
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "toolchain", "list", "-v"],
-            for_host!("/toolchains/nightly-{}"),
-        )
-        .await;
-    cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list"], "beta-2015-01-01")
-        .await;
-    #[cfg(windows)]
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "toolchain", "list", "-v"],
-            r"\toolchains\beta-2015-01-01",
-        )
-        .await;
-    #[cfg(not(windows))]
-    cx.config
-        .expect_stdout_ok(
-            &["rustup", "toolchain", "list", "-v"],
-            "/toolchains/beta-2015-01-01",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "list", "-v"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+beta-2015-01-01-[HOST_TRIPLE] [..]/toolchains/beta-2015-01-01-[HOST_TRIPLE]
+nightly-[HOST_TRIPLE] (active, default) [..]/toolchains/nightly-[HOST_TRIPLE]
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn list_toolchains_with_none() {
     let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains")
-        .await;
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+no installed toolchains
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn remove_toolchain() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "remove", "nightly"])
-        .await;
-    cx.config.expect_ok(&["rustup", "toolchain", "list"]).await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustup", "toolchain", "list"], "no installed toolchains")
-        .await;
+        .expect(["rustup", "toolchain", "remove", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "list"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+no installed toolchains
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn remove_override_toolchain_err_handling() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let mut cx = cx.change_dir(tempdir.path());
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = cx.change_dir(tempdir.path());
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta"])
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "toolchain", "remove", "beta"])
-        .await;
+        .expect(["rustup", "override", "add", "beta"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok_contains(
-            &["rustc", "--version"],
-            "1.2.0 (hash-beta-1.2.0)",
-            "info: downloading component 'rust'",
-        )
-        .await;
+        .expect(["rustup", "toolchain", "remove", "beta"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+...
+info: downloading component 'rust'
+...
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
@@ -210,8 +300,14 @@ async fn bad_sha_on_manifest() {
     let sha_str = String::from_utf8(sha_bytes).unwrap();
     rustup::utils::raw::write_file(&sha_file, &sha_str).unwrap();
     cx.config
-        .expect_err(&["rustup", "default", "nightly"], "checksum failed")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: checksum failed[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
@@ -227,80 +323,137 @@ async fn bad_sha_on_installer() {
         }
     }
     cx.config
-        .expect_err(&["rustup", "default", "nightly"], "checksum failed")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: checksum failed[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn install_override_toolchain_from_channel() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_ok(&["rustup", "override", "add", "nightly"])
-        .await;
+        .expect(["rustup", "override", "add", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta"])
-        .await;
+        .expect(["rustup", "override", "add", "beta"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "stable"])
-        .await;
+        .expect(["rustup", "override", "add", "stable"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn install_override_toolchain_from_archive() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV1).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV1).await;
     cx.config
-        .expect_ok(&["rustup", "override", "add", "nightly-2015-01-01"])
-        .await;
+        .expect(["rustup", "override", "add", "nightly-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta-2015-01-01"])
-        .await;
+        .expect(["rustup", "override", "add", "beta-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.1.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-beta-1.1.0)
+
+"#]])
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "stable-2015-01-01"])
-        .await;
+        .expect(["rustup", "override", "add", "stable-2015-01-01"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.0.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.0.0 (hash-stable-1.0.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn install_override_toolchain_from_version() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_ok(&["rustup", "override", "add", "1.1.0"])
-        .await;
+        .expect(["rustup", "override", "add", "1.1.0"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn override_overrides_default() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
-    let mut cx = cx.change_dir(tempdir.path());
+    let cx = cx.change_dir(tempdir.path());
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta"])
-        .await;
+        .expect(["rustup", "override", "add", "beta"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
@@ -309,37 +462,57 @@ async fn multiple_overrides() {
     let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
 
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-    {
-        let mut cx = cx.change_dir(tempdir1.path());
-        cx.config
-            .expect_ok(&["rustup", "override", "add", "beta"])
-            .await;
-    }
-
-    {
-        let mut cx = cx.change_dir(tempdir2.path());
-        cx.config
-            .expect_ok(&["rustup", "override", "add", "stable"])
-            .await;
-    }
-
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
-
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     {
         let cx = cx.change_dir(tempdir1.path());
         cx.config
-            .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0")
-            .await;
+            .expect(["rustup", "override", "add", "beta"])
+            .await
+            .is_ok();
     }
 
     {
         let cx = cx.change_dir(tempdir2.path());
         cx.config
-            .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-            .await;
+            .expect(["rustup", "override", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
+
+    {
+        let cx = cx.change_dir(tempdir1.path());
+        cx.config
+            .expect(["rustc", "--version"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+            .is_ok();
+    }
+
+    {
+        let cx = cx.change_dir(tempdir2.path());
+        cx.config
+            .expect(["rustc", "--version"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+            .is_ok();
     }
 }
 
@@ -347,48 +520,73 @@ async fn multiple_overrides() {
 async fn change_override() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let mut cx = cx.change_dir(tempdir.path());
+    let cx = cx.change_dir(tempdir.path());
     cx.config
-        .expect_ok(&["rustup", "override", "add", "nightly"])
-        .await;
+        .expect(["rustup", "override", "add", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta"])
-        .await;
+        .expect(["rustup", "override", "add", "beta"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-beta-1.2.0")
-        .await;
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn remove_override_no_default() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let mut cx = cx.change_dir(tempdir.path());
+    let cx = cx.change_dir(tempdir.path());
     cx.config
-        .expect_ok(&["rustup", "override", "add", "nightly"])
-        .await;
-    cx.config.expect_ok(&["rustup", "override", "remove"]).await;
+        .expect(["rustup", "override", "add", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_err(
-            &["rustc"],
-            "rustup could not choose a version of rustc to run",
-        )
-        .await;
+        .expect(["rustup", "override", "remove"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: rustup could not choose a version of rustc to run[..]
+...
+"#]])
+        .is_err();
 }
 
 #[tokio::test]
 async fn remove_override_with_default() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    let mut cx = cx.change_dir(tempdir.path());
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
+    let cx = cx.change_dir(tempdir.path());
     cx.config
-        .expect_ok(&["rustup", "override", "add", "beta"])
-        .await;
-    cx.config.expect_ok(&["rustup", "override", "remove"]).await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustup", "override", "add", "beta"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "override", "remove"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
@@ -396,87 +594,148 @@ async fn remove_override_with_multiple_overrides() {
     let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
     let tempdir1 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
     let tempdir2 = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
-
-    {
-        let mut cx = cx.change_dir(tempdir1.path());
-        cx.config
-            .expect_ok(&["rustup", "override", "add", "beta"])
-            .await;
-    }
-
-    {
-        let mut cx = cx.change_dir(tempdir2.path());
-        cx.config
-            .expect_ok(&["rustup", "override", "add", "stable"])
-            .await;
-    }
-
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
 
     {
-        let mut cx = cx.change_dir(tempdir1.path());
-        cx.config.expect_ok(&["rustup", "override", "remove"]).await;
+        let cx = cx.change_dir(tempdir1.path());
         cx.config
-            .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-            .await;
+            .expect(["rustup", "override", "add", "beta"])
+            .await
+            .is_ok();
     }
 
     {
         let cx = cx.change_dir(tempdir2.path());
         cx.config
-            .expect_stdout_ok(&["rustc", "--version"], "hash-stable-1.1.0")
-            .await;
+            .expect(["rustup", "override", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
+
+    {
+        let cx = cx.change_dir(tempdir1.path());
+        cx.config
+            .expect(["rustup", "override", "remove"])
+            .await
+            .is_ok();
+        cx.config
+            .expect(["rustc", "--version"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+            .is_ok();
+    }
+
+    {
+        let cx = cx.change_dir(tempdir2.path());
+        cx.config
+            .expect(["rustc", "--version"])
+            .await
+            .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+            .is_ok();
     }
 }
 
 #[tokio::test]
 async fn no_update_on_channel_when_date_has_not_changed() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(&["rustup", "update", "nightly"], "unchanged")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+
+  nightly-[HOST_TRIPLE] unchanged - 1.3.0 (hash-nightly-2)
+
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn update_on_channel_when_date_has_changed() {
-    let mut cx = CliTestContext::new(Scenario::ArchivesV1).await;
+    let cx = CliTestContext::new(Scenario::ArchivesV1).await;
     cx.config.set_current_dist_date("2015-01-01");
-    cx.config.expect_ok(&["rustup", "default", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-1")
-        .await;
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-nightly-1)
+
+"#]])
+        .is_ok();
     cx.config.set_current_dist_date("2015-01-02");
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
     cx.config
-        .expect_stdout_ok(&["rustc", "--version"], "hash-nightly-2")
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn run_command() {
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "update", "nightly"]).await;
-    cx.config.expect_ok(&["rustup", "default", "beta"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_stdout_ok(
-            &["rustup", "run", "nightly", "rustc", "--version"],
-            "hash-nightly-2",
-        )
-        .await;
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "run", "nightly", "rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.3.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
 }
 
 #[tokio::test]
 async fn remove_toolchain_then_add_again() {
     // Issue brson/multirust #53
-    let mut cx = CliTestContext::new(Scenario::SimpleV1).await;
-    cx.config.expect_ok(&["rustup", "default", "beta"]).await;
+    let cx = CliTestContext::new(Scenario::SimpleV1).await;
     cx.config
-        .expect_ok(&["rustup", "toolchain", "remove", "beta"])
-        .await;
-    cx.config.expect_ok(&["rustup", "update", "beta"]).await;
-    cx.config.expect_ok(&["rustc", "--version"]).await;
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "remove", "beta"])
+        .await
+        .is_ok();
+    cx.config.expect(["rustup", "update", "beta"]).await.is_ok();
+    cx.config.expect(["rustc", "--version"]).await.is_ok();
 }


### PR DESCRIPTION
Part of #4359.

> [!NOTE]
> This PR is relatively short.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4366/commits)