### PR TITLE
Update the default Windows SDK version

### DIFF
--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -298,7 +298,7 @@ pub(crate) async fn try_install_msvc(
     if !has_windows_sdk_libs(cfg.process) {
         cmd.args([
             "--add",
-            "Microsoft.VisualStudio.Component.Windows11SDK.22000",
+            "Microsoft.VisualStudio.Component.Windows11SDK.26100",
         ]);
     }
     info!("running the Visual Studio install");


### PR DESCRIPTION
This is a temporary workaround for #4446. The problem with the installer is that the version of the SDK we requested was removed due to security issues. Since a new rustup release is near, this PR simply changes to a version that is available as a temporary workaround. It does not fix the underlying problem (that of SDKs potentially being removed) but that is a very unusual scenario so hopefully this will be good enough for the short term.

In any case, Visual Studio 2026 is set for release very soon so I'd rather wait for that before figuring out what to do in the long term.