### PR TITLE
refactor: Replace termcolor with anstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,16 +75,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstyle-termcolor"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8969b2b476cad1bf03d37494ad7b8a84ae9e030e248fddc62bdc4484e5ed4a95"
-dependencies = [
- "anstyle",
- "termcolor",
-]
-
-[[package]]
 name = "anstyle-wincon"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,8 +2205,8 @@ dependencies = [
 name = "rustup"
 version = "1.28.2"
 dependencies = [
+ "anstream",
  "anstyle",
- "anstyle-termcolor",
  "anyhow",
  "cc",
  "cfg-if 1.0.3",
@@ -2266,7 +2256,6 @@ dependencies = [
  "strsim",
  "tar",
  "tempfile",
- "termcolor",
  "thiserror 2.0.17",
  "threadpool",
  "tokio",
@@ -2614,15 +2603,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle-termcolor"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8969b2b476cad1bf03d37494ad7b8a84ae9e030e248fddc62bdc4484e5ed4a95"
+dependencies = [
+ "anstyle",
+ "termcolor",
+]
+
+[[package]]
 name = "anstyle-wincon"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2206,6 +2216,7 @@ name = "rustup"
 version = "1.28.2"
 dependencies = [
  "anstyle",
+ "anstyle-termcolor",
  "anyhow",
  "cc",
  "cfg-if 1.0.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ test = ["dep:snapbox", "dep:walkdir"]
 # Sorted by alphabetic order
 [dependencies]
 anstyle = "1.0.11"
+anstyle-termcolor = "1.1.4"
 anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ test = ["dep:snapbox", "dep:walkdir"]
 
 # Sorted by alphabetic order
 [dependencies]
+anstream = "0.6.20"
 anstyle = "1.0.11"
-anstyle-termcolor = "1.1.4"
 anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
@@ -87,7 +87,6 @@ sharded-slab = "0.1.1"
 strsim = "0.11"
 tar = "0.4.26"
 tempfile = "3.8"
-termcolor = "1.2"
 thiserror = "2"
 threadpool = "1"
 tokio = { version = "1.26.0", default-features = false, features = ["macros", "rt-multi-thread", "sync"] }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -7,9 +7,9 @@ use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 use std::{cmp, env};
 
+use anstyle::AnsiColor;
 use anyhow::{Context, Result, anyhow};
 use git_testament::{git_testament, render_testament};
-use termcolor::Color;
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
@@ -152,10 +152,10 @@ fn show_channel_updates(
 ) -> Result<()> {
     let data = updates.into_iter().map(|(pkg, result)| {
         let (banner, color) = match &result {
-            Ok(UpdateStatus::Installed) => ("installed", Some(Color::Green)),
-            Ok(UpdateStatus::Updated(_)) => ("updated", Some(Color::Green)),
+            Ok(UpdateStatus::Installed) => ("installed", Some(AnsiColor::Green)),
+            Ok(UpdateStatus::Updated(_)) => ("updated", Some(AnsiColor::Green)),
             Ok(UpdateStatus::Unchanged) => ("unchanged", None),
-            Err(_) => ("update failed", Some(Color::Red)),
+            Err(_) => ("update failed", Some(AnsiColor::Red)),
         };
 
         let (previous_version, version) = match &pkg {

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -1,8 +1,8 @@
 // Write Markdown to the terminal
 use std::io::Write;
 
+use anstyle::AnsiColor;
 use pulldown_cmark::{Event, Tag, TagEnd};
-use termcolor::Color;
 
 use crate::process::{Attr, ColorableTerminal};
 
@@ -151,7 +151,7 @@ impl<'a> LineFormatter<'a> {
                 self.wrapper.write_line();
             }
             Tag::Emphasis => {
-                self.push_attr(Attr::ForegroundColor(Color::Red));
+                self.push_attr(Attr::ForegroundColor(AnsiColor::Red));
             }
             Tag::Strong => {}
             Tag::Strikethrough => {}

--- a/src/cli/markdown.rs
+++ b/src/cli/markdown.rs
@@ -1,7 +1,7 @@
 // Write Markdown to the terminal
 use std::io::Write;
 
-use anstyle::{AnsiColor, Style};
+use anstyle::{AnsiColor, Reset, Style};
 use pulldown_cmark::{Event, Tag, TagEnd};
 
 use crate::process::ColorableTerminal;
@@ -111,7 +111,7 @@ impl<'a> LineFormatter<'a> {
     fn push_attr(&mut self, attr: Attr) {
         self.attrs.push(attr);
         attr.apply_to(&mut self.style);
-        let _ = self.wrapper.w.style(&self.style);
+        let _ = write!(self.wrapper.w.lock(), "{Reset}{}", self.style);
     }
     fn pop_attr(&mut self) {
         self.attrs.pop();
@@ -119,7 +119,7 @@ impl<'a> LineFormatter<'a> {
         for attr in &self.attrs {
             attr.apply_to(&mut self.style);
         }
-        let _ = self.wrapper.w.style(&self.style);
+        let _ = write!(self.wrapper.w.lock(), "{Reset}{}", self.style);
     }
 
     fn start_tag(&mut self, tag: Tag<'a>) {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use anstream::ColorChoice;
 use anstyle::Style;
 use anyhow::{Context, Error, Result, anyhow};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
@@ -18,7 +19,6 @@ use console::style;
 use futures_util::stream::StreamExt;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use itertools::Itertools;
-use termcolor::ColorChoice;
 use tokio::sync::Semaphore;
 use tracing::{info, trace, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use anstyle::Style;
 use anyhow::{Context, Error, Result, anyhow};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
 use clap_complete::Shell;
@@ -39,7 +40,7 @@ use crate::{
     },
     errors::RustupError,
     install::{InstallMethod, UpdateStatus},
-    process::{Attr, ColorableTerminal, Process},
+    process::{ColorableTerminal, Process},
     toolchain::{
         CustomToolchainName, DistributableToolchain, LocalToolchainName,
         MaybeResolvableToolchainName, ResolvableLocalToolchainName, ResolvableToolchainName,
@@ -1072,10 +1073,12 @@ async fn which(
 async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
+    let bold = Style::new().bold();
+
     // Print host triple
     {
         let mut t = cfg.process.stdout();
-        t.attr(Attr::Bold)?;
+        t.style(&bold)?;
         write!(t.lock(), "Default host: ")?;
         t.reset()?;
         writeln!(t.lock(), "{}", cfg.get_default_host_triple()?)?;
@@ -1084,7 +1087,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     // Print rustup home directory
     {
         let mut t = cfg.process.stdout();
-        t.attr(Attr::Bold)?;
+        t.style(&bold)?;
         write!(t.lock(), "rustup home:  ")?;
         t.reset()?;
         writeln!(t.lock(), "{}", cfg.rustup_dir.display())?;
@@ -1193,7 +1196,8 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
     }
 
     fn print_header(t: &mut ColorableTerminal, s: &str) -> Result<(), Error> {
-        t.attr(Attr::Bold)?;
+        let bold = Style::new().bold();
+        t.style(&bold)?;
         {
             let mut term_lock = t.lock();
             writeln!(term_lock, "{s}")?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1077,21 +1077,25 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
 
     // Print host triple
     {
-        let mut t = cfg.process.stdout();
-        t.style(&bold)?;
-        write!(t.lock(), "Default host: ")?;
-        t.reset()?;
-        writeln!(t.lock(), "{}", cfg.get_default_host_triple()?)?;
+        let t = cfg.process.stdout();
+        let mut t = t.lock();
+        writeln!(
+            t,
+            "{bold}Default host: {bold:#}{}",
+            cfg.get_default_host_triple()?
+        )?;
     }
 
     // Print rustup home directory
     {
-        let mut t = cfg.process.stdout();
-        t.style(&bold)?;
-        write!(t.lock(), "rustup home:  ")?;
-        t.reset()?;
-        writeln!(t.lock(), "{}", cfg.rustup_dir.display())?;
-        writeln!(t.lock())?;
+        let t = cfg.process.stdout();
+        let mut t = t.lock();
+        writeln!(
+            t,
+            "{bold}rustup home:  {bold:#}{}",
+            cfg.rustup_dir.display()
+        )?;
+        writeln!(t)?;
     }
 
     let installed_toolchains = cfg.list_toolchains()?;
@@ -1195,15 +1199,12 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<utils::ExitCode> {
         }
     }
 
-    fn print_header(t: &mut ColorableTerminal, s: &str) -> Result<(), Error> {
+    fn print_header(t: &mut ColorableTerminal, text: &str) -> Result<(), Error> {
         let bold = Style::new().bold();
-        t.style(&bold)?;
-        {
-            let mut term_lock = t.lock();
-            writeln!(term_lock, "{s}")?;
-            writeln!(term_lock, "{}", "-".repeat(s.len()))?;
-        } // drop the term_lock
-        t.reset()?;
+        let divider = "-".repeat(text.len());
+        let mut term_lock = t.lock();
+        writeln!(term_lock, "{bold}{text}{bold:#}")?;
+        writeln!(term_lock, "{bold}{divider}{bold:#}")?;
         Ok(())
     }
 

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -40,7 +40,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::{fmt, fs};
 
-use anstyle::AnsiColor;
+use anstyle::{AnsiColor, Style};
 use anyhow::{Context, Result, anyhow};
 use cfg_if::cfg_if;
 use clap::ValueEnum;
@@ -63,7 +63,7 @@ use crate::{
     download::download_file,
     errors::RustupError,
     install::UpdateStatus,
-    process::{Attr, Process},
+    process::Process,
     toolchain::{
         DistributableToolchain, MaybeOfficialToolchainName, ResolvableToolchainName, Toolchain,
         ToolchainName,
@@ -1364,17 +1364,21 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Res
     // Get available rustup version
     let available_version = get_available_rustup_version(dl_cfg).await?;
 
-    let _ = t.attr(Attr::Bold);
+    let bold = Style::new().bold();
+    let yellow = AnsiColor::Yellow.on_default().bold();
+    let green = AnsiColor::Green.on_default().bold();
+
+    let _ = t.style(&bold);
     write!(t.lock(), "rustup - ")?;
 
     Ok(if current_version != available_version {
-        let _ = t.fg(AnsiColor::Yellow);
+        let _ = t.style(&yellow);
         write!(t.lock(), "Update available")?;
         let _ = t.reset();
         writeln!(t.lock(), " : {current_version} -> {available_version}")?;
         true
     } else {
-        let _ = t.fg(AnsiColor::Green);
+        let _ = t.style(&green);
         write!(t.lock(), "Up to date")?;
         let _ = t.reset();
         writeln!(t.lock(), " : {current_version}")?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1357,7 +1357,8 @@ impl fmt::Display for SchemaVersion {
 
 /// Returns whether an update was available
 pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Result<bool> {
-    let mut t = dl_cfg.process.stdout();
+    let t = dl_cfg.process.stdout();
+    let mut t = t.lock();
     // Get current rustup version
     let current_version = env!("CARGO_PKG_VERSION");
 
@@ -1368,20 +1369,16 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Res
     let yellow = AnsiColor::Yellow.on_default().bold();
     let green = AnsiColor::Green.on_default().bold();
 
-    let _ = t.style(&bold);
-    write!(t.lock(), "rustup - ")?;
+    write!(t, "{bold}rustup - {bold:#}")?;
 
     Ok(if current_version != available_version {
-        let _ = t.style(&yellow);
-        write!(t.lock(), "Update available")?;
-        let _ = t.reset();
-        writeln!(t.lock(), " : {current_version} -> {available_version}")?;
+        writeln!(
+            t,
+            "{yellow}Update available{yellow:#} : {current_version} -> {available_version}"
+        )?;
         true
     } else {
-        let _ = t.style(&green);
-        write!(t.lock(), "Up to date")?;
-        let _ = t.reset();
-        writeln!(t.lock(), " : {current_version}")?;
+        writeln!(t, "{green}Up to date{green:#} : {current_version}")?;
         false
     })
 }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -40,6 +40,7 @@ use std::process::Command;
 use std::str::FromStr;
 use std::{fmt, fs};
 
+use anstyle::AnsiColor;
 use anyhow::{Context, Result, anyhow};
 use cfg_if::cfg_if;
 use clap::ValueEnum;
@@ -47,7 +48,6 @@ use clap::builder::PossibleValue;
 use itertools::Itertools;
 use same_file::Handle;
 use serde::{Deserialize, Serialize};
-use termcolor::Color;
 use tracing::{error, info, trace, warn};
 
 use crate::dist::download::DownloadCfg;
@@ -1368,13 +1368,13 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Res
     write!(t.lock(), "rustup - ")?;
 
     Ok(if current_version != available_version {
-        let _ = t.fg(Color::Yellow);
+        let _ = t.fg(AnsiColor::Yellow);
         write!(t.lock(), "Update available")?;
         let _ = t.reset();
         writeln!(t.lock(), " : {current_version} -> {available_version}")?;
         true
     } else {
-        let _ = t.fg(Color::Green);
+        let _ = t.fg(AnsiColor::Green);
         write!(t.lock(), "Up to date")?;
         let _ = t.reset();
         writeln!(t.lock(), " : {current_version}")?;

--- a/src/process.rs
+++ b/src/process.rs
@@ -28,7 +28,7 @@ use crate::cli::log;
 
 mod file_source;
 mod terminal_source;
-pub use terminal_source::{Attr, ColorableTerminal};
+pub use terminal_source::ColorableTerminal;
 
 /// Allows concrete types for the process abstraction.
 #[derive(Clone, Debug)]

--- a/src/process/terminal_source.rs
+++ b/src/process/terminal_source.rs
@@ -9,7 +9,10 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, StandardStreamLock, WriteColor};
+use anstyle::AnsiColor;
+use anstyle_termcolor::to_termcolor_color;
+use termcolor::ColorChoice;
+use termcolor::{ColorSpec, StandardStream, StandardStreamLock, WriteColor};
 
 use super::Process;
 #[cfg(feature = "test")]
@@ -108,10 +111,10 @@ impl ColorableTerminal {
         }
     }
 
-    pub fn fg(&mut self, color: Color) -> io::Result<()> {
+    pub fn fg(&mut self, color: AnsiColor) -> io::Result<()> {
         match self.inner.lock().unwrap().deref_mut() {
             TerminalInner::StandardStream(s, spec) => {
-                spec.set_fg(Some(color));
+                spec.set_fg(Some(to_termcolor_color(color.into())));
                 s.set_color(spec)
             }
             #[cfg(feature = "test")]
@@ -124,7 +127,9 @@ impl ColorableTerminal {
             TerminalInner::StandardStream(s, spec) => {
                 match attr {
                     Attr::Bold => spec.set_bold(true),
-                    Attr::ForegroundColor(color) => spec.set_fg(Some(color)),
+                    Attr::ForegroundColor(color) => {
+                        spec.set_fg(Some(to_termcolor_color(color.into())))
+                    }
                 };
                 s.set_color(spec)
             }
@@ -356,7 +361,7 @@ impl StreamSelector {
 #[derive(Copy, Clone, Debug)]
 pub enum Attr {
     Bold,
-    ForegroundColor(Color),
+    ForegroundColor(AnsiColor),
 }
 
 #[cfg(test)]

--- a/src/process/terminal_source.rs
+++ b/src/process/terminal_source.rs
@@ -14,7 +14,7 @@ use anstyle::{Reset, Style};
 
 use super::Process;
 #[cfg(feature = "test")]
-use super::file_source::{TestWriter, TestWriterLock};
+use super::file_source::TestWriter;
 
 /// A colorable terminal that can be written to
 pub struct ColorableTerminal {
@@ -102,7 +102,7 @@ impl ColorableTerminal {
                     TerminalInnerLocked::Stderr(AutoStream::new(locked, self.color_choice))
                 }
                 #[cfg(feature = "test")]
-                TerminalInner::TestWriter(w, _) => TerminalInnerLocked::TestWriter(w.lock()),
+                TerminalInner::TestWriter(w, _) => TerminalInnerLocked::TestWriter(w.clone()),
             });
             // ColorableTerminalLocked { inner, guard, locked }
             uninit.assume_init()
@@ -282,7 +282,7 @@ enum TerminalInnerLocked {
     Stdout(AutoStream<io::StdoutLock<'static>>),
     Stderr(AutoStream<io::StderrLock<'static>>),
     #[cfg(feature = "test")]
-    TestWriter(TestWriterLock<'static>),
+    TestWriter(TestWriter),
 }
 
 impl TerminalInnerLocked {


### PR DESCRIPTION
`anstream` is an existing dependency through clap that allows a simpler, more natural way of writing styled text by making ANSI escape codes the API for styling, rather than a `stream.set_color(_)`.  You write ANSI escape codes unconditionally, and `anstream` will automatically strip them if needed (or convert them to wincon API calls for old Windows 8 systems).  The caller can use whatever styling API they want and don't have to worry about what stream type they are ultimately written to.

This will unblock `clap` output being styled.  Clap can either directly handle writing output to the terminal, write unstyled output to a string, or write styled output to a string.  With Rustup requiring all output to go through custom, termcolor-like streams for testing, this limited Rustup to only getting unstyled output.  With this change, Rustup can get Clap's styled output and then have `anstream` process it as needed.

To generate ANSI escape codes, this uses `anstyle` which is primarily intended to be a low-policy API for ANSI escape codes so they are API stable for theming in APIs like `clap` or `annotate-snippets`. Using the formatting `alternate` though provides a nice way to reset the stream.

To simplify the transition for callers of `ColorableTerminal` through this transition, intermediate steps are taken, including adding the `anstyle-termcolor` adapter and then removing it.

I manually tested what I could of Rustup's output to spot check the styling.  Cargo uses `snapbox` (the core of `trycmd`) to perform snapshot testing of ANSI escape codes by rendering them as SVGs which get rendered in GitHub diffs.  Rustc integrated the lower level `anstyle-svg` package into their existing snapshotting system.  I have considered SVG support for `trycmd` but haven't implemented it yet.