### PR TITLE
test: detach snapshots from component installation order

### DIFF
--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -22,15 +22,20 @@ async fn update_once() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'nightly-[HOST_TRIPLE]'
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
 
 "#]]);
 }
@@ -64,14 +69,18 @@ rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
+"#]]);
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
 
 "#]]);
 }
@@ -103,16 +112,21 @@ async fn update_once_and_self_update() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: checking for self-update (current version: [CURRENT_VERSION])
 info: downloading self-update (new version: [TEST_VERSION])
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
 
 "#]]);
 }
@@ -309,15 +323,20 @@ async fn default() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'nightly-[HOST_TRIPLE]'
+
+"#]]);
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
 
 "#]]);
 }
@@ -738,11 +757,15 @@ async fn cross_install_indicates_target() {
         .expect(["rustup", "target", "add", CROSS_ARCH1])
         .await
         .is_ok()
-        .with_stdout(snapbox::str![[""]])
-        .with_stderr(snapbox::str![[r#"
-info: downloading component 'rust-std' for '[CROSS_ARCH_I]'
-info: installing component 'rust-std' for '[CROSS_ARCH_I]'
-
+        .with_stdout(snapbox::str![[""]]);
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+...
+rust-std-[CROSS_ARCH_I]
+...
 "#]]);
 }
 

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -608,12 +608,18 @@ async fn rustup_run_install() {
             "--version",
         ])
         .await
-        .with_stderr(snapbox::str![[r#"
-...
-info: installing component 'rustc'
-...
-"#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -35,22 +35,23 @@ async fn rustup_stable() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'stable-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: cleaning up downloads & tmp directories
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -130,50 +131,53 @@ async fn rustup_all_channels() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'stable-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: syncing channel updates for 'beta-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.2.0 (hash-beta-1.2.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: cleaning up downloads & tmp directories
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+stable", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+beta", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -204,37 +208,50 @@ async fn rustup_some_channels_up_to_date() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'stable-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: syncing channel updates for 'beta-[HOST_TRIPLE]'
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: removing previous version of component 'cargo'
-info: removing previous version of component 'rust-docs'
-info: removing previous version of component 'rust-std'
-info: removing previous version of component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: cleaning up downloads & tmp directories
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+stable", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+beta", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -267,18 +284,23 @@ async fn default() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'nightly-[HOST_TRIPLE]'
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -1234,12 +1256,18 @@ installed targets:
   [HOST_TRIPLE]
 
 "#]])
-        .with_stderr(snapbox::str![[r#"
-...
-info: installing component 'rustc'
-...
-"#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -1680,13 +1708,21 @@ channel = "nightly"
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'rustc'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: the active toolchain `nightly-[HOST_TRIPLE]` has been installed
 info: it's active because: overridden by '[TOOLCHAIN_FILE]'
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+rustc-[HOST_TRIPLE]
+
+"#]]);
 
     cx.config
         .expect(["rustup", "toolchain", "install"])
@@ -2657,11 +2693,6 @@ components = [ "rust-src" ]
     cx.config
         .expect(["rustup", "toolchain", "install"])
         .await
-        .with_stderr(snapbox::str![[r#"
-...
-info: installing component 'rust-src'
-...
-"#]])
         .is_ok();
     cx.config
         .expect(["rustup", "component", "list"])
@@ -2703,11 +2734,6 @@ targets = [ "{CROSS_ARCH2}" ]
     cx.config
         .expect(["rustup", "toolchain", "install"])
         .await
-        .with_stderr(snapbox::str![[r#"
-...
-info: installing component 'rust-std' for '[CROSS_ARCH_II]'
-...
-"#]])
         .is_ok();
     cx.config
         .expect(["rustup", "component", "list"])
@@ -2760,9 +2786,14 @@ async fn file_override_toml_format_specify_profile() {
     cx.config
         .expect(&["rustup", "default", "stable"])
         .await
-        .with_stderr(snapbox::str![[r#"
+        .is_ok();
+    cx.config
+        .expect(&["rustup", "component", "list"])
+        .await
+        // The `rust-docs-[HOST_TRIPLE]` component is installed.
+        .with_stdout(snapbox::str![[r#"
 ...
-info: downloading component 'rust-docs'
+rust-docs-[HOST_TRIPLE] (installed)
 ...
 "#]])
         .is_ok();
@@ -3688,14 +3719,21 @@ async fn custom_toolchain_with_components_toolchains_profile_does_not_err() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
-info: downloading component 'cargo'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'nightly-[HOST_TRIPLE]'
 
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 
     // link the toolchain
     let toolchains = cx.config.rustupdir.join("toolchains");

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -72,14 +72,8 @@ async fn install_bins_to_cargo_home() {
 ...
 info: syncing channel updates for 'stable-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'stable-[HOST_TRIPLE]'
 
 "#]])
@@ -123,14 +117,8 @@ async fn proxies_are_relative_symlinks() {
 ...
 info: syncing channel updates for 'stable-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.1.0 (hash-stable-1.1.0)
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rust-std'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rust-std'
-info: installing component 'rustc'
+info: downloading component[..]
+...
 info: default toolchain set to 'stable-[HOST_TRIPLE]'
 ...
 "#]])

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -278,8 +278,7 @@ async fn remove_override_toolchain_err_handling() {
 
 "#]])
         .with_stderr(snapbox::str![[r#"
-...
-info: downloading component 'rust'
+info: syncing channel updates for 'beta-[HOST_TRIPLE]'
 ...
 "#]])
         .is_ok();

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -485,11 +485,23 @@ async fn remove_override_toolchain_err_handling() {
 
 "#]])
         .with_stderr(snapbox::str![[r#"
-...
-info: downloading component 'rustc'
+info: syncing channel updates for 'beta-[HOST_TRIPLE]'
+info: latest update on 2015-01-02, rust version 1.2.0 (hash-beta-1.2.0)
+info: downloading component[..]
 ...
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -506,11 +518,23 @@ async fn file_override_toolchain_err_handling() {
 
 "#]])
         .with_stderr(snapbox::str![[r#"
-...
-info: downloading component 'rustc'
+info: syncing channel updates for 'beta-[HOST_TRIPLE]'
+info: latest update on 2015-01-02, rust version 1.2.0 (hash-beta-1.2.0)
+info: downloading component[..]
 ...
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rust-std-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]
@@ -2437,15 +2461,20 @@ async fn run_with_install_flag_against_unavailable_component() {
 info: syncing channel updates for 'nightly-[HOST_TRIPLE]'
 info: latest update on 2015-01-02, rust version 1.3.0 (hash-nightly-2)
 warn: Force-skipping unavailable component 'rust-std-[HOST_TRIPLE]'
-info: downloading component 'cargo'
-info: downloading component 'rust-docs'
-info: downloading component 'rustc'
-info: installing component 'cargo'
-info: installing component 'rust-docs'
-info: installing component 'rustc'
-
+info: downloading component[..]
+...
 "#]])
         .is_ok();
+    cx.config
+        .expect(["rustup", "+nightly", "component", "list", "--installed"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+cargo-[HOST_TRIPLE]
+rust-docs-[HOST_TRIPLE]
+rustc-[HOST_TRIPLE]
+
+"#]]);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Currently, quite a few of our test snapshots rely on the messages sent to our notification center similar to the following:

```console
info: downloading component 'cargo'
info: downloading component 'rust-docs'
...
info: installing component 'cargo'
...
```

... however, the order will no longer be guaranteed once @FranciscoTGouveia makes these events concurrent, meaning there will be a different CLI output format which doesn't guarantee the order of such events.

This PR has made such snapshots agnostic to the specific forms of these message, and turn to other means such as `rustup component list --installed` if necessary.

## Concerns

- [x] Proper verification: verified in https://github.com/rust-lang/rustup/actions/runs/16726200278/job/47342369030?pr=4436.