### PR TITLE
docs(changelog): describe default profile change during auto-install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ The headlines of this release are:
 - Fixed a bug in Nushell integration that might generate invalid commands in the shell configuration.
   Reinstalling rustup might be required for the fix to work. [pr#4265]
 
+- The logic of fetching the active toolchain's profile has been adjusted in automatic installation.
+  Now, when the profile is not specified, the profile from `rustup override set profile` will be chosen
+  instead of the profile named `default`. This aligns with the behavior of `rustup toolchain install`.
+  [pr#4258]
+
 ### Detailed changes
 
 - Fix build script `cargo` instructions by @ChrisDenton in https://github.com/rust-lang/rustup/pull/4235
@@ -64,6 +69,7 @@ The headlines of this release are:
 
 [1.28.2]: https://github.com/rust-lang/rustup/releases/tag/1.28.2
 [pr#4254]: https://github.com/rust-lang/rustup/pull/4254
+[pr#4258]: https://github.com/rust-lang/rustup/pull/4258
 [pr#4259]: https://github.com/rust-lang/rustup/pull/4259
 [pr#4265]: https://github.com/rust-lang/rustup/pull/4265
 [pr#4277]: https://github.com/rust-lang/rustup/pull/4277


### PR DESCRIPTION
Closes #4337 by addressing https://github.com/rust-lang/rustup/issues/4337#issuecomment-2898311845:

> [..] since this ship has sailed, I've focused my previous comments on the question of whether we should revert this or not. Also, we probably should retroactively add this to the release notes.

Further analysis indicated that the reuse of pre-existing logic has reduced inconsistencies (`cfg.get_profile()?` instead of `Profile::default()` in `profile.unwrap_or_default()`) in that particular issue, even if it means different behaviors being exposed compared to v1.28.1.