### PR TITLE
fix(check): Use Cargo's colors

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -819,19 +819,11 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
         Some(_) | None => channels_len,
     };
 
-    let bold = if use_colors {
-        Style::new().bold()
+    let (bold, transient, error, good, warn) = if use_colors {
+        (Style::new().bold(), TRANSIENT, ERROR, GOOD, WARN)
     } else {
-        Style::new()
+        Default::default()
     };
-
-    let transient = if use_colors { TRANSIENT } else { Style::new() };
-
-    let error = if use_colors { ERROR } else { Style::new() };
-
-    let good = if use_colors { GOOD } else { Style::new() };
-
-    let warn = if use_colors { WARN } else { Style::new() };
 
     // Ensure that `.buffered()` is never called with 0 as this will cause a hang.
     // See: https://github.com/rust-lang/futures-rs/pull/1194#discussion_r209501774

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -40,11 +40,12 @@ use std::process::Command;
 use std::str::FromStr;
 use std::{fmt, fs};
 
-use anstyle::{AnsiColor, Style};
+use anstyle::Style;
 use anyhow::{Context, Result, anyhow};
 use cfg_if::cfg_if;
 use clap::ValueEnum;
 use clap::builder::PossibleValue;
+use clap_cargo::style::{GOOD, WARN};
 use itertools::Itertools;
 use same_file::Handle;
 use serde::{Deserialize, Serialize};
@@ -1398,8 +1399,8 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> Result<bool
     let available_version = get_available_rustup_version(dl_cfg).await?;
 
     let bold = Style::new().bold();
-    let yellow = AnsiColor::Yellow.on_default().bold();
-    let green = AnsiColor::Green.on_default().bold();
+    let yellow = WARN;
+    let green = GOOD;
 
     write!(t, "{bold}rustup - {bold:#}")?;
 

--- a/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_check_updates_none.stdout.term.svg
@@ -2,7 +2,7 @@
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
-    .fg-green { fill: #00AA00 }
+    .fg-bright-green { fill: #55FF55 }
     .container {
       padding: 0 10px;
       line-height: 18px;
@@ -18,11 +18,11 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="bold">stable-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">up to date</tspan><tspan>: 1.1.0 (hash-stable-1.1.0)</tspan>
+    <tspan x="10px" y="28px"><tspan class="bold">stable-[HOST_TRIPLE] - </tspan><tspan class="fg-bright-green bold">up to date</tspan><tspan>: 1.1.0 (hash-stable-1.1.0)</tspan>
 </tspan>
-    <tspan x="10px" y="46px"><tspan class="bold">beta-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">up to date</tspan><tspan>: 1.2.0 (hash-beta-1.2.0)</tspan>
+    <tspan x="10px" y="46px"><tspan class="bold">beta-[HOST_TRIPLE] - </tspan><tspan class="fg-bright-green bold">up to date</tspan><tspan>: 1.2.0 (hash-beta-1.2.0)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="bold">nightly-[HOST_TRIPLE] - </tspan><tspan class="fg-green bold">up to date</tspan><tspan>: 1.3.0 (hash-nightly-2)</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">nightly-[HOST_TRIPLE] - </tspan><tspan class="fg-bright-green bold">up to date</tspan><tspan>: 1.3.0 (hash-nightly-2)</tspan>
 </tspan>
     <tspan x="10px" y="82px">
 </tspan>


### PR DESCRIPTION
With `rustup check`s colors being testable (#4561), this updates it to match Cargo's colors