### PR TITLE
Visual Studio prerequisites changes

### DIFF
--- a/doc/user-guide/src/installation/windows-msvc.md
+++ b/doc/user-guide/src/installation/windows-msvc.md
@@ -14,7 +14,7 @@ If you chose the automatic install this winget command will run in the backgroun
 winget install --id Microsoft.VisualStudio.BuildTools --force --interactive  --custom "--focusedUi --addProductLang En-us --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
 ```
 
-But you could [download the Microsoft Build Tools for Visual Studio][vs download] Installer yourself and do the same steps manual.
+But you could [download the Microsoft Build Tools for Visual Studio][vs download] Installer yourself and do the same steps manually.
 
 The installer will start by linking to the [Build Tools license][vs licences] and will install the "Visual Studio Installer", a tool to manage Visual Studio components.
 

--- a/doc/user-guide/src/installation/windows-msvc.md
+++ b/doc/user-guide/src/installation/windows-msvc.md
@@ -5,70 +5,32 @@ For `msvc` targets these can be acquired through Visual Studio.
 
 ## Automatic install
 
-If you don't have Visual Studio already installed then [rustup-init] will offer to automatically install the prerequisites.
-Doing so means you can skip the rest of this page.
-However, it installs Visual Studio Community edition which may not be appropriate for all users.
-It is free for individuals, academic and open source use, but not for other uses, such as in proprietary enterprise software.
-Users should ask their organisation which edition is right for them.
-See [licensing terms][vs licences] for more details.
+If you don't have Visual Studio already installed then the [rustup-init.exe][rustinstall] installer will offer to automatically install the prerequisites. 
 
 ## Manual install
 
-[Download Visual Studio][vs downloads].
-Rust supports Visual Studio 2017 and later but it is recommended that you use the latest version (currently 2022) for new projects.
-You can opt to download only the Build Tools for Visual Studio, which does not include the IDE.
-However this requires you already have a license to the Community, Professional or Enterprise edition.
+If you chose the automatic install this winget command will run in the background:
+```Batchfile
+winget install --id Microsoft.VisualStudio.BuildTools --force --interactive  --custom "--focusedUi --addProductLang En-us --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows11SDK.26100"
+```
 
-Once you've downloaded and started the installer, the easiest way to get everything installed is to select "Desktop Development with C++".
-This will include the necessary components.
-On the "Language Packs" tab, make sure the English language pack is installed in addition to your preferred language.
+But you could [download the Microsoft Build Tools for Visual Studio][vs download] Installer yourself and do the same steps manual.
 
-If you want more details on the installation process or want to further customize the install then follow the walkthrough below.
-Otherwise complete the Visual Studio install and continue with installing Rust.
-
-## Walkthrough: Installing Visual Studio 2022
-
-This walkthrough uses the Community edition of Visual Studio but the Professional, Enterprise and the Build Tools all work the same way.
-
-The installer will start by linking to the [license][vs licences] and for your edition of Visual Studio and then preparing the installer.
+The installer will start by linking to the [Build Tools license][vs licences] and will install the "Visual Studio Installer", a tool to manage Visual Studio components.
 
 ![Accept the license](images/step1.png)
-![Installing the installer](images/step2.png)
 
-Once this finishes, you can then select the components to be installed.
-Here we use the "Workload" tab to select the "Desktop Development with C++" workload.
-This will includes all needed components for Rust:
-![Select the C++ Workload](images/step3.png)
 
-### Installing only the required components (optional)
+Then you need to install the "Individual components":
+* MSVC Build Tools for x64/x86 (Latest)
+* Windows 11 SDK (10.0.26100.XXXX)
 
-If you'd like a more minimal install (and won't be doing C++ development) then you can use the "Individual Components" tab to select just the essentials, which are:
+And the "Language pack":
+* English
 
-* MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest)
-* Windows 11 SDK (10.0.22621.0)
 
-Note that the specific version of the Windows SDK doesn't matter for pure Rust code but if using C++ as well you'll likely want either the latest or whichever version is required by the C++ project (or both).
+Once finished, you can continue on to installing Rust and the installer should detect MSVC.
 
-![Select the latest MSVC component](images/component-msvc.png)
-![Select the Windows 11 SDK component](images/component-sdk.png)
-
-### Adding Language Packs (optional)
-
-After choosing the components, you may also want to select the language packs to install.
-Switch to the "Language Packs" tab and add the languages.
-It is recommended that you add the English language pack in addition to your preferred language.
-This will provide English language error messages, which may help when reporting errors.
-
-![Add the English language](images/step4.png)
-
-### Completing the install
-
-Finally click the install button and wait for everything to be installed.
-
-![Wait for the install to complete](images/step5.png)
-
-Once finished, you can continue on to installing Rust.
-
-[rustup-init]: https://rustup.rs
-[vs downloads]: https://visualstudio.microsoft.com/downloads/
-[vs licences]: https://visualstudio.microsoft.com/license-terms/
+[vs licences]: https://visualstudio.microsoft.com/license-terms/vs2026-ga-diagnostic-buildtools
+[vs download]: https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026
+[rustinstall]: https://rust-lang.org/tools/install/

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -260,11 +260,12 @@ pub(crate) async fn try_install_msvc(
     opts: &InstallOpts<'_>,
     cfg: &Cfg<'_>,
 ) -> Result<ContinueInstall> {
-
     info!("running the Visual Studio Installer\n");
     info!("Follow the Installation and Close the Window to continue with rustup!\n");
 
-    let mut vsi_args = String::from("--focusedUi --addProductLang En-us --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64");
+    let mut vsi_args = String::from(
+        "--focusedUi --addProductLang En-us --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64",
+    );
     // It's possible an earlier or later version of the Windows SDK has been
     // installed separately from Visual Studio so installing it can be skipped.
     if !has_windows_sdk_libs(cfg.process) {
@@ -276,7 +277,7 @@ pub(crate) async fn try_install_msvc(
     let mut cmd = Command::new("winget");
     cmd.arg("install")
         .args(["--id", "Microsoft.VisualStudio.BuildTools"])
-        // Simple force update the Installer 
+        // Simple force update the Installer
         .arg("--force")
         // Overide winget silent mode
         .arg("--interactive")

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -22,8 +22,6 @@ use super::{InstallOpts, install_bins, report_error};
 use crate::cli::markdown::md;
 use crate::config::Cfg;
 use crate::dist::TargetTriple;
-use crate::dist::download::DownloadCfg;
-use crate::download::download_file;
 use crate::process::{ColorableTerminal, Process};
 use crate::utils;
 
@@ -52,7 +50,7 @@ fn choice(max: u8, process: &Process) -> Result<Option<u8>> {
 pub(crate) fn choose_vs_install(process: &Process) -> Result<Option<VsInstallPlan>> {
     writeln!(
         process.stdout().lock(),
-        "\n1) Quick install via the Visual Studio Community installer"
+        "\n1) Quick install via the Visual Studio Installer"
     )?;
     writeln!(
         process.stdout().lock(),
@@ -145,13 +143,14 @@ later, but they don't seem to be installed.
 "#;
 
 static MSVC_MANUAL_INSTALL_MESSAGE: &str = r#"
-You can acquire the build tools by installing Microsoft Visual Studio.
+You can acquire the build tools by installing the Build Tools for Microsoft Visual Studio:
 
-    https://visualstudio.microsoft.com/downloads/
+    https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026
 
-Check the box for "Desktop development with C++" which will ensure that the
-needed components are installed. If your locale language is not English,
-then additionally check the box for English under Language packs.
+You will need the following components to be installed:
+    MSVC Build Tools for x64/x86 (Latest)
+    Windows 11 SDK (10.0.26100.XXXX)
+    Language pack: English
 
 For more details see:
 
@@ -199,9 +198,8 @@ pub(crate) fn do_msvc_check(opts: &InstallOpts<'_>, process: &Process) -> Option
         // If the user does not have Visual Studio installed and their host
         // machine is i686 or x86_64 then it's OK to try an auto install.
         // Otherwise a manual install will be required.
-        let has_any_vs = windows_registry::find_vs_version().is_ok();
         let is_x86 = host_triple.contains("i686") || host_triple.contains("x86_64");
-        if is_x86 && !has_any_vs {
+        if is_x86 {
             Some(VsInstallPlan::Automatic)
         } else {
             Some(VsInstallPlan::Manual)
@@ -262,47 +260,31 @@ pub(crate) async fn try_install_msvc(
     opts: &InstallOpts<'_>,
     cfg: &Cfg<'_>,
 ) -> Result<ContinueInstall> {
-    // download the installer
-    let visual_studio_url = utils::parse_url("https://aka.ms/vs/17/release/vs_community.exe")?;
 
-    let tempdir = tempfile::Builder::new()
-        .prefix("rustup-visualstudio")
-        .tempdir()
-        .context("error creating temp directory")?;
+    info!("running the Visual Studio Installer\n");
+    info!("Follow the Installation and Close the Window to continue with rustup!\n");
 
-    let visual_studio = tempdir.path().join("vs_setup.exe");
-    let dl_cfg = DownloadCfg::new(cfg);
-    info!("downloading Visual Studio installer");
-    download_file(
-        &visual_studio_url,
-        &visual_studio,
-        None,
-        None,
-        dl_cfg.process,
-    )
-    .await?;
-
-    // Run the installer. Arguments are documented at:
-    // https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio
-    let mut cmd = Command::new(visual_studio);
-    cmd.arg("--wait")
-        // Display an interactive GUI focused on installing just the selected components.
-        .arg("--focusedUi")
-        // Add the English language pack
-        .args(["--addProductLang", "En-us"])
-        // Add the linker and C runtime libraries.
-        .args(["--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64"]);
-
+    let mut vsi_args = String::from("--focusedUi --addProductLang En-us --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64");
     // It's possible an earlier or later version of the Windows SDK has been
     // installed separately from Visual Studio so installing it can be skipped.
     if !has_windows_sdk_libs(cfg.process) {
-        cmd.args([
-            "--add",
-            "Microsoft.VisualStudio.Component.Windows11SDK.26100",
-        ]);
+        vsi_args.push_str(" --add Microsoft.VisualStudio.Component.Windows11SDK.26100");
     }
-    info!("running the Visual Studio install");
-    info!("rustup will continue once Visual Studio installation is complete\n");
+
+    // Run the installer. Arguments are documented at:
+    // https://docs.microsoft.com/en-us/visualstudio/install/use-command-line-parameters-to-install-visual-studio
+    let mut cmd = Command::new("winget");
+    cmd.arg("install")
+        .args(["--id", "Microsoft.VisualStudio.BuildTools"])
+        // Simple force update the Installer 
+        .arg("--force")
+        // Overide winget silent mode
+        .arg("--interactive")
+        // Add custom arguments to the installer
+        .arg("--custom")
+        // Has all to be an argument value of --custom
+        .arg(vsi_args);
+
     let exit_status = cmd
         .spawn()
         .and_then(|mut child| child.wait())


### PR DESCRIPTION
**rustup auto install script:**
- Update Visual Studio Installer download via winget
_winget is very stable and the download is official maintained by microsoft and used official_
- Remove the extra check if Visual Studio Installer is installed
_This is simple not necessary or brings any negative aspect. The download is only 4mb and it will try update the the VS Installer but don't change any installations. Its a indented and the reason why the VS Installer-Installer itself can take setup arguments._

**documentation**
- shrink down the documentation
_maybe it shouldn't even have an extra site for a step you can do in a single command-line._
- update manual download link and info's in the rustup tool
_Was very confusing, reads like you're installing the entire IDE._
- winget command line to install (but gui install because of license agreement)

**To the license thing of the build tools:**
First of all they are indented to be used outside of an whole VS IDE. Official VSCode advertising it for the C#/C++ programming. Just like "Visual Studio Community", where you don't need an account or anything, the "Build Tools for Visual Studio" is also a Visual Studio Product itself where you "get an free license" by agree to it. The winget download runs the installer in gui mode and the user has to accept the license itself.