### PR TITLE
fix(diskio): fall back to single-threaded unpacking 

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -40,7 +40,7 @@ fn main() -> Result<ExitCode> {
     let process = Process::os();
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .worker_threads(process.io_thread_count()?)
+        .worker_threads(process.io_thread_count()?.into())
         .build()
         .unwrap();
 

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -163,3 +163,46 @@ fn test_complete_file_immediate() {
 fn test_complete_file_threaded() {
     test_complete_file("2").unwrap()
 }
+
+#[test]
+fn test_effective_thread_count() {
+    use super::{LOW_MEMORY_THRESHOLD, effective_thread_count};
+    use crate::process::IoThreadCount::{Default, UserSpecified};
+
+    // Already single-threaded: no change regardless of budget
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 16, Default(1)),
+        1
+    );
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 16, Default(0)),
+        0
+    );
+
+    // Below threshold: forced to single-threaded
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 2, Default(8)),
+        1
+    );
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 2, Default(4)),
+        1
+    );
+
+    // At or above threshold: thread count unchanged
+    assert_eq!(effective_thread_count(LOW_MEMORY_THRESHOLD, Default(4)), 4);
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD * 2, Default(8)),
+        8
+    );
+
+    // User-specified threads are always respected
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 16, UserSpecified(4)),
+        4
+    );
+    assert_eq!(
+        effective_thread_count(LOW_MEMORY_THRESHOLD / 2, UserSpecified(8)),
+        8
+    );
+}

--- a/src/install.rs
+++ b/src/install.rs
@@ -41,7 +41,7 @@ impl InstallMethod<'_, '_> {
         // Initialize rayon for use by the remove_dir_all crate limiting the number of threads.
         // This will error if rayon is already initialized but it's fine to ignore that.
         let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(self.cfg().process.io_thread_count()?)
+            .num_threads(self.cfg().process.io_thread_count()?.into())
             .build_global();
         match &self {
             InstallMethod::Copy { .. }


### PR DESCRIPTION
When`ram_budget`< 512MB, fall back to single-threaded unpacking to avoid OOM on memory-constrained systems.

Rustup OOMs on systems with <1GB RAM because it spawns multiple I/O threads for unpacking regardless of available memory. The Threaded executor uses far more memory than its buffer pool budget tracks. This PR adds a 512MB `ram_budget` threshold below which rustup falls back to single-threaded unpacking, which peaks at ~110MB.

Fixes #3125