### PR TITLE
fix(process): Ensure stdout/stderr lock is held across calls 

### DIFF
--- a/src/process/terminalsource.rs
+++ b/src/process/terminalsource.rs
@@ -226,9 +226,24 @@ impl io::Write for ColorableTerminal {
         locked.deref_mut().as_write().write(buf)
     }
 
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        let mut locked = self.inner.lock().unwrap();
+        locked.deref_mut().as_write().write_vectored(bufs)
+    }
+
     fn flush(&mut self) -> std::result::Result<(), io::Error> {
         let mut locked = self.inner.lock().unwrap();
         locked.deref_mut().as_write().flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        let mut locked = self.inner.lock().unwrap();
+        locked.deref_mut().as_write().write_all(buf)
+    }
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> std::io::Result<()> {
+        let mut locked = self.inner.lock().unwrap();
+        locked.deref_mut().as_write().write_fmt(args)
     }
 }
 
@@ -237,8 +252,20 @@ impl io::Write for ColorableTerminalLocked {
         self.locked.as_write().write(buf)
     }
 
+    fn write_vectored(&mut self, bufs: &[std::io::IoSlice<'_>]) -> std::io::Result<usize> {
+        self.locked.as_write().write_vectored(bufs)
+    }
+
     fn flush(&mut self) -> io::Result<()> {
         self.locked.as_write().flush()
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.locked.as_write().write_all(buf)
+    }
+
+    fn write_fmt(&mut self, args: std::fmt::Arguments<'_>) -> std::io::Result<()> {
+        self.locked.as_write().write_fmt(args)
     }
 }
 


### PR DESCRIPTION
While `std::io::Write` only has a few required methods,
while implementing `anstream` I found its better to implement
as many as possible when dealing with `stdout` or `stderr`
so that the implicitly acquired lock is aquired once for the call,
rather than multiple times as the inherent methods break down a single higher
level calls into multiple lower level calls.

This is likely not a problem right now but the different layers of APIs, especially in interacting with `tracing`, could hit problems with this in the future.