### PR TITLE
fix(dist/manifestation): print "downloading component" only on `InstallEvents`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use anyhow::{Context, Result, anyhow, bail};
 use serde::Deserialize;
 use thiserror::Error as ThisError;
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 use crate::{
     cli::{common, self_update::SelfUpdateMode},

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -216,8 +216,8 @@ impl Manifestation {
             tx = self.uninstall_component(component, &new_manifest, tx)?;
         }
 
-        info!("downloading component(s)");
         let mut tx = if !components.is_empty() {
+            info!("downloading component(s)");
             let mut stream = InstallEvents::new(components.into_iter(), Arc::new(self));
             let mut transaction = Some(tx);
             let tx = loop {


### PR DESCRIPTION
This avoids the following regression:

```console
> rustup component remove rust-analyzer
info: removing component rust-analyzer
info: downloading component(s)
```