### PR TITLE
Block broken snap curl

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -642,7 +642,22 @@ downloader() {
     local _status
     local _retry
     if check_cmd curl; then
-        _dld=curl
+        # Check if we have a broken snap curl
+        # https://github.com/boukendesho/curl-snap/issues/1
+        _curl_path=$(command -v curl)
+        if echo "$_curl_path" | grep "/snap/" > /dev/null 2>&1; then
+            if check_cmd wget; then
+                _dld=wget
+            else
+                err "curl installed with snap cannot be used to install Rust"
+                err "due to missing permissions. Please uninstall it and"
+                err "reinstall curl with a different package manager (e.g., apt)."
+                err "See https://github.com/boukendesho/curl-snap/issues/1"
+                exit 1
+            fi
+        else
+            _dld=curl
+        fi
     elif check_cmd wget; then
         _dld=wget
     else


### PR DESCRIPTION
When curl is installed with snap, it lacks permissions to write to the directories installers need (https://github.com/boukendesho/curl-snap/issues/1), which breaks rustup-init.sh (https://github.com/rust-lang/rustup/issues/2948).

To fix this, we error when the only available downloader is snap curl.

We hit this problem in uv (https://github.com/astral-sh/uv/issues/11849) and deployed a fix in our cargo-dist fork (https://github.com/astral-sh/cargo-dist/pull/28). I've ported this fix to rustup.

I've tested the change manually on my machine:
* apt url works
* snap curl and wget works
* snap curl and no wget fails

Unfortunately, snap doesn't run in docker so I can't provide a test script.

Fixes https://github.com/rust-lang/rustup/issues/2948

Solves:
 * https://github.com/rust-lang/rustup/issues/924#issuecomment-921375292, though it's unclear if solves the original report too
 * https://github.com/rust-lang/rustup/issues/2775#issuecomment-1512845583