### PR TITLE
fix(www): removes www subdomain from all rust-lang.org urls

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -7,9 +7,9 @@
   <meta name="description" content="The Rust toolchain installer">
   <link rel="stylesheet" href="normalize.css">
   <link rel="stylesheet" href="rustup.css">
-  <link rel="icon" type="image/png" sizes="32x32" href="https://www.rust-lang.org/static/images/favicon-32x32.png">
-  <link rel="icon" type="image/svg+xml" href="https://www.rust-lang.org/static/images/favicon.svg">
-  <link rel="mask-icon" href="https://www.rust-lang.org/static/images/safari-pinned-tab.svg" color="#000">
+  <link rel="icon" type="image/png" sizes="32x32" href="https://rust-lang.org/static/images/favicon-32x32.png">
+  <link rel="icon" type="image/svg+xml" href="https://rust-lang.org/static/images/favicon.svg">
+  <link rel="mask-icon" href="https://rust-lang.org/static/images/safari-pinned-tab.svg" color="#000">
 
 </head>
 
@@ -19,7 +19,7 @@
 <header>
   <div>
     <h1>rustup</h1>
-    <h2>An installer for the systems programming language <a href="https://www.rust-lang.org">Rust</a></h2>
+    <h2>An installer for the systems programming language <a href="https://rust-lang.org">Rust</a></h2>
   </div>
 </header>
 <a id="platform-button" class="display-none" href="#">
@@ -222,11 +222,11 @@
 
 <p id="help">
   Need help?<br>
-  Ask the <a href="https://www.rust-lang.org/community">community</a>!
+  Ask the <a href="https://rust-lang.org/community">community</a>!
 </p>
 
 <p id="about">
-  <img src="https://www.rust-lang.org/logos/rust-logo-blk.svg" alt="" />
+  <img src="https://rust-lang.org/logos/rust-logo-blk.svg" alt="" />
   rustup is an official Rust project.
   <br/>
   <a href="https://rust-lang.github.io/rustup/installation/other.html">other installation options</a>

--- a/www/website_config.json
+++ b/www/website_config.json
@@ -5,6 +5,6 @@
         "X-Frame-Options": "DENY",
         "X-XSS-Protection": "1; mode=block",
         "Referrer-Policy": "no-referrer, strict-origin-when-cross-origin",
-        "Content-Security-Policy": "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' https://www.rust-lang.org; font-src 'self'"
+        "Content-Security-Policy": "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' https://rust-lang.org; font-src 'self'"
     }
 }


### PR DESCRIPTION
# The issue
All `www.rust-lang.org` requests are being redirected to `rust-lang.org` with no subdomain.

![Image 10-14-25 at 3 25 PM](https://github.com/user-attachments/assets/2b1ea987-aea2-43b8-b997-4f35bf1ff86b)

This is resulting in a content security policy violation because due to the strict requirement on `img-src 'self' https://www.rust-lang.org;`. 
<img width="659" height="155" alt="Screenshot 2025-10-14 at 3 33 56 PM 1" src="https://github.com/user-attachments/assets/37ce477c-1866-4850-93ab-561e24cd5f7b" />


This violation is preventing logos and favicons from displaying.
<img width="326" height="66" alt="Screenshot 2025-10-14 at 3 28 34 PM" src="https://github.com/user-attachments/assets/46eebded-7f29-46ff-99b9-49c210624494" />
<img width="140" height="37" alt="Screenshot 2025-10-14 at 3 28 38 PM" src="https://github.com/user-attachments/assets/4a5841a4-2121-4426-99a0-fef7614ec7a0" />


# The fix

1. Updates the Content-Security-Policy img-src url, removing the `www` subdomain.
2. Removes all `www` subdomain references in HTML to prevent unnecessarily going through the redirect every load.