### PR TITLE
style: Remove wildcard imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ unused_qualifications = "warn"
 # `dbg!()` and `todo!()` clearly shouldn't make it to production:
 dbg_macro = "warn"
 todo = "warn"
+wildcard_imports = "warn"
 
 [lib]
 name = "rustup"

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -41,9 +41,13 @@ mod imp {
     use std::ptr;
 
     use tracing::info;
-    use windows_sys::Win32::Foundation::*;
-    use windows_sys::Win32::System::JobObjects::*;
-    use windows_sys::Win32::System::Threading::*;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+        SetInformationJobObject,
+    };
+    use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
     pub(crate) struct Setup {
         job: Handle,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -27,7 +27,13 @@ use crate::{
     cli::{
         common::{self, PackageUpdate, update_console_filter},
         errors::CliError,
-        help::*,
+        help::{
+            completions_help, default_help, doc_help, install_help,
+            maybe_resolvable_toolchain_arg_help, official_toolchain_arg_help, override_help,
+            override_unset_help, resolvable_local_toolchain_arg_help,
+            resolvable_toolchain_arg_help, run_help, rustup_help, show_active_toolchain_help,
+            show_help, toolchain_help, toolchain_link_help, topic_arg_help, update_help,
+        },
         self_update::{self, SelfUpdateMode, check_rustup_update},
         topical_doc,
     },

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -55,7 +55,7 @@ use crate::{
     DUP_TOOLS, TOOLS,
     cli::{
         common::{self, Confirm, PackageUpdate, ignorable_error, report_error},
-        errors::*,
+        errors::CliError,
         markdown::md,
     },
     config::Cfg,

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -16,7 +16,7 @@ use windows_registry::{CURRENT_USER, HSTRING, Key};
 use windows_result::HRESULT;
 use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_INVALID_DATA};
 
-use super::super::errors::*;
+use super::super::errors::CliError;
 use super::common;
 use super::{InstallOpts, install_bins, report_error};
 use crate::cli::markdown::md;
@@ -460,7 +460,7 @@ pub(crate) fn do_add_to_path(process: &Process) -> Result<()> {
 
 fn _apply_new_path(new_path: Option<HSTRING>) -> Result<()> {
     use std::ptr;
-    use windows_sys::Win32::Foundation::*;
+    use windows_sys::Win32::Foundation::{LPARAM, WPARAM};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
         HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutA, WM_SETTINGCHANGE,
     };

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -14,11 +14,11 @@ use tar::EntryType;
 use tracing::{error, trace, warn};
 
 use crate::diskio::{CompletedIo, Executor, FileBuffer, IO_CHUNK_SIZE, Item, Kind, get_executor};
-use crate::dist::component::components::*;
-use crate::dist::component::transaction::*;
+use crate::dist::component::components::{ComponentPart, ComponentPartKind, Components};
+use crate::dist::component::transaction::Transaction;
 use crate::dist::download::DownloadCfg;
 use crate::dist::temp;
-use crate::errors::*;
+use crate::errors::RustupError;
 use crate::utils;
 use crate::utils::units::Size;
 

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -17,7 +17,7 @@ use tracing::{error, info};
 
 use crate::dist::prefix::InstallPrefix;
 use crate::dist::temp;
-use crate::errors::*;
+use crate::errors::RustupError;
 use crate::process::Process;
 use crate::utils;
 

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
 use super::manifest::Component;
-use crate::errors::*;
+use crate::errors::RustupError;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct Config {

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -14,7 +14,7 @@ use url::Url;
 use crate::config::Cfg;
 use crate::dist::temp;
 use crate::download::{download_file, download_file_with_resume};
-use crate::errors::*;
+use crate::errors::RustupError;
 use crate::process::Process;
 use crate::utils;
 

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     dist::{Profile, TargetTriple, ToolchainDesc, config::Config},
-    errors::*,
+    errors::RustupError,
     toolchain::DistributableToolchain,
 };
 
@@ -249,7 +249,7 @@ impl Hash for Component {
 }
 
 mod component_target {
-    use super::*;
+    use super::{Result, TargetTriple};
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -635,7 +635,7 @@ impl Update {
             .components_to_install
             .iter()
             .filter(|c| {
-                use crate::dist::manifest::*;
+                use crate::dist::manifest::{Package, TargetedPackage};
                 let pkg: Option<&Package> =
                     new_manifest.get_package(c.short_name_in_manifest()).ok();
                 let target_pkg: Option<&TargetedPackage> =

--- a/src/process/file_source.rs
+++ b/src/process/file_source.rs
@@ -28,7 +28,7 @@ mod test_support {
         sync::{Arc, Mutex, MutexGuard},
     };
 
-    use super::*;
+    use super::{BufRead, Read, Stdin, StdinLock, io};
 
     // ----------------------- test support for stdin ------------------
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,7 +10,7 @@ use tracing::info;
 
 use crate::cli::self_update::SelfUpdateMode;
 use crate::dist::{AutoInstallMode, Profile};
-use crate::errors::*;
+use crate::errors::RustupError;
 use crate::utils;
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,7 +14,7 @@ use retry::{OperationResult, retry};
 use tracing::{debug, info, warn};
 use url::Url;
 
-use crate::errors::*;
+use crate::errors::RustupError;
 use crate::process::Process;
 
 #[cfg(not(windows))]

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -148,11 +148,14 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
 fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
     use std::os::windows::ffi::OsStrExt;
     use std::ptr;
-    use windows_sys::Win32::Foundation::*;
-    use windows_sys::Win32::Storage::FileSystem::*;
-    use windows_sys::Win32::System::IO::*;
+    use windows_sys::Win32::Foundation::GENERIC_WRITE;
+    use windows_sys::Win32::Storage::FileSystem::{
+        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
+        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    };
+    use windows_sys::Win32::System::IO::DeviceIoControl;
     use windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT;
-    use windows_sys::Win32::System::SystemServices::*;
+    use windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT;
 
     const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
 


### PR DESCRIPTION
This is based on review feedback from #4551.

I experimented with a `clippy.toml` file for "blessing" some of these, like `errors`, but for some reason I wasn't able to get it to work.