### PR TITLE
Emphasize that `llvm-tools` dist component is not subject to compiler stability guarantees

### DIFF
--- a/doc/user-guide/src/concepts/components.md
+++ b/doc/user-guide/src/concepts/components.md
@@ -54,8 +54,10 @@ toolchains. The following is an overview of the different components:
 * `rust-mingw` --- This contains a linker and platform libraries for building on
   the `x86_64-pc-windows-gnu` platform.
 * `llvm-tools` --- This component contains a collection of [LLVM] tools.
-  Note that this component has not been stabilized and may change in the
-  future and is provided as-is.
+  **This component has not been stabilized and may change in the future and is
+  provided as-is.** Availability of individual LLVM tools may
+  change over LLVM versions (including removal of specific LLVM tools), and
+  **is not subject to compiler or toolchain stability guarantees**.
   See [#85658](https://github.com/rust-lang/rust/issues/85658).
 * `rustc-dev` --- This component contains the compiler as a library. Most users
   will not need this; it is only needed for development *of* tools that link


### PR DESCRIPTION
See discussions over at [#t-compiler > &#96;llvm-tools-preview&#96; dist component](https://rust-lang.zulipchat.com/#narrow/channel/131828-t-compiler/topic/.60llvm-tools-preview.60.20dist.20component/with/524067760).