### PR TITLE
feat(rustup-mode): add `no_update` flag to `rustup toolchain install`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -386,6 +386,10 @@ struct UpdateOpts {
     #[arg(long)]
     no_self_update: bool,
 
+    /// Don't try to update the installed toolchain
+    #[arg(long)]
+    no_update: bool,
+
     /// Force an update, even if some components are missing
     #[arg(long)]
     force: bool,
@@ -971,9 +975,13 @@ async fn update(
 
             let status = match DistributableToolchain::new(cfg, desc.clone()) {
                 Ok(d) => {
-                    InstallMethod::Dist(dist_opts.for_update(&d, opts.allow_downgrade))
-                        .install()
-                        .await?
+                    if !opts.no_update {
+                        InstallMethod::Dist(dist_opts.for_update(&d, opts.allow_downgrade))
+                            .install()
+                            .await?
+                    } else {
+                        UpdateStatus::Unchanged
+                    }
                 }
                 Err(RustupError::ToolchainNotInstalled { .. }) => {
                     DistributableToolchain::install(dist_opts).await?.0

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1738,6 +1738,32 @@ info: it's active because: overridden by '[TOOLCHAIN_FILE]'
 }
 
 #[tokio::test]
+async fn toolchain_install_no_change_with_no_update() {
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    cx.config
+        .expect(["rustup", "install", "--no-update", "stable"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+
+  stable-[HOST_TRIPLE] unchanged - 1.0.0 (hash-stable-1.0.0)
+
+
+"#]])
+        .with_stderr(snapbox::str![[""]])
+        .is_ok();
+}
+
+#[tokio::test]
 async fn toolchain_update_is_like_update() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="578px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="596px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -48,39 +48,41 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>                               command</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>                  Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-update</tspan><tspan>              Don't try to update the installed toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>        Allow rustup to downgrade the toolchain to satisfy your component</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>                  Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>                               choice</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>        Allow rustup to downgrade the toolchain to satisfy your component</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>         Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="334px"><tspan>                               choice</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>                               https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>         Install toolchains that require an emulator. See</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>                               https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="460px">
+    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="514px">
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="568px">
+    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Closes #4505. Adding a flag to don't try to update already installed toolchains.