### PR TITLE
Report the real elapsed time of a download instead of the cumulative time

### DIFF
--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -81,6 +81,7 @@ impl DownloadTracker {
     /// Sets the length for a new ProgressBar and gives it a style.
     pub(crate) fn content_length_received(&mut self, content_len: u64, url: &str) {
         if let Some(pb) = self.file_progress_bars.get(url) {
+            pb.reset();
             pb.set_length(content_len);
         }
     }


### PR DESCRIPTION
Related to the introduction of the `RUSTUP_CONCURRENT_DOWNLOADS` environment variable in #4450.

This fixes the erroneous behavior of making the progress bar start ticking for all downloads at once, even when we are not in a situation of max concurrency.

**PS:** This situation can be observed in [this](https://github.com/rust-lang/rustup/pull/4455#issue-3349739692) animation (the first one).