### PR TITLE
[STABLE] Prepare for mdbook 0.5 migration

### DIFF
--- a/doc/dev-guide/book.toml
+++ b/doc/dev-guide/book.toml
@@ -1,12 +1,10 @@
 [book]
 authors = ["The Rust Project Developers"]
 language = "en"
-multilingual = false
-src = "src"
 title = "The Rustup developer guide"
 
 [output.html]
-curly-quotes = true
+smart-punctuation = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/master/doc/dev-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/master/doc/dev-guide"
 site-url = "https://rust-lang.github.io/rustup/dev-guide"

--- a/doc/user-guide/book.toml
+++ b/doc/user-guide/book.toml
@@ -3,7 +3,7 @@ authors = ["The Rust Project Developers"]
 title = "The rustup book"
 
 [output.html]
-curly-quotes = true
+smart-punctuation = true
 edit-url-template = "https://github.com/rust-lang/rustup/edit/master/doc/user-guide/{path}"
 git-repository-url = "https://github.com/rust-lang/rustup/tree/master/doc/user-guide"
 site-url = "https://rust-lang.github.io/rustup/"


### PR DESCRIPTION
This is the stable-branch version of https://github.com/rust-lang/rustup/pull/4612

Because the pull_request checks are building docs from main and stable, the checks fail due to mdbook 0.5 changing and removing some fields. This change should allow the books to work with both 0.4 and 0.5. In particular:

- `multilingual` -- This was never used, is optional, and is ignored in 0.4. This is rejected in 0.5.
- `curly-quotes` -- This was renamed to `smart-punctuation` a long while ago. Both 0.4 and 0.5 use `smart-punctuation`, and 0.5 has removed the old `curly-quotes`.
- `src` -- This isn't needed and is an artifact of an `mdbook init` bug.