### PR TITLE
refactor: Simplify abstracted stdout/stderr

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -244,7 +244,7 @@ fn show_channel_updates(
         Ok((pkg, banner, width, color, version, previous_version))
     });
 
-    let mut t = cfg.process.stdout().terminal(cfg.process);
+    let mut t = cfg.process.stdout();
 
     let data: Vec<_> = data.collect::<Result<_>>()?;
     let max_width = data
@@ -307,7 +307,7 @@ pub(super) fn list_items(
     quiet: bool,
     process: &Process,
 ) -> Result<utils::ExitCode> {
-    let mut t = process.stdout().terminal(process);
+    let mut t = process.stdout();
     for (name, installed) in items {
         if installed && !installed_only && !quiet {
             t.attr(terminalsource::Attr::Bold)?;

--- a/src/cli/log.rs
+++ b/src/cli/log.rs
@@ -54,7 +54,7 @@ where
         Ok(s) if s.eq_ignore_ascii_case("never") => false,
         // `RUSTUP_TERM_COLOR` is prioritized over `NO_COLOR`.
         _ if process.var("NO_COLOR").is_ok() => false,
-        _ => process.stderr().is_a_tty(process),
+        _ => process.stderr().is_a_tty(),
     };
     let maybe_rustup_log_directives = process.var("RUSTUP_LOG");
     let process = process.clone();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -797,7 +797,7 @@ async fn default_(
 }
 
 async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode> {
-    let t = cfg.process.stdout().terminal(cfg.process);
+    let t = cfg.process.stdout();
     let use_colors = matches!(t.color_choice(), ColorChoice::Auto | ColorChoice::Always);
     let mut update_available = false;
     let channels = cfg.list_channels()?;
@@ -890,7 +890,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<utils::ExitCode
                 .await
         };
 
-        let t = cfg.process.stdout().terminal(cfg.process);
+        let t = cfg.process.stdout();
         for result in channels {
             let (update_a, message) = result?;
             if update_a {
@@ -1072,7 +1072,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     // Print host triple
     {
-        let mut t = cfg.process.stdout().terminal(cfg.process);
+        let mut t = cfg.process.stdout();
         t.attr(terminalsource::Attr::Bold)?;
         write!(t.lock(), "Default host: ")?;
         t.reset()?;
@@ -1081,7 +1081,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     // Print rustup home directory
     {
-        let mut t = cfg.process.stdout().terminal(cfg.process);
+        let mut t = cfg.process.stdout();
         t.attr(terminalsource::Attr::Bold)?;
         write!(t.lock(), "rustup home:  ")?;
         t.reset()?;
@@ -1121,7 +1121,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     // show installed toolchains
     {
-        let mut t = cfg.process.stdout().terminal(cfg.process);
+        let mut t = cfg.process.stdout();
 
         print_header::<Error>(&mut t, "installed toolchains")?;
 
@@ -1157,7 +1157,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     // show active toolchain
     {
-        let mut t = cfg.process.stdout().terminal(cfg.process);
+        let mut t = cfg.process.stdout();
 
         writeln!(t.lock())?;
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -537,7 +537,7 @@ pub(crate) async fn install(
         exit_code &= unix::do_anti_sudo_check(no_prompt, process)?;
     }
 
-    let mut term = process.stdout().terminal(process);
+    let mut term = process.stdout();
 
     #[cfg(windows)]
     windows::maybe_install_msvc(&mut term, no_prompt, quiet, &opts, process).await?;
@@ -991,7 +991,7 @@ pub(crate) fn uninstall(no_prompt: bool, process: &Process) -> Result<utils::Exi
             pre_uninstall_msg!(),
             cargo_home = canonical_cargo_home(process)?
         );
-        md(&mut process.stdout().terminal(process), msg);
+        md(&mut process.stdout(), msg);
         if !common::confirm("\nContinue? (y/N)", false, process)? {
             info!("aborting uninstallation");
             return Ok(utils::ExitCode(0));
@@ -1347,7 +1347,7 @@ impl fmt::Display for SchemaVersion {
 
 /// Returns whether an update was available
 pub(crate) async fn check_rustup_update(process: &Process) -> anyhow::Result<bool> {
-    let mut t = process.stdout().terminal(process);
+    let mut t = process.stdout();
     // Get current rustup version
     let current_version = env!("CARGO_PKG_VERSION");
 

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -97,6 +97,7 @@ pub async fn main(
     } = match RustupInit::try_parse() {
         Ok(args) => args,
         Err(e) if [ErrorKind::DisplayHelp, ErrorKind::DisplayVersion].contains(&e.kind()) => {
+            use std::io::Write as _;
             write!(process.stdout().lock(), "{e}")?;
             return Ok(utils::ExitCode(0));
         }

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -456,6 +456,7 @@ fn unpack_without_first_dir<R: Read>(
                 None => {
                     // Tar has item before containing directory
                     // Complain about this so we can see if these exist.
+                    use std::io::Write as _;
                     writeln!(
                         cx.process.stderr().lock(),
                         "Unexpected: missing parent '{}' for '{}'",

--- a/src/process/filesource.rs
+++ b/src/process/filesource.rs
@@ -1,6 +1,6 @@
 use std::io::{self, BufRead, Read, Write};
 
-use super::terminalsource::{ColorableTerminal, StreamSelector};
+use super::terminalsource::ColorableTerminal;
 use crate::process::Process;
 
 /// Stand-in for std::io::Stdin
@@ -59,7 +59,7 @@ impl Writer for io::Stdout {
     }
 
     fn terminal(&self, process: &Process) -> ColorableTerminal {
-        ColorableTerminal::new(StreamSelector::Stdout, process)
+        ColorableTerminal::stdout(process)
     }
 }
 
@@ -79,7 +79,7 @@ impl Writer for io::Stderr {
     }
 
     fn terminal(&self, process: &Process) -> ColorableTerminal {
-        ColorableTerminal::new(StreamSelector::Stderr, process)
+        ColorableTerminal::stderr(process)
     }
 }
 
@@ -174,7 +174,7 @@ mod test_support {
         }
 
         fn terminal(&self, process: &Process) -> ColorableTerminal {
-            ColorableTerminal::new(StreamSelector::TestWriter(self.clone()), process)
+            ColorableTerminal::test(self.clone(), process)
         }
     }
 

--- a/src/process/terminalsource.rs
+++ b/src/process/terminalsource.rs
@@ -104,12 +104,25 @@ impl TerminalInnerLocked {
 }
 
 impl ColorableTerminal {
+    pub(super) fn stdout(process: &Process) -> Self {
+        Self::new(StreamSelector::Stdout, process)
+    }
+
+    pub(super) fn stderr(process: &Process) -> Self {
+        Self::new(StreamSelector::Stderr, process)
+    }
+
+    #[cfg(feature = "test")]
+    pub(super) fn test(writer: TestWriter, process: &Process) -> Self {
+        Self::new(StreamSelector::TestWriter(writer), process)
+    }
+
     /// A terminal that supports colorisation of a stream.
     /// If `RUSTUP_TERM_COLOR` is set to `always`, or if the stream is a tty and
     /// `RUSTUP_TERM_COLOR` either unset or set to `auto`,
     /// then color commands will be sent to the stream.
     /// Otherwise color commands are discarded.
-    pub(super) fn new(stream: StreamSelector, process: &Process) -> Self {
+    fn new(stream: StreamSelector, process: &Process) -> Self {
         let is_a_tty = stream.is_a_tty(process);
         let choice = match process.var("RUSTUP_TERM_COLOR") {
             Ok(s) if s.eq_ignore_ascii_case("always") => ColorChoice::Always,


### PR DESCRIPTION
To write colored output on a locked stream, you had to:
1. Call `process.stdout()` to get a `Box<dyn Writer>`
2. Call `Writer::terminal(process)` to get a `ColorableTerminal` (enum)
3. Call `ColorableTerminal::lock` to get a `ColorableTerminalLocked` (enum)

This cuts out the first step, making sure everything goes through `ColorableTerminal`.