### PR TITLE
fix(dist): adjust printed newlines in `components_missing_msg()`

### DIFF
--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -77,7 +77,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
                 .map(|c| manifest.description(c))
                 .collect::<Vec<_>>()
                 .join(", ");
-            let _ = write!(
+            let _ = writeln!(
                 buf,
                 "some components are unavailable for download for channel '{toolchain}': {cs_str}"
             );
@@ -87,7 +87,7 @@ fn components_missing_msg(cs: &[Component], manifest: &ManifestV2, toolchain: &s
     if toolchain.starts_with("nightly") {
         let _ = write!(
             buf,
-            "\n{NIGHTLY_COMPONENT_NOTE}\n\
+            "{NIGHTLY_COMPONENT_NOTE}\n\
         help: if you don't need these components, you could try a minimal installation with:\n\
         help:     rustup toolchain add {toolchain} --profile minimal\n\
         help: if you require these components, please install and use the latest successfully built version,\n\

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1986,7 +1986,7 @@ note: sometimes not all components are available in any given nightly
 }
 
 #[tokio::test]
-async fn add_missing_component_toolchain() {
+async fn add_toolchain_with_missing_component() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     make_component_unavailable(&cx.config, "rust-std", this_host_triple());
     cx.config
@@ -1995,6 +1995,32 @@ async fn add_missing_component_toolchain() {
         .with_stderr(snapbox::str![[r#"
 ...
 error: component 'rust-std' for target '[HOST_TRIPLE]' is unavailable for download for channel 'nightly'
+note: sometimes not all components are available in any given nightly
+help: if you don't need these components, you could try a minimal installation with:
+help:     rustup toolchain add nightly --profile minimal
+help: if you require these components, please install and use the latest successfully built version,
+help: which you can find at <https://rust-lang.github.io/rustup-components-history>
+help: after determining the correct date, install it with a command such as:
+help:     rustup toolchain install nightly-2018-12-27
+help: then you can use the toolchain with commands such as:
+help:     cargo +nightly-2018-12-27 build
+
+"#]])
+        .is_err();
+}
+
+#[tokio::test]
+async fn add_toolchain_with_missing_components() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    for comp in &["rust-std", "cargo"] {
+        make_component_unavailable(&cx.config, comp, this_host_triple());
+    }
+    cx.config
+        .expect(["rustup", "toolchain", "add", "nightly"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+...
+error: some components are unavailable for download for channel 'nightly': 'cargo' for target '[HOST_TRIPLE]', 'rust-std' for target '[HOST_TRIPLE]'
 note: sometimes not all components are available in any given nightly
 help: if you don't need these components, you could try a minimal installation with:
 help:     rustup toolchain add nightly --profile minimal

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1995,7 +1995,6 @@ async fn add_missing_component_toolchain() {
         .with_stderr(snapbox::str![[r#"
 ...
 error: component 'rust-std' for target '[HOST_TRIPLE]' is unavailable for download for channel 'nightly'
-
 note: sometimes not all components are available in any given nightly
 help: if you don't need these components, you could try a minimal installation with:
 help:     rustup toolchain add nightly --profile minimal
@@ -2005,7 +2004,7 @@ help: after determining the correct date, install it with a command such as:
 help:     rustup toolchain install nightly-2018-12-27
 help: then you can use the toolchain with commands such as:
 help:     cargo +nightly-2018-12-27 build
-...
+
 "#]])
         .is_err();
 }


### PR DESCRIPTION
Follow up of https://github.com/rust-lang/rustup/pull/4670. My apologies for having unintentionally overlooked the extra newline in the snapshot that should not be there all along.

Anyway, the output format should be unified now. I have added one more verification test to further demonstrate this point.

cc @enthropy7 