### PR TITLE
fix(cli/rustup_mode): use ASCII-compatible spinner

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -815,7 +815,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
             pb.set_style(
                 ProgressStyle::with_template("{msg:.bold} - Checking... {spinner:.green}")
                     .unwrap()
-                    .tick_chars("⠁⠂⠄⡀⢀⠠⠐⠈ "),
+                    .tick_chars(r"|/-\ "),
             );
             pb.set_message(format!("{name}"));
             pb.enable_steady_tick(Duration::from_millis(100));


### PR DESCRIPTION
Continuation of #4388.

When reviewing #4471 (cc @FranciscoTGouveia) I realized that the spinner should also be ASCII-compatible, i.e. my previous comment on the progress bar (https://github.com/rust-lang/rustup/pull/4426#issuecomment-3124288998) applies to spinners as well.

https://stackoverflow.com/a/12305221 proposes some options that meet this criterion:

- _The Bar_: `r"|/-\ "`
- _The Ballon_: `".oO@* "`

... and even if  I decided to go with _The Bar_ for the familiarity (personally I have been seeing that a lot on Windows since I first learnt to use a PC), but please feel free to propose other options.