### PR TITLE
chore(deps): downgrade `openssl-src` to 300.5.4+3.5.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,9 +1538,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.5+3.5.5"
+version = "300.5.4+3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
 dependencies = [
  "cc",
 ]
@@ -2193,6 +2193,7 @@ dependencies = [
  "libc",
  "opener",
  "openssl",
+ "openssl-src",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,9 @@ opener = "0.8.0"
 # `openssl` is used by `curl` or `reqwest` backend although it isn't imported by rustup: this
 # allows controlling the vendoring status without exposing the presence of the download crate.
 openssl = { version = "0.10", optional = true }
+# HACK: Temporarily pinned due to ppc64 ELFv1/v2 ABI issue in 300.5.5, to be
+# removed when <https://github.com/openssl/openssl/issues/29815> lands.
+openssl-src = { version = "=300.5.4", optional = true }
 opentelemetry = { version = "0.31", optional = true }
 opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"], optional = true }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"], optional = true }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -554,10 +554,11 @@ mod curl {
 
 #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
 mod reqwest_be {
-    use std::io;
+    #[cfg(feature = "reqwest-rustls-tls")]
+    use std::sync::Arc;
     #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
-    use std::sync::{Arc, OnceLock};
-    use std::time::Duration;
+    use std::sync::OnceLock;
+    use std::{io, time::Duration};
 
     #[cfg(all(feature = "reqwest-rustls-tls", not(target_os = "android")))]
     use crate::anchors::RUSTUP_TRUST_ANCHORS;


### PR DESCRIPTION
Closes #4707, verified in https://github.com/rust-lang/rustup/actions/runs/21796260865/job/62884244255?pr=4708.