### PR TITLE
Replace `$nu.home-path` with `~` in `env.nu` file

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -454,7 +454,7 @@ the corresponding `env` file under {cargo_home}.
 This is usually done by running one of the following (note the leading DOT):
     . "{cargo_home}/env"            # For sh/bash/zsh/ash/dash/pdksh
     source "{cargo_home}/env.fish"  # For fish
-    source $"{cargo_home_nushell}/env.nu"  # For nushell
+    source "{cargo_home_nushell}/env.nu"  # For nushell
     source "{cargo_home}/env.tcsh"  # For tcsh
     . "{cargo_home}/env.ps1"        # For pwsh
     source "{cargo_home}/env.xsh"   # For xonsh

--- a/src/cli/self_update/env.nu
+++ b/src/cli/self_update/env.nu
@@ -1,2 +1,2 @@
 use std/util "path add"
-path add $"{cargo_bin}"
+path add "{cargo_bin}"

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -317,7 +317,7 @@ impl UnixShell for Nu {
     }
 
     fn cargo_home_str(&self, process: &Process) -> Result<Cow<'static, str>> {
-        cargo_home_str_with_home("($nu.home-path)", process)
+        cargo_home_str_with_home("~", process)
     }
 }
 

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -311,7 +311,7 @@ impl UnixShell for Nu {
 
     fn source_string(&self, process: &Process) -> Result<String> {
         Ok(format!(
-            r#"source $"{}/env.nu""#,
+            r#"source "{}/env.nu""#,
             self.cargo_home_str(process)?
         ))
     }


### PR DESCRIPTION
`$nu.home-path` was renamed to `$nu.home-dir` in the latest nushell 0.110 release (https://github.com/nushell/nushell/pull/17129).

This PR replaces `$nu.home-path` with `~`, so that both old and new versions of nushell remain compatible.

`~` is a shorthand for `$nu.home-dir`, as per [nushell's doc](https://www.nushell.sh/book/special_variables.html#nu).