### PR TITLE
fix(ci/run): specify target triple for bindgen-cli installation

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -10,7 +10,10 @@ cargo -vV
 if [ -n "$INSTALL_BINDGEN" ]; then
   # Install `cargo-binstall` first for faster installation.
   curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-  cargo binstall -y --force --locked bindgen-cli
+  # An explicit `--target` is required to ensure that `bindgen-cli` is built for the
+  # same target as the rest of the toolchain.
+  # See: <https://github.com/rust-lang/rustup/issues/4396>
+  cargo binstall -y --force --locked bindgen-cli "--target=$(rustc --print host-tuple)"
   mkdir "$CARGO_HOME"/bin/bindgen-cli
   mv "$CARGO_HOME"/bin/bindgen "$CARGO_HOME"/bin/bindgen-cli/
   export PATH="$CARGO_HOME/bin/bindgen-cli:$PATH"


### PR DESCRIPTION
Closes #4396.

Following @Kobzol's suggestion in https://github.com/rust-lang/rustup/issues/4396#issuecomment-3016383313, this PR makes use of `rustc --print host-tuple` to ensure compatibility with the host system when installing `codegen-cli`.

https://github.com/rust-lang/rustup/actions/runs/15953788042?pr=4398 proves that this approach works well with `aarch64-unknown-linux-musl` and `powerpc64le-unknown-linux-musl` targets, effectively eliminating the recent CI errors on `master`.
