### PR TITLE
Introduce a `Semaphore` to fully honor `RUSTUP_CONCURRENT_DOWNLOADS`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
     process::ExitStatus,
     str::FromStr,
+    sync::Arc,
     time::Duration,
 };
 
@@ -16,6 +17,7 @@ use console::style;
 use futures_util::stream::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use itertools::Itertools;
+use tokio::sync::Semaphore;
 use tracing::{info, trace, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
@@ -799,13 +801,15 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
     let use_colors = matches!(t.color_choice(), ColorChoice::Auto | ColorChoice::Always);
     let mut update_available = false;
     let channels = cfg.list_channels()?;
-    let num_channels = cfg.process.concurrent_downloads().unwrap_or(channels.len());
+    let channels_len = channels.len();
+    let num_channels = cfg.process.concurrent_downloads().unwrap_or(channels_len);
 
     // Ensure that `.buffered()` is never called with 0 as this will cause a hang.
     // See: https://github.com/rust-lang/futures-rs/pull/1194#discussion_r209501774
     if num_channels > 0 {
         let multi_progress_bars =
             MultiProgress::with_draw_target(cfg.process.progress_draw_target());
+        let semaphore = Arc::new(Semaphore::new(num_channels));
         let channels = tokio_stream::iter(channels.into_iter()).map(|(name, distributable)| {
             let pb = multi_progress_bars.add(ProgressBar::new(1));
             pb.set_style(
@@ -815,7 +819,10 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
             );
             pb.set_message(format!("{name}"));
             pb.enable_steady_tick(Duration::from_millis(100));
+
+            let sem = semaphore.clone();
             async move {
+                let _permit = sem.acquire().await.unwrap();
                 let current_version = distributable.show_version()?;
                 let dist_version = distributable.show_dist_version().await?;
                 let mut update_a = false;
@@ -867,7 +874,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
         // `indicatif`.
         let channels = if !multi_progress_bars.is_hidden() {
             channels
-                .buffer_unordered(num_channels)
+                .buffer_unordered(channels_len)
                 .collect::<Vec<_>>()
                 .await
         } else {


### PR DESCRIPTION
Follow-up on #4450.

Although introducing the `RUSTUP_CONCURRENT_DOWNLOADS` environment variable allows the user to opt in to concurrency, there may be moments where this variable is not fully honored.

An example would be when installing a toolchain (6 components) and the user had `RUSTUP_CONCURRENT_DOWNLOADS=2`.
This would create some situations where there would only be one download being done, where two could have been downloaded instead; this situation has been reported [here](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20Make.20Rustup.20Concurrent/near/535051136).

This is not a surprise as per the nature of the [`.buffered()`](https://docs.rs/futures-util/0.3.31/futures_util/stream/trait.StreamExt.html#method.buffered) method which, unfortunately, cannot ensure that `n` futures will always be buffered at a same point in time.

To overcome this, and ensure that the environment variable is honored at all times, I decided to introduce a [`Semaphore`](https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html) that guarantees that there are always `n` downloads happening concurrently.

---

For reference, I leave below a small animation of the old (faulty) behavior:

![faulty](https://github.com/user-attachments/assets/e8dea58d-7235-41d8-9289-bbcd2868b29f)


... and the new (corrected) behavior:

![fixed](https://github.com/user-attachments/assets/236ca335-78d7-429c-a9eb-90fda8e43922)


