### PR TITLE
Unify nightly component unavailable messages

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -21,7 +21,7 @@ use tracing::{debug, info, warn};
 
 use crate::{
     config::Cfg,
-    errors::RustupError,
+    errors::{NIGHTLY_COMPONENT_NOTE, RustupError},
     process::Process,
     toolchain::{DistributableToolchain, ToolchainName},
     utils,
@@ -87,22 +87,15 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
     if toolchain.starts_with("nightly") {
         let _ = write!(
             buf,
-            "\
-Sometimes not all components are available in any given nightly.
-If you don't need these components, you could try a minimal installation with:
-
-    rustup toolchain add {toolchain} --profile minimal
-
-If you require these components, please install and use the latest successfully built version,
-which you can find at <https://rust-lang.github.io/rustup-components-history>.
-
-After determining the correct date, install it with a command such as:
-
-    rustup toolchain install nightly-2018-12-27
-
-Then you can use the toolchain with commands such as:
-
-    cargo +nightly-2018-12-27 build"
+            "\n{NIGHTLY_COMPONENT_NOTE}\n\
+        help: if you don't need these components, you could try a minimal installation with:\n\
+        help:     rustup toolchain add {toolchain} --profile minimal\n\
+        help: if you require these components, please install and use the latest successfully built version,\n\
+        help: which you can find at <https://rust-lang.github.io/rustup-components-history>\n\
+        help: after determining the correct date, install it with a command such as:\n\
+        help:     rustup toolchain install nightly-2018-12-27\n\
+        help: then you can use the toolchain with commands such as:\n\
+        help:     cargo +nightly-2018-12-27 build"
         );
     } else if ["beta", "stable"].iter().any(|&p| toolchain.starts_with(p)) {
         let _ = write!(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -181,6 +181,9 @@ fn suggest_message(suggestion: &Option<String>) -> String {
     }
 }
 
+pub(crate) const NIGHTLY_COMPONENT_NOTE: &str =
+    "note: sometimes not all components are available in any given nightly";
+
 /// Returns a error message indicating that certain [`Component`]s are unavailable.
 ///
 /// See also [`components_missing_msg`](../dist/dist/fn.components_missing_msg.html)
@@ -203,10 +206,7 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
             );
 
             if toolchain.starts_with("nightly") {
-                let _ = write!(
-                    buf,
-                    "(sometimes not all components are available in any given nightly)"
-                );
+                let _ = write!(buf, "{NIGHTLY_COMPONENT_NOTE}");
             }
         }
         cs => {
@@ -227,16 +227,13 @@ fn component_unavailable_msg(cs: &[Component], manifest: &Manifest, toolchain: &
                     .join(", ")
             };
 
-            let _ = write!(
+            let _ = writeln!(
                 buf,
-                "some components are unavailable for download for channel '{toolchain}': {cs_str}"
+                "some components are unavailable for download for channel '{toolchain}': {cs_str}",
             );
 
             if toolchain.starts_with("nightly") {
-                let _ = write!(
-                    buf,
-                    "(sometimes not all components are available in any given nightly)"
-                );
+                let _ = write!(buf, "{NIGHTLY_COMPONENT_NOTE}");
             }
         }
     }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1972,7 +1972,7 @@ async fn add_missing_component() {
         .with_stderr(snapbox::str![[r#"
 ...
 error: component 'rls' for target '[HOST_TRIPLE]' is unavailable for download for channel 'nightly'
-(sometimes not all components are available in any given nightly)
+note: sometimes not all components are available in any given nightly
 ...
 "#]])
         .is_err();
@@ -1995,21 +1995,16 @@ async fn add_missing_component_toolchain() {
         .with_stderr(snapbox::str![[r#"
 ...
 error: component 'rust-std' for target '[HOST_TRIPLE]' is unavailable for download for channel 'nightly'
-Sometimes not all components are available in any given nightly.
-If you don't need these components, you could try a minimal installation with:
 
-    rustup toolchain add nightly --profile minimal
-
-If you require these components, please install and use the latest successfully built version,
-which you can find at <https://rust-lang.github.io/rustup-components-history>.
-
-After determining the correct date, install it with a command such as:
-
-    rustup toolchain install nightly-2018-12-27
-
-Then you can use the toolchain with commands such as:
-
-    cargo +nightly-2018-12-27 build
+note: sometimes not all components are available in any given nightly
+help: if you don't need these components, you could try a minimal installation with:
+help:     rustup toolchain add nightly --profile minimal
+help: if you require these components, please install and use the latest successfully built version,
+help: which you can find at <https://rust-lang.github.io/rustup-components-history>
+help: after determining the correct date, install it with a command such as:
+help:     rustup toolchain install nightly-2018-12-27
+help: then you can use the toolchain with commands such as:
+help:     cargo +nightly-2018-12-27 build
 ...
 "#]])
         .is_err();


### PR DESCRIPTION
fixes https://github.com/rust-lang/rustup/issues/4667

Unified two versions of the "sometimes not all components are available" message for nightly builds. Added `nightly_component_unavailable_help()` to generate a consistent `note/help` format. Removed parentheses from the error string in `component_unavailable_msg()` - error is separate, explanation via `note/help`. Replaced the long text block in `components_missing_msg()` with structured `note/help` lines. Updated tests, all code paths use single message in a consistent format, eliminating duplication.