### PR TITLE
feat(www): improve "copy" button style compatibility with Chromium

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -175,9 +175,7 @@ hr {
     height: 58px;
     margin: 0;
     padding: 0 5px 0 5px;
-    border-radius: 0 3px 3px 0;
-    border-left-width: 0px;
-    border-left-style: solid;
+    border-width: 0px;
     cursor: pointer;
 }
 
@@ -191,7 +189,7 @@ hr {
     width: fit-content;
     height: fit-content;
     top: 27px;
-    left: 50%;
+    left: 23px;
     transform: translate(-50%, -50%);
 }
 
@@ -208,7 +206,7 @@ hr {
     width: 41px;
     height: 15px;
     position: relative;
-    top: 5px;
+    top: 6px;
 }
 
 #platform-instructions-win32 a.windows-download,


### PR DESCRIPTION
#4080 works pretty well on Firefox and Safari. However, recent Chromium builds fail to handle the "solid" button style correctly.

Given the wide use of Chromium-based browsers, this PR has removed the "solid" style together with the button border for better consistency across platforms. The position of the SVG icon and that of the caption have also been slightly adjusted to be more coherent with the new style.

Below is a before/after comparison on both Chromium and Firefox:

|          | Before                                                                                    | After                                                                                     |
|----------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| Chromium | ![image](https://github.com/user-attachments/assets/11db1d97-45d9-48b7-9e8f-25db41e95b42) | ![image](https://github.com/user-attachments/assets/7411b4b8-d2fa-421b-9d3b-1800fb86e2e3) |
| Firefox  | ![image](https://github.com/user-attachments/assets/7abf4ffd-9089-4444-9a3c-400412b37e74) | ![image](https://github.com/user-attachments/assets/75191722-34bb-4662-8f93-e14a6877426c) |

