### PR TITLE
feat(cli/self-update): add support for PowerShell on Unix systems

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -401,6 +401,7 @@ This is usually done by running one of the following (note the leading DOT):
     source "{cargo_home}/env.fish"  # For fish
     source $"{cargo_home_nushell}/env.nu"  # For nushell
     source "{cargo_home}/env.tcsh"  # For tcsh
+    . "{cargo_home}/env.ps1"        # For pwsh
 "#
     };
 }

--- a/src/cli/self_update/env.ps1
+++ b/src/cli/self_update/env.ps1
@@ -1,0 +1,4 @@
+# rustup shell setup
+if (-not ":${env:PATH}:".Contains(":{cargo_bin}:")) {
+    ${env:PATH} = "{cargo_bin}:${env:PATH}";
+}


### PR DESCRIPTION
This PR adds PowerShell support on Unix systems. Some may find it unusual to use PowerShell on macOS or Linux, but it is already supported by popular technologies as follows:

- [GitHub Actions](https://docs.github.com/en/actions/tutorials/build-and-test-code/powershell) (`shell: pwsh` is supported in every type of runner)
- Visual Studio Code
- Python virtual environment managers like [Conda](https://docs.conda.io/projects/conda/en/stable/dev-guide/deep-dives/activation.html) and [venv](https://docs.python.org/3/library/venv.html#how-venvs-work).

This is my first contribution to an official Rust project, so please let me know if there's anything else I should do. Thanks!