### PR TITLE
dist(rustup-init/sh): update commit shasum in help string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [1.29.0] - Unreleased
+## [1.29.0] - 2026-03-05
 
 This new release of rustup comes with significant changes.
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -33,7 +33,7 @@ RUSTUP_QUIET=no
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.29.0 (2eaaa4bb0 2025-12-11)
+rustup-init 1.29.0 (d243d7d4e 2026-03-04)
 
 The installer for rustup
 

--- a/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
@@ -16,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>rustup-init 1.29.0 (2eaaa4bb0 2025-12-11)</tspan>
+    <tspan x="10px" y="28px"><tspan>rustup-init 1.29.0 (d243d7d4e 2026-03-04)</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
Following #4697, this is the 2nd PR for the `1.29.0` stable release according to our [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#making-a-release).