### PR TITLE
Upgrade to rustls-platform-verifier 0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.3"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19787cda76408ec5404443dc8b31795c87cd8fec49762dc75fa727740d34acc1"
+checksum = "eda84358ed17f1f354cf4b1909ad346e6c7bc2513e8c40eb08e0157aa13a9070"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -2180,7 +2180,7 @@ dependencies = [
  "rustls-webpki",
  "security-framework 3.2.0",
  "security-framework-sys",
- "webpki-root-certs 0.26.11",
+ "webpki-root-certs",
  "windows-sys 0.59.0",
 ]
 
@@ -3256,15 +3256,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-root-certs"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
-dependencies = [
- "webpki-root-certs 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 retry = { version = "2", default-features = false, features = ["random"] }
 rs_tracing = { version = "1.1", features = ["rs_tracing"] }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["logging", "aws_lc_rs", "tls12"] }
-rustls-platform-verifier = { version = "0.5", optional = true }
+rustls-platform-verifier = { version = "0.6", optional = true }
 same-file = "1"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This is a little involved because the `with_platform_verifier()` call is now fallible, which means using a `LazyLock` would be a little annoying/wasteful since we'd have to store a `Result` in it. Use a `OnceLock` instead.

The changes in rustls-platform-verifier 0.6 (which I created) were directly inspired by #4305, and should make rustup error out (earlier/at all) when no certificates can be found in the platform certificate store on Unix platforms that don't have their own platform verifier (like Linux, the BSDs, etc -- pretty much any Unix except Darwin-based platforms and Android).

Fixes #4305.