### PR TITLE
Be more consistent about aliases for different subcommands

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -123,14 +123,14 @@ fn plus_toolchain_value_parser(s: &str) -> clap::error::Result<ResolvableToolcha
 #[command(name = "rustup", bin_name = "rustup[EXE]")]
 enum RustupSubcmd {
     /// Install or update the given toolchains, or by default the active toolchain
-    #[command(hide = true, after_help = install_help())]
+    #[command(hide = true, after_help = install_help(), aliases = ["add"])]
     Install {
         #[command(flatten)]
         opts: UpdateOpts,
     },
 
     /// Uninstall the given toolchains
-    #[command(hide = true)]
+    #[command(hide = true, aliases = ["remove", "rm", "delete", "del"])]
     Uninstall {
         #[command(flatten)]
         opts: UninstallOpts,
@@ -332,7 +332,7 @@ enum ToolchainSubcmd {
     },
 
     /// Install or update the given toolchains, or by default the active toolchain
-    #[command(aliases = ["update", "add"], after_help = toolchain_install_help())]
+    #[command(aliases = ["update", "up", "add"], after_help = toolchain_install_help())]
     Install {
         #[command(flatten)]
         opts: UpdateOpts,
@@ -541,6 +541,7 @@ enum OverrideSubcmd {
 )]
 enum SelfSubcmd {
     /// Download and install updates to rustup
+    #[command(alias = "up")]
     Update,
 
     /// Uninstall rustup


### PR DESCRIPTION
In some cases we have the same subcommand in multiple places, but it accepts different aliases in each place. For instance, you can write either `rustup toolchain uninstall` or `rustup toolchain rm`, but you can only write `rustup uninstall`, not `rustup rm`.

Add aliases for consistency:
- `rustup add` for `rustup install`, for consistency with `rustup toolchain install`.
- `rustup rm` (or "remove" or "delete" or "del") for `rustup uninstall`, for consistency with `rustup toolchain uninstall`.
- `rustup self up` for `rustup self update`, for consistency with other `update` commands.
- `rustup toolchain up` for `rustup toolchain update`, for consistency with other `update` commands.

I've also added `rustup status` as an alias for `rustup show`, for consistency with `git status`. :smile: