### PR TITLE
fix(list): Match show command's styling 

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -251,7 +251,7 @@ pub(super) fn list_items(
     let bold = Style::new().bold();
     for (name, installed) in items {
         if installed && !installed_only && !quiet {
-            writeln!(t, "{bold}{name} (installed){bold:#}")?;
+            writeln!(t, "{bold}{name}{bold:#} {CONTEXT}(installed){CONTEXT:#}")?;
         } else if installed || !installed_only {
             writeln!(t, "{name}")?;
         }

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -137,6 +137,29 @@ fn rustup_component_cmd_add_cmd_help_flag() {
     );
 }
 
+#[tokio::test]
+async fn rustup_component_list() {
+    let name = "rustup_component_list";
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect_with_env(
+            ["rustup", "component", "list"],
+            [("RUSTUP_TERM_COLOR", "always")],
+        )
+        .await
+        .sort_stdout(true)
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr("")
+        .is_ok();
+}
+
 #[test]
 fn rustup_component_cmd_list_cmd_help_flag() {
     test_help(

--- a/tests/suite/cli_rustup_ui/rustup_component_list.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_list.stdout.term.svg
@@ -2,6 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -17,13 +18,13 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="bold">cargo-[HOST_TRIPLE] (installed)</tspan>
+    <tspan x="10px" y="28px"><tspan class="bold">cargo-[HOST_TRIPLE]</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">(installed)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="bold">rust-docs-[HOST_TRIPLE] (installed)</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">rust-docs-[HOST_TRIPLE]</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">(installed)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="bold">rust-std-[HOST_TRIPLE] (installed)</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">rust-std-[HOST_TRIPLE]</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">(installed)</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">rustc-[HOST_TRIPLE] (installed)</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">rustc-[HOST_TRIPLE]</tspan><tspan> </tspan><tspan class="fg-bright-blue bold">(installed)</tspan>
 </tspan>
     <tspan x="10px" y="100px"><tspan>rls-[HOST_TRIPLE]</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_component_list.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_component_list.stdout.term.svg
@@ -1,0 +1,40 @@
+<svg width="740px" height="182px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan class="bold">cargo-[HOST_TRIPLE] (installed)</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">rust-docs-[HOST_TRIPLE] (installed)</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">rust-std-[HOST_TRIPLE] (installed)</tspan>
+</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">rustc-[HOST_TRIPLE] (installed)</tspan>
+</tspan>
+    <tspan x="10px" y="100px"><tspan>rls-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>rust-analysis-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>rust-src</tspan>
+</tspan>
+    <tspan x="10px" y="154px"><tspan>rust-std-[CROSS_ARCH_II]</tspan>
+</tspan>
+    <tspan x="10px" y="172px"><tspan>rust-std-[CROSS_ARCH_I]</tspan>
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
This changes the parenthetical from `bold` to `CONTEXT` to match what
was done in #4556.

This does not remove the bolding of the item itself.
We could do that. I figured its fine for now since there is a clearer
meaning with `installed` than when you can have `active` and `default`
on separate items.