### PR TITLE
ci(check): make installation of `taplo-cli` faster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1464,7 +1464,8 @@ jobs:
       - name: Install taplo
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli
+          tool: taplo
+          fallback: none
       - name: Run TOML formatting checks
         run: |
           taplo fmt

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -68,7 +68,8 @@ jobs: # skip-all
       - name: Install taplo
         uses: taiki-e/install-action@v2
         with:
-          tool: taplo-cli
+          tool: taplo
+          fallback: none
       - name: Run TOML formatting checks
         run: |
           taplo fmt


### PR DESCRIPTION
As discussed with the author of [`taiki-e/install-action`](https://github.com/taiki-e/install-action) in https://github.com/taiki-e/install-action/issues/1100, `taplo` should be used instead of `taplo-cli` as the tool name for the `install-action` Action, otherwise `install-action` falls back on using [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall), which itself seems to currently fall back on using QuickInstall. This makes the installation of `taplo-cli` in CI very slow (it currently takes more than two minutes).

This PR fixes the tool name and disables the fallback on `cargo-binstall` as that would then fail anyway, because `cargo-binstall` would try to install the `taplo` *lib* crate, instead of the `taplo-cli` bin crate.

---

Feel free to push to this PR's branch as needed.