### PR TITLE
docs(dev-guide): mention the arg0 override trick on welcome page

### DIFF
--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -8,8 +8,15 @@
 6. Push to the branch: `git push origin my-new-feature`
 7. Submit a pull request :D
 
-For developing on `rustup` itself, you may want to install into a temporary
-directory, with a series of commands similar to this:
+For developing on `rustup` itself, the easiest way is to run the development
+build on your current installation. This approach is best used for minor fixes
+or improvements. See the documentation for [`RUSTUP_FORCE_ARG0`] for more info.
+
+[`RUSTUP_FORCE_ARG0`]: tips-and-tricks.md#rustup_force_arg0
+
+A more formal solution involves installing rustup into a temporary directory as
+your dedicated test environment.
+To do so, you can run a series of commands similar to this:
 
 ```bash
 cargo build

--- a/doc/dev-guide/src/tips-and-tricks.md
+++ b/doc/dev-guide/src/tips-and-tricks.md
@@ -7,9 +7,15 @@ it's a particular binary, rather than e.g. copying it, symlinking it or other
 tricks with exec. This is handy when testing particular code paths from cargo
 run.
 
-```shell
-RUSTUP_FORCE_ARG0=rustup cargo run -- uninstall nightly
+For example, if you want to run `rustup show` with `cargo run`, you may execute:
+
+```console
+> cargo run --config env.RUSTUP_FORCE_ARG0=\'rustup\' -- show
 ```
+
+This command passes the `RUSTUP_FORCE_ARG0` environment variable to the
+`rustup-init` binary without influencing the `cargo run` command itself,
+which is very important since `cargo` could also be a rustup proxy.
 
 ## `RUSTUP_BACKTRACK_LIMIT`
 


### PR DESCRIPTION
Addresses the following concern from @Kobzol by making the arg0 override trick more visible:

> I have some brief idea on how to set RUSTUP_HOME and how to use rustup-init, but I suppose that most people won't know what to do with it
_[#gsoc > Project: Make Rustup Concurrent @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20Make.20Rustup.20Concurrent/near/534838154)_

The [original command](https://rust-lang.zulipchat.com/#narrow/channel/421156-gsoc/topic/Project.3A.20Make.20Rustup.20Concurrent/near/534898119) using `rustup run` is replaced with `cargo run --config` according to https://github.com/rust-lang/cargo/issues/4505#issuecomment-3271293295 's suggestion for better consistency across different default toolchain configs.