### PR TITLE
Add powerpc64 unknown linux musl support

### DIFF
--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -34,6 +34,7 @@ jobs: # skip-main skip-pr skip-stable
           - x86_64-unknown-netbsd          # skip-pr skip-main
           - x86_64-unknown-illumos         # skip-pr skip-main
           - powerpc-unknown-linux-gnu      # skip-pr skip-main
+          - powerpc64-unknown-linux-musl   # skip-pr skip-main skip-stable
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-main
           - powerpc64le-unknown-linux-musl # skip-pr skip-main
           - s390x-unknown-linux-gnu        # skip-pr skip-main

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -47,6 +47,8 @@ rustup/dist/powerpc-unknown-linux-gnu/rustup-init
 rustup/dist/powerpc-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/powerpc64-unknown-linux-gnu/rustup-init
 rustup/dist/powerpc64-unknown-linux-gnu/rustup-init.sha256
+rustup/dist/powerpc64-unknown-linux-musl/rustup-init
+rustup/dist/powerpc64-unknown-linux-musl/rustup-init.sha256
 rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init
 rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/powerpc64le-unknown-linux-musl/rustup-init

--- a/ci/docker/powerpc64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-musl/Dockerfile
@@ -1,0 +1,9 @@
+FROM rust-powerpc64-unknown-linux-musl
+
+# Building `aws-lc-rs` for Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
+ENV CC_powerpc64_unknown_linux_musl=powerpc64-unknown-linux-musl-gcc \
+    CARGO_TARGET_POWERPC64_UNKNOWN_LINUX_MUSL_LINKER=powerpc64-unknown-linux-musl-gcc \
+    RUSTFLAGS="-C target-feature=+crt-static -C link-arg=-lgcc"

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -33,7 +33,8 @@ case "$TARGET" in
   mips64el-unknown-linux-gnuabi64) image=dist-mips64el-linux ;;
   mipsel-unknown-linux-gnu)        image=dist-mipsel-linux ;;
   powerpc-unknown-linux-gnu)       image=dist-powerpc-linux ;;
-  powerpc64-unknown-linux-gnu)     image=dist-powerpc64-linux ;;
+  powerpc64-unknown-linux-gnu)     image=dist-powerpc64-linux-gnu ;;
+  powerpc64-unknown-linux-musl)    image=dist-powerpc64-linux-musl ;;
   powerpc64le-unknown-linux-gnu)   image=dist-powerpc64le-linux-gnu ;;
   powerpc64le-unknown-linux-musl)  image=dist-powerpc64le-linux-musl ;;
   s390x-unknown-linux-gnu)         image=dist-s390x-linux ;;

--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -153,6 +153,8 @@ You can manually download `rustup-init` for a given target from
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc-unknown-linux-gnu/rustup-init.sha256)
 - [powerpc64-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/powerpc64-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64-unknown-linux-gnu/rustup-init.sha256)
+- [powerpc64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/powerpc64-unknown-linux-musl/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64-unknown-linux-musl/rustup-init.sha256)
 - [powerpc64le-unknown-linux-gnu](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-gnu/rustup-init.sha256)
 - [powerpc64le-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/powerpc64le-unknown-linux-musl/rustup-init)

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -264,6 +264,10 @@ const TRIPLE_LOONGARCH64_UNKNOWN_LINUX: &str = "loongarch64-unknown-linux-gnu";
 #[cfg(all(not(windows), target_env = "musl"))]
 const TRIPLE_LOONGARCH64_UNKNOWN_LINUX: &str = "loongarch64-unknown-linux-musl";
 #[cfg(all(not(windows), not(target_env = "musl")))]
+const TRIPLE_POWERPC64_UNKNOWN_LINUX: &str = "powerpc64-unknown-linux-gnu";
+#[cfg(all(not(windows), target_env = "musl"))]
+const TRIPLE_POWERPC64_UNKNOWN_LINUX: &str = "powerpc64-unknown-linux-musl";
+#[cfg(all(not(windows), not(target_env = "musl")))]
 const TRIPLE_POWERPC64LE_UNKNOWN_LINUX: &str = "powerpc64le-unknown-linux-gnu";
 #[cfg(all(not(windows), target_env = "musl"))]
 const TRIPLE_POWERPC64LE_UNKNOWN_LINUX: &str = "powerpc64le-unknown-linux-musl";
@@ -512,6 +516,7 @@ impl TargetTriple {
                     TRIPLE_AARCH64_UNKNOWN_LINUX
                 }),
                 (b"Linux", b"loongarch64") => Some(TRIPLE_LOONGARCH64_UNKNOWN_LINUX),
+                (b"Linux", b"ppc64") => Some(TRIPLE_POWERPC64_UNKNOWN_LINUX),
                 (b"Linux", b"ppc64le") => Some(TRIPLE_POWERPC64LE_UNKNOWN_LINUX),
                 (b"Darwin", b"x86_64") => Some("x86_64-apple-darwin"),
                 (b"Darwin", b"i686") => Some("i686-apple-darwin"),


### PR DESCRIPTION
Hi, this target is now tier 2 with host tools (since yesterday). The PR adds support for it in rustup. Since the job for the `powerpc64-unknown-linux-gnu` build was renamed at the same time, I took the freedom to also rename it here.

I built the `rustup-init` binary cross using the Docker image from an x86_64 host and ran it on the target:

<details>
<summary>rustup-init on the target</summary>

```
aelin@algol /tmp> ./rustup-init

Welcome to Rust!

This will download and install the official compiler for the Rust
programming language, and its package manager, Cargo.

Rustup metadata and toolchains will be installed into the Rustup
home directory, located at:

  /home/aelin/.rustup

This can be modified with the RUSTUP_HOME environment variable.

The Cargo home directory is located at:

  /home/aelin/.cargo

This can be modified with the CARGO_HOME environment variable.

The cargo, rustc, rustup and other commands will be added to
Cargo's bin directory, located at:

  /home/aelin/.cargo/bin

This path will then be added to your PATH environment variable by
modifying the profile files located at:

  /home/aelin/.profile
  /home/aelin/.config/fish/conf.d/rustup.fish

You can uninstall at any time with rustup self uninstall and
these changes will be reverted.

Current installation options:


   default host triple: powerpc64-unknown-linux-musl
     default toolchain: stable (default)
               profile: default
  modify PATH variable: yes

1) Proceed with standard installation (default - just press enter)
2) Customize installation
3) Cancel installation
>2

I'm going to ask you the value of each of these installation options.
You may simply press the Enter key to leave unchanged.

Default host triple? [powerpc64-unknown-linux-musl]


Default toolchain? (stable/beta/nightly/none) [stable]
nightly

Profile (which tools and data to install)? (minimal/default/complete) [default]
minimal

Modify PATH variable? (Y/n)
n


Current installation options:


   default host triple: powerpc64-unknown-linux-musl
     default toolchain: nightly
               profile: minimal
  modify PATH variable: no

1) Proceed with selected options (default - just press enter)
2) Customize installation
3) Cancel installation
>1

info: profile set to minimal
info: setting default host triple to powerpc64-unknown-linux-musl
info: syncing channel updates for nightly-powerpc64-unknown-linux-musl
info: latest update on 2026-01-26 for version 1.95.0-nightly (873d4682c 2026-01-25)
info: downloading 3 components
        cargo installed                       10.72 MiB
     rust-std installed                       23.88 MiB
        rustc installed                      102.95 MiB                                                                                                                                                              info: default toolchain set to nightly-powerpc64-unknown-linux-musl

  nightly-powerpc64-unknown-linux-musl installed - rustc 1.95.0-nightly (873d4682c 2026-01-25)


Rust is installed now. Great!

To get started you need Cargo's bin directory ($HOME/.cargo/bin) in your PATH
environment variable. This has not been done automatically.

To configure your current shell, you need to source
the corresponding env file under $HOME/.cargo.

This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
source $"($nu.home-path)/.cargo/env.nu"  # For nushell
source "$HOME/.cargo/env.tcsh"  # For tcsh
. "$HOME/.cargo/env.ps1"        # For pwsh
source "$HOME/.cargo/env.xsh"   # For xonsh
```

</details>