### PR TITLE
Update to mdbook 0.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1567,7 +1567,7 @@ jobs:
         uses: taiki-e/install-action@v2
         env:
           # renovate: datasource=crate depName=mdbook
-          MDBOOK_VERSION: "0.4.43"
+          MDBOOK_VERSION: "0.5.2"
         with:
           tool: mdbook@${{ env.MDBOOK_VERSION }}
       - name: Build user-guide (stable)

--- a/ci/actions-templates/test-docs-template.yaml
+++ b/ci/actions-templates/test-docs-template.yaml
@@ -15,7 +15,7 @@ jobs: # skip-all
         uses: taiki-e/install-action@v2
         env:
           # renovate: datasource=crate depName=mdbook
-          MDBOOK_VERSION: "0.4.43"
+          MDBOOK_VERSION: "0.5.2"
         with:
           tool: mdbook@${{ env.MDBOOK_VERSION }}
       - name: Build user-guide (stable)

--- a/doc/dev-guide/book.toml
+++ b/doc/dev-guide/book.toml
@@ -4,7 +4,6 @@ language = "en"
 title = "The Rustup developer guide"
 
 [output.html]
-smart-punctuation = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/HEAD/doc/dev-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/HEAD/doc/dev-guide"
 site-url = "https://rust-lang.github.io/rustup/dev-guide"

--- a/doc/user-guide/book.toml
+++ b/doc/user-guide/book.toml
@@ -3,7 +3,6 @@ authors = ["The Rust Project Developers"]
 title = "The rustup book"
 
 [output.html]
-smart-punctuation = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/HEAD/doc/user-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/HEAD/doc/user-guide"
 site-url = "https://rust-lang.github.io/rustup/"


### PR DESCRIPTION
This updates from mdbook 0.4.43 to mdbook 0.5.2.

The 0.5 release includes a large number of changes. Additionally there were quite a few changes between 0.4.43 and 0.4.52. If you want all the details, see the changelog which includes a 0.5 migration guide:
https://github.com/rust-lang/mdBook/blob/master/CHANGELOG.md#mdbook-051
