### PR TITLE
Remove the mixed singular/plural phrasing as “`component(s)`”

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -217,7 +217,15 @@ impl Manifestation {
         }
 
         if !components.is_empty() {
-            info!("downloading component(s)");
+            if components.len() > 2 {
+                info!("downloading {} components", components.len());
+            } else {
+                info!(
+                    "downloading component {}",
+                    components[0].manifest.short_name(&components[0].component),
+                );
+            };
+
             let mut stream = InstallEvents::new(components.into_iter(), Arc::new(self));
             let mut transaction = Some(tx);
             tx = loop {

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -22,8 +22,7 @@ async fn update_once() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: default toolchain set to nightly-[HOST_TRIPLE]
 
 "#]]);
@@ -69,8 +68,8 @@ rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading 4 components
+
 "#]]);
     cx.config
         .expect(["rustup", "+nightly", "component", "list", "--installed"])
@@ -112,8 +111,7 @@ async fn update_once_and_self_update() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: checking for self-update (current version: [CURRENT_VERSION])
 info: downloading self-update (new version: [TEST_VERSION])
 
@@ -323,8 +321,7 @@ async fn default() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: default toolchain set to nightly-[HOST_TRIPLE]
 
 "#]]);

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -284,8 +284,7 @@ async fn default() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: default toolchain set to nightly-[HOST_TRIPLE]
 
 "#]])
@@ -1708,8 +1707,7 @@ channel = "nightly"
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading component rustc
 info: the active toolchain `nightly-[HOST_TRIPLE]` has been installed
 info: it's active because: overridden by '[TOOLCHAIN_FILE]'
 
@@ -3893,8 +3891,7 @@ async fn custom_toolchain_with_components_toolchains_profile_does_not_err() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component[..]
-...
+info: downloading component cargo
 info: default toolchain set to nightly-[HOST_TRIPLE]
 
 "#]])

--- a/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
@@ -21,7 +21,7 @@
 </tspan>
     <tspan x="10px" y="46px"><tspan class="bold">info:</tspan><tspan> latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)</tspan>
 </tspan>
-    <tspan x="10px" y="64px"><tspan class="bold">info:</tspan><tspan> downloading component(s)</tspan>
+    <tspan x="10px" y="64px"><tspan class="bold">info:</tspan><tspan> downloading 4 components</tspan>
 </tspan>
     <tspan x="10px" y="82px"><tspan class="bold">info:</tspan><tspan> default toolchain set to nightly-[HOST_TRIPLE]</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_update_updated.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_updated.stderr.term.svg
@@ -29,7 +29,7 @@
 </tspan>
     <tspan x="10px" y="118px"><tspan class="bold">info:</tspan><tspan> removing previous version of component rustc</tspan>
 </tspan>
-    <tspan x="10px" y="136px"><tspan class="bold">info:</tspan><tspan> downloading component(s)</tspan>
+    <tspan x="10px" y="136px"><tspan class="bold">info:</tspan><tspan> downloading 4 components</tspan>
 </tspan>
     <tspan x="10px" y="154px"><tspan class="bold">info:</tspan><tspan> cleaning up downloads &amp; tmp directories</tspan>
 </tspan>

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -72,8 +72,7 @@ async fn install_bins_to_cargo_home() {
 ...
 info: syncing channel updates for stable-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: default toolchain set to stable-[HOST_TRIPLE]
 
 "#]])
@@ -117,8 +116,7 @@ async fn proxies_are_relative_symlinks() {
 ...
 info: syncing channel updates for stable-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
-info: downloading component[..]
-...
+info: downloading 4 components
 info: default toolchain set to stable-[HOST_TRIPLE]
 ...
 "#]])

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -487,8 +487,8 @@ async fn remove_override_toolchain_err_handling() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for beta-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.2.0 (hash-beta-1.2.0)
-info: downloading component[..]
-...
+info: downloading 4 components
+
 "#]])
         .is_ok();
     cx.config
@@ -520,8 +520,8 @@ async fn file_override_toolchain_err_handling() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for beta-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.2.0 (hash-beta-1.2.0)
-info: downloading component[..]
-...
+info: downloading 4 components
+
 "#]])
         .is_ok();
     cx.config
@@ -2481,8 +2481,8 @@ async fn run_with_install_flag_against_unavailable_component() {
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 warn: skipping unavailable component rust-std
-info: downloading component[..]
-...
+info: downloading 3 components
+
 "#]])
         .is_ok();
     cx.config


### PR DESCRIPTION
Instead, we can use "components" or "component" depending on the number (which is always known).
In the latter case also add the name of the component for more consistent messaging style with other `info!` outputs about single components.

Screenshot comparing the output for 2 scenarios in action (top half is *before* this PR):

<img width="1570" height="873" alt="Bildschirmfoto_20260116_030854" src="https://github.com/user-attachments/assets/0f3bd398-a94a-45f2-9108-6f635934bc6c" />

---

Also I feel like it could be a reasonable idea [which this PR currently does *not* do (yet?)] to also add the number of components in the middle, i.e. `downloading components` would further become `downloading 6 components` then.

---

I do expect some CI failure as `component(s)` appears in some ui test – but I haven’t yet figured out how to run tests locally correctly, and it’s getting too late today.