### PR TITLE
refactor: Switch logging to anstyle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
 name = "rustup"
 version = "1.28.2"
 dependencies = [
+ "anstyle",
  "anyhow",
  "cc",
  "cfg-if 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ test = ["dep:snapbox", "dep:walkdir"]
 
 # Sorted by alphabetic order
 [dependencies]
+anstyle = "1.0.11"
 anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }


### PR DESCRIPTION
This removes a use of `termcolor` where it isn't offering much value and instead uses `anstyle` for styling which is already a dependency through clap.