### PR TITLE
feat(cli/rustup-mode): support `rustup` completion for nushell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_nushell"
+version = "4.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685bc86fd34b7467e0532a4f8435ab107960d69a243785ef0275e571b35b641a"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2146,6 +2156,7 @@ dependencies = [
  "clap",
  "clap-cargo",
  "clap_complete",
+ "clap_complete_nushell",
  "console",
  "curl",
  "effective-limits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help", "string"] }
 clap-cargo = "0.18.3"
 clap_complete = "4"
+clap_complete_nushell = "4.5"
 console = "0.16"
 curl = { version = "0.4.44", optional = true }
 effective-limits = "0.5.5"

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1868,13 +1868,12 @@ fn output_completion_script(
             );
         }
         CompletionCommand::Cargo => {
-            if let Shell::Zsh = shell {
-                writeln!(process.stdout().lock(), "#compdef cargo")?;
-            }
-
             let script = match shell {
                 Shell::Bash => "/etc/bash_completion.d/cargo",
-                Shell::Zsh => "/share/zsh/site-functions/_cargo",
+                Shell::Zsh => {
+                    writeln!(process.stdout().lock(), "#compdef cargo")?;
+                    "/share/zsh/site-functions/_cargo"
+                }
                 _ => {
                     return Err(anyhow!(
                         "{command} does not currently support completions for {shell}",

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -281,7 +281,7 @@ enum RustupSubcmd {
     /// Generate tab-completion scripts for your shell
     #[command(after_help = completions_help(), arg_required_else_help = true)]
     Completions {
-        shell: Shell,
+        shell: CompletionShell,
 
         #[arg(default_value = "rustup")]
         command: CompletionCommand,
@@ -1853,8 +1853,57 @@ impl fmt::Display for CompletionCommand {
     }
 }
 
+#[derive(clap::ValueEnum, Clone, Copy, Debug)]
+enum CompletionShell {
+    Bash,
+    Elvish,
+    Fish,
+    Nushell,
+    PowerShell,
+    Zsh,
+}
+
+impl fmt::Display for CompletionShell {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            CompletionShell::Bash => "bash",
+            CompletionShell::Elvish => "elvish",
+            CompletionShell::Fish => "fish",
+            CompletionShell::Nushell => "nushell",
+            CompletionShell::PowerShell => "powershell",
+            CompletionShell::Zsh => "zsh",
+        })
+    }
+}
+
+impl clap_complete::Generator for CompletionShell {
+    fn file_name(&self, name: &str) -> String {
+        match self {
+            CompletionShell::Bash => Shell::Bash.file_name(name),
+            CompletionShell::Elvish => Shell::Elvish.file_name(name),
+            CompletionShell::Fish => Shell::Fish.file_name(name),
+            CompletionShell::PowerShell => Shell::PowerShell.file_name(name),
+            CompletionShell::Zsh => Shell::Zsh.file_name(name),
+
+            CompletionShell::Nushell => clap_complete_nushell::Nushell.file_name(name),
+        }
+    }
+
+    fn generate(&self, cmd: &clap::Command, buf: &mut dyn Write) {
+        match self {
+            CompletionShell::Bash => Shell::Bash.generate(cmd, buf),
+            CompletionShell::Elvish => Shell::Elvish.generate(cmd, buf),
+            CompletionShell::Fish => Shell::Fish.generate(cmd, buf),
+            CompletionShell::PowerShell => Shell::PowerShell.generate(cmd, buf),
+            CompletionShell::Zsh => Shell::Zsh.generate(cmd, buf),
+
+            CompletionShell::Nushell => clap_complete_nushell::Nushell.generate(cmd, buf),
+        }
+    }
+}
+
 fn output_completion_script(
-    shell: Shell,
+    shell: CompletionShell,
     command: CompletionCommand,
     process: &Process,
 ) -> Result<ExitCode> {
@@ -1869,8 +1918,8 @@ fn output_completion_script(
         }
         CompletionCommand::Cargo => {
             let script = match shell {
-                Shell::Bash => "/etc/bash_completion.d/cargo",
-                Shell::Zsh => {
+                CompletionShell::Bash => "/etc/bash_completion.d/cargo",
+                CompletionShell::Zsh => {
                     writeln!(process.stdout().lock(), "#compdef cargo")?;
                     "/share/zsh/site-functions/_cargo"
                 }

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1877,9 +1877,7 @@ fn output_completion_script(
                 Shell::Zsh => "/share/zsh/site-functions/_cargo",
                 _ => {
                     return Err(anyhow!(
-                        "{} does not currently support completions for {}",
-                        command,
-                        shell
+                        "{command} does not currently support completions for {shell}",
                     ));
                 }
             };

--- a/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_completions_cmd_help_flag.stdout.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Arguments:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;SHELL&gt;</tspan><tspan>    [possible values: bash, elvish, fish, powershell, zsh]</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-cyan">&lt;SHELL&gt;</tspan><tspan>    [possible values: bash, elvish, fish, nushell, power-shell, zsh]</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-cyan">[COMMAND]</tspan><tspan>  [default: rustup] [possible values: rustup, cargo]</tspan>
 </tspan>


### PR DESCRIPTION
Mirrors https://github.com/jj-vcs/jj/blob/54511ee3fde4f381a67a38ca3a4a0f1c7412753a/cli/src/commands/util/completion.rs#L80; closes #4603.