### PR TITLE
Implement dark mode for rustup.rs website

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -226,7 +226,7 @@
 </p>
 
 <p id="about">
-  <img src="https://rust-lang.org/logos/rust-logo-blk.svg" alt="" />
+  <img class="rust-logo" src="https://rust-lang.org/logos/rust-logo-blk.svg" alt="" />
   rustup is an official Rust project.
   <br/>
   <a href="https://rust-lang.github.io/rustup/installation/other.html">other installation options</a>

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -216,25 +216,19 @@ hr {
 #platform-instructions-win-arm64 button.copy-button,
 #platform-instructions-default button.copy-button,
 #platform-instructions-unknown button.copy-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    aspect-ratio: 51 / 58;
     height: 58px;
     margin: 0;
-    padding: 0 5px 0 5px;
     border-width: 0px;
     cursor: pointer;
 }
 
-#platform-instructions-unix div.copy-icon,
-#platform-instructions-win32 div.copy-icon,
-#platform-instructions-win64 div.copy-icon,
-#platform-instructions-win-arm64 div.copy-icon,
-#platform-instructions-default div.copy-icon,
-#platform-instructions-unknown div.copy-icon {
-    position: relative;
-    width: fit-content;
-    height: fit-content;
-    top: 27px;
-    left: 23px;
-    transform: translate(-50%, -50%);
+div.copy-icon {
+    transform: translateX(3px);
 }
 
 #platform-instructions-unix div.copy-button-text,
@@ -244,13 +238,14 @@ hr {
 #platform-instructions-default div.copy-button-text,
 #platform-instructions-unknown div.copy-button-text {
     transition: opacity 0.2s ease-in-out;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: 8px;
+    color: var(--rustup-teal);
+    font-size: 14px;
     opacity: 0;
-    font-size: 10px;
-    color: var(--copy-button-text-color);
-    width: 41px;
-    height: 15px;
-    position: relative;
-    top: 6px;
 }
 
 #platform-instructions-win32 a.windows-download,

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -40,10 +40,30 @@
         url("fonts/AlfaSlabOne-Regular.woff") format('woff');
 }
 
+:root {
+    --rustup-teal: #0b7261;
+    --rustup-teal-hover: #0d8b75;
+    --gray: #515151;
+    --white: white;
+    --black: black;
+
+    --body-background-color: var(--white);
+    --body-color: var(--gray);
+    --heading-color: var(--black);
+    --code-color: var(--black);
+    --code-shadow-color: #f1eeee;
+    --link-color: var(--rustup-teal);
+    --link-color-hover: var(--rustup-teal-hover);
+    --hr-color: var(--rustup-teal);
+    --platform-button-background-color: var(--gray);
+    --platform-button-color: var(--white);
+    --copy-button-text-color: var(--rustup-teal);
+}
+
 body {
     margin-top: 2em;
-    background-color: white;
-    color: #515151;
+    background-color: var(--body-background-color);
+    color: var(--body-color);
     font-family: "Fira Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-weight: 300;
     font-size: 25px;
@@ -62,7 +82,7 @@ header > div {
 
 header > div > h1 {
     font-family: "Alfa Slab One", serif;
-    color: black;
+    color: var(--heading-color);
     font-size: 4rem;
     margin-bottom: 0;
     margin-top: 1rem;
@@ -72,18 +92,18 @@ header > div > h1 {
 }
 
 header > div > h2 {
-    color: black;
+    color: var(--heading-color);
     font-size: 2rem;
     font-weight: 300;
 }
 
 a {
-    color: #0b7261;
+    color: var(--link-color);
     text-decoration: underline;
 }
 
 a:hover {
-    color: #0d8b75;
+    color: var(--link-color-hover);
     text-decoration: underline;
 }
 
@@ -119,7 +139,7 @@ body#idx p.other-platforms-help {
 }
 
 hr {
-    border-color: #0b7261;
+    border-color: var(--hr-color);
     margin-top: 2em;
     margin-bottom: 2em;
 }
@@ -134,18 +154,18 @@ hr {
 }
 
 .rustup-command::before {
-    color: black;
+    color: var(--code-color);
     content: " $ ";
-	margin-left: 15px;
+    margin-left: 15px;
 }
 
 .rustup-command {
-    color: black;
+    color: var(--code-color);
     padding: 1rem 1rem 1rem 0;
     height: auto;
     text-align: center;
     border-radius: 3px 0 0 3px;
-    box-shadow: inset 0px 0px 20px 0px #f1eeee;
+    box-shadow: inset 0px 0px 20px 0px var(--code-shadow-color);
     overflow: hidden;
     font-size: 0.6em;
     white-space: nowrap;
@@ -202,7 +222,7 @@ hr {
     transition: opacity 0.2s ease-in-out;
     opacity: 0;
     font-size: 10px;
-    color: #0b7261;
+    color: var(--copy-button-text-color);
     width: 41px;
     height: 15px;
     position: relative;
@@ -246,8 +266,8 @@ hr {
 }
 
 #platform-button {
-    background-color: #515151;
-    color: white;
+    background-color: var(--platform-button-background-color);
+    color: var(--platform-button-color);
     margin-left: auto;
     margin-right: auto;
     padding: 1em;

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -58,6 +58,7 @@
     --platform-button-background-color: var(--gray);
     --platform-button-color: var(--white);
     --copy-button-text-color: var(--rustup-teal);
+    --rust-logo-filter: initital;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -79,6 +80,7 @@
         --platform-button-background-color: var(--gray);
         --platform-button-color: var(--black);
         --copy-button-text-color: var(--rustup-teal);
+        --rust-logo-filter: drop-shadow(1px 0 0px #fff) drop-shadow(0 1px 0 #fff) drop-shadow(-1px 0 0 #fff) drop-shadow(0 -1px 0 #fff);
     }
 }
 
@@ -305,4 +307,8 @@ hr {
 
 .display-inline {
     display: inline;
+}
+
+.rust-logo {
+    filter: var(--rust-logo-filter);
 }

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -60,6 +60,28 @@
     --copy-button-text-color: var(--rustup-teal);
 }
 
+@media (prefers-color-scheme: dark) {
+    :root {
+        --rustup-teal: #2d9b8e;
+        --rustup-teal-hover: #4aad9f;
+        --gray: #e8e6e3;
+        --white: white;
+        --black: #181a1b;
+
+        --body-background-color: var(--black);
+        --body-color: var(--gray);
+        --heading-color: var(--white);
+        --code-color: var(--white);
+        --code-shadow-color: rgba(213, 203, 198, 0.1);
+        --link-color: var(--rustup-teal);
+        --link-color-hover: var(--rustup-teal-hover);
+        --hr-color: var(--rustup-teal);
+        --platform-button-background-color: var(--gray);
+        --platform-button-color: var(--black);
+        --copy-button-text-color: var(--rustup-teal);
+    }
+}
+
 body {
     margin-top: 2em;
     background-color: var(--body-background-color);

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -168,12 +168,7 @@ hr {
     margin-bottom: 2em;
 }
 
-#platform-instructions-unix > p,
-#platform-instructions-win32 > p,
-#platform-instructions-win64 > p,
-#platform-instructions-win-arm64 > p,
-#platform-instructions-default > p,
-#platform-instructions-unknown > p {
+.instructions > p {
     width: 80%;
 }
 
@@ -198,24 +193,14 @@ hr {
     overflow-x: auto;
 }
 
-#platform-instructions-unix div.copy-container,
-#platform-instructions-win32 div.copy-container,
-#platform-instructions-win64 div.copy-container,
-#platform-instructions-win-arm64 div.copy-container,
-#platform-instructions-default div.copy-container,
-#platform-instructions-unknown div.copy-container {
+.instructions div.copy-container {
     display: flex;
     align-items: center;
     width: 90%;
     justify-content: center;
 }
 
-#platform-instructions-unix button.copy-button,
-#platform-instructions-win32 button.copy-button,
-#platform-instructions-win64 button.copy-button,
-#platform-instructions-win-arm64 button.copy-button,
-#platform-instructions-default button.copy-button,
-#platform-instructions-unknown button.copy-button {
+.instructions button.copy-button {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -240,12 +225,7 @@ button.copy-button:hover svg {
     fill: var(--rustup-teal);
 }
 
-#platform-instructions-unix div.copy-button-text,
-#platform-instructions-win32 div.copy-button-text,
-#platform-instructions-win64 div.copy-button-text,
-#platform-instructions-win-arm64 div.copy-button-text,
-#platform-instructions-default div.copy-button-text,
-#platform-instructions-unknown div.copy-button-text {
+.instructions div.copy-button-text {
     transition: opacity 0.2s ease-in-out;
     position: absolute;
     bottom: 100%;
@@ -257,11 +237,7 @@ button.copy-button:hover svg {
     opacity: 0;
 }
 
-#platform-instructions-win32 a.windows-download,
-#platform-instructions-win64 a.windows-download,
-#platform-instructions-win-arm64 a.windows-download,
-#platform-instructions-default a.windows-download,
-#platform-instructions-unknown a.windows-download {
+.instructions a.windows-download {
     display: block;
     padding-top: 0.4rem;
     padding-bottom: 0.6rem;

--- a/www/rustup.css
+++ b/www/rustup.css
@@ -225,10 +225,19 @@ hr {
     margin: 0;
     border-width: 0px;
     cursor: pointer;
+    background-color: var(--code-shadow-color);
 }
 
 div.copy-icon {
     transform: translateX(3px);
+}
+
+div.copy-icon svg {
+    fill: var(--body-color);
+}
+
+button.copy-button:hover svg {
+    fill: var(--rustup-teal);
 }
 
 #platform-instructions-unix div.copy-button-text,


### PR DESCRIPTION
This PR introduces dark mode for rustup.rs website. For simplicity, I haven't added theme-switching logic in javascript. Instead, it relies solely on `@media
  (prefers-color-scheme: dark)` to override css variables for dark mode. The color palette is adapted from the blog's dark mode with a little modification (rust-lang/blog.rust-lang.org#1343).

However, I am not sure whther the I should adjust of the copy button. It currently uses the browser's default styles, which makes the "Copied!" feedback text slightly difficult to read in dark mode.

## Screenshots

before:

<img width="948" height="1512" alt="image" src="https://github.com/user-attachments/assets/29788abf-05e5-4fc7-8768-665d62c46b06" />

<img width="948" height="661" alt="image" src="https://github.com/user-attachments/assets/8b0e2eda-06a4-4693-b275-ea0e3a07fa91" />

after:

<img width="948" height="1512" alt="image" src="https://github.com/user-attachments/assets/6cab6269-b4db-4cc4-8f94-1117804b22d9" />

<img width="948" height="661" alt="image" src="https://github.com/user-attachments/assets/890cd676-291b-493a-b70e-359b8189ac60" />

Close #4209 