### PR TITLE
fix(check): Respect RUSTUP_TERM_COLOR  in `rustup check`

### DIFF
--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -67,6 +67,50 @@ fn rustup_only_options() {
     test_error("rustup_only_options", &["-q"]);
 }
 
+#[tokio::test]
+async fn rustup_check_updates_none() {
+    let name = "rustup_check_updates_none";
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect_with_env(["rustup", "check"], [("RUSTUP_TERM_COLOR", "always")])
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr("")
+        .is_err();
+}
+
+#[tokio::test]
+async fn rustup_check_updates_some() {
+    let name = "rustup_check_updates_some";
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    cx.config
+        .expect_with_env(["rustup", "check"], [("RUSTUP_TERM_COLOR", "always")])
+        .await
+        .with_stdout(Data::read_from(
+            Path::new(&format!("tests/suite/cli_rustup_ui/{name}.stdout.term.svg")),
+            None,
+        ))
+        .with_stderr("")
+        .is_ok();
+}
+
 #[test]
 fn rustup_check_cmd_help_flag() {
     test_help("rustup_check_cmd_help_flag", &["check", "--help"]);

--- a/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
@@ -1,0 +1,29 @@
+<svg width="740px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>stable-[HOST_TRIPLE] - Up to date : 1.1.0 (hash-stable-1.1.0)</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>beta-[HOST_TRIPLE] - Up to date : 1.2.0 (hash-beta-1.2.0)</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>nightly-[HOST_TRIPLE] - Up to date : 1.3.0 (hash-nightly-2)</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>

--- a/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
@@ -2,10 +2,12 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-green { fill: #00AA00 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>stable-[HOST_TRIPLE] - Up to date : 1.1.0 (hash-stable-1.1.0)</tspan>
+    <tspan x="10px" y="28px"><tspan class="bold">stable-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">Up to date</tspan><tspan> : 1.1.0 (hash-stable-1.1.0)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>beta-[HOST_TRIPLE] - Up to date : 1.2.0 (hash-beta-1.2.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">beta-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">Up to date</tspan><tspan> : 1.2.0 (hash-beta-1.2.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>nightly-[HOST_TRIPLE] - Up to date : 1.3.0 (hash-nightly-2)</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">nightly-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">Up to date</tspan><tspan> : 1.3.0 (hash-nightly-2)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_check_updates_some.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_updates_some.stdout.term.svg
@@ -2,10 +2,12 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
+    .fg-yellow { fill: #AA5500 }
     .container {
       padding: 0 10px;
       line-height: 18px;
     }
+    .bold { font-weight: bold; }
     tspan {
       font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
       white-space: pre;
@@ -16,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>stable-[HOST_TRIPLE] - Update available : 1.0.0 (hash-stable-1.0.0) -&gt; 1.1.0 (hash-stable-1.1.0)</tspan>
+    <tspan x="10px" y="28px"><tspan class="bold">stable-[HOST_TRIPLE] - </tspan><tspan class="fg-yellow bold">Update available</tspan><tspan> : 1.0.0 (hash-stable-1.0.0) -&gt; 1.1.0 (hash-stable-1.1.0)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan>beta-[HOST_TRIPLE] - Update available : 1.1.0 (hash-beta-1.1.0) -&gt; 1.2.0 (hash-beta-1.2.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">beta-[HOST_TRIPLE] - </tspan><tspan class="fg-yellow bold">Update available</tspan><tspan> : 1.1.0 (hash-beta-1.1.0) -&gt; 1.2.0 (hash-beta-1.2.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan>nightly-[HOST_TRIPLE] - Update available : 1.2.0 (hash-nightly-1) -&gt; 1.3.0 (hash-nightly-2)</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">nightly-[HOST_TRIPLE] - </tspan><tspan class="fg-yellow bold">Update available</tspan><tspan> : 1.2.0 (hash-nightly-1) -&gt; 1.3.0 (hash-nightly-2)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_check_updates_some.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_updates_some.stdout.term.svg
@@ -1,0 +1,29 @@
+<svg width="827px" height="92px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>stable-[HOST_TRIPLE] - Update available : 1.0.0 (hash-stable-1.0.0) -&gt; 1.1.0 (hash-stable-1.1.0)</tspan>
+</tspan>
+    <tspan x="10px" y="46px"><tspan>beta-[HOST_TRIPLE] - Update available : 1.1.0 (hash-beta-1.1.0) -&gt; 1.2.0 (hash-beta-1.2.0)</tspan>
+</tspan>
+    <tspan x="10px" y="64px"><tspan>nightly-[HOST_TRIPLE] - Update available : 1.2.0 (hash-nightly-1) -&gt; 1.3.0 (hash-nightly-2)</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
`rustup check` was using `console::style` which will do its own "can I
style" checks, overriding `RUSTUP_TERM_COLOR`.

See https://docs.rs/console/0.16.1/src/console/utils.rs.html#696-702