### PR TITLE
feat(cli): Add color to clap help/errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-cargo"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c7f07f2b3c9fc1a21da5b4fa268083ac4d4d145a711b286055fdd70d149fcf"
+dependencies = [
+ "anstyle",
+ "clap",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2140,6 +2150,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "chrono",
  "clap",
+ "clap-cargo",
  "clap_complete",
  "console",
  "curl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ otel = [
 ]
 
 # Exports code dependent on private interfaces for the integration test suite
-test = ["dep:snapbox", "dep:walkdir"]
+test = ["dep:snapbox", "dep:walkdir", "clap-cargo/testing_colors"]
 
 # Sorted by alphabetic order
 [dependencies]
@@ -47,6 +47,7 @@ anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help"] }
+clap-cargo = "0.18.2"
 clap_complete = "4"
 console = "0.16"
 curl = { version = "0.4.44", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ anstyle = "1.0.11"
 anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
-clap = { version = "4", features = ["derive", "wrap_help"] }
+clap = { version = "4", features = ["derive", "wrap_help", "string"] }
 clap-cargo = "0.18.2"
 clap_complete = "4"
 console = "0.16"

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,5 +1,8 @@
-pub(crate) fn rustup_help() -> &'static str {
-    r"Discussion:
+use clap_cargo::style::{HEADER, LITERAL, PLACEHOLDER};
+
+pub(crate) fn rustup_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes
@@ -8,10 +11,12 @@ pub(crate) fn rustup_help() -> &'static str {
 
     If you are new to Rust consider running `rustup doc --book` to
     learn Rust."
+    )
 }
 
-pub(crate) fn show_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn show_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Shows the name of the active toolchain and the version of `rustc`.
 
     If the active toolchain has installed support for additional
@@ -19,10 +24,12 @@ pub(crate) fn show_help() -> &'static str {
 
     If there are multiple toolchains installed then all installed
     toolchains are listed as well."
+    )
 }
 
-pub(crate) fn show_active_toolchain_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn show_active_toolchain_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Shows the name of the active toolchain.
 
     This is useful for figuring out the active tool chain from
@@ -30,49 +37,57 @@ pub(crate) fn show_active_toolchain_help() -> &'static str {
 
     You should use `rustc --print sysroot` to get the sysroot, or
     `rustc --version` to get the toolchain version."
+    )
 }
 
-pub(crate) fn update_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn update_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.
 
     If given a toolchain argument then `update` updates that
     toolchain, the same as `rustup toolchain install`."
+    )
 }
 
-pub(crate) fn install_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn install_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Installs a specific rust toolchain.
 
     The 'install' command is an alias for 'rustup update <toolchain>'."
+    )
 }
 
-pub(crate) fn default_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn default_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Sets the default toolchain to the one specified. If the toolchain
     is not already installed then it is installed first."
+    )
 }
 
-pub(crate) fn toolchain_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn toolchain_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Many `rustup` commands deal with *toolchains*, a single
     installation of the Rust compiler. `rustup` supports multiple
     types of toolchains. The most basic track the official release
-    channels: 'stable', 'beta' and 'nightly'} but `rustup` can also
+    channels: 'stable', 'beta' and 'nightly'; but `rustup` can also
     install specific toolchains from the official archives, toolchains for
     alternate host platforms, and from local builds ('custom toolchains').
 
     Standard release channel toolchain names have the following form:
 
-        <channel>[-<date>][-<host>]
+        {PLACEHOLDER}<channel>[-<date>][-<host>]{PLACEHOLDER:#}
 
-        <channel>       = stable|beta|nightly|<versioned>[-<prerelease>]
-        <versioned>     = <major.minor>|<major.minor.patch>
-        <prerelease>    = beta[.<number>]
-        <date>          = YYYY-MM-DD
-        <host>          = <target-triple>
+        {PLACEHOLDER}<channel>       = stable|beta|nightly|<versioned>[-<prerelease>]{PLACEHOLDER:#}
+        {PLACEHOLDER}<versioned>     = <major.minor>|<major.minor.patch>{PLACEHOLDER:#}
+        {PLACEHOLDER}<prerelease>    = beta[.<number>]{PLACEHOLDER:#}
+        {PLACEHOLDER}<date>          = YYYY-MM-DD{PLACEHOLDER:#}
+        {PLACEHOLDER}<host>          = <target-triple>{PLACEHOLDER:#}
 
     'channel' is a named release channel, a major and minor version
     number such as `1.42`, or a fully specified version number, such
@@ -84,25 +99,27 @@ pub(crate) fn toolchain_help() -> &'static str {
     for installing a 32-bit compiler on a 64-bit platform, or for
     installing the [MSVC-based toolchain] on Windows. For example:
 
-        $ rustup toolchain install stable-x86_64-pc-windows-msvc
+        {LITERAL}$ rustup toolchain install stable-x86_64-pc-windows-msvc{LITERAL:#}
 
     For convenience, omitted elements of the target triple will be
     inferred, so the above could be written:
 
-        $ rustup toolchain install stable-msvc
+        {LITERAL}$ rustup toolchain install stable-msvc{LITERAL:#}
 
     The `rustup default` command may be used to both install and set
     the desired toolchain as default in a single command:
 
-        $ rustup default stable-msvc
+        {LITERAL}$ rustup default stable-msvc{LITERAL:#}
 
     rustup can also manage symlinked local toolchain builds, which are
     often used for developing Rust itself. For more information see
     `rustup toolchain help link`."
+    )
 }
 
-pub(crate) fn toolchain_link_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn toolchain_link_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     'toolchain' is the custom name to be assigned to the new toolchain.
     Any name is permitted as long as:
     - it does not include '/' or '\' except as the last character
@@ -117,15 +134,17 @@ pub(crate) fn toolchain_link_help() -> &'static str {
     the build directory. After building, you can test out different
     compiler versions as follows:
 
-        $ rustup toolchain link latest-stage1 build/x86_64-unknown-linux-gnu/stage1
-        $ rustup override set latest-stage1
+        {LITERAL}$ rustup toolchain link latest-stage1 build/x86_64-unknown-linux-gnu/stage1{LITERAL:#}
+        {LITERAL}$ rustup override set latest-stage1{LITERAL:#}
 
     If you now compile a crate in the current directory, the custom
     toolchain 'latest-stage1' will be used."
+    )
 }
 
-pub(crate) fn override_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn override_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Overrides configure Rustup to use a specific toolchain when
     running in a specific directory.
 
@@ -136,28 +155,32 @@ pub(crate) fn override_help() -> &'static str {
 
     To pin to a specific nightly:
 
-        $ rustup override set nightly-2014-12-18
+        {LITERAL}$ rustup override set nightly-2014-12-18{LITERAL:#}
 
     Or a specific stable release:
 
-        $ rustup override set 1.0.0
+        {LITERAL}$ rustup override set 1.0.0{LITERAL:#}
 
     To see the active toolchain use `rustup show`. To remove the
     override and use the default toolchain again, `rustup override
     unset`."
+    )
 }
 
-pub(crate) fn override_unset_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn override_unset_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     If `--path` argument is present, removes the override toolchain
     for the specified directory. If `--nonexistent` argument is
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
     current directory."
+    )
 }
 
-pub(crate) fn run_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn run_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Configures an environment to use the given toolchain and then runs
     the specified program. The command may be any program, not just
     rustc or cargo. This can be used for testing arbitrary toolchains
@@ -168,22 +191,26 @@ pub(crate) fn run_help() -> &'static str {
     can be set by using `+toolchain` as the first argument. These are
     equivalent:
 
-        $ cargo +nightly build
+        {LITERAL}$ cargo +nightly build{LITERAL:#}
 
-        $ rustup run nightly cargo build"
+        {LITERAL}$ rustup run nightly cargo build{LITERAL:#}"
+    )
 }
 
-pub(crate) fn doc_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn doc_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Opens the documentation for the currently active toolchain with
     the default browser.
 
     By default, it opens the documentation index. Use the various
     flags to open specific pieces of documentation."
+    )
 }
 
-pub(crate) fn completions_help() -> &'static str {
-    r"Discussion:
+pub(crate) fn completions_help() -> String {
+    format!(
+        r"{HEADER}Discussion:{HEADER:#}
     Enable tab completion for Bash, Fish, Zsh, or PowerShell
     The script is output on `stdout`, allowing one to re-direct the
     output to the file of their choosing. Where you place the file
@@ -201,8 +228,8 @@ pub(crate) fn completions_help() -> &'static str {
     `~/.local/share/bash-completion/completions` for user-specific commands.
     Run the command:
 
-        $ mkdir -p ~/.local/share/bash-completion/completions
-        $ rustup completions bash > ~/.local/share/bash-completion/completions/rustup
+        {LITERAL}$ mkdir -p ~/.local/share/bash-completion/completions{LITERAL:#}
+        {LITERAL}$ rustup completions bash > ~/.local/share/bash-completion/completions/rustup{LITERAL:#}
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.
@@ -212,16 +239,16 @@ pub(crate) fn completions_help() -> &'static str {
     Homebrew stores bash completion files within the Homebrew directory.
     With the `bash-completion` brew formula installed, run the command:
 
-        $ mkdir -p $(brew --prefix)/etc/bash_completion.d
-        $ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion
+        {LITERAL}$ mkdir -p $(brew --prefix)/etc/bash_completion.d{LITERAL:#}
+        {LITERAL}$ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion{LITERAL:#}
 
     Fish:
 
     Fish completion files are commonly stored in
     `$HOME/.config/fish/completions`. Run the command:
 
-        $ mkdir -p ~/.config/fish/completions
-        $ rustup completions fish > ~/.config/fish/completions/rustup.fish
+        {LITERAL}$ mkdir -p ~/.config/fish/completions{LITERAL:#}
+        {LITERAL}$ rustup completions fish > ~/.config/fish/completions/rustup.fish{LITERAL:#}
 
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.
@@ -234,25 +261,25 @@ pub(crate) fn completions_help() -> &'static str {
     own to this list.
 
     Adding a custom directory is often the safest bet if you are
-    unsure of which directory to use. First create the directory} for
+    unsure of which directory to use. First create the directory; for
     this example we'll create a hidden directory inside our `$HOME`
     directory:
 
-        $ mkdir ~/.zfunc
+        {LITERAL}$ mkdir ~/.zfunc{LITERAL:#}
 
     Then add the following lines to your `.zshrc` just before
     `compinit`:
 
-        fpath+=~/.zfunc
+        {LITERAL}fpath+=~/.zfunc{LITERAL:#}
 
     Now you can install the completions script using the following
     command:
 
-        $ rustup completions zsh > ~/.zfunc/_rustup
+        {LITERAL}$ rustup completions zsh > ~/.zfunc/_rustup{LITERAL:#}
 
     You must then either log out and log back in, or simply run
 
-        $ exec zsh
+        {LITERAL}$ exec zsh{LITERAL:#}
 
     for the new completions to take effect.
 
@@ -272,21 +299,21 @@ pub(crate) fn completions_help() -> &'static str {
 
     First, check if a profile has already been set
 
-        PS C:\> Test-Path $profile
+        {LITERAL}PS C:\> Test-Path $profile{LITERAL:#}
 
     If the above command returns `False` run the following
 
-        PS C:\> New-Item -path $profile -type file -force
+        {LITERAL}PS C:\> New-Item -path $profile -type file -force{LITERAL:#}
 
     Now open the file provided by `$profile` (if you used the
     `New-Item` command it will be
-    `${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
+    `${{env:USERPROFILE}}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1`
 
     Next, we either save the completions file into our profile, or
     into a separate file and source it inside our profile. To save the
     completions into our profile simply use
 
-        PS C:\> rustup completions powershell >> ${env:USERPROFILE}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1
+        {LITERAL}PS C:\> rustup completions powershell >> ${{env:USERPROFILE}}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1{LITERAL:#}
 
     Cargo:
 
@@ -297,11 +324,12 @@ pub(crate) fn completions_help() -> &'static str {
 
     Bash:
 
-        $ rustup completions bash cargo >> ~/.local/share/bash-completion/completions/cargo
+        {LITERAL}$ rustup completions bash cargo >> ~/.local/share/bash-completion/completions/cargo{LITERAL:#}
 
     Zsh:
 
-        $ rustup completions zsh cargo > ~/.zfunc/_cargo"
+        {LITERAL}$ rustup completions zsh cargo > ~/.zfunc/_cargo{LITERAL:#}"
+    )
 }
 
 pub(crate) fn official_toolchain_arg_help() -> &'static str {

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,4 +1,5 @@
-pub(crate) static RUSTUP_HELP: &str = r"Discussion:
+pub(crate) fn rustup_help() -> &'static str {
+    r"Discussion:
     Rustup installs The Rust Programming Language from the official
     release channels, enabling you to easily switch between stable,
     beta, and nightly compilers and keep them updated. It makes
@@ -6,48 +7,60 @@ pub(crate) static RUSTUP_HELP: &str = r"Discussion:
     for common platforms.
 
     If you are new to Rust consider running `rustup doc --book` to
-    learn Rust.";
+    learn Rust."
+}
 
-pub(crate) static SHOW_HELP: &str = r"Discussion:
+pub(crate) fn show_help() -> &'static str {
+    r"Discussion:
     Shows the name of the active toolchain and the version of `rustc`.
 
     If the active toolchain has installed support for additional
     compilation targets, then they are listed as well.
 
     If there are multiple toolchains installed then all installed
-    toolchains are listed as well.";
+    toolchains are listed as well."
+}
 
-pub(crate) static SHOW_ACTIVE_TOOLCHAIN_HELP: &str = r"Discussion:
+pub(crate) fn show_active_toolchain_help() -> &'static str {
+    r"Discussion:
     Shows the name of the active toolchain.
 
     This is useful for figuring out the active tool chain from
     scripts.
 
     You should use `rustc --print sysroot` to get the sysroot, or
-    `rustc --version` to get the toolchain version.";
+    `rustc --version` to get the toolchain version."
+}
 
-pub(crate) static UPDATE_HELP: &str = r"Discussion:
+pub(crate) fn update_help() -> &'static str {
+    r"Discussion:
     With no toolchain specified, the `update` command updates each of
     the installed toolchains from the official release channels, then
     updates rustup itself.
 
     If given a toolchain argument then `update` updates that
-    toolchain, the same as `rustup toolchain install`.";
+    toolchain, the same as `rustup toolchain install`."
+}
 
-pub(crate) static INSTALL_HELP: &str = r"Discussion:
+pub(crate) fn install_help() -> &'static str {
+    r"Discussion:
     Installs a specific rust toolchain.
 
-    The 'install' command is an alias for 'rustup update <toolchain>'.";
+    The 'install' command is an alias for 'rustup update <toolchain>'."
+}
 
-pub(crate) static DEFAULT_HELP: &str = r"Discussion:
+pub(crate) fn default_help() -> &'static str {
+    r"Discussion:
     Sets the default toolchain to the one specified. If the toolchain
-    is not already installed then it is installed first.";
+    is not already installed then it is installed first."
+}
 
-pub(crate) static TOOLCHAIN_HELP: &str = r"Discussion:
+pub(crate) fn toolchain_help() -> &'static str {
+    r"Discussion:
     Many `rustup` commands deal with *toolchains*, a single
     installation of the Rust compiler. `rustup` supports multiple
     types of toolchains. The most basic track the official release
-    channels: 'stable', 'beta' and 'nightly'; but `rustup` can also
+    channels: 'stable', 'beta' and 'nightly'} but `rustup` can also
     install specific toolchains from the official archives, toolchains for
     alternate host platforms, and from local builds ('custom toolchains').
 
@@ -85,9 +98,11 @@ pub(crate) static TOOLCHAIN_HELP: &str = r"Discussion:
 
     rustup can also manage symlinked local toolchain builds, which are
     often used for developing Rust itself. For more information see
-    `rustup toolchain help link`.";
+    `rustup toolchain help link`."
+}
 
-pub(crate) static TOOLCHAIN_LINK_HELP: &str = r"Discussion:
+pub(crate) fn toolchain_link_help() -> &'static str {
+    r"Discussion:
     'toolchain' is the custom name to be assigned to the new toolchain.
     Any name is permitted as long as:
     - it does not include '/' or '\' except as the last character
@@ -106,9 +121,11 @@ pub(crate) static TOOLCHAIN_LINK_HELP: &str = r"Discussion:
         $ rustup override set latest-stage1
 
     If you now compile a crate in the current directory, the custom
-    toolchain 'latest-stage1' will be used.";
+    toolchain 'latest-stage1' will be used."
+}
 
-pub(crate) static OVERRIDE_HELP: &str = r"Discussion:
+pub(crate) fn override_help() -> &'static str {
+    r"Discussion:
     Overrides configure Rustup to use a specific toolchain when
     running in a specific directory.
 
@@ -127,16 +144,20 @@ pub(crate) static OVERRIDE_HELP: &str = r"Discussion:
 
     To see the active toolchain use `rustup show`. To remove the
     override and use the default toolchain again, `rustup override
-    unset`.";
+    unset`."
+}
 
-pub(crate) static OVERRIDE_UNSET_HELP: &str = r"Discussion:
+pub(crate) fn override_unset_help() -> &'static str {
+    r"Discussion:
     If `--path` argument is present, removes the override toolchain
     for the specified directory. If `--nonexistent` argument is
     present, removes the override toolchain for all nonexistent
     directories. Otherwise, removes the override toolchain for the
-    current directory.";
+    current directory."
+}
 
-pub(crate) static RUN_HELP: &str = r"Discussion:
+pub(crate) fn run_help() -> &'static str {
+    r"Discussion:
     Configures an environment to use the given toolchain and then runs
     the specified program. The command may be any program, not just
     rustc or cargo. This can be used for testing arbitrary toolchains
@@ -149,16 +170,20 @@ pub(crate) static RUN_HELP: &str = r"Discussion:
 
         $ cargo +nightly build
 
-        $ rustup run nightly cargo build";
+        $ rustup run nightly cargo build"
+}
 
-pub(crate) static DOC_HELP: &str = r"Discussion:
+pub(crate) fn doc_help() -> &'static str {
+    r"Discussion:
     Opens the documentation for the currently active toolchain with
     the default browser.
 
     By default, it opens the documentation index. Use the various
-    flags to open specific pieces of documentation.";
+    flags to open specific pieces of documentation."
+}
 
-pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
+pub(crate) fn completions_help() -> &'static str {
+    r"Discussion:
     Enable tab completion for Bash, Fish, Zsh, or PowerShell
     The script is output on `stdout`, allowing one to re-direct the
     output to the file of their choosing. Where you place the file
@@ -209,7 +234,7 @@ pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
     own to this list.
 
     Adding a custom directory is often the safest bet if you are
-    unsure of which directory to use. First create the directory; for
+    unsure of which directory to use. First create the directory} for
     this example we'll create a hidden directory inside our `$HOME`
     directory:
 
@@ -276,22 +301,33 @@ pub(crate) static COMPLETIONS_HELP: &str = r"Discussion:
 
     Zsh:
 
-        $ rustup completions zsh cargo > ~/.zfunc/_cargo";
+        $ rustup completions zsh cargo > ~/.zfunc/_cargo"
+}
 
-pub(crate) static OFFICIAL_TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \
+pub(crate) fn official_toolchain_arg_help() -> &'static str {
+    "Toolchain name, such as 'stable', 'nightly', \
                                        or '1.8.0'. For more information see `rustup \
-                                       help toolchain`";
-pub(crate) static RESOLVABLE_LOCAL_TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \
+                                       help toolchain`"
+}
+pub(crate) fn resolvable_local_toolchain_arg_help() -> &'static str {
+    "Toolchain name, such as 'stable', 'nightly', \
                                        '1.8.0', or a custom toolchain name, or an absolute path. For more \
-                                       information see `rustup help toolchain`";
-pub(crate) static RESOLVABLE_TOOLCHAIN_ARG_HELP: &str = "Toolchain name, such as 'stable', 'nightly', \
+                                       information see `rustup help toolchain`"
+}
+pub(crate) fn resolvable_toolchain_arg_help() -> &'static str {
+    "Toolchain name, such as 'stable', 'nightly', \
                                        '1.8.0', or a custom toolchain name. For more information see `rustup \
-                                       help toolchain`";
-pub(crate) static MAYBE_RESOLVABLE_TOOLCHAIN_ARG_HELP: &str = "'none', a toolchain name, such as 'stable', 'nightly', \
+                                       help toolchain`"
+}
+pub(crate) fn maybe_resolvable_toolchain_arg_help() -> &'static str {
+    "'none', a toolchain name, such as 'stable', 'nightly', \
                                        '1.8.0', or a custom toolchain name. For more information see `rustup \
-                                       help toolchain`";
+                                       help toolchain`"
+}
 
-pub(crate) static TOPIC_ARG_HELP: &str = "Topic such as 'core', 'fn', 'usize', 'eprintln!', \
+pub(crate) fn topic_arg_help() -> &'static str {
+    "Topic such as 'core', 'fn', 'usize', 'eprintln!', \
                                    'core::arch', 'alloc::format!', 'std::fs', \
                                    'std::fs::read_dir', 'std::io::Bytes', \
-                                   'std::iter::Sum', 'std::io::error::Result' etc...";
+                                   'std::iter::Sum', 'std::io::error::Result' etc..."
+}

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -1,3 +1,4 @@
+use anstyle::Style;
 use clap_cargo::style::{HEADER, LITERAL, PLACEHOLDER};
 
 pub(crate) fn rustup_help() -> String {
@@ -221,7 +222,7 @@ pub(crate) fn completions_help() -> String {
     Here are some common set ups for the three supported shells under
     Unix and similar operating systems (such as GNU/Linux).
 
-    Bash:
+    {SUBHEADER}Bash:{SUBHEADER:#}
 
     Completion files are commonly stored in `/etc/bash_completion.d/` for
     system-wide commands, but can be stored in
@@ -234,7 +235,7 @@ pub(crate) fn completions_help() -> String {
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.
 
-    Bash (macOS/Homebrew):
+    {SUBHEADER}Bash (macOS/Homebrew):{SUBHEADER:#}
 
     Homebrew stores bash completion files within the Homebrew directory.
     With the `bash-completion` brew formula installed, run the command:
@@ -242,7 +243,7 @@ pub(crate) fn completions_help() -> String {
         {LITERAL}$ mkdir -p $(brew --prefix)/etc/bash_completion.d{LITERAL:#}
         {LITERAL}$ rustup completions bash > $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion{LITERAL:#}
 
-    Fish:
+    {SUBHEADER}Fish:{SUBHEADER:#}
 
     Fish completion files are commonly stored in
     `$HOME/.config/fish/completions`. Run the command:
@@ -253,7 +254,7 @@ pub(crate) fn completions_help() -> String {
     This installs the completion script. You may have to log out and
     log back in to your shell session for the changes to take effect.
 
-    Zsh:
+    {SUBHEADER}Zsh:{SUBHEADER:#}
 
     ZSH completions are commonly stored in any directory listed in
     your `$fpath` variable. To use these completions, you must either
@@ -283,7 +284,7 @@ pub(crate) fn completions_help() -> String {
 
     for the new completions to take effect.
 
-    Custom locations:
+    {SUBHEADER}Custom locations:{SUBHEADER:#}
 
     Alternatively, you could save these files to the place of your
     choosing, such as a custom directory inside your $HOME. Doing so
@@ -291,7 +292,7 @@ pub(crate) fn completions_help() -> String {
     inside your login script. Consult your shells documentation for
     how to add such directives.
 
-    PowerShell:
+    {SUBHEADER}PowerShell:{SUBHEADER:#}
 
     The powershell completion scripts require PowerShell v5.0+ (which
     comes with Windows 10, but can be downloaded separately for windows 7
@@ -315,18 +316,18 @@ pub(crate) fn completions_help() -> String {
 
         {LITERAL}PS C:\> rustup completions powershell >> ${{env:USERPROFILE}}\Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1{LITERAL:#}
 
-    Cargo:
+    {SUBHEADER}Cargo:{SUBHEADER:#}
 
     Rustup can also generate a completion script for `cargo`. The script output
     by `rustup` will source the completion script distributed with your default
     toolchain. Not all shells are currently supported. Here are examples for
     the currently supported shells.
 
-    Bash:
+    {SUBHEADER}Bash:{SUBHEADER:#}
 
         {LITERAL}$ rustup completions bash cargo >> ~/.local/share/bash-completion/completions/cargo{LITERAL:#}
 
-    Zsh:
+    {SUBHEADER}Zsh:{SUBHEADER:#}
 
         {LITERAL}$ rustup completions zsh cargo > ~/.zfunc/_cargo{LITERAL:#}"
     )
@@ -359,3 +360,5 @@ pub(crate) fn topic_arg_help() -> &'static str {
                                    'std::fs::read_dir', 'std::io::Bytes', \
                                    'std::iter::Sum', 'std::io::error::Result' etc..."
 }
+
+const SUBHEADER: Style = Style::new().bold();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -75,6 +75,7 @@ fn handle_epipe(res: Result<ExitCode>) -> Result<ExitCode> {
     version = common::version(),
     before_help = format!("rustup {}", common::version()),
     after_help = rustup_help(),
+    styles = clap_cargo::style::CLAP_STYLING,
 )]
 struct Rustup {
     /// Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
@@ -578,11 +579,11 @@ pub async fn main(
     let matches = match Rustup::try_parse_from(process.args_os()) {
         Ok(matches) => matches,
         Err(err) if err.kind() == DisplayHelp => {
-            write!(process.stdout().lock(), "{err}")?;
+            write!(process.stdout().lock(), "{}", err.render().ansi())?;
             return Ok(ExitCode(0));
         }
         Err(err) if err.kind() == DisplayVersion => {
-            write!(process.stdout().lock(), "{err}")?;
+            write!(process.stdout().lock(), "{}", err.render().ansi())?;
             display_version(current_dir, process).await?;
             return Ok(ExitCode(0));
         }
@@ -594,9 +595,9 @@ pub async fn main(
             ]
             .contains(&err.kind())
             {
-                write!(process.stdout().lock(), "{err}")?;
+                write!(process.stdout().lock(), "{}", err.render().ansi())?;
             } else {
-                write!(process.stderr().lock(), "{err}")?;
+                write!(process.stderr().lock(), "{}", err.render().ansi())?;
             }
             return Ok(ExitCode(1));
         }
@@ -609,7 +610,7 @@ pub async fn main(
 
     let Some(subcmd) = matches.subcmd else {
         let help = Rustup::command().render_long_help();
-        writeln!(process.stderr().lock(), "{help}")?;
+        writeln!(process.stderr().lock(), "{}", help.ansi())?;
         return Ok(ExitCode(1));
     };
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -74,7 +74,7 @@ fn handle_epipe(res: Result<ExitCode>) -> Result<ExitCode> {
     bin_name = "rustup[EXE]",
     version = common::version(),
     before_help = format!("rustup {}", common::version()),
-    after_help = RUSTUP_HELP,
+    after_help = rustup_help(),
 )]
 struct Rustup {
     /// Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
@@ -115,7 +115,7 @@ fn plus_toolchain_value_parser(s: &str) -> clap::error::Result<ResolvableToolcha
 #[command(name = "rustup", bin_name = "rustup[EXE]")]
 enum RustupSubcmd {
     /// Install or update the given toolchains, or by default the active toolchain
-    #[command(hide = true, after_help = INSTALL_HELP)]
+    #[command(hide = true, after_help = install_help())]
     Install {
         #[command(flatten)]
         opts: UpdateOpts,
@@ -139,9 +139,9 @@ enum RustupSubcmd {
     },
 
     /// Set the default toolchain
-    #[command(after_help = DEFAULT_HELP)]
+    #[command(after_help = default_help())]
     Default {
-        #[arg(help = MAYBE_RESOLVABLE_TOOLCHAIN_ARG_HELP)]
+        #[arg(help = maybe_resolvable_toolchain_arg_help())]
         toolchain: Option<MaybeResolvableToolchainName>,
 
         /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
@@ -150,7 +150,7 @@ enum RustupSubcmd {
     },
 
     /// Show the active and installed toolchains or profiles
-    #[command(after_help = SHOW_HELP)]
+    #[command(after_help = show_help())]
     Show {
         /// Enable verbose output with rustc information for all installed toolchains
         #[arg(short, long)]
@@ -162,7 +162,7 @@ enum RustupSubcmd {
 
     /// Update Rust toolchains and rustup
     #[command(
-        after_help = UPDATE_HELP,
+        after_help = update_help(),
         aliases = ["upgrade", "up"],
     )]
     Update {
@@ -208,9 +208,9 @@ enum RustupSubcmd {
     },
 
     /// Run a command with an environment configured for a given toolchain
-    #[command(after_help = RUN_HELP, trailing_var_arg = true)]
+    #[command(after_help = run_help(), trailing_var_arg = true)]
     Run {
-        #[arg(help = RESOLVABLE_LOCAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(help = resolvable_local_toolchain_arg_help())]
         toolchain: ResolvableLocalToolchainName,
 
         #[arg(required = true, num_args = 1..)]
@@ -225,24 +225,24 @@ enum RustupSubcmd {
     Which {
         command: String,
 
-        #[arg(long, help = RESOLVABLE_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = resolvable_toolchain_arg_help())]
         toolchain: Option<ResolvableToolchainName>,
     },
 
     /// Open the documentation for the current toolchain
     #[command(
         alias = "docs",
-        after_help = DOC_HELP,
+        after_help = doc_help(),
     )]
     Doc {
         /// Only print the path to the documentation
         #[arg(long)]
         path: bool,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
 
-        #[arg(help = TOPIC_ARG_HELP)]
+        #[arg(help = topic_arg_help())]
         topic: Option<String>,
 
         #[command(flatten)]
@@ -254,7 +254,7 @@ enum RustupSubcmd {
     Man {
         command: String,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
     },
 
@@ -271,7 +271,7 @@ enum RustupSubcmd {
     },
 
     /// Generate tab-completion scripts for your shell
-    #[command(after_help = COMPLETIONS_HELP, arg_required_else_help = true)]
+    #[command(after_help = completions_help(), arg_required_else_help = true)]
     Completions {
         shell: Shell,
 
@@ -291,7 +291,7 @@ fn update_toolchain_value_parser(s: &str) -> Result<PartialToolchainDesc> {
 #[derive(Debug, Subcommand)]
 enum ShowSubcmd {
     /// Show the active toolchain
-    #[command(after_help = SHOW_ACTIVE_TOOLCHAIN_HELP)]
+    #[command(after_help = show_active_toolchain_help())]
     ActiveToolchain {
         /// Enable verbose output with rustc information
         #[arg(short, long)]
@@ -309,7 +309,7 @@ enum ShowSubcmd {
 #[command(
     arg_required_else_help = true,
     subcommand_required = true,
-    after_help = TOOLCHAIN_HELP,
+    after_help = toolchain_help(),
 )]
 enum ToolchainSubcmd {
     /// List installed toolchains
@@ -338,7 +338,7 @@ enum ToolchainSubcmd {
     },
 
     /// Create a custom toolchain by symlinking to a directory
-    #[command(after_help = TOOLCHAIN_LINK_HELP)]
+    #[command(after_help = toolchain_link_help())]
     Link {
         /// Custom toolchain name
         toolchain: CustomToolchainName,
@@ -358,7 +358,7 @@ struct CheckOpts {
 #[derive(Debug, Default, Args)]
 struct UpdateOpts {
     #[arg(
-        help = OFFICIAL_TOOLCHAIN_ARG_HELP,
+        help = official_toolchain_arg_help(),
         num_args = 1..,
     )]
     toolchain: Vec<PartialToolchainDesc>,
@@ -394,7 +394,7 @@ struct UpdateOpts {
 #[derive(Debug, Default, Args)]
 struct UninstallOpts {
     #[arg(
-        help = RESOLVABLE_TOOLCHAIN_ARG_HELP,
+        help = resolvable_toolchain_arg_help(),
         required = true,
         num_args = 1..,
     )]
@@ -408,7 +408,7 @@ enum TargetSubcmd {
     List {
         #[arg(
             long,
-            help = OFFICIAL_TOOLCHAIN_ARG_HELP,
+            help = official_toolchain_arg_help(),
         )]
         toolchain: Option<PartialToolchainDesc>,
 
@@ -428,7 +428,7 @@ enum TargetSubcmd {
         #[arg(required = true, num_args = 1..)]
         target: Vec<String>,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
     },
 
@@ -439,7 +439,7 @@ enum TargetSubcmd {
         #[arg(required = true, num_args = 1..)]
         target: Vec<String>,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
     },
 }
@@ -449,7 +449,7 @@ enum TargetSubcmd {
 enum ComponentSubcmd {
     /// List installed and available components
     List {
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
 
         /// List only installed components
@@ -466,7 +466,7 @@ enum ComponentSubcmd {
         #[arg(required = true, num_args = 1..)]
         component: Vec<String>,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
 
         #[arg(long)]
@@ -479,7 +479,7 @@ enum ComponentSubcmd {
         #[arg(required = true, num_args = 1..)]
         component: Vec<String>,
 
-        #[arg(long, help = OFFICIAL_TOOLCHAIN_ARG_HELP)]
+        #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
 
         #[arg(long)]
@@ -489,7 +489,7 @@ enum ComponentSubcmd {
 
 #[derive(Debug, Subcommand)]
 #[command(
-    after_help = OVERRIDE_HELP,
+    after_help = override_help(),
     arg_required_else_help = true,
     subcommand_required = true,
 )]
@@ -500,7 +500,7 @@ enum OverrideSubcmd {
     /// Set the override toolchain for a directory
     #[command(alias = "add")]
     Set {
-        #[arg(help = RESOLVABLE_TOOLCHAIN_ARG_HELP)]
+        #[arg(help = resolvable_toolchain_arg_help())]
         toolchain: ResolvableToolchainName,
 
         /// Path to the directory
@@ -509,7 +509,7 @@ enum OverrideSubcmd {
     },
 
     /// Remove the override toolchain for a directory
-    #[command(aliases = ["remove", "rm", "delete", "del"], after_help = OVERRIDE_UNSET_HELP)]
+    #[command(aliases = ["remove", "rm", "delete", "del"], after_help = override_unset_help())]
     Unset {
         /// Path to the directory
         #[arg(long)]

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Result, format_err};
 use clap::Parser;
 use tracing::warn;
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
@@ -24,6 +24,7 @@ use crate::{
     bin_name = "rustup-init[EXE]",
     version = common::version(),
     before_help = format!("rustup-init {}", common::version()),
+    styles = clap_cargo::style::CLAP_STYLING
 )]
 struct RustupInit {
     /// Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
@@ -99,10 +100,10 @@ pub async fn main(
         Ok(args) => args,
         Err(e) if [ErrorKind::DisplayHelp, ErrorKind::DisplayVersion].contains(&e.kind()) => {
             use std::io::Write as _;
-            write!(process.stdout().lock(), "{e}")?;
+            write!(process.stdout().lock(), "{}", e.render().ansi())?;
             return Ok(utils::ExitCode(0));
         }
-        Err(e) => return Err(e.into()),
+        Err(e) => return Err(format_err!("{}", e.render().ansi())),
     };
 
     if self_replace {

--- a/tests/suite/cli_rustup_init_ui/rustup_init_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_init_ui/rustup_init_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -24,57 +28,57 @@
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Usage: rustup-init[EXE] [OPTIONS]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup-init[EXE]</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Options:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  -v, --verbose</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan>
 </tspan>
     <tspan x="10px" y="172px"><tspan>          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -q, --quiet</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -y</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>          Disable confirmation prompt</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      --default-host &lt;DEFAULT_HOST&gt;</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--default-host</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DEFAULT_HOST&gt;</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>          Choose a default host triple</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      --default-toolchain &lt;DEFAULT_TOOLCHAIN&gt;</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--default-toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;DEFAULT_TOOLCHAIN&gt;</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>          Choose a default toolchain to install. Use 'none' to not install any toolchains at all</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --profile &lt;PROFILE&gt;</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE&gt;</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>          [default: default] [possible values: minimal, default, complete]</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  -c, --component &lt;COMPONENT&gt;</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-c</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--component</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;</tspan>
 </tspan>
     <tspan x="10px" y="388px"><tspan>          Comma-separated list of component names to also install</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  -t, --target &lt;TARGET&gt;</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-t</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan>
 </tspan>
     <tspan x="10px" y="424px"><tspan>          Comma-separated list of target names to also install</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --no-update-default-toolchain</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-update-default-toolchain</tspan>
 </tspan>
     <tspan x="10px" y="460px"><tspan>          Don't update any existing default toolchain after install</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      --no-modify-path</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-modify-path</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>          Don't configure the PATH environment variable</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  -h, --help</tspan>
+    <tspan x="10px" y="514px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan>
 </tspan>
     <tspan x="10px" y="532px"><tspan>          Print help</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  -V, --version</tspan>
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>          Print version</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_check_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,15 +24,15 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] check [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] check</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --no-self-update  Don't check for self update when running the `rustup check` command</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't check for self update when running the `rustup check` command</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  -h, --help            Print help</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>    Enable tab completion for Bash, Fish, Zsh, or PowerShell</tspan>
 </tspan>
@@ -78,9 +78,9 @@
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>        $ mkdir -p ~/.local/share/bash-completion/completions</tspan>
+    <tspan x="10px" y="550px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ mkdir -p ~/.local/share/bash-completion/completions</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>        $ rustup completions bash &gt; ~/.local/share/bash-completion/completions/rustup</tspan>
+    <tspan x="10px" y="568px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions bash &gt; ~/.local/share/bash-completion/completions/rustup</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>
@@ -100,9 +100,9 @@
 </tspan>
     <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan>        $ mkdir -p $(brew --prefix)/etc/bash_completion.d</tspan>
+    <tspan x="10px" y="748px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ mkdir -p $(brew --prefix)/etc/bash_completion.d</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>        $ rustup completions bash &gt; $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion</tspan>
+    <tspan x="10px" y="766px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions bash &gt; $(brew --prefix)/etc/bash_completion.d/rustup.bash-completion</tspan>
 </tspan>
     <tspan x="10px" y="784px">
 </tspan>
@@ -116,9 +116,9 @@
 </tspan>
     <tspan x="10px" y="874px">
 </tspan>
-    <tspan x="10px" y="892px"><tspan>        $ mkdir -p ~/.config/fish/completions</tspan>
+    <tspan x="10px" y="892px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ mkdir -p ~/.config/fish/completions</tspan>
 </tspan>
-    <tspan x="10px" y="910px"><tspan>        $ rustup completions fish &gt; ~/.config/fish/completions/rustup.fish</tspan>
+    <tspan x="10px" y="910px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions fish &gt; ~/.config/fish/completions/rustup.fish</tspan>
 </tspan>
     <tspan x="10px" y="928px">
 </tspan>
@@ -152,7 +152,7 @@
 </tspan>
     <tspan x="10px" y="1198px">
 </tspan>
-    <tspan x="10px" y="1216px"><tspan>        $ mkdir ~/.zfunc</tspan>
+    <tspan x="10px" y="1216px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ mkdir ~/.zfunc</tspan>
 </tspan>
     <tspan x="10px" y="1234px">
 </tspan>
@@ -162,7 +162,7 @@
 </tspan>
     <tspan x="10px" y="1288px">
 </tspan>
-    <tspan x="10px" y="1306px"><tspan>        fpath+=~/.zfunc</tspan>
+    <tspan x="10px" y="1306px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">fpath+=~/.zfunc</tspan>
 </tspan>
     <tspan x="10px" y="1324px">
 </tspan>
@@ -172,7 +172,7 @@
 </tspan>
     <tspan x="10px" y="1378px">
 </tspan>
-    <tspan x="10px" y="1396px"><tspan>        $ rustup completions zsh &gt; ~/.zfunc/_rustup</tspan>
+    <tspan x="10px" y="1396px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions zsh &gt; ~/.zfunc/_rustup</tspan>
 </tspan>
     <tspan x="10px" y="1414px">
 </tspan>
@@ -180,7 +180,7 @@
 </tspan>
     <tspan x="10px" y="1450px">
 </tspan>
-    <tspan x="10px" y="1468px"><tspan>        $ exec zsh</tspan>
+    <tspan x="10px" y="1468px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ exec zsh</tspan>
 </tspan>
     <tspan x="10px" y="1486px">
 </tspan>
@@ -220,7 +220,7 @@
 </tspan>
     <tspan x="10px" y="1810px">
 </tspan>
-    <tspan x="10px" y="1828px"><tspan>        PS C:/&gt; Test-Path $profile</tspan>
+    <tspan x="10px" y="1828px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">PS C:/&gt; Test-Path $profile</tspan>
 </tspan>
     <tspan x="10px" y="1846px">
 </tspan>
@@ -228,7 +228,7 @@
 </tspan>
     <tspan x="10px" y="1882px">
 </tspan>
-    <tspan x="10px" y="1900px"><tspan>        PS C:/&gt; New-Item -path $profile -type file -force</tspan>
+    <tspan x="10px" y="1900px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">PS C:/&gt; New-Item -path $profile -type file -force</tspan>
 </tspan>
     <tspan x="10px" y="1918px">
 </tspan>
@@ -248,9 +248,9 @@
 </tspan>
     <tspan x="10px" y="2062px">
 </tspan>
-    <tspan x="10px" y="2080px"><tspan>        PS C:/&gt; rustup completions powershell &gt;&gt;</tspan>
+    <tspan x="10px" y="2080px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">PS C:/&gt; rustup completions powershell &gt;&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="2098px"><tspan>        ${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1</tspan>
+    <tspan x="10px" y="2098px"><tspan class="fg-bright-cyan bold">        ${env:USERPROFILE}/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1</tspan>
 </tspan>
     <tspan x="10px" y="2116px">
 </tspan>
@@ -272,7 +272,7 @@
 </tspan>
     <tspan x="10px" y="2278px">
 </tspan>
-    <tspan x="10px" y="2296px"><tspan>        $ rustup completions bash cargo &gt;&gt; ~/.local/share/bash-completion/completions/cargo</tspan>
+    <tspan x="10px" y="2296px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions bash cargo &gt;&gt; ~/.local/share/bash-completion/completions/cargo</tspan>
 </tspan>
     <tspan x="10px" y="2314px">
 </tspan>
@@ -280,7 +280,7 @@
 </tspan>
     <tspan x="10px" y="2350px">
 </tspan>
-    <tspan x="10px" y="2368px"><tspan>        $ rustup completions zsh cargo &gt; ~/.zfunc/_cargo</tspan>
+    <tspan x="10px" y="2368px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup completions zsh cargo &gt; ~/.zfunc/_cargo</tspan>
 </tspan>
     <tspan x="10px" y="2386px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,21 +24,21 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] completions &lt;SHELL&gt; [COMMAND]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] completions</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;SHELL&gt;</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;SHELL&gt;    [possible values: bash, elvish, fish, powershell, zsh]</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;SHELL&gt;</tspan><tspan>    [possible values: bash, elvish, fish, powershell, zsh]</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  [COMMAND]  [default: rustup] [possible values: rustup, cargo]</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan">[COMMAND]</tspan><tspan>  [default: rustup] [possible values: rustup, cargo]</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
@@ -64,7 +64,7 @@
 </tspan>
     <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>    Bash:</tspan>
+    <tspan x="10px" y="424px"><tspan>    </tspan><tspan class="bold">Bash:</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
@@ -90,7 +90,7 @@
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan>    Bash (macOS/Homebrew):</tspan>
+    <tspan x="10px" y="658px"><tspan>    </tspan><tspan class="bold">Bash (macOS/Homebrew):</tspan>
 </tspan>
     <tspan x="10px" y="676px">
 </tspan>
@@ -106,7 +106,7 @@
 </tspan>
     <tspan x="10px" y="784px">
 </tspan>
-    <tspan x="10px" y="802px"><tspan>    Fish:</tspan>
+    <tspan x="10px" y="802px"><tspan>    </tspan><tspan class="bold">Fish:</tspan>
 </tspan>
     <tspan x="10px" y="820px">
 </tspan>
@@ -128,7 +128,7 @@
 </tspan>
     <tspan x="10px" y="982px">
 </tspan>
-    <tspan x="10px" y="1000px"><tspan>    Zsh:</tspan>
+    <tspan x="10px" y="1000px"><tspan>    </tspan><tspan class="bold">Zsh:</tspan>
 </tspan>
     <tspan x="10px" y="1018px">
 </tspan>
@@ -188,7 +188,7 @@
 </tspan>
     <tspan x="10px" y="1522px">
 </tspan>
-    <tspan x="10px" y="1540px"><tspan>    Custom locations:</tspan>
+    <tspan x="10px" y="1540px"><tspan>    </tspan><tspan class="bold">Custom locations:</tspan>
 </tspan>
     <tspan x="10px" y="1558px">
 </tspan>
@@ -204,7 +204,7 @@
 </tspan>
     <tspan x="10px" y="1666px">
 </tspan>
-    <tspan x="10px" y="1684px"><tspan>    PowerShell:</tspan>
+    <tspan x="10px" y="1684px"><tspan>    </tspan><tspan class="bold">PowerShell:</tspan>
 </tspan>
     <tspan x="10px" y="1702px">
 </tspan>
@@ -254,7 +254,7 @@
 </tspan>
     <tspan x="10px" y="2116px">
 </tspan>
-    <tspan x="10px" y="2134px"><tspan>    Cargo:</tspan>
+    <tspan x="10px" y="2134px"><tspan>    </tspan><tspan class="bold">Cargo:</tspan>
 </tspan>
     <tspan x="10px" y="2152px">
 </tspan>
@@ -268,7 +268,7 @@
 </tspan>
     <tspan x="10px" y="2242px">
 </tspan>
-    <tspan x="10px" y="2260px"><tspan>    Bash:</tspan>
+    <tspan x="10px" y="2260px"><tspan>    </tspan><tspan class="bold">Bash:</tspan>
 </tspan>
     <tspan x="10px" y="2278px">
 </tspan>
@@ -276,7 +276,7 @@
 </tspan>
     <tspan x="10px" y="2314px">
 </tspan>
-    <tspan x="10px" y="2332px"><tspan>    Zsh:</tspan>
+    <tspan x="10px" y="2332px"><tspan>    </tspan><tspan class="bold">Zsh:</tspan>
 </tspan>
     <tspan x="10px" y="2350px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_component_cmd_add_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_cmd_add_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] component add [OPTIONS] &lt;COMPONENT&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] component add</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;COMPONENT&gt;...  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;...</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --target &lt;TARGET&gt;        </tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan><tspan>        </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_component_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] component &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] component</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  list    List installed and available components</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">list</tspan><tspan>    List installed and available components</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  add     Add a component to a Rust toolchain</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">add</tspan><tspan>     Add a component to a Rust toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  remove  Remove a component from a Rust toolchain</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">remove</tspan><tspan>  Remove a component from a Rust toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  help    Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>    Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Options:</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_component_cmd_list_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_cmd_list_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,21 +24,21 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] component list [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] component list</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      --installed              List only installed components</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--installed</tspan><tspan>              List only installed components</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -q, --quiet                  Force the output to be a single column</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                  Force the output to be a single column</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_component_cmd_remove_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_cmd_remove_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] component remove [OPTIONS] &lt;COMPONENT&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] component remove</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;COMPONENT&gt;...  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;...</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --target &lt;TARGET&gt;        </tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan><tspan>        </tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_default_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default_cmd_help_flag.stdout.term.svg
@@ -46,7 +46,7 @@
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>    Sets the default toolchain to the one specified. If the toolchain</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_default_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] default [OPTIONS] [TOOLCHAIN]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] default</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOOLCHAIN]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOOLCHAIN]  'none', a toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOOLCHAIN]</tspan><tspan>  'none', a toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>               name. For more information see `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --force-non-host  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help            Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
@@ -90,7 +90,7 @@
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="658px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>    Opens the documentation for the currently active toolchain with</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +24,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] doc [OPTIONS] [TOPIC]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] doc</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOPIC]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOPIC]  Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!',</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOPIC]</tspan><tspan>  Topic such as 'core', 'fn', 'usize', 'eprintln!', 'core::arch', 'alloc::format!',</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>           'std::fs', 'std::fs::read_dir', 'std::io::Bytes', 'std::iter::Sum',</tspan>
 </tspan>
@@ -34,55 +38,55 @@
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan>Options:</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --path                   Only print the path to the documentation</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan>                   Only print the path to the documentation</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      --alloc                  The Rust core allocation and collections library</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--alloc</tspan><tspan>                  The Rust core allocation and collections library</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      --book                   The Rust Programming Language book</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--book</tspan><tspan>                   The Rust Programming Language book</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      --cargo                  The Cargo Book</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--cargo</tspan><tspan>                  The Cargo Book</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      --clippy                 The Clippy Documentation</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--clippy</tspan><tspan>                 The Clippy Documentation</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --core                   The Rust Core Library</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--core</tspan><tspan>                   The Rust Core Library</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      --edition-guide          The Rust Edition Guide</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition-guide</tspan><tspan>          The Rust Edition Guide</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      --embedded-book          The Embedded Rust Book</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--embedded-book</tspan><tspan>          The Embedded Rust Book</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      --error-codes            The Rust Error Codes Index</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--error-codes</tspan><tspan>            The Rust Error Codes Index</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      --nomicon                The Dark Arts of Advanced and Unsafe Rust Programming</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--nomicon</tspan><tspan>                The Dark Arts of Advanced and Unsafe Rust Programming</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      --proc_macro             A support library for macro authors when defining new macros</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--proc_macro</tspan><tspan>             A support library for macro authors when defining new macros</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      --reference              The Rust Reference</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--reference</tspan><tspan>              The Rust Reference</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      --rust-by-example        A collection of runnable examples that illustrate various Rust</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rust-by-example</tspan><tspan>        A collection of runnable examples that illustrate various Rust</tspan>
 </tspan>
     <tspan x="10px" y="478px"><tspan>                               concepts and standard libraries</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>      --rustc                  The compiler for the Rust programming language</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc</tspan><tspan>                  The compiler for the Rust programming language</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      --rustdoc                Documentation generator for Rust projects</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustdoc</tspan><tspan>                Documentation generator for Rust projects</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      --std                    Standard library API documentation</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--std</tspan><tspan>                    Standard library API documentation</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      --style-guide            The Rust Style Guide</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--style-guide</tspan><tspan>            The Rust Style Guide</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      --test                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan>                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
 </tspan>
     <tspan x="10px" y="586px"><tspan>                               framework</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      --unstable-book          The Unstable Book</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unstable-book</tspan><tspan>          The Unstable Book</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="622px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -24,61 +28,61 @@
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE]</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[+toolchain]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  toolchain    Install, uninstall, or list toolchains</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">toolchain</tspan><tspan>    Install, uninstall, or list toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  default      Set the default toolchain</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">default</tspan><tspan>      Set the default toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  show         Show the active and installed toolchains or profiles</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">show</tspan><tspan>         Show the active and installed toolchains or profiles</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  update       Update Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">update</tspan><tspan>       Update Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  check        Check for updates to Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">check</tspan><tspan>        Check for updates to Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  target       Modify a toolchain's supported targets</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">target</tspan><tspan>       Modify a toolchain's supported targets</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  component    Modify a toolchain's installed components</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">component</tspan><tspan>    Modify a toolchain's installed components</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  override     Modify toolchain overrides for directories</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">override</tspan><tspan>     Modify toolchain overrides for directories</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  run          Run a command with an environment configured for a given toolchain</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">run</tspan><tspan>          Run a command with an environment configured for a given toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  which        Display which binary will be run for a given command</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">which</tspan><tspan>        Display which binary will be run for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  doc          Open the documentation for the current toolchain</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">doc</tspan><tspan>          Open the documentation for the current toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  man          View the man page for a given command</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">man</tspan><tspan>          View the man page for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  self         Modify the rustup installation</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">self</tspan><tspan>         Modify the rustup installation</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  set          Alter rustup settings</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">set</tspan><tspan>          Alter rustup settings</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  completions  Generate tab-completion scripts for your shell</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">completions</tspan><tspan>  Generate tab-completion scripts for your shell</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  help         Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>         Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  [+toolchain]  Release channel (e.g. +stable) or custom toolchain to set override</tspan>
+    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan">[+toolchain]</tspan><tspan>  Release channel (e.g. +stable) or custom toolchain to set override</tspan>
 </tspan>
     <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>Options:</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  -v, --verbose  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
+    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan>  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  -q, --quiet    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  -V, --version  Print version</tspan>
+    <tspan x="10px" y="586px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan>  Print version</tspan>
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
@@ -86,7 +86,7 @@
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>
-    <tspan x="10px" y="622px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="640px"><tspan>    Rustup installs The Rust Programming Language from the official</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -24,61 +28,61 @@
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE]</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[+toolchain]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  toolchain    Install, uninstall, or list toolchains</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">toolchain</tspan><tspan>    Install, uninstall, or list toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  default      Set the default toolchain</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">default</tspan><tspan>      Set the default toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  show         Show the active and installed toolchains or profiles</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">show</tspan><tspan>         Show the active and installed toolchains or profiles</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  update       Update Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">update</tspan><tspan>       Update Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  check        Check for updates to Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">check</tspan><tspan>        Check for updates to Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  target       Modify a toolchain's supported targets</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">target</tspan><tspan>       Modify a toolchain's supported targets</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  component    Modify a toolchain's installed components</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">component</tspan><tspan>    Modify a toolchain's installed components</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  override     Modify toolchain overrides for directories</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">override</tspan><tspan>     Modify toolchain overrides for directories</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  run          Run a command with an environment configured for a given toolchain</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">run</tspan><tspan>          Run a command with an environment configured for a given toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  which        Display which binary will be run for a given command</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">which</tspan><tspan>        Display which binary will be run for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  doc          Open the documentation for the current toolchain</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">doc</tspan><tspan>          Open the documentation for the current toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  man          View the man page for a given command</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">man</tspan><tspan>          View the man page for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  self         Modify the rustup installation</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">self</tspan><tspan>         Modify the rustup installation</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  set          Alter rustup settings</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">set</tspan><tspan>          Alter rustup settings</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  completions  Generate tab-completion scripts for your shell</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">completions</tspan><tspan>  Generate tab-completion scripts for your shell</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  help         Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>         Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  [+toolchain]  Release channel (e.g. +stable) or custom toolchain to set override</tspan>
+    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan">[+toolchain]</tspan><tspan>  Release channel (e.g. +stable) or custom toolchain to set override</tspan>
 </tspan>
     <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>Options:</tspan>
+    <tspan x="10px" y="514px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  -v, --verbose  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
+    <tspan x="10px" y="532px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan>  Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  -q, --quiet    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>    Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="568px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  -V, --version  Print version</tspan>
+    <tspan x="10px" y="586px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan><tspan>  Print version</tspan>
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
@@ -86,7 +86,7 @@
 </tspan>
     <tspan x="10px" y="604px">
 </tspan>
-    <tspan x="10px" y="622px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="640px"><tspan>    Rustup installs The Rust Programming Language from the official</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_man_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_man_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] man [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] man</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;COMMAND&gt;  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
@@ -102,7 +102,7 @@
 </tspan>
     <tspan x="10px" y="748px">
 </tspan>
-    <tspan x="10px" y="766px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="766px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="784px"><tspan>    Rustup installs The Rust Programming Language from the official</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -24,75 +28,75 @@
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Usage: rustup[EXE] [OPTIONS] [+toolchain] [COMMAND]</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE]</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[+toolchain]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="118px">
 </tspan>
-    <tspan x="10px" y="136px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="136px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  toolchain    Install, uninstall, or list toolchains</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">toolchain</tspan><tspan>    Install, uninstall, or list toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  default      Set the default toolchain</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">default</tspan><tspan>      Set the default toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  show         Show the active and installed toolchains or profiles</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">show</tspan><tspan>         Show the active and installed toolchains or profiles</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  update       Update Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">update</tspan><tspan>       Update Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  check        Check for updates to Rust toolchains and rustup</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">check</tspan><tspan>        Check for updates to Rust toolchains and rustup</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  target       Modify a toolchain's supported targets</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">target</tspan><tspan>       Modify a toolchain's supported targets</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  component    Modify a toolchain's installed components</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">component</tspan><tspan>    Modify a toolchain's installed components</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  override     Modify toolchain overrides for directories</tspan>
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">override</tspan><tspan>     Modify toolchain overrides for directories</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>  run          Run a command with an environment configured for a given toolchain</tspan>
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">run</tspan><tspan>          Run a command with an environment configured for a given toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  which        Display which binary will be run for a given command</tspan>
+    <tspan x="10px" y="316px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">which</tspan><tspan>        Display which binary will be run for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  doc          Open the documentation for the current toolchain</tspan>
+    <tspan x="10px" y="334px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">doc</tspan><tspan>          Open the documentation for the current toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  man          View the man page for a given command</tspan>
+    <tspan x="10px" y="352px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">man</tspan><tspan>          View the man page for a given command</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  self         Modify the rustup installation</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">self</tspan><tspan>         Modify the rustup installation</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  set          Alter rustup settings</tspan>
+    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">set</tspan><tspan>          Alter rustup settings</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  completions  Generate tab-completion scripts for your shell</tspan>
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">completions</tspan><tspan>  Generate tab-completion scripts for your shell</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  help         Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>         Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  [+toolchain]</tspan>
+    <tspan x="10px" y="478px"><tspan>  </tspan><tspan class="fg-cyan">[+toolchain]</tspan>
 </tspan>
     <tspan x="10px" y="496px"><tspan>          Release channel (e.g. +stable) or custom toolchain to set override</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>Options:</tspan>
+    <tspan x="10px" y="532px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  -v, --verbose</tspan>
+    <tspan x="10px" y="550px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan>
 </tspan>
     <tspan x="10px" y="568px"><tspan>          Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  -q, --quiet</tspan>
+    <tspan x="10px" y="604px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan>
 </tspan>
     <tspan x="10px" y="622px"><tspan>          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
     <tspan x="10px" y="640px">
 </tspan>
-    <tspan x="10px" y="658px"><tspan>  -h, --help</tspan>
+    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan>
 </tspan>
     <tspan x="10px" y="676px"><tspan>          Print help</tspan>
 </tspan>
     <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  -V, --version</tspan>
+    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-V</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--version</tspan>
 </tspan>
     <tspan x="10px" y="730px"><tspan>          Print version</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_add_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_add_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override set [OPTIONS] &lt;TOOLCHAIN&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override set</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name. For</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name. For</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>               more information see `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --path &lt;PATH&gt;  Path to the directory</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to the directory</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help         Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>         Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  list   List directory toolchain overrides</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">list</tspan><tspan>   List directory toolchain overrides</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  set    Set the override toolchain for a directory</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">set</tspan><tspan>    Set the override toolchain for a directory</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  unset  Remove the override toolchain for a directory</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">unset</tspan><tspan>  Remove the override toolchain for a directory</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  help   Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>   Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Options:</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_help_flag.stdout.term.svg
@@ -46,7 +46,7 @@
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>    Overrides configure Rustup to use a specific toolchain when</tspan>
 </tspan>
@@ -68,7 +68,7 @@
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>        $ rustup override set nightly-2014-12-18</tspan>
+    <tspan x="10px" y="460px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup override set nightly-2014-12-18</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
@@ -76,7 +76,7 @@
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>        $ rustup override set 1.0.0</tspan>
+    <tspan x="10px" y="532px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup override set 1.0.0</tspan>
 </tspan>
     <tspan x="10px" y="550px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_list_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_list_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,13 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +23,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override list</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override list</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_remove_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_remove_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,17 +24,17 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override unset [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override unset</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --path &lt;PATH&gt;  Path to the directory</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to the directory</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      --nonexistent  Remove override toolchain for all nonexistent directories</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--nonexistent</tspan><tspan>  Remove override toolchain for all nonexistent directories</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  -h, --help         Print help</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>         Print help</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_remove_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_remove_cmd_help_flag.stdout.term.svg
@@ -38,7 +38,7 @@
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>    If `--path` argument is present, removes the override toolchain</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_set_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_set_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override set [OPTIONS] &lt;TOOLCHAIN&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override set</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name. For</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name. For</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>               more information see `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --path &lt;PATH&gt;  Path to the directory</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to the directory</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help         Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>         Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_unset_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_unset_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,17 +24,17 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] override unset [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] override unset</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --path &lt;PATH&gt;  Path to the directory</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>  Path to the directory</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>      --nonexistent  Remove override toolchain for all nonexistent directories</tspan>
+    <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--nonexistent</tspan><tspan>  Remove override toolchain for all nonexistent directories</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  -h, --help         Print help</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>         Print help</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_override_cmd_unset_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_override_cmd_unset_cmd_help_flag.stdout.term.svg
@@ -38,7 +38,7 @@
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="208px"><tspan>    If `--path` argument is present, removes the override toolchain</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] run [OPTIONS] &lt;TOOLCHAIN&gt; &lt;COMMAND&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] run</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TOOLCHAIN&gt;   Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name, or</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>   Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name, or</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                an absolute path. For more information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  &lt;COMMAND&gt;...  </tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;...</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>
-    <tspan x="10px" y="190px"><tspan>Options:</tspan>
+    <tspan x="10px" y="190px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --install  Install the requested toolchain if needed</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--install</tspan><tspan>  Install the requested toolchain if needed</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
@@ -46,7 +46,7 @@
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>
-    <tspan x="10px" y="262px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="262px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="280px"><tspan>    Configures an environment to use the given toolchain and then runs</tspan>
 </tspan>
@@ -68,11 +68,11 @@
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>        $ cargo +nightly build</tspan>
+    <tspan x="10px" y="460px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ cargo +nightly build</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>        $ rustup run nightly cargo build</tspan>
+    <tspan x="10px" y="496px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup run nightly cargo build</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_self_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_self_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] self &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] self</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  update        Download and install updates to rustup</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">update</tspan><tspan>        Download and install updates to rustup</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  uninstall     Uninstall rustup</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">uninstall</tspan><tspan>     Uninstall rustup</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  upgrade-data  Upgrade the internal data format</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">upgrade-data</tspan><tspan>  Upgrade the internal data format</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  help          Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>          Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Options:</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_self_cmd_uninstall_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_self_cmd_uninstall_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,15 +24,15 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] self uninstall [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] self uninstall</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -y          </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan><tspan>          </tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_self_cmd_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_self_cmd_update_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,13 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +23,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] self update</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] self update</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_self_cmd_upgrade_data_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_self_cmd_upgrade_data_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,13 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +23,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] self upgrade-data</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] self upgrade-data</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_auto_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_auto_install_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,19 +24,19 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] set auto-install [AUTO_INSTALL_MODE]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] set auto-install</tspan><tspan> </tspan><tspan class="fg-cyan">[AUTO_INSTALL_MODE]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [AUTO_INSTALL_MODE]  [default: enable] [possible values: enable, disable]</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[AUTO_INSTALL_MODE]</tspan><tspan>  [default: enable] [possible values: enable, disable]</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_auto_self_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_auto_self_update_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,19 +24,19 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] set auto-self-update [AUTO_SELF_UPDATE_MODE]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] set auto-self-update</tspan><tspan> </tspan><tspan class="fg-cyan">[AUTO_SELF_UPDATE_MODE]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [AUTO_SELF_UPDATE_MODE]  [default: enable] [possible values: enable, disable, check-only]</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[AUTO_SELF_UPDATE_MODE]</tspan><tspan>  [default: enable] [possible values: enable, disable, check-only]</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_default_host_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_default_host_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,19 +24,19 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] set default-host &lt;HOST_TRIPLE&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] set default-host</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;HOST_TRIPLE&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;HOST_TRIPLE&gt;  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;HOST_TRIPLE&gt;</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,27 +24,27 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] set &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] set</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  default-host      The triple used to identify toolchains when not specified</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">default-host</tspan><tspan>      The triple used to identify toolchains when not specified</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  profile           The default components installed with a toolchain</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">profile</tspan><tspan>           The default components installed with a toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  auto-self-update  The rustup auto self update mode</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">auto-self-update</tspan><tspan>  The rustup auto self update mode</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  auto-install      The auto toolchain install mode</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">auto-install</tspan><tspan>      The auto toolchain install mode</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  help              Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>              Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan>Options:</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_profile_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_profile_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,19 +24,19 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] set profile [PROFILE_NAME]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] set profile</tspan><tspan> </tspan><tspan class="fg-cyan">[PROFILE_NAME]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [PROFILE_NAME]  [default: default] [possible values: minimal, default, complete]</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[PROFILE_NAME]</tspan><tspan>  [default: default] [possible values: minimal, default, complete]</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_active_toolchain_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_active_toolchain_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,15 +24,15 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] show active-toolchain [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] show active-toolchain</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -v, --verbose  Enable verbose output with rustc information</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan>  Enable verbose output with rustc information</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_active_toolchain_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_active_toolchain_cmd_help_flag.stdout.term.svg
@@ -36,7 +36,7 @@
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>    Shows the name of the active toolchain.</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_help_flag.stdout.term.svg
@@ -48,7 +48,7 @@
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>
-    <tspan x="10px" y="280px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>    Shows the name of the active toolchain and the version of `rustc`.</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,27 +24,27 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] show [OPTIONS] [COMMAND]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] show</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[COMMAND]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  active-toolchain  Show the active toolchain</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">active-toolchain</tspan><tspan>  Show the active toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  home              Display the computed value of RUSTUP_HOME</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">home</tspan><tspan>              Display the computed value of RUSTUP_HOME</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  profile           Show the default profile used for the `rustup install` command</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">profile</tspan><tspan>           Show the default profile used for the `rustup install` command</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  help              Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>              Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Options:</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -v, --verbose  Enable verbose output with rustc information for all installed toolchains</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan>  Enable verbose output with rustc information for all installed toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_home_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_home_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,13 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +23,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] show home</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] show home</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_show_cmd_profile_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_cmd_profile_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,13 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,13 +23,13 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] show profile</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] show profile</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_target_cmd_add_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_target_cmd_add_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] target add [OPTIONS] &lt;TARGET&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] target add</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TARGET&gt;...  List of targets to install; "all" installs all available targets</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TARGET&gt;...</tspan><tspan>  List of targets to install; "all" installs all available targets</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_target_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_target_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,25 +24,25 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] target &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] target</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  list    List installed and available targets</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">list</tspan><tspan>    List installed and available targets</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  add     Add a target to a Rust toolchain</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">add</tspan><tspan>     Add a target to a Rust toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  remove  Remove a target from a Rust toolchain</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">remove</tspan><tspan>  Remove a target from a Rust toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  help    Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>    Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="190px">
 </tspan>
-    <tspan x="10px" y="208px"><tspan>Options:</tspan>
+    <tspan x="10px" y="208px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="244px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_target_cmd_list_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_target_cmd_list_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,21 +24,21 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] target list [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] target list</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="118px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>      --installed              List only installed targets</tspan>
+    <tspan x="10px" y="154px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--installed</tspan><tspan>              List only installed targets</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  -q, --quiet                  Force the output to be a single column</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>                  Force the output to be a single column</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_target_cmd_remove_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_target_cmd_remove_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] target remove [OPTIONS] &lt;TARGET&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] target remove</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TARGET&gt;...  List of targets to uninstall</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TARGET&gt;...</tspan><tspan>  List of targets to uninstall</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,27 +24,27 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] toolchain &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] toolchain</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Commands:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  list       List installed toolchains</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">list</tspan><tspan>       List installed toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  install    Install or update the given toolchains, or by default the active toolchain</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">install</tspan><tspan>    Install or update the given toolchains, or by default the active toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  uninstall  Uninstall the given toolchains</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">uninstall</tspan><tspan>  Uninstall the given toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>  link       Create a custom toolchain by symlinking to a directory</tspan>
+    <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">link</tspan><tspan>       Create a custom toolchain by symlinking to a directory</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  help       Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>       Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan>Options:</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
@@ -48,7 +48,7 @@
 </tspan>
     <tspan x="10px" y="262px">
 </tspan>
-    <tspan x="10px" y="280px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="280px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="298px"><tspan>    Many `rustup` commands deal with *toolchains*, a single</tspan>
 </tspan>
@@ -68,19 +68,19 @@
 </tspan>
     <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>        &lt;channel&gt;[-&lt;date&gt;][-&lt;host&gt;]</tspan>
+    <tspan x="10px" y="460px"><tspan>        </tspan><tspan class="fg-cyan">&lt;channel&gt;[-&lt;date&gt;][-&lt;host&gt;]</tspan>
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>        &lt;channel&gt;       = stable|beta|nightly|&lt;versioned&gt;[-&lt;prerelease&gt;]</tspan>
+    <tspan x="10px" y="496px"><tspan>        </tspan><tspan class="fg-cyan">&lt;channel&gt;       = stable|beta|nightly|&lt;versioned&gt;[-&lt;prerelease&gt;]</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>        &lt;versioned&gt;     = &lt;major.minor&gt;|&lt;major.minor.patch&gt;</tspan>
+    <tspan x="10px" y="514px"><tspan>        </tspan><tspan class="fg-cyan">&lt;versioned&gt;     = &lt;major.minor&gt;|&lt;major.minor.patch&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>        &lt;prerelease&gt;    = beta[.&lt;number&gt;]</tspan>
+    <tspan x="10px" y="532px"><tspan>        </tspan><tspan class="fg-cyan">&lt;prerelease&gt;    = beta[.&lt;number&gt;]</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>        &lt;date&gt;          = YYYY-MM-DD</tspan>
+    <tspan x="10px" y="550px"><tspan>        </tspan><tspan class="fg-cyan">&lt;date&gt;          = YYYY-MM-DD</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>        &lt;host&gt;          = &lt;target-triple&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>        </tspan><tspan class="fg-cyan">&lt;host&gt;          = &lt;target-triple&gt;</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>
@@ -104,7 +104,7 @@
 </tspan>
     <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px"><tspan>        $ rustup toolchain install stable-x86_64-pc-windows-msvc</tspan>
+    <tspan x="10px" y="784px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain install stable-x86_64-pc-windows-msvc</tspan>
 </tspan>
     <tspan x="10px" y="802px">
 </tspan>
@@ -114,7 +114,7 @@
 </tspan>
     <tspan x="10px" y="856px">
 </tspan>
-    <tspan x="10px" y="874px"><tspan>        $ rustup toolchain install stable-msvc</tspan>
+    <tspan x="10px" y="874px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain install stable-msvc</tspan>
 </tspan>
     <tspan x="10px" y="892px">
 </tspan>
@@ -124,7 +124,7 @@
 </tspan>
     <tspan x="10px" y="946px">
 </tspan>
-    <tspan x="10px" y="964px"><tspan>        $ rustup default stable-msvc</tspan>
+    <tspan x="10px" y="964px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup default stable-msvc</tspan>
 </tspan>
     <tspan x="10px" y="982px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,41 +24,41 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] toolchain install [OPTIONS] [TOOLCHAIN]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] toolchain install</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOOLCHAIN]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                  `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --profile &lt;PROFILE&gt;      [possible values: minimal, default, complete]</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--profile</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;PROFILE&gt;</tspan><tspan>      [possible values: minimal, default, complete]</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -c, --component &lt;COMPONENT&gt;  Comma-separated list of components to be added on installation</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-c</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--component</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;COMPONENT&gt;</tspan><tspan>  Comma-separated list of components to be added on installation</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -t, --target &lt;TARGET&gt;        Comma-separated list of targets to be added on installation</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-t</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--target</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TARGET&gt;</tspan><tspan>        Comma-separated list of targets to be added on installation</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>      --no-self-update         Don't perform self update when running the `rustup toolchain install`</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>         Don't perform self update when running the `rustup toolchain install`</tspan>
 </tspan>
     <tspan x="10px" y="262px"><tspan>                               command</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      --force                  Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>                  Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      --allow-downgrade        Allow rustup to downgrade the toolchain to satisfy your component</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>        Allow rustup to downgrade the toolchain to satisfy your component</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>                               choice</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      --force-non-host         Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>         Install toolchains that require an emulator. See</tspan>
 </tspan>
     <tspan x="10px" y="352px"><tspan>                               https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="370px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="388px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_link_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_link_cmd_help_flag.stdout.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>
-    <tspan x="10px" y="226px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>    'toolchain' is the custom name to be assigned to the new toolchain.</tspan>
 </tspan>
@@ -72,9 +72,9 @@
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>        $ rustup toolchain link latest-stage1 build/x86_64-unknown-linux-gnu/stage1</tspan>
+    <tspan x="10px" y="496px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain link latest-stage1 build/x86_64-unknown-linux-gnu/stage1</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>        $ rustup override set latest-stage1</tspan>
+    <tspan x="10px" y="514px"><tspan>        </tspan><tspan class="fg-bright-cyan bold">$ rustup override set latest-stage1</tspan>
 </tspan>
     <tspan x="10px" y="532px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_link_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_link_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,21 +24,21 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] toolchain link &lt;TOOLCHAIN&gt; &lt;PATH&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] toolchain link</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TOOLCHAIN&gt;  Custom toolchain name</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Custom toolchain name</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  &lt;PATH&gt;       Path to the directory</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan">&lt;PATH&gt;</tspan><tspan>       Path to the directory</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_list_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_list_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,17 +24,17 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] toolchain list [OPTIONS]</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] toolchain list</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Options:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  -v, --verbose  Enable verbose output with toolchain information</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-v</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--verbose</tspan><tspan>  Enable verbose output with toolchain information</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan>  -q, --quiet    Force the output to be a single column</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-q</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--quiet</tspan><tspan>    Force the output to be a single column</tspan>
 </tspan>
-    <tspan x="10px" y="154px"><tspan>  -h, --help     Print help</tspan>
+    <tspan x="10px" y="154px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>     Print help</tspan>
 </tspan>
     <tspan x="10px" y="172px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_uninstall_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_uninstall_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,21 +24,21 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] toolchain uninstall &lt;TOOLCHAIN&gt;...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] toolchain uninstall</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;TOOLCHAIN&gt;...  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name.</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;...</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom toolchain name.</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                  For more information see `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  -h, --help  Print help</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
 </tspan>
     <tspan x="10px" y="208px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_unknown_arg.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_unknown_arg.stderr.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-red { fill: #FF5555 }
+    .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,11 +20,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>error: invalid value 'random' for '[+toolchain]': error: "random" is not a valid subcommand, so it was interpreted as a toolchain name, but it is also invalid. To override the toolchain using the 'rustup +toolchain' syntax, make sure to prefix the toolchain override with a '+'</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-red bold">error:</tspan><tspan> invalid value '</tspan><tspan class="fg-yellow bold">random</tspan><tspan>' for '</tspan><tspan class="fg-bright-cyan bold">[+toolchain]</tspan><tspan>': error: "random" is not a valid subcommand, so it was interpreted as a toolchain name, but it is also invalid. To override the toolchain using the 'rustup +toolchain' syntax, make sure to prefix the toolchain override with a '+'</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>For more information, try '--help'.</tspan>
+    <tspan x="10px" y="64px"><tspan>For more information, try '</tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>'.</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,29 +24,29 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] update [OPTIONS] [TOOLCHAIN]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] update</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOOLCHAIN]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                  `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --no-self-update  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --force           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --force-non-host  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  -h, --help            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
@@ -50,7 +50,7 @@
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>    With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,29 +24,29 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] update [OPTIONS] [TOOLCHAIN]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] update</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOOLCHAIN]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                  `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --no-self-update  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --force           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --force-non-host  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  -h, --help            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
@@ -50,7 +50,7 @@
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>    With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,29 +24,29 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] update [OPTIONS] [TOOLCHAIN]...</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] update</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  [TOOLCHAIN]...  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">[TOOLCHAIN]...</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more information see</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>                  `rustup help toolchain`</tspan>
 </tspan>
     <tspan x="10px" y="154px">
 </tspan>
-    <tspan x="10px" y="172px"><tspan>Options:</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      --no-self-update  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      --force           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      --force-non-host  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  -h, --help            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
@@ -50,7 +50,7 @@
 </tspan>
     <tspan x="10px" y="280px">
 </tspan>
-    <tspan x="10px" y="298px"><tspan>Discussion:</tspan>
+    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
     <tspan x="10px" y="316px"><tspan>    With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_which_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_which_cmd_help_flag.stdout.term.svg
@@ -2,10 +2,14 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -20,23 +24,23 @@
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>
-    <tspan x="10px" y="64px"><tspan>Usage: rustup[EXE] which [OPTIONS] &lt;COMMAND&gt;</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] which</tspan><tspan> </tspan><tspan class="fg-cyan">[OPTIONS]</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>
-    <tspan x="10px" y="100px"><tspan>Arguments:</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  &lt;COMMAND&gt;  </tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan><tspan>  </tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan>Options:</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan>      --toolchain &lt;TOOLCHAIN&gt;  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom</tspan>
+    <tspan x="10px" y="172px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', '1.8.0', or a custom</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>                               toolchain name. For more information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>  -h, --help                   Print help</tspan>
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
     <tspan x="10px" y="226px">
 </tspan>


### PR DESCRIPTION
This adds styling to clap help and errors to make it easier to scan.  This uses Cargo's styling (via `clap-cargo`) for consistency across the project.
- For consistency, my main priorities are end-user commands like `rustup` and `cargo` and not plumbing commands like `rustfmt` and `rustc`.
- We've not yet decided how to handle this through an official crate, so doing it unofficially for now.

To ensure consistency, the Discussion sections were updated.
- I was limited in my use of color within Discussion to match at least the initial approach we've taken in Cargo. I worry that if we color every literal, placeholder, etc then it will be a sea of colors and lose the benefit.  Instead color is limited to items we want to draw extra attention to or visually big items to help set them apart
- Cargo doesn't have sub-headers, so I had to define that myself for `rustup completions`
- I could have used something like `color-print` to do the styling at compile time but that would require duplicating Cargo's styling which would have been harder to maintain.  Instead, we style at runtime so we can use `clap-cargo`.