### PR TITLE
Add `--override` flag in `rustup toolchain install`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -402,6 +402,10 @@ struct UpdateOpts {
     /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
     #[arg(long)]
     force_non_host: bool,
+
+    /// Set the installed toolchain as the override for the current directory
+    #[arg(long)]
+    r#override: bool,
 }
 
 #[derive(Debug, Default, Args)]
@@ -946,6 +950,7 @@ async fn update(
     let self_update_mode = SelfUpdateMode::from_cfg(cfg)?;
     let should_self_update = !opts.no_self_update;
     let force_non_host = opts.force_non_host;
+    let set_override = opts.r#override;
     cfg.profile_override = opts.profile;
 
     let cfg = &cfg;
@@ -1003,6 +1008,11 @@ async fn update(
                 PackageUpdate::Toolchain(desc.clone()),
                 Ok(status.clone()),
             )?;
+
+            if set_override {
+                cfg.make_override(&cfg.current_dir, &desc.clone().into())?;
+            }
+
             if cfg.get_default()?.is_none() && matches!(status, UpdateStatus::Installed) {
                 cfg.set_default(Some(&desc.into()))?;
             }

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="614px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -60,29 +60,31 @@
 </tspan>
     <tspan x="10px" y="370px"><tspan>                               https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--override</tspan><tspan>               Set the installed toolchain as the override for the current directory</tspan>
 </tspan>
-    <tspan x="10px" y="406px">
+    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="424px">
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Fixes #3105.

With this flag, instead of running `rustup toolchain install <some-toolchain>` followed by `rustup override set <some-toolchain>`, both steps can be combined into a single command: `rustup toolchain install <some-toolchain> --override`.

Feedback on the wording of the doc comment is welcome.