### PR TITLE
hack(ci/linux): disable BuildKit when building local images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -636,7 +636,10 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            # HACK: A possible regression in Docker will make this step fail
+            # when BuildKit is enabled, so disabling it for now. See
+            # <https://github.com/rust-lang/rustup/issues/4720> for more info.
+            DOCKER_BUILDKIT=0 docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -805,7 +808,10 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            # HACK: A possible regression in Docker will make this step fail
+            # when BuildKit is enabled, so disabling it for now. See
+            # <https://github.com/rust-lang/rustup/issues/4720> for more info.
+            DOCKER_BUILDKIT=0 docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -999,7 +1005,10 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            # HACK: A possible regression in Docker will make this step fail
+            # when BuildKit is enabled, so disabling it for now. See
+            # <https://github.com/rust-lang/rustup/issues/4720> for more info.
+            DOCKER_BUILDKIT=0 docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -636,7 +636,7 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -662,7 +662,7 @@ jobs:
             --volume "${PWD}":/checkout:ro \
             --volume "${PWD}"/target:/checkout/target \
             --workdir /checkout \
-            "${DOCKER}" \
+            "rustup/$DOCKER" \
             -c 'PATH="${PATH}":/rustc-sysroot/bin bash ci/run.bash'
       - name: Upload the built artifact
         uses: actions/upload-artifact@v6
@@ -805,7 +805,7 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -831,7 +831,7 @@ jobs:
             --volume "${PWD}":/checkout:ro \
             --volume "${PWD}"/target:/checkout/target \
             --workdir /checkout \
-            "${DOCKER}" \
+            "rustup/$DOCKER" \
             -c 'PATH="${PATH}":/rustc-sysroot/bin bash ci/run.bash'
       - name: Upload the built artifact
         uses: actions/upload-artifact@v6
@@ -999,7 +999,7 @@ jobs:
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -1025,7 +1025,7 @@ jobs:
             --volume "${PWD}":/checkout:ro \
             --volume "${PWD}"/target:/checkout/target \
             --workdir /checkout \
-            "${DOCKER}" \
+            "rustup/$DOCKER" \
             -c 'PATH="${PATH}":/rustc-sysroot/bin bash ci/run.bash'
       - name: Upload the built artifact
         uses: actions/upload-artifact@v6

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -129,7 +129,7 @@ jobs: # skip-main skip-pr skip-stable
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:
@@ -155,7 +155,7 @@ jobs: # skip-main skip-pr skip-stable
             --volume "${PWD}":/checkout:ro \
             --volume "${PWD}"/target:/checkout/target \
             --workdir /checkout \
-            "${DOCKER}" \
+            "rustup/$DOCKER" \
             -c 'PATH="${PATH}":/rustc-sysroot/bin bash ci/run.bash'
       - name: Upload the built artifact
         uses: actions/upload-artifact@v6

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -129,7 +129,10 @@ jobs: # skip-main skip-pr skip-stable
       - name: Maybe build a docker from there
         run: |
           if [ -f "ci/docker/$DOCKER/Dockerfile" ]; then
-            docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
+            # HACK: A possible regression in Docker will make this step fail
+            # when BuildKit is enabled, so disabling it for now. See
+            # <https://github.com/rust-lang/rustup/issues/4720> for more info.
+            DOCKER_BUILDKIT=0 docker build -t "rustup/$DOCKER" -f "ci/docker/${DOCKER}/Dockerfile" .
           fi
       - name: Run the build within the docker image
         env:


### PR DESCRIPTION
Closes #4720.

PS: If Docker wants us to use BuildKit forever, at least it should reach feature parity, eh?