### PR TITLE
fix(cli/self-update): fix output format for `rustup check` on TTY

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -865,7 +865,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
 
                 let template = match (current_version, dist_version) {
                     (None, None) => {
-                        let status = "Cannot identify installed or update versions";
+                        let status = "cannot identify installed or update versions";
                         format!("{msg}{error}{status}{error:#}")
                     }
                     (Some(cv), None) => {
@@ -880,7 +880,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
                     (None, Some(dv)) => {
                         let status = "update available";
                         update_a = true;
-                        format!("{msg}{warn}{status}{warn:#}: (Unknown version) -> {dv}")
+                        format!("{msg}{warn}{status}{warn:#}: (unknown version) -> {dv}")
                     }
                 };
                 pb.set_style(ProgressStyle::with_template(template.as_str()).unwrap());

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -915,6 +915,13 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
                 writeln!(t.lock(), "{message}")?;
             }
         }
+        if has_progress_bars {
+            // HACK: Add a final newline to avoid possible display issues with `indicatif` in
+            // certain terminal emulators. Currently, `indicatif` puts a series of spaces at the end
+            // of the line, forcing any output after the progress bar to be on a second line. This
+            // might not be desirable in all cases.
+            writeln!(t.lock())?;
+        }
     }
 
     let self_update_mode = SelfUpdateMode::from_cfg(cfg)?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -892,7 +892,8 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
         // If we are running in a TTY, we can use `buffer_unordered` since
         // displaying the output in the correct order is already handled by
         // `indicatif`.
-        let channels = if !multi_progress_bars.is_hidden() {
+        let has_progress_bars = !multi_progress_bars.is_hidden();
+        let channels = if has_progress_bars {
             channels
                 .buffer_unordered(channels_len)
                 .collect::<Vec<_>>()
@@ -910,7 +911,7 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
             if update_a {
                 update_available = true;
             }
-            if multi_progress_bars.is_hidden() {
+            if !has_progress_bars {
                 writeln!(t.lock(), "{message}")?;
             }
         }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1403,11 +1403,11 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> Result<bool
     Ok(if current_version != available_version {
         writeln!(
             t,
-            "{yellow}Update available{yellow:#} : {current_version} -> {available_version}"
+            "{yellow}update available{yellow:#} : {current_version} -> {available_version}"
         )?;
         true
     } else {
-        writeln!(t, "{green}Up to date{green:#} : {current_version}")?;
+        writeln!(t, "{green}up to date{green:#} : {current_version}")?;
         false
     })
 }

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -62,7 +62,7 @@ async fn update_once_and_check_self_update() {
 
   nightly-[HOST_TRIPLE] installed - 1.3.0 (hash-nightly-2)
 
-rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
+rustup - update available : [CURRENT_VERSION] -> [TEST_VERSION]
 
 "#]])
         .with_stderr(snapbox::str![[r#"
@@ -232,7 +232,7 @@ async fn check_updates_self() {
         .extend_redactions([("[TEST_VERSION]", test_version)])
         .has_code(100)
         .with_stdout(snapbox::str![[r#"
-rustup - Update available : [CURRENT_VERSION] -> [TEST_VERSION]
+rustup - update available : [CURRENT_VERSION] -> [TEST_VERSION]
 
 "#]]);
 }
@@ -254,7 +254,7 @@ async fn check_updates_self_no_change() {
         .await
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-rustup - Up to date : [CURRENT_VERSION]
+rustup - up to date : [CURRENT_VERSION]
 
 "#]]);
 }


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rustup/issues/4560 by manually adding a newline if multi-progress bars from `indicatif` are used.

PS: On my machine this works with or without the newline, I cannot see any difference except when resizing the window/reloading the output afterwards (this doesn't get rid of all trailing whitespaces on the final line that was supposed to push later contents to the following line).

@epage I am curious how this patch will run on your machine 👀 

@djc Could this upstream hack be an acceptable approach towards this issue, or is it better resolved on `indicatif`'s side?