### PR TITLE
Specify --speed-limit and --speed-time for the fetch script

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -791,17 +791,27 @@ check_help_for() {
 
 # Check if curl supports the --retry flag, then pass it to the curl invocation.
 check_curl_for_retry_support() {
-    local _retry_supported=""
+    local _retry_part=""
+    local _continue_part=""
+    local _speed_limit_part=""
+
     # "unspecified" is for arch, allows for possibility old OS using macports, homebrew, etc.
     if check_help_for "notspecified" "curl" "--retry"; then
-        _retry_supported="--retry 3"
+        _retry_part="--retry 3"
+
         if check_help_for "notspecified" "curl" "--continue-at"; then
-            # "-C -" tells curl to automatically find where to resume the download when retrying.
-            _retry_supported="--retry 3 -C -"
+            # "--continue-at -" tells curl to automatically find where to resume the download when retrying.
+            _continue_part="--continue-at -"
+        fi
+
+        if check_help_for "notspecified" "curl" "--speed-limit" \
+           && check_help_for "notspecified" "curl" "--speed-time"; then
+            # 250000 is approximately 20% of the bandwidth of typical DSL
+            _speed_limit_part="--speed-limit 250000 --speed-time 15"
         fi
     fi
 
-    RETVAL="$_retry_supported"
+    RETVAL="$_retry_part $_continue_part $_speed_limit_part"
 }
 
 # Return cipher suite string specified by user, otherwise return strong TLS 1.2-1.3 cipher suites


### PR DESCRIPTION
This change will cause curl to cancel and retry the connection if the connection to the remote is exceedingly slow.

Note this change does apply some "policy" by expecting the user's internet connection to be at least 20% the speed of modern DSL: If the connection can't sustain at least 250,000 bytes per second for 15 seconds, curl will disconnect and try again.

I don't know if the rust project has data on users in that threshold or not, but this is upstreaming a change from our fork of this script in DeterminateSystems/nix-installer.