### PR TITLE
Avoid panicking when parsing a toolchain version with leading zeros

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -304,7 +304,7 @@ impl FromStr for ParsedToolchainDesc {
                     "stable",
                     // Allow from 1.0.0 through to 9.999.99 with optional patch version
                     // and optional beta tag
-                    r"[0-9]{1}\.[0-9]{1,3}(?:\.[0-9]{1,2})?(?:-beta(?:\.[0-9]{1,2})?)?",
+                    r"[0-9]{1}\.(?:0|[1-9][0-9]{0,2})(?:\.(?:0|[1-9][0-9]?))?(?:-beta(?:\.[0-9]{1,2})?)?",
                 ]
                 .join("|")
             ))
@@ -1358,7 +1358,15 @@ mod tests {
             assert_eq!(parsed.unwrap(), expected, "input: `{input}`");
         }
 
-        let failure_cases = vec!["anything", "00.0000.000", "3", "", "--", "0.0.0-"];
+        let failure_cases = vec![
+            "anything",
+            "00.0000.000",
+            "3",
+            "",
+            "--",
+            "0.0.0-",
+            "1.90.01",
+        ];
 
         for input in failure_cases {
             let parsed = input.parse::<ParsedToolchainDesc>();


### PR DESCRIPTION
Fixes #4638.

As requested, following with [this](https://github.com/rust-lang/rustup/issues/4638#issuecomment-3649488650) comment, the *regex* was edited to reject toolchain versions with leading zeros.
Moreover, the `unwrap` that was causing the panic was removed; even if the _regex_ fails, an error message will be presented rather than a panic.