### PR TITLE
fix(update): Match 'cargo update's colors

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -7,8 +7,9 @@ use std::path::Path;
 use std::sync::LazyLock;
 use std::{cmp, env};
 
-use anstyle::{AnsiColor, Style};
+use anstyle::Style;
 use anyhow::{Context, Result, anyhow};
+use clap_cargo::style::{ERROR, UPDATE_ADDED, UPDATE_UNCHANGED, UPDATE_UPGRADED};
 use git_testament::{git_testament, render_testament};
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
@@ -147,10 +148,10 @@ fn show_channel_updates(
 ) -> Result<()> {
     let data = updates.into_iter().map(|(pkg, result)| {
         let (banner, style) = match &result {
-            Ok(UpdateStatus::Installed) => ("installed", AnsiColor::Green.on_default().bold()),
-            Ok(UpdateStatus::Updated(_)) => ("updated", AnsiColor::Green.on_default().bold()),
-            Ok(UpdateStatus::Unchanged) => ("unchanged", Style::new().bold()),
-            Err(_) => ("update failed", AnsiColor::Red.on_default().bold()),
+            Ok(UpdateStatus::Installed) => ("installed", UPDATE_ADDED),
+            Ok(UpdateStatus::Updated(_)) => ("updated", UPDATE_UPGRADED),
+            Ok(UpdateStatus::Unchanged) => ("unchanged", UPDATE_UNCHANGED),
+            Err(_) => ("update failed", ERROR),
         };
 
         let (previous_version, version) = match &pkg {

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -146,11 +146,11 @@ fn show_channel_updates(
     updates: Vec<(PackageUpdate, Result<UpdateStatus>)>,
 ) -> Result<()> {
     let data = updates.into_iter().map(|(pkg, result)| {
-        let (banner, color) = match &result {
-            Ok(UpdateStatus::Installed) => ("installed", Some(AnsiColor::Green)),
-            Ok(UpdateStatus::Updated(_)) => ("updated", Some(AnsiColor::Green)),
-            Ok(UpdateStatus::Unchanged) => ("unchanged", None),
-            Err(_) => ("update failed", Some(AnsiColor::Red)),
+        let (banner, style) = match &result {
+            Ok(UpdateStatus::Installed) => ("installed", AnsiColor::Green.on_default().bold()),
+            Ok(UpdateStatus::Updated(_)) => ("updated", AnsiColor::Green.on_default().bold()),
+            Ok(UpdateStatus::Unchanged) => ("unchanged", Style::new().bold()),
+            Err(_) => ("update failed", AnsiColor::Red.on_default().bold()),
         };
 
         let (previous_version, version) = match &pkg {
@@ -185,7 +185,7 @@ fn show_channel_updates(
 
         let width = pkg.to_string().len() + 1 + banner.len();
 
-        Ok((pkg, banner, width, color, version, previous_version))
+        Ok((pkg, banner, width, style, version, previous_version))
     });
 
     let t = cfg.process.stdout();
@@ -196,14 +196,9 @@ fn show_channel_updates(
         .iter()
         .fold(0, |a, &(_, _, width, _, _, _)| cmp::max(a, width));
 
-    for (pkg, banner, width, color, version, previous_version) in data {
+    for (pkg, banner, width, style, version, previous_version) in data {
         let padding = max_width - width;
         let padding: String = " ".repeat(padding);
-        let style = match color {
-            Some(color) => color.on_default(),
-            None => Style::new(),
-        }
-        .bold();
         let _ = write!(t, "  {padding}{style}{pkg} {banner}{style:#} - {version}");
         if let Some(previous_version) = previous_version {
             let _ = write!(t, " (from {previous_version})");

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -109,6 +109,27 @@ fn rustup_component_cmd_remove_cmd_help_flag() {
     );
 }
 
+#[tokio::test]
+async fn rustup_default() {
+    let name = "rustup_default";
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect_with_env(
+            ["rustup", "default", "nightly"],
+            [("RUSTUP_TERM_COLOR", "always")],
+        )
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stderr.term.svg")),
+            None,
+        ))
+        .is_ok();
+}
+
 #[test]
 fn rustup_default_cmd_help_flag() {
     test_help("rustup_default_cmd_help_flag", &["default", "--help"]);
@@ -359,6 +380,56 @@ fn rustup_toolchain_cmd_uninstall_cmd_help_flag() {
 #[test]
 fn rustup_up_cmd_help_flag() {
     test_help("rustup_up_cmd_help_flag", &["up", "--help"]);
+}
+
+#[tokio::test]
+async fn rustup_update_no_change() {
+    let name = "rustup_update_no_change";
+    let cx = CliTestContext::new(Scenario::ArchivesV2_2015_01_01).await;
+    cx.config
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect_with_env(["rustup", "update"], [("RUSTUP_TERM_COLOR", "always")])
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stderr.term.svg")),
+            None,
+        ))
+        .is_ok();
+}
+
+#[tokio::test]
+async fn rustup_update_updated() {
+    let name = "rustup_update_updated";
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    cx.config
+        .expect_with_env(["rustup", "update"], [("RUSTUP_TERM_COLOR", "always")])
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stderr.term.svg")),
+            None,
+        ))
+        .is_ok();
 }
 
 #[test]

--- a/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
@@ -1,0 +1,32 @@
+<svg width="740px" height="110px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">info:</tspan><tspan> syncing channel updates for nightly-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">info:</tspan><tspan> latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">info:</tspan><tspan> downloading component(s)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">info:</tspan><tspan> default toolchain set to nightly-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="100px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_default.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default.stdout.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px">
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-green bold">nightly-[HOST_TRIPLE] installed</tspan><tspan> - 1.3.0 (hash-nightly-2)</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-green bold">nightly-[HOST_TRIPLE] installed</tspan><tspan> - 1.3.0 (hash-nightly-2)</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_default.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default.stdout.term.svg
@@ -1,0 +1,31 @@
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-green bold">nightly-[HOST_TRIPLE] installed</tspan><tspan> - 1.3.0 (hash-nightly-2)</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_update_no_change.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_no_change.stderr.term.svg
@@ -1,0 +1,28 @@
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">info:</tspan><tspan> syncing channel updates for stable-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">info:</tspan><tspan> cleaning up downloads &amp; tmp directories</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_update_no_change.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_no_change.stdout.term.svg
@@ -1,0 +1,30 @@
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="bold">stable-[HOST_TRIPLE] unchanged</tspan><tspan> - 1.0.0 (hash-stable-1.0.0)</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_update_updated.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_updated.stderr.term.svg
@@ -1,0 +1,40 @@
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">info:</tspan><tspan> syncing channel updates for stable-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">info:</tspan><tspan> latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">info:</tspan><tspan> downloading component(s)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">info:</tspan><tspan> removing previous version of component cargo</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="bold">info:</tspan><tspan> removing previous version of component rust-docs</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan class="bold">info:</tspan><tspan> removing previous version of component rust-std</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan class="bold">info:</tspan><tspan> removing previous version of component rustc</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan class="bold">info:</tspan><tspan> cleaning up downloads &amp; tmp directories</tspan>
+</tspan>
+    <tspan x="10px" y="172px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_update_updated.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_updated.stdout.term.svg
@@ -1,0 +1,31 @@
+<svg width="785px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px">
+</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-green bold">stable-[HOST_TRIPLE] updated</tspan><tspan> - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_update_updated.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_updated.stdout.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -20,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px">
 </tspan>
-    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-green bold">stable-[HOST_TRIPLE] updated</tspan><tspan> - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))</tspan>
+    <tspan x="10px" y="46px"><tspan>  </tspan><tspan class="fg-bright-green bold">stable-[HOST_TRIPLE] updated</tspan><tspan> - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>


### PR DESCRIPTION
This is adjusting "channel updates" to use `cargo update` style colors like we did with `rustup show` and `cargo info` in #4556.