### PR TITLE
docs: replace Discord links

### DIFF
--- a/doc/dev-guide/src/linting.md
+++ b/doc/dev-guide/src/linting.md
@@ -3,7 +3,8 @@
 We use `cargo clippy` to ensure high-quality code and to enforce a set of best practices for Rust programming.
 However, not all lints provided by `cargo clippy` are relevant or applicable to our project.
 We may choose to ignore some lints if they are unstable, experimental, or specific to our project.
-If you are unsure about a lint, please ask us in the [rustup Discord channel](https://discord.com/channels/442252698964721669/463480252723888159).
+If you are unsure about a lint, please ask us in the
+[rustup Zulip channel](https://rust-lang.zulipchat.com/#narrow/channel/490103-t-rustup).
 
 ## Manual linting
 

--- a/www/index.html
+++ b/www/index.html
@@ -221,8 +221,8 @@
 </div>
 
 <p id="help">
-  Need help?<br>Ask on <a href="https://discord.gg/rust-lang">#beginners in the Rust Discord</a><br>
-  or in the <a href="https://users.rust-lang.org">Rust Users Forum</a>.
+  Need help?<br>
+  Ask the <a href="https://www.rust-lang.org/community">community</a>!
 </p>
 
 <p id="about">


### PR DESCRIPTION
Continuation of https://github.com/rust-lang/team/pull/1888.