### PR TITLE
Justify the presence of an `.unwrap()` on getting the content of an `OnceLock`

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -649,7 +649,8 @@ mod reqwest_be {
             .map_err(DownloadError::Reqwest)?;
 
         let _ = CLIENT_NATIVE_TLS.set(client);
-
+        // "The cell is guaranteed to contain a value when `set` returns, though not necessarily
+        // the one provided."
         Ok(CLIENT_NATIVE_TLS.get().unwrap())
     }
 


### PR DESCRIPTION
Follow-up on #4440 (based on [this](https://github.com/rust-lang/rustup/pull/4440#discussion_r2276890338) comment).