### PR TITLE
add Solaris support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -900,6 +900,7 @@ jobs:
           - i686-unknown-linux-gnu         # skip-pr skip-master
           - arm-unknown-linux-gnueabi      # skip-pr skip-master
           - arm-unknown-linux-gnueabihf    # skip-pr skip-master
+          - x86_64-pc-solaris              # skip-pr skip-master
           - x86_64-unknown-freebsd         # skip-pr skip-master
           - x86_64-unknown-netbsd          # skip-pr skip-master
           - x86_64-unknown-illumos         # skip-pr skip-master
@@ -907,6 +908,7 @@ jobs:
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-master
           - powerpc64le-unknown-linux-musl # skip-pr skip-master
           - s390x-unknown-linux-gnu        # skip-pr skip-master
+          - sparcv9-sun-solaris            # skip-pr skip-master
           - arm-linux-androideabi          # skip-pr skip-master
           - armv7-linux-androideabi        # skip-pr skip-master
           - x86_64-linux-android           # skip-pr skip-master

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -29,6 +29,7 @@ jobs: # skip-master skip-pr skip-stable
           - i686-unknown-linux-gnu         # skip-pr skip-master
           - arm-unknown-linux-gnueabi      # skip-pr skip-master
           - arm-unknown-linux-gnueabihf    # skip-pr skip-master
+          - x86_64-pc-solaris              # skip-pr skip-master
           - x86_64-unknown-freebsd         # skip-pr skip-master
           - x86_64-unknown-netbsd          # skip-pr skip-master
           - x86_64-unknown-illumos         # skip-pr skip-master
@@ -36,6 +37,7 @@ jobs: # skip-master skip-pr skip-stable
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-master
           - powerpc64le-unknown-linux-musl # skip-pr skip-master
           - s390x-unknown-linux-gnu        # skip-pr skip-master
+          - sparcv9-sun-solaris            # skip-pr skip-master
           - arm-linux-androideabi          # skip-pr skip-master
           - armv7-linux-androideabi        # skip-pr skip-master
           - x86_64-linux-android           # skip-pr skip-master

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -53,10 +53,14 @@ rustup/dist/powerpc64le-unknown-linux-musl/rustup-init
 rustup/dist/powerpc64le-unknown-linux-musl/rustup-init.sha256
 rustup/dist/s390x-unknown-linux-gnu/rustup-init
 rustup/dist/s390x-unknown-linux-gnu/rustup-init.sha256
+rustup/dist/sparcv9-sun-solaris/rustup-init.exe
+rustup/dist/sparcv9-sun-solaris/rustup-init.exe.sha256
 rustup/dist/x86_64-apple-darwin/rustup-init
 rustup/dist/x86_64-apple-darwin/rustup-init.sha256
 rustup/dist/x86_64-linux-android/rustup-init
 rustup/dist/x86_64-linux-android/rustup-init.sha256
+rustup/dist/x86_64-pc-solaris/rustup-init.exe
+rustup/dist/x86_64-pc-solaris/rustup-init.exe.sha256
 rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe
 rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe.sha256
 rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe

--- a/ci/docker/sparcv9-sun-solaris/Dockerfile
+++ b/ci/docker/sparcv9-sun-solaris/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust-sparcv9-sun-solaris
+
+# Building `aws-lc-rs` for Solaris on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
+ENV \
+  AR_sparcv9_sun_solaris=sparcv9-solaris-ar \
+  RANLIB_sparcv9_sun_solaris=sparcv9-solaris-ranlib \
+  CC_sparcv9_sun_solaris=sparcv9-solaris-gcc \
+  CXX_sparcv9_sun_solaris=sparcv9-solaris-g++ \
+  CARGO_TARGET_SPARCV9_SUN_SOLARIS_LINKER=sparcv9-solaris-gcc

--- a/ci/docker/x86_64-pc-solaris/Dockerfile
+++ b/ci/docker/x86_64-pc-solaris/Dockerfile
@@ -1,0 +1,12 @@
+FROM rust-x86_64-pc-solaris
+
+# Building `aws-lc-rs` for Solaris on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
+ENV \
+  AR_x86_64_pc_solaris=x86_64-solaris-ar \
+  RANLIB_x86_64_pc_solaris=x86_64-solaris-ranlib \
+  CC_x86_64_pc_solaris=x86_64-solaris-gcc \
+  CXX_x86_64_pc_solaris=x86_64-solaris-g++ \
+  CARGO_TARGET_X86_64_PC_SOLARIS_LINKER=x86_64-solaris-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -37,6 +37,8 @@ case "$TARGET" in
   powerpc64le-unknown-linux-gnu)   image=dist-powerpc64le-linux-gnu ;;
   powerpc64le-unknown-linux-musl)  image=dist-powerpc64le-linux-musl ;;
   s390x-unknown-linux-gnu)         image=dist-s390x-linux ;;
+  sparcv9-sun-solaris)             image=dist-sparcv9-solaris ;;
+  x86_64-pc-solaris)               image=dist-x86_64-solaris ;;
   x86_64-unknown-freebsd)          image=dist-x86_64-freebsd ;;
   x86_64-unknown-illumos)          image=dist-x86_64-illumos ;;
   x86_64-unknown-linux-gnu)        image=dist-x86_64-linux ;;

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -33,6 +33,7 @@ case "$TARGET" in
   loongarch* ) ;;
   *netbsd* ) ;;
   *illumos* ) ;;
+  *solaris* ) ;;
   # default case, build with rustls enabled
   * ) FEATURES+=('--features' 'reqwest-rustls-tls') ;;
 esac

--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -159,10 +159,14 @@ You can manually download `rustup-init` for a given target from
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-musl/rustup-init.sha256)
 - [s390x-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/s390x-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/s390x-unknown-linux-gnu/rustup-init.sha256)
+- [sparcv9-sun-solaris](https://static.rust-lang.org/rustup/dist/sparcv9-sun-solaris/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/sparcv9-sun-solaris/rustup-init.sha256)
 - [x86_64-apple-darwin](https://static.rust-lang.org/rustup/dist/x86_64-apple-darwin/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/x86_64-apple-darwin/rustup-init.sha256)
 - [x86_64-linux-android](https://static.rust-lang.org/rustup/dist/x86_64-linux-android/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/x86_64-linux-android/rustup-init.sha256)
+- [x86_64-pc-solaris](https://static.rust-lang.org/rustup/dist/x86_64-pc-solaris/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/x86_64-pc-solaris/rustup-init.sha256)
 - [x86_64-pc-windows-gnu](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe)[^msys2]
   - [sha256 file](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-gnu/rustup-init.exe.sha256)
 - [x86_64-pc-windows-msvc](https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe)[^msvc]

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -414,6 +414,14 @@ get_architecture() {
             _ostype=unknown-illumos
             ;;
 
+        SunOS)
+            if [ "$_cputype" = sparcv9 ]; then
+               _ostype=sun-solaris
+            else
+               _ostype=pc-solaris
+            fi
+            ;;
+
         MINGW* | MSYS* | CYGWIN* | Windows_NT)
             _ostype=pc-windows-gnu
             ;;
@@ -490,6 +498,9 @@ get_architecture() {
 
         s390x)
             _cputype=s390x
+            ;;
+        sparcv9)
+            _cputype=sparcv9
             ;;
         riscv64)
             _cputype=riscv64gc

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -497,7 +497,7 @@ impl TargetTriple {
             let mut sys_info;
             let (sysname, machine) = unsafe {
                 sys_info = mem::zeroed();
-                if libc::uname(&mut sys_info) != 0 {
+                if libc::uname(&mut sys_info) == -1 {
                     return None;
                 }
 
@@ -532,7 +532,11 @@ impl TargetTriple {
                 (b"NetBSD", b"x86_64") => Some("x86_64-unknown-netbsd"),
                 (b"NetBSD", b"i686") => Some("i686-unknown-netbsd"),
                 (b"DragonFly", b"x86_64") => Some("x86_64-unknown-dragonfly"),
+                #[cfg(target_os = "illumos")]
                 (b"SunOS", b"i86pc") => Some("x86_64-unknown-illumos"),
+                #[cfg(target_os = "solaris")]
+                (b"SunOS", b"i86pc") => Some("x86_64-pc-solaris"),
+                (b"SunOS", b"sun4v") => Some("sparcv9-sun-solaris"),
                 _ => None,
             };
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -157,6 +157,8 @@ pub fn this_host_triple() -> String {
         "powerpc64le"
     } else if cfg!(target_arch = "s390x") {
         "s390x"
+    } else if cfg!(target_arch = "sparc64") {
+        "sparcv9"
     } else {
         unimplemented!()
     };
@@ -168,6 +170,12 @@ pub fn this_host_triple() -> String {
         "unknown-illumos"
     } else if cfg!(target_os = "freebsd") {
         "unknown-freebsd"
+    } else if cfg!(target_os = "solaris") {
+        if cfg!(target_arch = "sparc64") {
+            "sun-solaris"
+        } else {
+            "pc-solaris"
+        }
     } else {
         unimplemented!()
     };

--- a/www/index.html
+++ b/www/index.html
@@ -115,7 +115,7 @@
   <!-- unrecognized platform: ask for help -->
   <p>I don't recognize your platform.</p>
   <p>
-    rustup runs on Windows, Linux, macOS, FreeBSD, NetBSD, and illumos. If
+    rustup runs on Windows, Linux, macOS, FreeBSD, NetBSD, Solaris and illumos. If
     you are on one of these platforms and are seeing this then please
     <a href="https://github.com/rust-lang/rustup/issues/new">report an issue</a>,
     along with the following values:


### PR DESCRIPTION
Rustup should be built also for Solaris (after https://github.com/rust-lang/rust/pull/138699).