### PR TITLE
chore(deps): disable default features for zstd

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 url = "2.4"
 wait-timeout = "0.2"
 xz2 = "0.1.3"
-zstd = "0.13"
+zstd = { version = "0.13", default-features = false }
 
 # test only (depends on `test` feature)
 snapbox = { version = "0.6.21", optional = true }


### PR DESCRIPTION
Zstd not really currently used(as i understand), so no need to support legacy/dict features. Slightly reduces binary size.