### PR TITLE
Introduce `RUSTUP_DOWNLOAD_TIMEOUT` to override the download timeout

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -66,6 +66,9 @@
 
 - `RUSTUP_TERM_WIDTH` (default: none). Allows to override the terminal width for progress bars.
 
+- `RUSTUP_DOWNLOAD_TIMEOUT` *unstable* (default: 180). Allows to override the default
+  timeout (in seconds) for downloading components.
+
 [directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md

--- a/src/download/tests.rs
+++ b/src/download/tests.rs
@@ -19,6 +19,7 @@ use tempfile::TempDir;
 mod curl {
     use std::sync::Mutex;
     use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
 
     use url::Url;
 
@@ -36,7 +37,13 @@ mod curl {
 
         let from_url = Url::from_file_path(&from_path).unwrap();
         Backend::Curl
-            .download_to_path(&from_url, &target_path, true, None)
+            .download_to_path(
+                &from_url,
+                &target_path,
+                true,
+                None,
+                Duration::from_secs(180),
+            )
             .await
             .expect("Test download failed");
 
@@ -83,6 +90,7 @@ mod curl {
 
                     Ok(())
                 }),
+                Duration::from_secs(180),
             )
             .await
             .expect("Test download failed");
@@ -185,7 +193,13 @@ mod reqwest {
 
         let from_url = Url::from_file_path(&from_path).unwrap();
         Backend::Reqwest(TlsBackend::NativeTls)
-            .download_to_path(&from_url, &target_path, true, None)
+            .download_to_path(
+                &from_url,
+                &target_path,
+                true,
+                None,
+                Duration::from_secs(180),
+            )
             .await
             .expect("Test download failed");
 
@@ -232,6 +246,7 @@ mod reqwest {
 
                     Ok(())
                 }),
+                Duration::from_secs(180),
             )
             .await
             .expect("Test download failed");


### PR DESCRIPTION
Fixes #4439.

Besides increasing the default timeout from 30 seconds to 3 minutes, a new environment variable (`RUSTUP_DOWNLOAD_TIMEOUT`) is introduced to allow users to override this value.