### PR TITLE
feat: adjust default concurrent download count

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -806,7 +806,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
 
     // Ensure that `.buffered()` is never called with 0 as this will cause a hang.
     // See: https://github.com/rust-lang/futures-rs/pull/1194#discussion_r209501774
-    if num_channels > 0 {
+    if channels_len > 0 {
         let multi_progress_bars =
             MultiProgress::with_draw_target(cfg.process.progress_draw_target());
         let semaphore = Arc::new(Semaphore::new(num_channels));

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -802,14 +802,14 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
     let mut update_available = false;
     let channels = cfg.list_channels()?;
     let channels_len = channels.len();
-    let num_channels = cfg.process.concurrent_downloads().unwrap_or(channels_len);
+    let concurrent_downloads = cfg.process.concurrent_downloads().unwrap_or(channels_len);
 
     // Ensure that `.buffered()` is never called with 0 as this will cause a hang.
     // See: https://github.com/rust-lang/futures-rs/pull/1194#discussion_r209501774
     if channels_len > 0 {
         let multi_progress_bars =
             MultiProgress::with_draw_target(cfg.process.progress_draw_target());
-        let semaphore = Arc::new(Semaphore::new(num_channels));
+        let semaphore = Arc::new(Semaphore::new(concurrent_downloads));
         let channels = tokio_stream::iter(channels.into_iter()).map(|(name, distributable)| {
             let pb = multi_progress_bars.add(ProgressBar::new(1));
             pb.set_style(
@@ -878,7 +878,10 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
                 .collect::<Vec<_>>()
                 .await
         } else {
-            channels.buffered(num_channels).collect::<Vec<_>>().await
+            channels
+                .buffered(concurrent_downloads)
+                .collect::<Vec<_>>()
+                .await
         };
 
         let t = cfg.process.stdout().terminal(cfg.process);

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -200,7 +200,7 @@ impl Manifestation {
                     .await
                 }
             });
-        if num_channels > 0 {
+        if components_len > 0 {
             let results = component_stream
                 .buffered(components_len)
                 .collect::<Vec<_>>()

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -157,10 +157,12 @@ impl Manifestation {
         let mut things_downloaded: Vec<String> = Vec::new();
         let components = update.components_urls_and_hashes(new_manifest)?;
         let components_len = components.len();
+
+        const DEFAULT_CONCURRENT_DOWNLOADS: usize = 2;
         let concurrent_downloads = download_cfg
             .process
             .concurrent_downloads()
-            .unwrap_or(components_len);
+            .unwrap_or(DEFAULT_CONCURRENT_DOWNLOADS);
 
         const DEFAULT_MAX_RETRIES: usize = 3;
         let max_retries: usize = download_cfg

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -157,7 +157,7 @@ impl Manifestation {
         let mut things_downloaded: Vec<String> = Vec::new();
         let components = update.components_urls_and_hashes(new_manifest)?;
         let components_len = components.len();
-        let num_channels = download_cfg
+        let concurrent_downloads = download_cfg
             .process
             .concurrent_downloads()
             .unwrap_or(components_len);
@@ -180,7 +180,7 @@ impl Manifestation {
             ));
         }
 
-        let semaphore = Arc::new(Semaphore::new(num_channels));
+        let semaphore = Arc::new(Semaphore::new(concurrent_downloads));
         let component_stream =
             tokio_stream::iter(components.into_iter()).map(|(component, format, url, hash)| {
                 let sem = semaphore.clone();

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -1314,6 +1314,33 @@ async fn remove_extensions_does_not_remove_other_components() {
 }
 
 #[tokio::test]
+async fn remove_extensions_does_not_hang_with_concurrent_downloads_override() {
+    let cx = TestContext::with_env(
+        None,
+        GZOnly,
+        [("RUSTUP_CONCURRENT_DOWNLOADS".to_owned(), "2".to_owned())].into(),
+    );
+
+    let adds = vec![Component::new(
+        "rust-std".to_string(),
+        Some(TargetTriple::new("i686-apple-darwin")),
+        false,
+    )];
+
+    cx.update_from_dist(&adds, &[], false).await.unwrap();
+
+    let removes = vec![Component::new(
+        "rust-std".to_string(),
+        Some(TargetTriple::new("i686-apple-darwin")),
+        false,
+    )];
+
+    cx.update_from_dist(&[], &removes, false).await.unwrap();
+
+    assert!(utils::path_exists(cx.prefix.path().join("bin/rustc")));
+}
+
+#[tokio::test]
 async fn add_and_remove_for_upgrade() {
     let cx = TestContext::new(None, GZOnly);
     change_channel_date(&cx.url, "nightly", "2016-02-01");

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1,7 +1,7 @@
 //! Easy file downloading
 
 use std::fs::remove_file;
-use std::num::NonZeroU64;
+use std::num::NonZero;
 use std::path::Path;
 use std::str::FromStr;
 use std::time::Duration;
@@ -201,9 +201,11 @@ async fn download_file_(
     };
 
     let timeout = Duration::from_secs(match process.var("RUSTUP_DOWNLOAD_TIMEOUT") {
-        Ok(s) => NonZeroU64::from_str(&s).context(
-            "invalid value in RUSTUP_DOWNLOAD_TIMEOUT -- must be a natural number greater than zero",
-        )?.get(),
+        Ok(s) => NonZero::from_str(&s)
+            .context(
+                "invalid value in RUSTUP_DOWNLOAD_TIMEOUT -- must be a natural number greater than zero",
+            )?
+            .get(),
         Err(_) => 180,
     });
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -188,12 +188,8 @@ impl Process {
     }
 
     pub fn concurrent_downloads(&self) -> Option<usize> {
-        match self.var("RUSTUP_CONCURRENT_DOWNLOADS") {
-            Ok(s) => Some(NonZeroU64::from_str(&s).context(
-                "invalid value in RUSTUP_CONCURRENT_DOWNLOADS -- must be a natural number greater than zero"
-            ).ok()?.get() as usize),
-            Err(_) => None,
-        }
+        let s = self.var("RUSTUP_CONCURRENT_DOWNLOADS").ok()?;
+        Some(NonZeroU64::from_str(&s).ok()?.get() as usize)
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::fmt::Debug;
 use std::io;
 use std::io::IsTerminal;
-use std::num::NonZeroU64;
+use std::num::NonZero;
 use std::path::PathBuf;
 use std::str::FromStr;
 #[cfg(feature = "test")]
@@ -189,7 +189,7 @@ impl Process {
 
     pub fn concurrent_downloads(&self) -> Option<usize> {
         let s = self.var("RUSTUP_CONCURRENT_DOWNLOADS").ok()?;
-        Some(NonZeroU64::from_str(&s).ok()?.get() as usize)
+        Some(NonZero::from_str(&s).ok()?.get())
     }
 }
 

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -263,6 +263,43 @@ no active toolchain
 }
 
 #[tokio::test]
+async fn with_no_toolchain_doesnt_hang() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    run_input(
+        &cx.config,
+        &[
+            "rustup-init",
+            "--no-modify-path",
+            "--default-toolchain=none",
+        ],
+        "\n\n",
+    )
+    .is_ok();
+
+    cx.config.expect(["rustup", "check"]).await.is_err();
+}
+
+#[tokio::test]
+async fn with_no_toolchain_doesnt_hang_with_concurrent_downloads_override() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    run_input(
+        &cx.config,
+        &[
+            "rustup-init",
+            "--no-modify-path",
+            "--default-toolchain=none",
+        ],
+        "\n\n",
+    )
+    .is_ok();
+
+    cx.config
+        .expect_with_env(["rustup", "check"], [("RUSTUP_CONCURRENT_DOWNLOADS", "2")])
+        .await
+        .is_err();
+}
+
+#[tokio::test]
 async fn with_non_default_toolchain_still_prompts() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     run_input(


### PR DESCRIPTION
I am currently test-driving the new concurrent downloads implementation and would like to try out different download counts. However when doing so I noticed that the previous decision of make both `rustup check` and `rustup toolchain` share a common default concurrent download count might not be optimal.

Thus, with this PR:

1. We check updates for all channels during `rustup check` unless the download count is overridden to 1.
2. We make the default download count 2 to hit a better balance between concurrent downloads and error recovery (this can be postponed to another PR if preferred).