### PR TITLE
fix(install): default to GNU host in Cygwin/MSYS/MinGW environments (#4421)

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -80,6 +80,13 @@ main() {
     local _arch="$RETVAL"
     assert_nz "$_arch" "arch"
 
+    local _default_host_override=""
+    case "$_arch" in
+        *windows*)
+            _default_host_override="--default-host=$_arch"
+            ;;
+    esac
+
     local _ext=""
     case "$_arch" in
         *windows*)
@@ -177,9 +184,9 @@ main() {
             exit 1;
         fi
 
-        ignore "$_file" "$@" < /dev/tty
+        ignore "$_file" ${_default_host_override:+"$_default_host_override"} "$@" < /dev/tty
     else
-        ignore "$_file" "$@"
+        ignore "$_file" ${_default_host_override:+"$_default_host_override"} "$@"
     fi
 
     local _retval=$?


### PR DESCRIPTION
Addresses first mentioned issue in #4421, modifying the install script to default to `x86_64-pc-windows-gnu` under Cygwin/MSYS when no --default-host is provided. 

The second issue requires changes in the compiled rustup-init binary (src/), which is out of scope for now