### PR TITLE
Ensure the server honors range requests to prevent download corruption

### DIFF
--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -587,9 +587,13 @@ mod reqwest_be {
             .await
             .context("error downloading file")?;
 
-        if !res.status().is_success() {
-            let code: u16 = res.status().into();
-            return Err(anyhow!(DownloadError::HttpStatus(u32::from(code))));
+        // If a download is being resumed, we expect a 206 response;
+        // otherwise, if the server ignored the range header,
+        // an error is thrown preemptively to avoid corruption.
+        let status = res.status().into();
+        match (resume_from > 0, status) {
+            (true, 206) | (false, 200..=299) => {}
+            _ => return Err(DownloadError::HttpStatus(u32::from(status)).into()),
         }
 
         if let Some(len) = res.content_length() {


### PR DESCRIPTION
Fixes #4710.

As discussed in the issue, I am still unsure what position rustup should take: should we simply throw an error, or should we go a step further and restart the download from scratch?

I am more inclined toward the former, since correctly handling the range header should be the server's responsibility.
This would only become an issue if `RUSTUP_DIST_SERVER` is overridden; of course, this is the case for all forks of rustup (e.g., `elan`, or `juliaup`).

On another note, I would appreciate feedback on the added test.
I introduced a small workaround by adding a variable to [`serve_contents`](https://github.com/rust-lang/rustup/blob/4cc92aad109e18ee5ced2a82a7a2fbceaec023cc/src/download/tests.rs#L348-L353) to allow the mock server to ignore the range request. Is there a cleaner way to achieve this?