### PR TITLE
ci: use macOS Intel runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1073,7 +1073,7 @@ jobs:
   build-macos-x86_64: # job-name skip-aarch64
     env: # skip-aarch64
       MACOSX_DEPLOYMENT_TARGET: 10.12 # skip-aarch64
-    runs-on: macos-latest
+    runs-on: macos-15-intel # skip-aarch64
     permissions:
       id-token: write
       contents: read
@@ -1205,7 +1205,7 @@ jobs:
   build-macos-aarch64: # job-name skip-x86_64
     env: # skip-x86_64
       MACOSX_DEPLOYMENT_TARGET: 11.0 # skip-x86_64
-    runs-on: macos-latest
+    runs-on: macos-latest # skip-x86_64
     permissions:
       id-token: write
       contents: read

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -7,7 +7,8 @@ jobs: # skip-x86_64 skip-aarch64
   build-macos-x86_64: # job-name skip-aarch64
     env: # skip-aarch64
       MACOSX_DEPLOYMENT_TARGET: 10.12 # skip-aarch64
-    runs-on: macos-latest
+    runs-on: macos-latest # skip-x86_64
+    runs-on: macos-15-intel # skip-aarch64
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
See https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/.