### PR TITLE
Fix the default number of `RUSTUP_CONCURRENT_DOWNLOADS` in the documentation

### DIFF
--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -69,7 +69,7 @@
 - `RUSTUP_DOWNLOAD_TIMEOUT` *unstable* (default: 180). Allows to override the default
   timeout (in seconds) for downloading components.
 
-- `RUSTUP_CONCURRENT_DOWNLOADS` *unstable* (default: the number of components to download). Controls the number of
+- `RUSTUP_CONCURRENT_DOWNLOADS` *unstable* (default: 2). Controls the number of
   downloads made concurrently.
 
 - `RUSTUP_TOOLCHAIN_SOURCE` *unstable*. Set by rustup to tell proxied tools how `RUSTUP_TOOLCHAIN` was determined. Non-rustup tools should not set this environment variable, except insofar as to mirror an earlier invocation from rustup.


### PR DESCRIPTION
The environment variable `RUSTUP_CONCURRENT_DOWNLOADS` was introduced in #4450.
Its default was later changed in #4474 (see [here](https://github.com/rust-lang/rustup/pull/4474/changes#diff-aa51ee662316e678d658bb58b30e2de77d486689843c8532419f5f8fd54fe1aeR161)).

This PR updates the documentation accordingly.