### PR TITLE
Set `RUSTUP_TOOLCHAIN_SOURCE`

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -72,6 +72,8 @@
 - `RUSTUP_CONCURRENT_DOWNLOADS` *unstable* (default: the number of components to download). Controls the number of
   downloads made concurrently.
 
+- `RUSTUP_TOOLCHAIN_SOURCE` *unstable*. Set by rustup to tell proxied tools how `RUSTUP_TOOLCHAIN` was determined.
+
 [directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
 [override]: overrides.md

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -332,7 +332,7 @@ pub(crate) async fn list_toolchains(
     } else {
         let default_toolchain_name = cfg.get_default()?;
         let active_toolchain_name: Option<ToolchainName> =
-            if let Ok(Some((LocalToolchainName::Named(toolchain), _reason))) =
+            if let Ok(Some((LocalToolchainName::Named(toolchain), _source))) =
                 cfg.maybe_ensure_active_toolchain(None).await
             {
                 Some(toolchain)

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -782,7 +782,10 @@ async fn default_(
         if let Some((toolchain, source)) = cfg.active_toolchain()?
             && !matches!(source, ActiveSource::Default)
         {
-            info!("note that the toolchain '{toolchain}' is currently in use ({source})");
+            info!(
+                "note that the toolchain '{toolchain}' is currently in use ({})",
+                source.to_reason()
+            );
         }
     } else {
         let default_toolchain = cfg
@@ -999,7 +1002,7 @@ async fn update(
     } else if ensure_active_toolchain {
         let (toolchain, source) = cfg.ensure_active_toolchain(force_non_host, true).await?;
         info!("the active toolchain `{toolchain}` has been installed");
-        info!("it's active because: {source}");
+        info!("it's active because: {}", source.to_reason());
     } else {
         exit_code &= common::update_all_channels(cfg, opts.force).await?;
         if self_update {
@@ -1169,7 +1172,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
                     &active_source,
                 )?;
                 writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-                writeln!(t.lock(), "active because: {active_source}")?;
+                writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
                 if verbose {
                     writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
                     writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
@@ -1212,7 +1215,7 @@ async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::Ex
                     cfg.process.stdout().lock(),
                     "{}\nactive because: {}\ncompiler: {}\npath: {}",
                     toolchain.name(),
-                    source,
+                    source.to_reason(),
                     toolchain.rustc_version(),
                     toolchain.path().display()
                 )?;
@@ -1223,7 +1226,7 @@ async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::Ex
                     toolchain.name(),
                     match source {
                         ActiveSource::Default => &"default" as &dyn fmt::Display,
-                        _ => &source,
+                        _ => &source.to_reason(),
                     }
                 )?;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug, Display};
+use std::fmt::{self, Debug};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -102,14 +102,16 @@ pub(crate) enum ActiveSource {
     ToolchainFile(PathBuf),
 }
 
-impl Display for ActiveSource {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::result::Result<(), fmt::Error> {
+impl ActiveSource {
+    pub fn to_reason(&self) -> String {
         match self {
-            Self::Default => write!(f, "it's the default toolchain"),
-            Self::Environment => write!(f, "overridden by environment variable RUSTUP_TOOLCHAIN"),
-            Self::CommandLine => write!(f, "overridden by +toolchain on the command line"),
-            Self::OverrideDB(path) => write!(f, "directory override for '{}'", path.display()),
-            Self::ToolchainFile(path) => write!(f, "overridden by '{}'", path.display()),
+            Self::Default => String::from("it's the default toolchain"),
+            Self::Environment => {
+                String::from("overridden by environment variable RUSTUP_TOOLCHAIN")
+            }
+            Self::CommandLine => String::from("overridden by +toolchain on the command line"),
+            Self::OverrideDB(path) => format!("directory override for '{}'", path.display()),
+            Self::ToolchainFile(path) => format!("overridden by '{}'", path.display()),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use std::fmt::{self, Debug};
+use std::fmt::{self, Debug, Display};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -113,6 +113,18 @@ impl ActiveSource {
             Self::OverrideDB(path) => format!("directory override for '{}'", path.display()),
             Self::ToolchainFile(path) => format!("overridden by '{}'", path.display()),
         }
+    }
+}
+
+impl Display for ActiveSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Default => "default",
+            Self::Environment => "env",
+            Self::CommandLine => "cli",
+            Self::OverrideDB(_) => "path-override",
+            Self::ToolchainFile(_) => "toolchain-file",
+        })
     }
 }
 

--- a/src/test/mock_bin_src.rs
+++ b/src/test/mock_bin_src.rs
@@ -106,6 +106,14 @@ fn main() {
             let mut out = io::stderr();
             writeln!(out, "{}", std::env::current_exe().unwrap().display()).unwrap();
         }
+        Some("--echo-rustup-toolchain-source") => {
+            let mut out = io::stderr();
+            if let Ok(rustup_toolchain_source) = std::env::var("RUSTUP_TOOLCHAIN_SOURCE") {
+                writeln!(out, "{rustup_toolchain_source}").unwrap();
+            } else {
+                panic!("RUSTUP_TOOLCHAIN_SOURCE environment variable not set");
+            }
+        }
         arg => panic!("bad mock proxy commandline: {:?}", arg),
     }
 }


### PR DESCRIPTION
This PR is in pursuit of https://github.com/rust-lang/cargo/issues/11036. Specifically, it sets an environment variable `RUST_TOOLCHAIN_SOURCE`. The variable's content will be used to issue a warning when a `cargo install` is performed with a non-default toolchain.

The variable's content is one of `cli`, `env`, `override`, `config`, or `default`.

Nits are welcome.

cc: @epage