### PR TITLE
fix(dist/download): align `total_bytes` fields in progress reporting UI

### DIFF
--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -288,7 +288,7 @@ impl<'a> DownloadCfg<'a> {
         let progress = ProgressBar::hidden();
         progress.set_style(
             ProgressStyle::with_template(
-                "{msg:>13.bold} downloading [{bar:15}] {total_bytes} ({bytes_per_sec}, ETA: {eta})",
+                "{msg:>13.bold} downloading [{bar:15}] {total_bytes:>11} ({bytes_per_sec}, ETA: {eta})",
             )
             .unwrap()
             .progress_chars("## "),
@@ -363,7 +363,7 @@ impl DownloadStatus {
         *retry_time = None;
         self.progress.set_style(
             ProgressStyle::with_template(
-                "{msg:>13.bold} downloading [{bar:15}] {total_bytes} ({bytes_per_sec}, ETA: {eta})",
+                "{msg:>13.bold} downloading [{bar:15}] {total_bytes:>11} ({bytes_per_sec}, ETA: {eta})",
             )
             .unwrap()
             .progress_chars("## "),
@@ -372,7 +372,7 @@ impl DownloadStatus {
 
     pub(crate) fn finished(&self) {
         self.progress.set_style(
-            ProgressStyle::with_template("{msg:>13.bold} pending installation {total_bytes:>18}")
+            ProgressStyle::with_template("{msg:>13.bold} pending installation {total_bytes:>20}")
                 .unwrap(),
         );
         self.progress.tick(); // A tick is needed for the new style to appear, as it is static.
@@ -396,7 +396,7 @@ impl DownloadStatus {
         self.progress.reset();
         self.progress.set_style(
             ProgressStyle::with_template(
-                "{msg:>13.bold} unpacking   [{bar:15}] {total_bytes} ({bytes_per_sec}, ETA: {eta})",
+                "{msg:>13.bold} unpacking   [{bar:15}] {total_bytes:>11} ({bytes_per_sec}, ETA: {eta})",
             )
             .unwrap()
             .progress_chars("## "),
@@ -407,7 +407,7 @@ impl DownloadStatus {
     pub(crate) fn installing(&self) {
         self.progress.set_style(
             ProgressStyle::with_template(
-                "{msg:>13.bold} installing {spinner:.green} {total_bytes:>26}",
+                "{msg:>13.bold} installing {spinner:.green} {total_bytes:>28}",
             )
             .unwrap()
             .tick_chars(r"|/-\ "),
@@ -417,7 +417,7 @@ impl DownloadStatus {
 
     pub(crate) fn installed(&self) {
         self.progress.set_style(
-            ProgressStyle::with_template("{msg:>13.bold} installed {total_bytes:>29}").unwrap(),
+            ProgressStyle::with_template("{msg:>13.bold} installed {total_bytes:>31}").unwrap(),
         );
         self.progress.finish();
     }

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -313,9 +313,6 @@ impl<'a> DownloadCfg<'a> {
 }
 
 /// Tracks download progress and displays information about it to a terminal.
-///
-/// *not* safe for tracking concurrent downloads yet - it is basically undefined
-/// what will happen.
 pub(crate) struct DownloadTracker {
     /// MultiProgress bar for the downloads.
     multi_progress_bars: MultiProgress,

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -216,11 +216,11 @@ impl Manifestation {
             tx = self.uninstall_component(component, &new_manifest, tx)?;
         }
 
-        let mut tx = if !components.is_empty() {
+        if !components.is_empty() {
             info!("downloading component(s)");
             let mut stream = InstallEvents::new(components.into_iter(), Arc::new(self));
             let mut transaction = Some(tx);
-            let tx = loop {
+            tx = loop {
                 // Refill downloads when there's capacity
                 // Must live outside of `InstallEvents` because we can't write the type of future
                 while stream.components.len() > 0 && stream.downloads.len() < concurrent_downloads {
@@ -246,10 +246,7 @@ impl Manifestation {
 
             download_cfg.clean(&stream.cleanup_downloads)?;
             drop(stream);
-            tx
-        } else {
-            tx
-        };
+        }
 
         // Install new distribution manifest
         let new_manifest_str = new_manifest.clone().stringify()?;


### PR DESCRIPTION
In #4604, the `total_bytes` fields seem to be inconsistently left-aligned in some places, and right-aligned in others. As such, scenarios like the following will occur from time to time (note the `cargo` line):

![t-y](https://github.com/user-attachments/assets/f1eb07ad-edbc-4f73-bebe-5a4f5633518c)

Thus, it is required to make them right-aligned with `:>`, however it seems (from my testing) that specifying the alignment without a width is a no-op, so a width of ~~10~~ 11 is deduced from the longest string from my observation ~~`123.45 MiB`~~ `1023.00 KiB`.

However, since the rest of the codebase assumes a width of 9, I have manually increased every appearance of explicit width by a value of ~~1~~ 2 for the sake of coherence.

This gives something like:

<img width="574" height="61" alt="image" src="https://github.com/user-attachments/assets/27acc63b-a4f2-4075-926b-e5aecee6cc2b" />

