### PR TITLE
Add vs-components.toml

### DIFF
--- a/vs-components.toml
+++ b/vs-components.toml
@@ -1,0 +1,12 @@
+schema-version = "1"
+installer = "https://aka.ms/vs/17/release/vs_community.exe"
+
+# Component names are listed at
+# https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+[components]
+x86_64 = ["Microsoft.VisualStudio.Component.VC.Tools.x86.x64"]
+aarch64 = [
+  "Microsoft.VisualStudio.Component.VC.Tools.ARM64",
+  "Microsoft.VisualStudio.Component.VC.Tools.ARM64EC",
+]
+sdk = "Microsoft.VisualStudio.Component.Windows11SDK.26100"


### PR DESCRIPTION
This is just a draft I'm posting to gather feedback and maybe discuss implementation details.

Related to https://github.com/rust-lang/rustup/issues/4446.

The configuration file in this PR tells rustup how to install the needed Visual Studio components. The components are listed per supported host architecture, except that i686 is included with x86_64. The Windows SDK is listed separately because it's independent of architecture and may be skipped if already installed via other means.

I used toml format but this could be json or a simpler `key=value` format but toml seemed more consistent with other files.

This file will need to be deployed to `https://static.rust-lang.org/rustup` independently of the rustup release process.