### PR TITLE
fix(cli/rustup-mode): `check` for self updates for `SelfUpdateMode::CheckOnly`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -914,10 +914,13 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
     let self_update_mode = SelfUpdateMode::from_cfg(cfg)?;
     // Priority: no-self-update feature > self_update_mode > no-self-update args.
     // Check for update only if rustup does **not** have the no-self-update feature,
-    // and auto-self-update is configured to **enable**
+    // and auto-self-update is configured to **enable** or **check-only**
     // and has **no** no-self-update parameter.
     let self_update = !cfg!(feature = "no-self-update")
-        && self_update_mode == SelfUpdateMode::Enable
+        && matches!(
+            self_update_mode,
+            SelfUpdateMode::Enable | SelfUpdateMode::CheckOnly
+        )
         && !opts.no_self_update;
 
     if self_update && check_rustup_update(&DownloadCfg::new(cfg)).await? {


### PR DESCRIPTION
This PR addresses the following concern of @steffahn:

> with a configuration of rustup set auto-self-update check-only, arguably I would prefer to still be able see the result of the self-update check.
_https://internals.rust-lang.org/t/seeking-beta-testers-for-rustup-v1-29-0/23814/3_

It is quite likely that this section was originally copied over from `rustup update` without careful verification/review. My apologies.