### PR TITLE
Correct `DownloadTracker` reporting on retries and failures

### DIFF
--- a/src/cli/download_tracker.rs
+++ b/src/cli/download_tracker.rs
@@ -59,6 +59,7 @@ impl DownloadTracker {
                 self.create_progress_bar(component.to_owned(), url.to_owned());
                 true
             }
+            Notification::Install(In::RetryingDownload(_url)) => true,
             _ => false,
         }
     }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -218,7 +218,10 @@ async fn download_file_(
         .download_to_path(url, path, resume_from_partial, Some(callback), timeout)
         .await;
 
-    notify_handler(Notification::DownloadFinished(Some(url.as_str())));
+    // The notification should only be sent if the download was successful (i.e. didn't timeout)
+    if res.is_ok() {
+        notify_handler(Notification::DownloadFinished(Some(url.as_str())));
+    }
 
     res
 }

--- a/src/utils/notifications.rs
+++ b/src/utils/notifications.rs
@@ -20,6 +20,8 @@ pub enum Notification<'a> {
     DownloadDataReceived(&'a [u8], Option<&'a str>),
     /// Download has finished.
     DownloadFinished(Option<&'a str>),
+    /// Download has failed.
+    DownloadFailed(&'a str),
     NoCanonicalPath(&'a Path),
     ResumingPartialDownload,
     /// This would make more sense as a crate::notifications::Notification
@@ -50,6 +52,7 @@ impl Notification<'_> {
             | DownloadContentLengthReceived(_, _)
             | DownloadDataReceived(_, _)
             | DownloadFinished(_)
+            | DownloadFailed(_)
             | ResumingPartialDownload
             | UsingCurl
             | UsingReqwest => NotificationLevel::Debug,
@@ -88,6 +91,7 @@ impl Display for Notification<'_> {
             DownloadContentLengthReceived(len, _) => write!(f, "download size is: '{len}'"),
             DownloadDataReceived(data, _) => write!(f, "received some data of size {}", data.len()),
             DownloadFinished(_) => write!(f, "download finished"),
+            DownloadFailed(_) => write!(f, "download failed"),
             NoCanonicalPath(path) => write!(f, "could not canonicalize path: '{}'", path.display()),
             ResumingPartialDownload => write!(f, "resuming partial download"),
             UsingCurl => write!(f, "downloading with curl"),


### PR DESCRIPTION
After refactoring the `DownloadTracker` to use `indicatif` and enabling concurrent downloads, a few *UX* issues arose.

This PR addresses those issues, specifically fixing the cluttered output that occurred whenever a download was retried or failed.

An example of the cluttered output described above is shown below:

<img width="793" height="683" alt="image" src="https://github.com/user-attachments/assets/9f5b6a42-f354-4cdd-8db8-71579d7d3662" />
