### PR TITLE
Delete unnecessary Download(Pop/Push)Unit notifications

### DIFF
--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -59,9 +59,6 @@ impl DownloadTracker {
                 self.create_progress_bar(component.to_owned(), url.to_owned());
                 true
             }
-            Notification::Install(In::Utils(Un::DownloadPushUnit(_))) => true,
-            Notification::Install(In::Utils(Un::DownloadPopUnit)) => true,
-
             _ => false,
         }
     }

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -16,7 +16,6 @@ use tracing::debug;
 
 use super::{CompletedIo, Executor, Item, perform};
 use crate::utils::notifications::Notification;
-use crate::utils::units::Unit;
 
 #[derive(Copy, Clone, Debug, Enum)]
 pub(crate) enum Bucket {
@@ -264,7 +263,6 @@ impl Executor for Threaded<'_> {
         let mut prev_files = self.n_files.load(Ordering::Relaxed);
         if let Some(handler) = self.notify_handler {
             handler(Notification::DownloadFinished(None));
-            handler(Notification::DownloadPushUnit(Unit::IO));
             handler(Notification::DownloadContentLengthReceived(
                 prev_files as u64,
                 None,
@@ -294,7 +292,6 @@ impl Executor for Threaded<'_> {
         self.pool.join();
         if let Some(handler) = self.notify_handler {
             handler(Notification::DownloadFinished(None));
-            handler(Notification::DownloadPopUnit);
         }
         // close the feedback channel so that blocking reads on it can
         // complete. send is atomic, and we know the threads completed from the

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use url::Url;
 
 use crate::utils::notify::NotificationLevel;
-use crate::utils::units::{self, Unit};
+use crate::utils::units;
 
 #[derive(Debug)]
 pub enum Notification<'a> {
@@ -20,12 +20,6 @@ pub enum Notification<'a> {
     DownloadDataReceived(&'a [u8], Option<&'a str>),
     /// Download has finished.
     DownloadFinished(Option<&'a str>),
-    /// The things we're tracking that are not counted in bytes.
-    /// Must be paired with a pop-units; our other calls are not
-    /// setup to guarantee this any better.
-    DownloadPushUnit(Unit),
-    /// finish using an unusual unit.
-    DownloadPopUnit,
     NoCanonicalPath(&'a Path),
     ResumingPartialDownload,
     /// This would make more sense as a crate::notifications::Notification
@@ -55,8 +49,6 @@ impl Notification<'_> {
             | DownloadingFile(_, _)
             | DownloadContentLengthReceived(_, _)
             | DownloadDataReceived(_, _)
-            | DownloadPushUnit(_)
-            | DownloadPopUnit
             | DownloadFinished(_)
             | ResumingPartialDownload
             | UsingCurl
@@ -90,13 +82,11 @@ impl Display for Notification<'_> {
             SetDefaultBufferSize(size) => write!(
                 f,
                 "using up to {} of RAM to unpack components",
-                units::Size::new(*size, units::Unit::B)
+                units::Size::new(*size)
             ),
             DownloadingFile(url, _) => write!(f, "downloading file from: '{url}'"),
             DownloadContentLengthReceived(len, _) => write!(f, "download size is: '{len}'"),
             DownloadDataReceived(data, _) => write!(f, "received some data of size {}", data.len()),
-            DownloadPushUnit(_) => Ok(()),
-            DownloadPopUnit => Ok(()),
             DownloadFinished(_) => write!(f, "download finished"),
             NoCanonicalPath(path) => write!(f, "could not canonicalize path: '{}'", path.display()),
             ResumingPartialDownload => write!(f, "resuming partial download"),

--- a/src/utils/units.rs
+++ b/src/utils/units.rs
@@ -1,65 +1,32 @@
 use std::fmt::{self, Display};
 
+/// Human readable size representation
 #[derive(Copy, Clone, Debug)]
-pub enum Unit {
-    B,
-    IO,
-}
-
-/// Human readable size (some units)
-pub(crate) enum Size {
-    B(usize),
-    IO(usize),
-}
+pub(crate) struct Size(usize);
 
 impl Size {
-    pub(crate) fn new(size: usize, unit: Unit) -> Self {
-        match unit {
-            Unit::B => Self::B(size),
-            Unit::IO => Self::IO(size),
-        }
+    pub(crate) fn new(size: usize) -> Self {
+        Self(size)
     }
 }
 
 impl Display for Size {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Size::B(size) => {
-                const KI: f64 = 1024.0;
-                const MI: f64 = KI * KI;
-                const GI: f64 = KI * KI * KI;
-                let size = *size as f64;
+        const KI: f64 = 1024.0;
+        const MI: f64 = KI * KI;
+        const GI: f64 = KI * KI * KI;
+        let size = self.0 as f64;
 
-                let suffix: String = "".into();
+        let suffix: String = "".into();
 
-                if size >= GI {
-                    write!(f, "{:5.1} GiB{}", size / GI, suffix)
-                } else if size >= MI {
-                    write!(f, "{:5.1} MiB{}", size / MI, suffix)
-                } else if size >= KI {
-                    write!(f, "{:5.1} KiB{}", size / KI, suffix)
-                } else {
-                    write!(f, "{size:3.0} B{suffix}")
-                }
-            }
-            Size::IO(size) => {
-                const K: f64 = 1000.0;
-                const M: f64 = K * K;
-                const G: f64 = K * K * K;
-                let size = *size as f64;
-
-                let suffix: String = "IO-ops".into();
-
-                if size >= G {
-                    write!(f, "{:5.1} giga-{}", size / G, suffix)
-                } else if size >= M {
-                    write!(f, "{:5.1} mega-{}", size / M, suffix)
-                } else if size >= K {
-                    write!(f, "{:5.1} kilo-{}", size / K, suffix)
-                } else {
-                    write!(f, "{size:3.0} {suffix}")
-                }
-            }
+        if size >= GI {
+            write!(f, "{:5.1} GiB{}", size / GI, suffix)
+        } else if size >= MI {
+            write!(f, "{:5.1} MiB{}", size / MI, suffix)
+        } else if size >= KI {
+            write!(f, "{:5.1} KiB{}", size / KI, suffix)
+        } else {
+            write!(f, "{size:3.0} B{suffix}")
         }
     }
 }
@@ -68,33 +35,12 @@ impl Display for Size {
 mod tests {
     #[test]
     fn unit_formatter_test() {
-        use crate::utils::units::{Size, Unit};
+        use crate::utils::units::Size;
 
         // Test Bytes
-        assert_eq!(format!("{}", Size::new(1, Unit::B)), "  1 B");
-        assert_eq!(format!("{}", Size::new(1024, Unit::B)), "  1.0 KiB");
-        assert_eq!(
-            format!("{}", Size::new(1024usize.pow(2), Unit::B)),
-            "  1.0 MiB"
-        );
-        assert_eq!(
-            format!("{}", Size::new(1024usize.pow(3), Unit::B)),
-            "  1.0 GiB"
-        );
-
-        //Test I/O Operations
-        assert_eq!(format!("{}", Size::new(1, Unit::IO)), "  1 IO-ops");
-        assert_eq!(
-            format!("{}", Size::new(1000, Unit::IO)),
-            "  1.0 kilo-IO-ops"
-        );
-        assert_eq!(
-            format!("{}", Size::new(1000usize.pow(2), Unit::IO)),
-            "  1.0 mega-IO-ops"
-        );
-        assert_eq!(
-            format!("{}", Size::new(1000usize.pow(3), Unit::IO)),
-            "  1.0 giga-IO-ops"
-        );
+        assert_eq!(format!("{}", Size::new(1)), "  1 B");
+        assert_eq!(format!("{}", Size::new(1024)), "  1.0 KiB");
+        assert_eq!(format!("{}", Size::new(1024usize.pow(2))), "  1.0 MiB");
+        assert_eq!(format!("{}", Size::new(1024usize.pow(3))), "  1.0 GiB");
     }
 }


### PR DESCRIPTION
Follow-up on #4426.

With the refactor of the `DownloadTracker` to use `indicatif`, the `DownloadPushUnit` and `DownloadPopUnit` notifications are no longer used.
This PR removes them since they are now obsolete.