### PR TITLE
feat: improve error message for `rustup which`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1045,7 +1045,7 @@ async fn which(
     };
 
     Err(anyhow!(
-        "'{binary}' is not installed for the toolchain '{toolchain_name}'.\nTo install, run `rustup component add {selector}{component_name}`"
+        "'{binary}' is not installed for the toolchain '{toolchain_name}'.\nhelp: run `rustup component add {selector}{component_name}` to install it"
     ))
 }
 
@@ -1714,11 +1714,8 @@ async fn doc(
             .as_slice()
     {
         info!(
-            "`rust-docs` not installed in toolchain `{}`",
-            distributable.desc()
-        );
-        info!(
-            "To install, try `rustup component add --toolchain {} rust-docs`",
+            "`rust-docs` not installed in toolchain `{}`\nhelp: run `rustup component add --toolchain {} rust-docs` to install it",
+            distributable.desc(),
             distributable.desc()
         );
         return Err(anyhow!(

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -453,7 +453,7 @@ impl<'a> DistributableToolchain<'a> {
                     _ => format!("--toolchain {} ", self.toolchain.name()),
                 };
                 Err(anyhow!(
-                    "'{binary_lossy}' is not installed for the toolchain '{desc}'.\nTo install, run `rustup component add {selector}{component_name}`"
+                    "'{binary_lossy}' is not installed for the toolchain '{desc}'.\nhelp: run `rustup component add {selector}{component_name}` to install it"
                 ))
             }
         } else {

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -705,7 +705,7 @@ async fn run_rls_when_not_installed() {
         .await
         .with_stderr(snapbox::str![[r#"
 error: 'rls[EXE]' is not installed for the toolchain 'stable-[HOST_TRIPLE]'.
-To install, run `rustup component add rls`
+help: run `rustup component add rls` to install it
 
 "#]])
         .is_err();
@@ -727,7 +727,7 @@ async fn run_rls_when_not_installed_for_nightly() {
         .await
         .with_stderr(snapbox::str![[r#"
 error: 'rls[EXE]' is not installed for the toolchain 'nightly-[HOST_TRIPLE]'.
-To install, run `rustup component add --toolchain nightly-[HOST_TRIPLE] rls`
+help: run `rustup component add --toolchain nightly-[HOST_TRIPLE] rls` to install it
 
 "#]])
         .is_err();
@@ -1403,7 +1403,7 @@ async fn which_asking_uninstalled_components() {
         .await
         .with_stderr(snapbox::str![[r#"
 error: 'rustfmt' is not installed for the toolchain 'custom-1'.
-[..]`rustup component add rustfmt`
+[..]`rustup component add rustfmt`[..]
 
 "#]])
         .is_err();
@@ -1419,7 +1419,7 @@ error: 'rustfmt' is not installed for the toolchain 'custom-1'.
         .await
         .with_stderr(snapbox::str![[r#"
 [..]'rustfmt' is not installed for the toolchain 'custom-2'.
-[..]`rustup component add --toolchain custom-2 rustfmt`
+[..]`rustup component add --toolchain custom-2 rustfmt`[..]
 
 "#]])
         .is_err();

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1385,6 +1385,70 @@ async fn which_asking_uninstalled_toolchain() {
 }
 
 #[tokio::test]
+async fn which_asking_uninstalled_components() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let path_1 = cx.config.customdir.join("custom-1");
+    let path_1 = path_1.to_string_lossy();
+    cx.config
+        .expect(["rustup", "toolchain", "link", "custom-1", &path_1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "custom-1"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "which", "rustfmt"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: 'rustfmt' is not installed for the toolchain 'custom-1'.
+[..]`rustup component add rustfmt`
+
+"#]])
+        .is_err();
+
+    let path_2 = cx.config.customdir.join("custom-2");
+    let path_2 = path_2.to_string_lossy();
+    cx.config
+        .expect(["rustup", "toolchain", "link", "custom-2", &path_2])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "which", "--toolchain=custom-2", "rustfmt"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+[..]'rustfmt' is not installed for the toolchain 'custom-2'.
+[..]`rustup component add --toolchain custom-2 rustfmt`
+
+"#]])
+        .is_err();
+}
+
+#[tokio::test]
+async fn which_unknown_binary() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let path_1 = cx.config.customdir.join("custom-1");
+    let path_1 = path_1.to_string_lossy();
+    cx.config
+        .expect(["rustup", "toolchain", "link", "custom-1", &path_1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "default", "custom-1"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "which", "ls"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+[..]unknown binary 'ls' in toolchain 'custom-1'
+
+"#]])
+        .is_err();
+}
+
+#[tokio::test]
 async fn override_by_toolchain_on_the_command_line() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -3342,7 +3342,7 @@ async fn docs_missing() {
         .await
         .with_stderr(snapbox::str![[r#"
 info: `rust-docs` not installed in toolchain `nightly-[HOST_TRIPLE]`
-info: To install, try `rustup component add --toolchain nightly-[HOST_TRIPLE] rust-docs`
+help: run `rustup component add --toolchain nightly-[HOST_TRIPLE] rust-docs` to install it
 error: unable to view documentation which is not installed
 
 "#]])

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -1020,7 +1020,7 @@ async fn rls_proxy_set_up_after_install() {
         .await
         .with_stderr(snapbox::str![[r#"
 error: 'rls[EXE]' is not installed for the toolchain 'stable-[HOST_TRIPLE]'.
-To install, run `rustup component add rls`
+help: run `rustup component add rls` to install it
 
 "#]])
         .is_err();


### PR DESCRIPTION
Close #3321 

This PR improves the error message for `rustup which` by providing a suggested command to install the missing component, provided that we know which one it is.

## Limitations

Some edge cases are not coverd, e.g. if a binary is expected to be provided by a component but not found on disk. (which is handled in `DistributableToolchain::recursion_error`)