### PR TITLE
Add common commands section in help text

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -11,7 +11,18 @@ pub(crate) fn rustup_help() -> String {
   for common platforms.
 
   If you are new to Rust consider running `rustup doc --book` to
-  learn Rust."
+  learn Rust.
+
+{HEADER}Common commands:{HEADER:#}
+
+  Update Rust toolchains and rustup
+
+    {LITERAL}$ rustup update{LITERAL:#}
+    
+  Install the current stable release of Rust for your host platform
+
+    {LITERAL}$ rustup toolchain install stable{LITERAL:#}
+  "
     )
 }
 

--- a/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_cmd.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="776px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="776px" height="1010px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -109,6 +109,26 @@
     <tspan x="10px" y="802px"><tspan>  learn Rust.</tspan>
 </tspan>
     <tspan x="10px" y="820px">
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-bright-green bold">Common commands:</tspan>
+</tspan>
+    <tspan x="10px" y="856px">
+</tspan>
+    <tspan x="10px" y="874px"><tspan>  Update Rust toolchains and rustup</tspan>
+</tspan>
+    <tspan x="10px" y="892px">
+</tspan>
+    <tspan x="10px" y="910px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup update</tspan>
+</tspan>
+    <tspan x="10px" y="928px"><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="946px"><tspan>  Install the current stable release of Rust for your host platform</tspan>
+</tspan>
+    <tspan x="10px" y="964px">
+</tspan>
+    <tspan x="10px" y="982px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain install stable</tspan>
+</tspan>
+    <tspan x="10px" y="1000px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="776px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="776px" height="1010px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -109,6 +109,26 @@
     <tspan x="10px" y="802px"><tspan>  learn Rust.</tspan>
 </tspan>
     <tspan x="10px" y="820px">
+</tspan>
+    <tspan x="10px" y="838px"><tspan class="fg-bright-green bold">Common commands:</tspan>
+</tspan>
+    <tspan x="10px" y="856px">
+</tspan>
+    <tspan x="10px" y="874px"><tspan>  Update Rust toolchains and rustup</tspan>
+</tspan>
+    <tspan x="10px" y="892px">
+</tspan>
+    <tspan x="10px" y="910px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup update</tspan>
+</tspan>
+    <tspan x="10px" y="928px"><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="946px"><tspan>  Install the current stable release of Rust for your host platform</tspan>
+</tspan>
+    <tspan x="10px" y="964px">
+</tspan>
+    <tspan x="10px" y="982px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain install stable</tspan>
+</tspan>
+    <tspan x="10px" y="1000px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_only_options.stderr.term.svg
@@ -1,4 +1,4 @@
-<svg width="768px" height="992px" xmlns="http://www.w3.org/2000/svg">
+<svg width="768px" height="1172px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -126,7 +126,27 @@
 </tspan>
     <tspan x="10px" y="964px">
 </tspan>
-    <tspan x="10px" y="982px">
+    <tspan x="10px" y="982px"><tspan class="fg-bright-green bold">Common commands:</tspan>
+</tspan>
+    <tspan x="10px" y="1000px">
+</tspan>
+    <tspan x="10px" y="1018px"><tspan>  Update Rust toolchains and rustup</tspan>
+</tspan>
+    <tspan x="10px" y="1036px">
+</tspan>
+    <tspan x="10px" y="1054px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup update</tspan>
+</tspan>
+    <tspan x="10px" y="1072px"><tspan>    </tspan>
+</tspan>
+    <tspan x="10px" y="1090px"><tspan>  Install the current stable release of Rust for your host platform</tspan>
+</tspan>
+    <tspan x="10px" y="1108px">
+</tspan>
+    <tspan x="10px" y="1126px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup toolchain install stable</tspan>
+</tspan>
+    <tspan x="10px" y="1144px">
+</tspan>
+    <tspan x="10px" y="1162px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Judging from user feedback coming out of Debian distros, it appears that after installing `rustup` from the package manager it is not immediately clear which command actually installs the toolchain. It is true that `rustup` from `rustup.rs` one-liner makes one-stop installation, Debian packaging actually skips the essential `rustup-init` step as of writing for a good reason. This left a few Debian users, who I talked to recently, feel lost in their first attempt to use the toolchain.

This patch adds a small text so that after installation of `rustup`, which normally does not invoke the toolchain installation for the user, the user can still receive guidance on how to set up the local toolchain immediately.