### PR TITLE
Interleave downloads with installations when downloading a toolchain

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -278,7 +278,7 @@ pub(crate) async fn try_install_msvc(
         &visual_studio,
         None,
         None,
-        dl_cfg.process,
+        &dl_cfg.process,
     )
     .await?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Debug, Display};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::Arc;
 
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
@@ -238,7 +239,7 @@ pub(crate) struct Cfg<'a> {
     pub toolchains_dir: PathBuf,
     update_hash_dir: PathBuf,
     pub download_dir: PathBuf,
-    pub tmp_cx: temp::Context,
+    pub tmp_cx: Arc<temp::Context>,
     pub toolchain_override: Option<ResolvableToolchainName>,
     env_override: Option<LocalToolchainName>,
     pub dist_root_url: String,
@@ -299,7 +300,10 @@ impl<'a> Cfg<'a> {
         };
 
         let dist_root_server = dist_root_server(process)?;
-        let tmp_cx = temp::Context::new(rustup_dir.join("tmp"), dist_root_server.as_str());
+        let tmp_cx = Arc::new(temp::Context::new(
+            rustup_dir.join("tmp"),
+            dist_root_server.as_str(),
+        ));
         let dist_root = dist_root_server + "/dist";
 
         let cfg = Self {

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -55,7 +55,7 @@ impl Components {
             Ok(None)
         }
     }
-    fn write_version(&self, tx: &mut Transaction<'_>) -> Result<()> {
+    fn write_version(&self, tx: &mut Transaction) -> Result<()> {
         tx.modify_file(self.prefix.rel_manifest_file(VERSION_FILE))?;
         utils::write_file(
             VERSION_FILE,
@@ -79,7 +79,7 @@ impl Components {
             })
             .collect())
     }
-    pub(crate) fn add<'a>(&self, name: &str, tx: Transaction<'a>) -> ComponentBuilder<'a> {
+    pub(crate) fn add(&self, name: &str, tx: Transaction) -> ComponentBuilder {
         ComponentBuilder {
             components: self.clone(),
             name: name.to_owned(),
@@ -96,14 +96,14 @@ impl Components {
     }
 }
 
-pub(crate) struct ComponentBuilder<'a> {
+pub(crate) struct ComponentBuilder {
     components: Components,
     name: String,
     parts: Vec<ComponentPart>,
-    tx: Transaction<'a>,
+    tx: Transaction,
 }
 
-impl<'a> ComponentBuilder<'a> {
+impl ComponentBuilder {
     pub(crate) fn copy_file(&mut self, path: PathBuf, src: &Path) -> Result<()> {
         self.parts.push(ComponentPart {
             kind: ComponentPartKind::File,
@@ -132,7 +132,7 @@ impl<'a> ComponentBuilder<'a> {
         });
         self.tx.move_dir(&self.name, path, src)
     }
-    pub(crate) fn finish(mut self) -> Result<Transaction<'a>> {
+    pub(crate) fn finish(mut self) -> Result<Transaction> {
         // Write component manifest
         let path = self.components.rel_component_manifest(&self.name);
         let abs_path = self.components.prefix.abs_path(&path);
@@ -255,11 +255,7 @@ impl Component {
         }
         Ok(result)
     }
-    pub fn uninstall<'a>(
-        &self,
-        mut tx: Transaction<'a>,
-        process: &Process,
-    ) -> Result<Transaction<'a>> {
+    pub fn uninstall(&self, mut tx: Transaction, process: &Process) -> Result<Transaction> {
         // Update components file
         let path = self.components.rel_components_file();
         let abs_path = self.components.prefix.abs_path(&path);

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -72,6 +72,7 @@ impl Drop for File {
     }
 }
 
+#[derive(Clone)]
 pub struct Context {
     root_directory: PathBuf,
     pub dist_server: String,

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,8 +1,8 @@
-use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::sync::RwLock;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -13,22 +13,22 @@ use crate::dist::{AutoInstallMode, Profile};
 use crate::errors::RustupError;
 use crate::utils;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug)]
 pub struct SettingsFile {
     path: PathBuf,
-    cache: RefCell<Option<Settings>>,
+    cache: RwLock<Option<Settings>>,
 }
 
 impl SettingsFile {
     pub(crate) fn new(path: PathBuf) -> Self {
         Self {
             path,
-            cache: RefCell::new(None),
+            cache: RwLock::default(),
         }
     }
 
     fn write_settings(&self) -> Result<()> {
-        let settings = self.cache.borrow();
+        let settings = self.cache.read().unwrap();
         utils::write_file(
             "settings",
             &self.path,
@@ -40,10 +40,10 @@ impl SettingsFile {
     fn read_settings(&self) -> Result<()> {
         let mut needs_save = false;
         {
-            let b = self.cache.borrow();
+            let b = self.cache.read().unwrap();
             if b.is_none() {
                 drop(b);
-                *self.cache.borrow_mut() = Some(if utils::is_file(&self.path) {
+                *self.cache.write().unwrap() = Some(if utils::is_file(&self.path) {
                     let content = utils::read_file("settings", &self.path)?;
                     Settings::parse(&content).with_context(|| RustupError::ParsingFile {
                         name: "settings",
@@ -65,14 +65,17 @@ impl SettingsFile {
         self.read_settings()?;
 
         // Settings can no longer be None so it's OK to unwrap
-        f(self.cache.borrow().as_ref().unwrap())
+        f(self.cache.read().unwrap().as_ref().unwrap())
     }
 
     pub(crate) fn with_mut<T, F: FnOnce(&mut Settings) -> Result<T>>(&self, f: F) -> Result<T> {
         self.read_settings()?;
 
         // Settings can no longer be None so it's OK to unwrap
-        let result = { f(self.cache.borrow_mut().as_mut().unwrap())? };
+        let result = {
+            let mut result = self.cache.write().unwrap();
+            f(result.as_mut().unwrap())?
+        };
         self.write_settings()?;
         Ok(result)
     }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -1,6 +1,9 @@
 #[cfg(windows)]
 use std::fs;
-use std::{convert::Infallible, env::consts::EXE_SUFFIX, ffi::OsStr, path::Path, process::Command};
+use std::{
+    convert::Infallible, env::consts::EXE_SUFFIX, ffi::OsStr, path::Path, process::Command,
+    sync::Arc,
+};
 
 #[cfg(windows)]
 use anyhow::Context;
@@ -111,12 +114,12 @@ impl<'a> DistributableToolchain<'a> {
         };
 
         let download_cfg = DownloadCfg::new(self.toolchain.cfg);
-        manifestation
+        Arc::new(manifestation)
             .update(
-                &manifest,
+                Arc::new(manifest),
                 changes,
                 false,
-                &download_cfg,
+                download_cfg,
                 &self.desc.manifest_name(),
                 false,
             )
@@ -508,12 +511,12 @@ impl<'a> DistributableToolchain<'a> {
         };
 
         let download_cfg = DownloadCfg::new(self.toolchain.cfg);
-        manifestation
+        Arc::new(manifestation)
             .update(
-                &manifest,
+                Arc::new(manifest),
                 changes,
                 false,
-                &download_cfg,
+                download_cfg,
                 &self.desc.manifest_name(),
                 false,
             )

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -35,7 +35,6 @@ async fn rustup_stable() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for stable-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
-info: downloading component[..]
 ...
 info: cleaning up downloads & tmp directories
 
@@ -131,15 +130,12 @@ async fn rustup_all_channels() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for stable-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
-info: downloading component[..]
 ...
 info: syncing channel updates for beta-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.2.0 (hash-beta-1.2.0)
-info: downloading component[..]
 ...
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
 ...
 info: cleaning up downloads & tmp directories
 
@@ -208,12 +204,10 @@ async fn rustup_some_channels_up_to_date() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for stable-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
-info: downloading component[..]
 ...
 info: syncing channel updates for beta-[HOST_TRIPLE]
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
 ...
 info: cleaning up downloads & tmp directories
 

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::Write;
+use std::sync::Arc;
 
 use rustup::dist::component::Components;
 use rustup::dist::component::Transaction;
@@ -169,7 +170,11 @@ fn uninstall() {
     tx.commit();
 
     // Now uninstall
-    let mut tx = Transaction::new(cx.prefix.clone(), &cx.cx, &cx.tp.process);
+    let mut tx = Transaction::new(
+        cx.prefix.clone(),
+        Arc::new(cx.cx),
+        Arc::new(cx.tp.process.clone()),
+    );
     for component in components.list().unwrap() {
         tx = component.uninstall(tx, &cx.tp.process).unwrap();
     }


### PR DESCRIPTION
Continuation of #4436.

This change aims to speed up the overall performance of the `rustup [toolchain] install` command by allowing the installation of a component to start immediately after its download completes.
This approach is particularly beneficial for slower connections, as it enables installations to progress in parallel with ongoing downloads -- so by the time all downloads are finished, all installations should be completed as well.

**NB:** This PR is not yet ready for review. I believe this change should be backed by benchmarks and user feedback before moving forward. I’ll share those here in the next couple of days.