### PR TITLE
Set a maximum thread limit for the `remove_dir_all` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,6 +2258,7 @@ dependencies = [
  "proptest",
  "pulldown-cmark",
  "rand 0.9.1",
+ "rayon",
  "regex",
  "remove_dir_all",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"], optional = true
 platforms = "3.4"
 pulldown-cmark = { version = "0.13", default-features = false }
 rand = "0.9"
+rayon = "1.10.0"
 regex = "1"
 remove_dir_all = { version = "1.0.0", features = ["parallel"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "gzip", "http2", "socks", "stream"], optional = true }

--- a/src/install.rs
+++ b/src/install.rs
@@ -39,6 +39,11 @@ impl InstallMethod<'_> {
     // Install a toolchain
     #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn install(&self) -> Result<UpdateStatus> {
+        // Initialize rayon for use by the remove_dir_all crate limiting the number of threads.
+        // This will error if rayon is already initialized but it's fine to ignore that.
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(utils::io_thread_count())
+            .build_global();
         let nh = &self.cfg().notify_handler;
         match self {
             InstallMethod::Copy { .. }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ use std::io::{self, BufReader, Write};
 use std::ops::{BitAnd, BitAndAssign};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
+use std::thread;
 
 use anyhow::{Context, Result, anyhow, bail};
 use retry::delay::{Fibonacci, jitter};
@@ -25,6 +26,16 @@ pub(crate) mod notifications;
 pub(crate) mod notify;
 pub mod raw;
 pub(crate) mod units;
+
+pub fn io_thread_count() -> usize {
+    // Don't spawn more than this many I/O threads unless the user tells us to.
+    // Feel free to increase this value if it improves performance.
+    const DEFAULT_IO_THREAD_LIMIT: usize = 8;
+
+    thread::available_parallelism()
+        .map_or(1, |p| p.get())
+        .min(DEFAULT_IO_THREAD_LIMIT)
+}
 
 #[must_use]
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Under the hood it uses rayon so we preinitialise rayon's global pool.

Follow up to #4407
Fixes #4403