### PR TITLE
Update bash completions instructions and test

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -177,7 +177,7 @@ pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
     Run the command:
 
         $ mkdir -p ~/.local/share/bash-completion/completions
-        $ rustup completions bash >> ~/.local/share/bash-completion/completions/rustup
+        $ rustup completions bash > ~/.local/share/bash-completion/completions/rustup
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.

--- a/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
+++ b/tests/suite/cli-ui/rustup/rustup_completions_cmd_help_flag_stdout.toml
@@ -32,7 +32,7 @@ Discussion:
     Run the command:
 
         $ mkdir -p ~/.local/share/bash-completion/completions
-        $ rustup completions bash >> ~/.local/share/bash-completion/completions/rustup
+        $ rustup completions bash > ~/.local/share/bash-completion/completions/rustup
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.


### PR DESCRIPTION
`>>` --> `>`   Update help.rs
Update rustup_completions_cmd_help_flag_stdout.toml    Fix bash completions test.

Closes #4375.