### PR TITLE
fix: `copy_dir` and `copy_file` to preserve symlinks instead of following them

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -842,7 +842,7 @@ fn install_bins(process: &Process) -> Result<()> {
     if rustup_path.exists() {
         utils::remove_file("rustup-bin", &rustup_path)?;
     }
-    utils::copy_file(&this_exe_path, &rustup_path)?;
+    utils::copy_file_symlink_to_source(&this_exe_path, &rustup_path)?;
     utils::make_executable(&rustup_path)?;
     install_proxies(process)
 }

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -706,7 +706,7 @@ pub(crate) fn delete_rustup_and_cargo_home(process: &Process) -> Result<()> {
     let numbah: u32 = rand::random();
     let gc_exe = work_path.join(format!("rustup-gc-{numbah:x}.exe"));
     // Copy rustup (probably this process's exe) to the gc exe
-    utils::copy_file(&rustup_path, &gc_exe)?;
+    utils::copy_file_symlink_to_source(&rustup_path, &gc_exe)?;
     let gc_exe_win: Vec<_> = gc_exe.as_os_str().encode_wide().chain(Some(0)).collect();
 
     // Make the sub-process opened by gc exe inherit its attribute.


### PR DESCRIPTION
This PR employs symlink preservation in `copy_file` and adds it to `copy_dir`.

PR #1504 added symlink preservation to fix crashes in lldb-preview, which contains internal symlinks (liblldb was loading twice due to broken symlinks). Then, PR #1521 later changed `copy_file` to create symlinks pointing  to the source path (for Homebrew integration), which may have regressed #1504. 

This PR restores #1504's behavior: read the symlink target and preserve it. What I'm curious about is what the intended behavior for #1521 was because shouldn't users be able to run `rustup-init --no-self-update`? Is that not the recommended way to manage `rustup` via external package managers?

If this PR steers out of scope of the goals of `rustup` I'm happy to close it but I feel like the former behavior is preferable for most use cases.