### PR TITLE
Introduce `RUSTUP_TERM_WIDTH` and `RUSTUP_TERM_PROGRESS_WHEN`

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -61,6 +61,9 @@
   symlink proxies and instead always use hardlinks. If you find this fixes
   a problem, then please report the issue on the [rustup issue tracker].
 
+- `RUSTUP_TERM_PROGRESS_WHEN` (defaults: `auto`). Controls whether progress bars are shown or not.
+  Set to `always` to always enable progress bars, and to `never` to disable them.
+
 [directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md

--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -64,6 +64,8 @@
 - `RUSTUP_TERM_PROGRESS_WHEN` (defaults: `auto`). Controls whether progress bars are shown or not.
   Set to `always` to always enable progress bars, and to `never` to disable them.
 
+- `RUSTUP_TERM_WIDTH` (default: none). Allows to override the terminal width for progress bars.
+
 [directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md


### PR DESCRIPTION
Follow-up on #4388 .

As discussed in these comments, [1](https://github.com/rust-lang/rustup/pull/4388#discussion_r2187891633) and [2](https://github.com/rust-lang/rustup/pull/4388#discussion_r2187892015), new environment variables are introduced.