### PR TITLE
opt(err): show renaming file error source

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,7 +2,6 @@
 
 use std::ffi::OsString;
 use std::fmt::Debug;
-#[cfg(not(windows))]
 use std::io;
 use std::io::Write;
 use std::path::PathBuf;
@@ -77,6 +76,13 @@ pub enum RustupError {
     RemovingDirectory { name: &'static str, path: PathBuf },
     #[error("could not remove '{name}' file: '{}'", .path.display())]
     RemovingFile { name: &'static str, path: PathBuf },
+    #[error("could not rename '{name}' file from '{src}' to '{dest}': {source}")]
+    RenamingFile {
+        name: &'static str,
+        src: PathBuf,
+        dest: PathBuf,
+        source: io::Error,
+    },
     #[error("{}", component_unavailable_msg(.components, .manifest, .toolchain))]
     RequestedComponentsUnavailable {
         components: Vec<Component>,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -471,13 +471,14 @@ where
             },
         },
     )
-    .with_context(|| {
-        format!(
-            "could not rename {} file from '{}' to '{}'",
+    .map_err(|e| {
+        RustupError::RenamingFile {
             name,
-            src.display(),
-            dest.display()
-        )
+            src: PathBuf::from(src),
+            dest: PathBuf::from(dest),
+            source: e.error,
+        }
+        .into()
     })
 }
 


### PR DESCRIPTION
## Problem you are trying to solve

We occasionally encounter the following error:

```
error: component download failed for cargo-aarch64-apple-darwin: could not rename downloaded file from '/Users/xxx/.rustup/downloads/344e710d......76ee75be1fff0c7bf3.partial' to '/Users/xxx/.rustup/downloads/344e710d......76ee75be1fff0c7bf3'
```

This issue is difficult to reproduce, so it's important to add a source for reporting first.

## Description

This pull request introduces a `RenamingFile` error with a `source` to improve error handling for file renaming operations in the `RustupError` enum. It updates the codebase to use this new error type, enhancing the clarity and consistency of error reporting.