### PR TITLE
Fix link in the bug reporting template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
       label: Verification
       description: Please verify that you've followed these steps.
       options:
-        - label: I searched for recent similar issues at https://github.com/rust-lang/rustup/issues?q=is%3Aissue+is%3Aopen%2Cclosed and found no duplicates.
+        - label: I searched for recent similar issues at https://github.com/rust-lang/rustup/issues?q=is%3Aissue and found no duplicates.
           required: true
         - label: I am on the latest version of Rustup according to https://github.com/rust-lang/rustup/tags and am still able to reproduce my issue.
           required: true


### PR DESCRIPTION
The existing link added the search parameter `is:open,closed` which results in no issues being found at all. Simply leaving it out will show all results, open and closed, which was most likely the intention here.