### PR TITLE
fix(deps): update rust crate tar to 0.4.44 as per Cargo.lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"
 sharded-slab = "0.1.1"
 strsim = "0.11"
-tar = "0.4.26"
+tar = "0.4.44"
 tempfile = "3.8"
 termcolor = "1.2"
 thiserror = "2"


### PR DESCRIPTION
In Cargo.lock, the version of crate tar dependency is 0.4.44, while in Cargo.toml it's version 0.4.26. Fix it.