### PR TITLE
Fix refresh rate for progress bars

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -215,7 +215,7 @@ impl Process {
         };
 
         match term {
-            Some(t) => ProgressDrawTarget::term_like(Box::new(t)),
+            Some(t) => ProgressDrawTarget::term_like_with_hz(Box::new(t), 20),
             None => ProgressDrawTarget::hidden(),
         }
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -205,12 +205,18 @@ impl Process {
             #[cfg(feature = "test")]
             Process::TestProcess(_) => return ProgressDrawTarget::hidden(),
         }
-        let t = self.stdout();
-        match self.var("RUSTUP_TERM_PROGRESS_WHEN") {
-            Ok(s) if s.eq_ignore_ascii_case("always") => ProgressDrawTarget::term_like(Box::new(t)),
-            Ok(s) if s.eq_ignore_ascii_case("never") => ProgressDrawTarget::hidden(),
-            _ if t.is_a_tty() => ProgressDrawTarget::term_like(Box::new(t)),
-            _ => ProgressDrawTarget::hidden(),
+
+        let term = self.stdout();
+        let term = match self.var("RUSTUP_TERM_PROGRESS_WHEN") {
+            Ok(s) if s.eq_ignore_ascii_case("always") => Some(term),
+            Ok(s) if s.eq_ignore_ascii_case("never") => None,
+            _ if term.is_a_tty() => Some(term),
+            _ => None,
+        };
+
+        match term {
+            Some(t) => ProgressDrawTarget::term_like(Box::new(t)),
+            None => ProgressDrawTarget::hidden(),
         }
     }
 


### PR DESCRIPTION
I guess it seemed like a good idea at the time to avoid applying a rate limit to progress bar drawing to a `TermLike`, since a consumer might want to be able to observe every draw. In this case, though, we really want some rate limiting to prevent flickering, so explicitly set the refresh rate to indicatif's default of 20 Hz.