### PR TITLE
reduce tracing lvl to debug for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ tokio = { version = "1.26.0", default-features = false, features = ["macros", "r
 tokio-retry = "0.3.0"
 tokio-stream = "0.1.14"
 toml = "0.9"
-tracing = "0.1"
+tracing = { version = "0.1", features = ["max_level_trace", "release_max_level_debug"] }
 tracing-log = "0.2"
 tracing-opentelemetry = { version = "0.31", optional = true }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }


### PR DESCRIPTION
This cuts ~300kb for `x86_64-pc-windows-msvc` release build.

Similar to fix in https://github.com/rust-lang/rust/pull/146188 (not really, there wasn't `max_level_*` feature set), docs: https://docs.rs/tracing/latest/tracing/level_filters/index.html

Can be changed to `release_max_level_info`, but it don't decrease size much (at least on `x86_64-pc-windows-msvc`). This change disables `trace` level for tracing for release build.