### PR TITLE
chore(deps/renovate): group version bumps for `windows-rs` crates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,12 @@
             "matchPackageNames": [
                 "/opentelemetry/"
             ]
+        },
+        {
+            "groupName": "windows-rs",
+            "matchPackageNames": [
+                "/^windows-/"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Addresses https://github.com/rust-lang/rustup/pull/4479#issuecomment-3265318490.