### PR TITLE
fix(dist/manifest): sort keys when serializing `Manifest`

### DIFF
--- a/src/dist/manifest/tests/channel-rust-nightly-example-reordered.toml
+++ b/src/dist/manifest/tests/channel-rust-nightly-example-reordered.toml
@@ -1,0 +1,59 @@
+manifest-version = "2"
+date = "2015-10-10"
+[pkg.rustc]
+version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+[pkg.cargo.target.x86_64-unknown-linux-gnu]
+available = true
+url = "example.com"
+hash = "..."
+[pkg.rustc.target.x86_64-unknown-linux-gnu]
+available = true
+url = "example.com"
+hash = "..."
+[pkg.cargo]
+version = "cargo 0.4.0-nightly (553b363 2015-08-03)"
+[pkg.rust-std]
+version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+[pkg.rust-std.target.x86_64-unknown-linux-gnu]
+available = true
+url = "example.com"
+hash = "..."
+[pkg.rust-std.target.x86_64-unknown-linux-musl]
+available = true
+url = "example.com"
+hash = "..."
+[pkg.rust-std.target.i686-unknown-linux-gnu]
+available = true
+url = "example.com"
+hash = "..."
+[pkg.rust-docs]
+version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+[pkg.rust-docs.target.x86_64-unknown-linux-gnu]
+available = true
+hash = "..."
+url = "example.com"
+[pkg.rust]
+version = "rustc 1.3.0 (9a92aaf19 2015-09-15)"
+[pkg.rust.target.x86_64-unknown-linux-gnu]
+available = true
+url = "example.com"
+hash = "..."
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rustc"
+target = "x86_64-unknown-linux-gnu"
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rust-docs"
+target = "x86_64-unknown-linux-gnu"
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "cargo"
+target = "x86_64-unknown-linux-gnu"
+[[pkg.rust.target.x86_64-unknown-linux-gnu.components]]
+pkg = "rust-std"
+target = "x86_64-unknown-linux-gnu"
+# extensions are rust-std or rust-docs that aren't in the rust tarball's component list
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-std"
+target = "x86_64-unknown-linux-musl"
+[[pkg.rust.target.x86_64-unknown-linux-gnu.extensions]]
+pkg = "rust-std"
+target = "i686-unknown-linux-gnu"

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -725,7 +725,9 @@ impl TryFrom<&ToolchainName> for ToolchainDesc {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(
+    Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize, PartialOrd, Ord,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum Profile {
     Minimal,

--- a/src/test/dist.rs
+++ b/src/test/dist.rs
@@ -1,7 +1,7 @@
 //! Tools for building and working with the filesystem of a mock Rust
 //! distribution server, with v1 and v2 manifests.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::{self, File};
 use std::io::{self, Read, Write};
 use std::path::{Path, PathBuf};
@@ -771,15 +771,15 @@ impl MockDistServer {
         let mut manifest = Manifest {
             manifest_version: ManifestVersion::V2,
             date: channel.date.clone(),
-            renames: HashMap::default(),
-            packages: HashMap::default(),
-            reverse_renames: HashMap::default(),
-            profiles: HashMap::default(),
+            renames: BTreeMap::default(),
+            packages: BTreeMap::default(),
+            reverse_renames: BTreeMap::default(),
+            profiles: BTreeMap::default(),
         };
 
         // [pkg.*]
         for package in &channel.packages {
-            let mut targets = HashMap::default();
+            let mut targets = BTreeMap::default();
 
             // [pkg.*.target.*]
             for target in &package.targets {


### PR DESCRIPTION
Closes #4715.

This is a quick and dirty fix by manually replacing all `HashMap` references with `BTreeMap` when relevant. An additional regression test has been added as well to demonstrate the establishment of what we hope to be the canonical form for the manifest file saved on the disk.

Many thanks again for @loynoir's report and pointers.