### PR TITLE
feat(cli/rustup-mode): add `doc --rustc-docs` to open rustdoc for Rust internals

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1663,6 +1663,11 @@ docs_data![
         "rustc/index.html"
     ),
     (
+        rustc_docs,
+        "The API documentation for the Rust compiler and other toolchain components",
+        "rustc-docs/index.html"
+    ),
+    (
         rustdoc,
         "Documentation generator for Rust projects",
         "rustdoc/index.html"

--- a/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="835px" height="776px" xmlns="http://www.w3.org/2000/svg">
+<svg width="835px" height="830px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -76,35 +76,39 @@
 </tspan>
     <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc</tspan><tspan>                  The compiler for the Rust programming language</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustdoc</tspan><tspan>                Documentation generator for Rust projects</tspan>
+    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc-docs</tspan><tspan>             The API documentation for the Rust compiler and other toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--std</tspan><tspan>                    Standard library API documentation</tspan>
+    <tspan x="10px" y="550px"><tspan>                               components</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--style-guide</tspan><tspan>            The Rust Style Guide</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustdoc</tspan><tspan>                Documentation generator for Rust projects</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan>                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
+    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--std</tspan><tspan>                    Standard library API documentation</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>                               framework</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--style-guide</tspan><tspan>            The Rust Style Guide</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unstable-book</tspan><tspan>          The Unstable Book</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan>                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="640px"><tspan>                               framework</tspan>
 </tspan>
-    <tspan x="10px" y="658px">
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unstable-book</tspan><tspan>          The Unstable Book</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="694px"><tspan>  Opens the documentation for the currently active toolchain with</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
-    <tspan x="10px" y="712px"><tspan>  the default browser.</tspan>
+    <tspan x="10px" y="712px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="730px">
+    <tspan x="10px" y="730px"><tspan>  Opens the documentation for the currently active toolchain with</tspan>
 </tspan>
-    <tspan x="10px" y="748px"><tspan>  By default, it opens the documentation index. Use the various</tspan>
+    <tspan x="10px" y="748px"><tspan>  the default browser.</tspan>
 </tspan>
-    <tspan x="10px" y="766px"><tspan>  flags to open specific pieces of documentation.</tspan>
+    <tspan x="10px" y="766px">
 </tspan>
-    <tspan x="10px" y="784px">
+    <tspan x="10px" y="784px"><tspan>  By default, it opens the documentation index. Use the various</tspan>
+</tspan>
+    <tspan x="10px" y="802px"><tspan>  flags to open specific pieces of documentation.</tspan>
+</tspan>
+    <tspan x="10px" y="820px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Mirrors:
- https://github.com/rust-lang/rust/pull/150289
- https://github.com/rust-lang/promote-release/pull/101

> [!IMPORTANT]
> This PR should NOT be merged until all the dependencies listed above are merged first. Setting to draft to make this clearer.

Closes #3717 via the newly-assigned path for `rustc-docs`, i.e. `share/doc/rust/html/rustc-docs/...`.

This prevents clashing with the existing `share/doc/rust/html/rustc/...` which is often occupied by the [Rustc Book](https://doc.rust-lang.org/rustc/index.html).

---

Update on 2026/01/20:

Tested locally with the following commands, no issues observed:

```console
> rustup update && rustup +nightly component add rustc-docs
> cargo run --config="env.RUSTUP_FORCE_ARG0='rustup'" --features=no-self-update -- +nightly doc --rustc-docs
```