### PR TITLE
cli: avoid dropped temporary

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1221,8 +1221,8 @@ async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode>
                     "{} ({})",
                     toolchain.name(),
                     match source {
-                        ActiveSource::Default => &"default" as &dyn fmt::Display,
-                        _ => &source.to_reason(),
+                        ActiveSource::Default => Cow::Borrowed("default"),
+                        _ => Cow::Owned(source.to_reason()),
                     }
                 )?;
             }


### PR DESCRIPTION
While testing

- https://github.com/rust-lang/rust/issues/148426

on nightly, I noticed that rustup doesn't compile on 1.93.0-nightly (b15a874aa 2025-11-02). I filed

- https://github.com/rust-lang/rust/issues/148427

for that, but apparently that's intentional. Proactively avoid failure to compile on 1.92.