### PR TITLE
fix(toolchain): Have 'list' match 'show's styling 

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -9,7 +9,7 @@ use std::{cmp, env};
 
 use anstyle::Style;
 use anyhow::{Context, Result, anyhow};
-use clap_cargo::style::{ERROR, UPDATE_ADDED, UPDATE_UNCHANGED, UPDATE_UPGRADED};
+use clap_cargo::style::{CONTEXT, ERROR, UPDATE_ADDED, UPDATE_UNCHANGED, UPDATE_UPGRADED};
 use git_testament::{git_testament, render_testament};
 use tracing::{error, info, warn};
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
@@ -328,7 +328,7 @@ pub(crate) async fn list_toolchains(
 
         writeln!(
             cfg.process.stdout().lock(),
-            "{toolchain}{status_str}{toolchain_path}",
+            "{toolchain}{CONTEXT}{status_str}{CONTEXT:#}{toolchain_path}",
         )?;
         Ok(())
     }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -327,10 +327,7 @@ pub(crate) async fn list_toolchains(
 
         writeln!(
             cfg.process.stdout().lock(),
-            "{}{}{}",
-            &toolchain,
-            status_str,
-            toolchain_path
+            "{toolchain}{status_str}{toolchain_path}",
         )?;
         Ok(())
     }

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -307,6 +307,13 @@ pub(crate) async fn list_toolchains(
             return Ok(());
         }
 
+        let status_str = match (is_default, is_active) {
+            (true, true) => " (active, default)",
+            (true, false) => " (default)",
+            (false, true) => " (active)",
+            (false, false) => "",
+        };
+
         let toolchain_path = cfg.toolchains_dir.join(toolchain);
         let toolchain_meta = fs::symlink_metadata(&toolchain_path)?;
         let toolchain_path = if verbose {
@@ -317,12 +324,6 @@ pub(crate) async fn list_toolchains(
             }
         } else {
             String::new()
-        };
-        let status_str = match (is_default, is_active) {
-            (true, true) => " (active, default)",
-            (true, false) => " (default)",
-            (false, true) => " (active)",
-            (false, false) => "",
         };
 
         writeln!(

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -405,6 +405,32 @@ fn rustup_toolchain_cmd_link_cmd_help_flag() {
     );
 }
 
+#[tokio::test]
+async fn rustup_toolchain_list() {
+    let name = "rustup_toolchain_list";
+    let cx = CliTestContext::new(Scenario::ArchivesV2).await;
+    cx.config
+        .expect(["rustup", "update", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "update", "beta-2015-01-01"])
+        .await
+        .is_ok();
+    cx.config
+        .expect_with_env(
+            ["rustup", "toolchain", "list"],
+            [("RUSTUP_TERM_COLOR", "always")],
+        )
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr("")
+        .is_ok();
+}
+
 #[test]
 fn rustup_toolchain_cmd_list_cmd_help_flag() {
     test_help(

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_list.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_list.stdout.term.svg
@@ -1,0 +1,27 @@
+<svg width="740px" height="74px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>beta-2015-01-01-[HOST_TRIPLE]</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>nightly-[HOST_TRIPLE] (active, default)</tspan>
+</tspan>
+    <tspan x="10px" y="64px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_list.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_list.stdout.term.svg
@@ -2,10 +2,12 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-bright-blue { fill: #5555FF }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -18,7 +20,7 @@
   <text xml:space="preserve" class="container fg">
     <tspan x="10px" y="28px"><tspan>beta-2015-01-01-[HOST_TRIPLE]</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>nightly-[HOST_TRIPLE] (active, default)</tspan>
+    <tspan x="10px" y="46px"><tspan>nightly-[HOST_TRIPLE]</tspan><tspan class="fg-bright-blue bold"> (active, default)</tspan>
 </tspan>
     <tspan x="10px" y="64px">
 </tspan>


### PR DESCRIPTION
`rustup show` and `rustup toolchain list` have similar lists but the
latter was unstyled.
This updates it to be styled to match `rustup show` as of #4556.

Maybe there would be a way to single source this in the future.
They do handle paths differently, so it would likely require a larger
conversation.