### PR TITLE
Preserve partial downloads on network failure

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,8 @@ pub struct OperationError(pub anyhow::Error);
 pub enum RustupError {
     #[error("partially downloaded file may have been damaged and was removed, please try again")]
     BrokenPartialFile,
+    #[error("partially downloaded file was kept for resumption, please try again")]
+    IncompletePartialFile,
     #[error("component download failed for {0}")]
     ComponentDownloadFailed(String),
     #[error("failure removing component '{name}', directory does not exist: '{}'", .path.display())]


### PR DESCRIPTION
Closes #4448.

If `resume_from_partial` is set to true, it short-circuits, ensuring the `remove_file(path)` is not called.