### PR TITLE
test: finish migration to `.expect()` APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,18 +407,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
-dependencies = [
- "encode_unicode",
- "libc",
- "once_cell",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,12 +587,6 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-map"
@@ -2247,7 +2229,6 @@ dependencies = [
  "serde",
  "sha2",
  "sharded-slab",
- "similar-asserts",
  "snapbox",
  "strsim",
  "tar",
@@ -2448,20 +2429,6 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
-dependencies = [
- "bstr",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b441962c817e33508847a22bd82f03a30cff43642dc2fae8b050566121eb9a"
-dependencies = [
- "console",
- "similar",
-]
 
 [[package]]
 name = "slab"
@@ -3057,12 +3024,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ otel = [
 ]
 
 # Exports code dependent on private interfaces for the integration test suite
-test = ["dep:similar-asserts", "dep:snapbox", "dep:walkdir"]
+test = ["dep:snapbox", "dep:walkdir"]
 
 # Sorted by alphabetic order
 [dependencies]
@@ -97,7 +97,6 @@ xz2 = "0.1.3"
 zstd = "0.13"
 
 # test only (depends on `test` feature)
-similar-asserts = { version = "1.7", optional = true }
 snapbox = { version = "0.6.21", optional = true }
 walkdir = { version = "2", optional = true }
 

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -500,7 +500,7 @@ impl Config {
         }
     }
 
-    pub async fn run<I, A>(&self, name: &str, args: I, env: &[(&str, &str)]) -> SanitizedOutput
+    async fn run<I, A>(&self, name: &str, args: I, env: &[(&str, &str)]) -> SanitizedOutput
     where
         I: IntoIterator<Item = A> + Clone + Debug,
         A: AsRef<OsStr>,

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -137,7 +137,7 @@ impl Assert {
         Self { output, redactions }
     }
 
-    /// Extend the redaction rules used in the currrent assertion with new values.
+    /// Extends the redaction rules used in the current assertion with new values.
     pub fn extend_redactions(
         &mut self,
         vars: impl IntoIterator<Item = (&'static str, impl Into<RedactedValue>)>,
@@ -148,6 +148,7 @@ impl Assert {
         self
     }
 
+    /// Removes the existing redaction rules used in the current assertion.
     pub fn remove_redactions(&mut self, vars: impl IntoIterator<Item = &'static str>) -> &mut Self {
         for var in vars {
             self.redactions
@@ -155,6 +156,11 @@ impl Assert {
                 .expect("invalid redactions detected");
         }
         self
+    }
+
+    /// Performs the redaction based on the existing rules.
+    pub fn redact(&self, input: &str) -> String {
+        self.redactions.redact(input)
     }
 
     /// Asserts that the command exited with an ok status.
@@ -171,7 +177,7 @@ impl Assert {
 
     /// Asserts that the command exited with the given `expected` stdout pattern.
     pub fn with_stdout(&self, expected: impl IntoData) -> &Self {
-        let stdout = self.redactions.redact(&self.output.stdout);
+        let stdout = self.redact(&self.output.stdout);
         assert_data_eq!(&stdout, expected);
         self
     }
@@ -187,7 +193,7 @@ impl Assert {
 
     /// Asserts that the command exited with the given `expected` stderr pattern.
     pub fn with_stderr(&self, expected: impl IntoData) -> &Self {
-        let stderr = self.redactions.redact(&self.output.stderr);
+        let stderr = self.redact(&self.output.stderr);
         assert_data_eq!(&stderr, expected);
         self
     }

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -114,7 +114,7 @@ pub struct Config {
 /// [`Assert::extend_redactions`] method to introduce new filters.
 #[derive(Clone)]
 pub struct Assert {
-    output: SanitizedOutput,
+    pub output: SanitizedOutput,
     redactions: Redactions,
 }
 

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -330,7 +330,7 @@ async fn override_again() {
     cx.config
         .expect(["rustup", "override", "add", "nightly"])
         .await
-        .extend_redactions([("[CWD]", cx.config.current_dir().display().to_string())])
+        .extend_redactions([("[CWD]", cx.config.current_dir())])
         .is_ok()
         .with_stdout(snapbox::str![[""]])
         .with_stderr(snapbox::str![[r#"
@@ -351,7 +351,7 @@ async fn remove_override() {
         cx.config
             .expect(["rustup", "override", keyword])
             .await
-            .extend_redactions([("[CWD]", cwd.display().to_string())])
+            .extend_redactions([("[CWD]", cwd)])
             .is_ok()
             .with_stdout(snapbox::str![[""]])
             .with_stderr(snapbox::str![[r#"
@@ -369,7 +369,7 @@ async fn remove_override_none() {
         cx.config
             .expect(["rustup", "override", keyword])
             .await
-            .extend_redactions([("[CWD]", cwd.display().to_string())])
+            .extend_redactions([("[CWD]", cwd)])
             .is_ok()
             .with_stdout(snapbox::str![[""]])
             .with_stderr(snapbox::str![[r#"
@@ -406,7 +406,7 @@ async fn remove_override_with_path() {
                 dir.path().to_str().unwrap(),
             ])
             .await
-            .extend_redactions([("[PATH]", dir.path().display().to_string())])
+            .extend_redactions([("[PATH]", dir.path().to_owned())])
             .is_ok()
             .with_stdout(snapbox::str![[""]])
             .with_stderr(snapbox::str![[r#"
@@ -442,7 +442,7 @@ async fn remove_override_with_path_deleted() {
                 path.to_str().unwrap(),
             ])
             .await
-            .extend_redactions([("[PATH]", path.display().to_string())])
+            .extend_redactions([("[PATH]", path)])
             .is_ok()
             .with_stdout(snapbox::str![[""]])
             .with_stderr(snapbox::str![[r#"
@@ -476,7 +476,7 @@ async fn remove_override_nonexistent() {
         cx.config
             .expect(["rustup", "override", keyword, "--nonexistent"])
             .await
-            .extend_redactions([("[PATH]", path.display().to_string())])
+            .extend_redactions([("[PATH]", path)])
             .is_ok()
             .with_stdout(snapbox::str![[""]])
             .with_stderr(snapbox::str![[r#"

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -210,8 +210,9 @@ async fn check_updates_self() {
 
     // We are checking an update to rustup itself in this test.
     cx.config
-        .run("rustup", ["set", "auto-self-update", "enable"], &[])
-        .await;
+        .expect(["rustup", "set", "auto-self-update", "enable"])
+        .await
+        .is_ok();
 
     cx.config
         .expect(["rustup", "check"])
@@ -232,8 +233,9 @@ async fn check_updates_self_no_change() {
 
     // We are checking an update to rustup itself in this test.
     cx.config
-        .run("rustup", ["set", "auto-self-update", "enable"], &[])
-        .await;
+        .expect(["rustup", "set", "auto-self-update", "enable"])
+        .await
+        .is_ok();
 
     cx.config
         .expect(["rustup", "check"])

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1643,7 +1643,7 @@ async fn rust_analyzer_proxy_falls_back_external() {
             [("PATH", &*extern_dir.display().to_string())],
         )
         .await
-        .extend_redactions([("[REAL_PATH]", real_path.display().to_string())])
+        .extend_redactions([("[REAL_PATH]", real_path.to_owned())])
         .with_stderr(snapbox::str![[r#"
 [REAL_PATH]
 
@@ -1658,7 +1658,7 @@ async fn rust_analyzer_proxy_falls_back_external() {
             [("PATH", &*extern_dir.display().to_string())],
         )
         .await
-        .extend_redactions([("[EXTERN_PATH]", &extern_path.display().to_string())])
+        .extend_redactions([("[EXTERN_PATH]", extern_path)])
         .with_stderr(snapbox::str![[r#"
 info: `rust-analyzer` is unavailable for the active toolchain
 info: falling back to "[EXTERN_PATH]"

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1394,8 +1394,25 @@ async fn override_by_toolchain_on_the_command_line() {
 "#]])
         .is_ok();
     cx.config
+        .expect(["rustup", "+nightly", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/nightly-[HOST_TRIPLE]/bin/rustc[EXE]
+
+"#]])
+        .is_ok();
+
+    cx.config
         .expect(["rustup", "default", "nightly"])
         .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "+stable", "which", "rustc"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/stable-[HOST_TRIPLE]/bin/rustc[EXE]
+
+"#]])
         .is_ok();
     cx.config
         .expect(["rustup", "+nightly", "which", "rustc"])

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -669,8 +669,8 @@ async fn recursive_cargo() {
     // The solution here is to copy from the "mock" `cargo.exe` into
     // `~/.cargo/bin/cargo-foo`. This is just for convenience to avoid
     // needing to build another executable just for this test.
-    let output = cx.config.run("rustup", ["which", "cargo"], &[]).await;
-    let real_mock_cargo = output.stdout.trim();
+    let which_cargo = cx.config.expect(["rustup", "which", "cargo"]).await;
+    let real_mock_cargo = which_cargo.output.stdout.trim();
     let cargo_bin_path = cx.config.cargodir.join("bin");
     let cargo_subcommand = cargo_bin_path.join(format!("cargo-foo{EXE_SUFFIX}"));
     fs::create_dir_all(&cargo_bin_path).unwrap();

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1187,8 +1187,8 @@ async fn show_toolchain_toolchain_file_override_not_installed() {
         .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
         .await
         .extend_redactions([
-            ("[RUSTUP_DIR]", &cx.config.rustupdir.to_string()),
-            ("[TOOLCHAIN_FILE]", &toolchain_file.display().to_string()),
+            ("[RUSTUP_DIR]", &cx.config.rustupdir.rustupdir),
+            ("[TOOLCHAIN_FILE]", &toolchain_file),
         ])
         .with_stdout(snapbox::str![[r#"
 Default host: [HOST_TRIPLE]
@@ -1676,7 +1676,7 @@ channel = "nightly"
     cx.config
         .expect(["rustup", "toolchain", "install"])
         .await
-        .extend_redactions([("[TOOLCHAIN_FILE]", &toolchain_file.display().to_string())])
+        .extend_redactions([("[TOOLCHAIN_FILE]", &toolchain_file)])
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
@@ -1691,7 +1691,7 @@ info: it's active because: overridden by '[TOOLCHAIN_FILE]'
     cx.config
         .expect(["rustup", "toolchain", "install"])
         .await
-        .extend_redactions([("[TOOLCHAIN_FILE]", &toolchain_file.display().to_string())])
+        .extend_redactions([("[TOOLCHAIN_FILE]", &toolchain_file)])
         .with_stderr(snapbox::str![[r#"
 info: using existing install for 'nightly-[HOST_TRIPLE]'
 info: the active toolchain `nightly-[HOST_TRIPLE]` has been installed
@@ -3636,7 +3636,7 @@ async fn only_toml_in_rust_toolchain_toml() {
     cx.config
         .expect(["rustc", "--version"])
         .await
-        .extend_redactions([("[CWD]", &cwd.display().to_string())])
+        .extend_redactions([("[CWD]", &cwd)])
         .with_stderr(snapbox::str![[r#"
 ...
 error: could not parse override file: '[CWD]/rust-toolchain.toml'[..]
@@ -3658,7 +3658,7 @@ async fn warn_on_duplicate_rust_toolchain_file() {
     cx.config
         .expect(&["rustup", "toolchain", "install"])
         .await
-        .extend_redactions([("[CWD]", &cwd.canonicalize().unwrap().display().to_string())])
+        .extend_redactions([("[CWD]", &cwd.canonicalize().unwrap())])
         .with_stderr(snapbox::str![[r#"
 ...
 warn: both `[CWD]/rust-toolchain` and `[CWD]/rust-toolchain.toml` exist. Using `[CWD]/rust-toolchain`
@@ -3720,7 +3720,7 @@ profile = "minimal"
     cx.config
         .expect(&["rustup", "show", "active-toolchain"])
         .await
-        .extend_redactions([("[CWD]", &cwd.display().to_string())])
+        .extend_redactions([("[CWD]", &cwd)])
         .with_stdout(snapbox::str![[r#"
 my-custom (overridden by '[CWD]/rust-toolchain.toml')
 

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -459,7 +459,7 @@ async fn update_but_not_installed() {
     cx.config
         .expect(["rustup", "self", "update"])
         .await
-        .extend_redactions([("[CARGO_DIR]", cx.config.cargodir.display().to_string())])
+        .extend_redactions([("[CARGO_DIR]", cx.config.cargodir)])
         .is_err()
         .with_stdout(snapbox::str![[""]])
         .with_stderr(snapbox::str![[r#"


### PR DESCRIPTION
Closes #4359.

[_SemanticDiff_](https://app.semanticdiff.com/gh/rust-lang/rustup/pull/4376/commits)