### PR TITLE
Check for updates concurrently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2240,6 +2240,7 @@ dependencies = [
  "env_proxy",
  "flate2",
  "fs_at",
+ "futures-util",
  "git-testament",
  "home",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,6 +407,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e09ced7ebbccb63b4c65413d821f2e00ce54c5ca4514ddc6b3c892fdbcbc69d"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "content_inspector"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +600,12 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-map"
@@ -1169,6 +1188,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a646d946d06bedbbc4cac4c218acf4bbf2d87757a784857025f4d447e4e1cd"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +1753,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b02ffed1bc8c2234bb6f8e760e34613776c5102a041f25330b869a78153a68c"
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2195,6 +2233,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_complete",
+ "console",
  "curl",
  "effective-limits",
  "enum-map",
@@ -2206,6 +2245,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "indicatif",
  "itertools 0.14.0",
  "libc",
  "opener",
@@ -3011,6 +3051,18 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = "4"
+console = "0.16"
 curl = { version = "0.4.44", optional = true }
 effective-limits = "0.5.5"
 enum-map = "2.5.0"
@@ -54,6 +55,7 @@ flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
 fs_at = "0.2.1"
 git-testament = "0.2"
 home = "0.5.4"
+indicatif = "0.18"
 itertools = "0.14"
 libc = "0.2"
 opener = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ enum-map = "2.5.0"
 env_proxy = { version = "0.4.1", optional = true }
 flate2 = { version = "1.1.1", default-features = false, features = ["zlib-rs"] }
 fs_at = "0.2.1"
+futures-util = "0.3.31"
 git-testament = "0.2"
 home = "0.5.4"
 indicatif = "0.18"


### PR DESCRIPTION
This change is related to #3132.

Currently, the `rustup check` command verifies updates for each toolchain sequentially.
This patch modifies that behavior to perform the checks concurrently.

To implement this change, the `futures_util` crate was introduced. I would appreciate feedback on this choice, and whether there might be a preferable alternative for handling concurrency.

My first attempt at adding concurrency caused all output to be printed only after every channel had been checked, which deviated from the current behavior of the command.
To preserve the existing behavior (reporting progress as each toolchain is checked), I tried printing concurrently as well.
However, this led to race conditions, resulting in inconsistent output order.

To address this, I used the `indicatif` crate (cc @djc) to display progress bars while maintaining the correct output order.

This PR will soon be updated to ensure progress bars are correctly written to _stdout_ in order to pass the tests.

Regarding performance, using `hyperfine`, a **2.2× speedup** was observed compared to the sequential version. These benchmarks were run 100 times (with 5 warmup runs) over a 50 Mbps connection.