### PR TITLE
fix(ci/docker): update `CC` name for `powerpc64le-unknown-linux-gnu`

### DIFF
--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -4,5 +4,5 @@ FROM rust-powerpc64le-unknown-linux-gnu
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
 RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
-ENV CC_powerpc64le_unknown_linux_gnu=powerpc64le-linux-gnu-gcc \
-    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-linux-gnu-gcc
+ENV CC_powerpc64le_unknown_linux_gnu=powerpc64le-unknown-linux-gnu-gcc \
+    CARGO_TARGET_POWERPC64LE_UNKNOWN_LINUX_GNU_LINKER=powerpc64le-unknown-linux-gnu-gcc

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -19,7 +19,7 @@ LOCAL_DOCKER_TAG="rust-$TARGET"
 # The following is a mapping from `$TARGET`s to cached Docker images built from `Dockerfile`s under
 # <https://github.com/rust-lang/rust/blob/master/src/ci/docker/host-x86_64/>,
 # e.g. `FROM rust-aarch64-unknown-linux-musl` means the base `Dockerfile` to look at is located under
-# <https://github.com/rust-lang/rust/blob/master/src/ci/docker/host-x86_64/dist-arm-linux>.
+# <https://github.com/rust-lang/rust/blob/master/src/ci/docker/host-x86_64/dist-arm-linux-musl>.
 case "$TARGET" in
   aarch64-unknown-linux-gnu)       image=dist-aarch64-linux ;;
   aarch64-unknown-linux-musl)      image=dist-arm-linux-musl ;;


### PR DESCRIPTION
Addresses breakage caused by https://github.com/rust-lang/rust/commit/12bc4096dcb81cb795fed68eeea3c36590befa25.

## Concerns
- [x] Do proper testing: Verified by https://github.com/rust-lang/rustup/actions/runs/16257049167/job/45895060162?pr=4411