### PR TITLE
fix: Use HEADER styling in 'rustup show' 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c7f07f2b3c9fc1a21da5b4fa268083ac4d4d145a711b286055fdd70d149fcf"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
 dependencies = [
  "anstyle",
  "clap",
@@ -653,7 +653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1471,7 +1471,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2061,7 +2061,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2533,7 +2533,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3206,7 +3206,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ anyhow = "1.0.69"
 cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help", "string"] }
-clap-cargo = "0.18.2"
+clap-cargo = "0.18.3"
 clap_complete = "4"
 console = "0.16"
 curl = { version = "0.4.44", optional = true }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 use anstream::ColorChoice;
-use anstyle::Style;
 use anyhow::{Context, Error, Result, anyhow};
 use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
+use clap_cargo::style::{CONTEXT, HEADER};
 use clap_complete::Shell;
 use console::style;
 use futures_util::stream::StreamExt;
@@ -1081,15 +1081,13 @@ async fn which(
 async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
-    let bold = Style::new().bold();
-
     // Print host triple
     {
         let t = cfg.process.stdout();
         let mut t = t.lock();
         writeln!(
             t,
-            "{bold}Default host: {bold:#}{}",
+            "{HEADER}Default host: {HEADER:#}{}",
             cfg.get_default_host_triple()?
         )?;
     }
@@ -1100,7 +1098,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
         let mut t = t.lock();
         writeln!(
             t,
-            "{bold}rustup home:  {bold:#}{}",
+            "{HEADER}rustup home:  {HEADER:#}{}",
             cfg.rustup_dir.display()
         )?;
         writeln!(t)?;
@@ -1155,7 +1153,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
                 (false, false) => "",
             };
 
-            writeln!(t.lock(), "{toolchain_name}{status_str}")?;
+            writeln!(t.lock(), "{toolchain_name}{CONTEXT}{status_str}{CONTEXT:#}")?;
 
             if verbose {
                 let toolchain = Toolchain::new(cfg, toolchain_name.into())?;
@@ -1208,11 +1206,10 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     }
 
     fn print_header(t: &mut ColorableTerminal, text: &str) -> Result<(), Error> {
-        let bold = Style::new().bold();
         let divider = "-".repeat(text.len());
         let mut term_lock = t.lock();
-        writeln!(term_lock, "{bold}{text}{bold:#}")?;
-        writeln!(term_lock, "{bold}{divider}{bold:#}")?;
+        writeln!(term_lock, "{HEADER}{text}{HEADER:#}")?;
+        writeln!(term_lock, "{HEADER}{divider}{HEADER:#}")?;
         Ok(())
     }
 

--- a/src/process/terminal_source.rs
+++ b/src/process/terminal_source.rs
@@ -59,7 +59,7 @@ impl ColorableTerminal {
             StreamSelector::Stdout => TerminalInner::Stdout(AutoStream::new(io::stdout(), choice)),
             StreamSelector::Stderr => TerminalInner::Stderr(AutoStream::new(io::stderr(), choice)),
             #[cfg(feature = "test")]
-            StreamSelector::TestWriter(w) => TerminalInner::TestWriter(w),
+            StreamSelector::TestWriter(w) => TerminalInner::TestWriter(StripStream::new(w)),
         };
         let width = process
             .var("RUSTUP_TERM_WIDTH")
@@ -84,9 +84,9 @@ impl ColorableTerminal {
                 self.color_choice,
             )),
             #[cfg(feature = "test")]
-            TerminalInner::TestWriter(w) => {
-                ColorableTerminalLocked::TestWriter(StripStream::new(Box::new(w.clone())))
-            }
+            TerminalInner::TestWriter(w) => ColorableTerminalLocked::TestWriter(StripStream::new(
+                Box::new(w.as_inner().clone()),
+            )),
         }
     }
 
@@ -230,7 +230,7 @@ enum TerminalInner {
     Stdout(AutoStream<io::Stdout>),
     Stderr(AutoStream<io::Stderr>),
     #[cfg(feature = "test")]
-    TestWriter(TestWriter),
+    TestWriter(StripStream<TestWriter>),
 }
 
 /// Select what stream to make a terminal on

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -1,6 +1,7 @@
 use std::fs::create_dir_all;
 use std::path::Path;
 
+use rustup::test::{CliTestContext, Scenario};
 use snapbox::Data;
 use snapbox::cmd::{Command, cargo_bin};
 
@@ -238,6 +239,26 @@ fn rustup_set_cmd_profile_cmd_help_flag() {
         "rustup_set_cmd_profile_cmd_help_flag",
         &["set", "profile", "--help"],
     );
+}
+
+#[tokio::test]
+async fn rustup_show_toolchain() {
+    let name = "rustup_show_toolchain";
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_TERM_COLOR", "always")])
+        .await
+        .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr("")
+        .is_ok();
 }
 
 #[test]

--- a/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
@@ -1,0 +1,50 @@
+<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">Default host: </tspan><tspan>[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">rustup home:  </tspan><tspan>[RUSTUP_DIR]</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">installed toolchains</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="bold">--------------------</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>nightly-[HOST_TRIPLE] (active, default)</tspan>
+</tspan>
+    <tspan x="10px" y="136px">
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="bold">active toolchain</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="bold">----------------</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>name: nightly-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="208px"><tspan>active because: it's the default toolchain</tspan>
+</tspan>
+    <tspan x="10px" y="226px"><tspan>installed targets:</tspan>
+</tspan>
+    <tspan x="10px" y="244px"><tspan>  [HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="262px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
@@ -2,6 +2,8 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -17,23 +19,23 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="bold">Default host: </tspan><tspan>[HOST_TRIPLE]</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">Default host: </tspan><tspan>[HOST_TRIPLE]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="bold">rustup home:  </tspan><tspan>[RUSTUP_DIR]</tspan>
+    <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">rustup home:  </tspan><tspan>[RUSTUP_DIR]</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">installed toolchains</tspan>
+    <tspan x="10px" y="82px"><tspan class="fg-bright-green bold">installed toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="100px"><tspan class="bold">--------------------</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">--------------------</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>nightly-[HOST_TRIPLE] (active, default)</tspan>
+    <tspan x="10px" y="118px"><tspan>nightly-[HOST_TRIPLE]</tspan><tspan class="fg-bright-blue bold"> (active, default)</tspan>
 </tspan>
     <tspan x="10px" y="136px">
 </tspan>
-    <tspan x="10px" y="154px"><tspan class="bold">active toolchain</tspan>
+    <tspan x="10px" y="154px"><tspan class="fg-bright-green bold">active toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="172px"><tspan class="bold">----------------</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">----------------</tspan>
 </tspan>
     <tspan x="10px" y="190px"><tspan>name: nightly-[HOST_TRIPLE]</tspan>
 </tspan>


### PR DESCRIPTION
This is continuing my effort to make end-user commands more similar. This isn't meant to force conformancy where it doesn't make sense. My assumption is to first get things similar and then work on if there is feedback. Cargo is doing that with rust; there are things we want to change but priority is on being the same before we try to change. At least for myself, I don't feel anything is sacred and can be re-evaluated.

<img width="516" height="375" alt="image" src="https://github.com/user-attachments/assets/a13e7278-cd78-4d80-884a-2f2c7a5ad93c" />

This is setup to match `cargo info`s style:
<img width="577" height="403" alt="image" src="https://github.com/user-attachments/assets/2c1fc9f7-318e-4ac8-b845-5642c9eb3f56" />
- Top-level keys are treated as headers
- Parentheticals are "context"

For testing, I forked an existing test rather than using SVGs for all of the existing tests.  Having the output inline with the existing tests makes it easier to reason about and the number of test cases relevant for checknng styling is much smaller than for the main logic.