### PR TITLE
fix(cli/rustup-mode): improve exit code of `rustup check`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -927,8 +927,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
         update_available = true;
     }
 
-    let exit_status = if update_available { 0 } else { 1 };
-    Ok(ExitCode(exit_status))
+    Ok(ExitCode(if update_available { 100 } else { 0 }))
 }
 
 async fn update(

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -180,7 +180,7 @@ async fn check_updates_none() {
     cx.config
         .expect(["rustup", "check"])
         .await
-        .is_err()
+        .is_ok()
         .with_stdout(snapbox::str![[r#"
 stable-[HOST_TRIPLE] - up to date: 1.1.0 (hash-stable-1.1.0)
 beta-[HOST_TRIPLE] - up to date: 1.2.0 (hash-beta-1.2.0)
@@ -205,7 +205,7 @@ async fn check_updates_some() {
     cx.config
         .expect(["rustup", "check"])
         .await
-        .is_ok()
+        .has_code(100)
         .with_stdout(snapbox::str![[r#"
 stable-[HOST_TRIPLE] - update available: 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
 beta-[HOST_TRIPLE] - update available: 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
@@ -230,7 +230,7 @@ async fn check_updates_self() {
         .expect(["rustup", "check"])
         .await
         .extend_redactions([("[TEST_VERSION]", test_version)])
-        .is_ok()
+        .has_code(100)
         .with_stdout(snapbox::str![[r#"
 rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
 
@@ -252,7 +252,7 @@ async fn check_updates_self_no_change() {
     cx.config
         .expect(["rustup", "check"])
         .await
-        .is_err()
+        .is_ok()
         .with_stdout(snapbox::str![[r#"
 rustup - Up to date : [CURRENT_VERSION]
 
@@ -272,7 +272,7 @@ async fn check_updates_with_update() {
         cx.config
             .expect(["rustup", "check"])
             .await
-            .is_err()
+            .is_ok()
             .with_stdout(snapbox::str![[r#"
 stable-[HOST_TRIPLE] - up to date: 1.0.0 (hash-stable-1.0.0)
 beta-[HOST_TRIPLE] - up to date: 1.1.0 (hash-beta-1.1.0)
@@ -285,7 +285,7 @@ nightly-[HOST_TRIPLE] - up to date: 1.2.0 (hash-nightly-1)
     cx.config
         .expect(["rustup", "check"])
         .await
-        .is_ok()
+        .has_code(100)
         .with_stdout(snapbox::str![[r#"
 stable-[HOST_TRIPLE] - update available: 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
 beta-[HOST_TRIPLE] - update available: 1.1.0 (hash-beta-1.1.0) -> 1.2.0 (hash-beta-1.2.0)
@@ -296,7 +296,7 @@ nightly-[HOST_TRIPLE] - update available: 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-
     cx.config
         .expect(["rustup", "check"])
         .await
-        .is_ok()
+        .has_code(100)
         .with_stdout(snapbox::str![[r#"
 stable-[HOST_TRIPLE] - update available: 1.0.0 (hash-stable-1.0.0) -> 1.1.0 (hash-stable-1.1.0)
 beta-[HOST_TRIPLE] - up to date: 1.2.0 (hash-beta-1.2.0)

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -276,7 +276,7 @@ async fn with_no_toolchain_doesnt_hang() {
     )
     .is_ok();
 
-    cx.config.expect(["rustup", "check"]).await.is_err();
+    cx.config.expect(["rustup", "check"]).await.is_ok();
 }
 
 #[tokio::test]
@@ -296,7 +296,7 @@ async fn with_no_toolchain_doesnt_hang_with_concurrent_downloads_override() {
     cx.config
         .expect_with_env(["rustup", "check"], [("RUSTUP_CONCURRENT_DOWNLOADS", "2")])
         .await
-        .is_err();
+        .is_ok();
 }
 
 #[tokio::test]

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -35,7 +35,7 @@ fn run_input_with_env(config: &Config, args: &[&str], input: &str, env: &[(&str,
     let out = child.wait_with_output().unwrap();
 
     Assert::new(SanitizedOutput {
-        ok: out.status.success(),
+        status: out.status.code(),
         stdout: String::from_utf8(out.stdout).unwrap(),
         stderr: String::from_utf8(out.stderr).unwrap(),
     })

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -83,7 +83,7 @@ async fn rustup_check_updates_none() {
             None,
         ))
         .with_stderr("")
-        .is_err();
+        .is_ok();
 }
 
 #[tokio::test]
@@ -108,7 +108,7 @@ async fn rustup_check_updates_some() {
             None,
         ))
         .with_stderr("")
-        .is_ok();
+        .has_code(100);
 }
 
 #[test]


### PR DESCRIPTION
Closes #4681.

Following the feedback on #4340 and particularly the previous discussion in https://github.com/rust-lang/rustup/issues/4681#issuecomment-3813523464, this change follows the convention of DNF where `0` is returned when no updates and `100` when updates are available.