### PR TITLE
use 'tuple' instead of 'triple' for env overrides

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,20 +3,33 @@ use std::env;
 use platforms::Platform;
 
 fn from_build() -> Result<String, String> {
-    let triple =
-        env::var("RUSTUP_OVERRIDE_BUILD_TRIPLE").unwrap_or_else(|_| env::var("TARGET").unwrap());
-    if Platform::ALL.iter().any(|p| p.target_triple == triple) {
-        Ok(triple)
+    let tuple = if let Ok(tuple) = env::var("RUSTUP_OVERRIDE_BUILD_TUPLE") {
+        tuple
+    } else if let Ok(tuple) = env::var("RUSTUP_OVERRIDE_BUILD_TRIPLE") {
+        println!(
+            "cargo:warning=RUSTUP_OVERRIDE_BUILD_TRIPLE is deprecated; use RUSTUP_OVERRIDE_BUILD_TUPLE instead"
+        );
+        tuple
+    } else if let Ok(tuple) = env::var("TARGET") {
+        tuple
     } else {
-        Err(triple)
+        panic!(
+            "Unable to get target tuple from environment; Be sure that TARGET env var, or its override, is set"
+        )
+    };
+    if Platform::ALL.iter().any(|p| p.target_triple == tuple) {
+        Ok(tuple)
+    } else {
+        Err(tuple)
     }
 }
 
 fn main() {
+    println!("cargo::rerun-if-env-changed=RUSTUP_OVERRIDE_BUILD_TUPLE");
     println!("cargo::rerun-if-env-changed=RUSTUP_OVERRIDE_BUILD_TRIPLE");
     println!("cargo::rerun-if-env-changed=TARGET");
     match from_build() {
-        Ok(triple) => eprintln!("Computed build based on target tuple: {triple:#?}"),
+        Ok(tuple) => eprintln!("Computed build based on target tuple: {tuple:#?}"),
         Err(s) => {
             eprintln!("Unable to parse target '{s}' as a known target tuple");
             eprintln!(

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1285,7 +1285,7 @@ pub(crate) async fn prepare_update(dl_cfg: &DownloadCfg<'_>) -> Result<Option<Pa
     // This ensures that we update to a version that's appropriate for users
     // and also works around if the website messed up the detection.
     // If someone really wants to use another version, they still can enforce
-    // that using the environment variable RUSTUP_OVERRIDE_HOST_TRIPLE.
+    // that using the environment variable RUSTUP_OVERRIDE_HOST_TUPLE.
     #[cfg(windows)]
     let triple = TargetTriple::from_host(dl_cfg.process).unwrap_or(triple);
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -377,8 +377,10 @@ impl TargetTriple {
     }
 
     pub(crate) fn from_build() -> Self {
-        if let Some(triple) = option_env!("RUSTUP_OVERRIDE_BUILD_TRIPLE") {
-            Self::new(triple)
+        if let Some(tuple) = option_env!("RUSTUP_OVERRIDE_BUILD_TUPLE") {
+            Self::new(tuple)
+        } else if let Some(tuple) = option_env!("RUSTUP_OVERRIDE_BUILD_TRIPLE") {
+            Self::new(tuple)
         } else {
             Self::new(env!("TARGET"))
         }
@@ -549,8 +551,10 @@ impl TargetTriple {
             host_triple.map(TargetTriple::new)
         }
 
-        if let Ok(triple) = process.var("RUSTUP_OVERRIDE_HOST_TRIPLE") {
-            Some(Self(triple))
+        if let Ok(tuple) = process.var("RUSTUP_OVERRIDE_HOST_TUPLE") {
+            Some(Self(tuple))
+        } else if let Ok(tuple) = process.var("RUSTUP_OVERRIDE_HOST_TRIPLE") {
+            Some(Self(tuple))
         } else {
             inner()
         }

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -280,7 +280,7 @@ impl Config {
             format!("file://{}", distdir.to_string_lossy()),
         );
         cmd.env("CARGO_HOME", self.cargodir.to_string_lossy().to_string());
-        cmd.env("RUSTUP_OVERRIDE_HOST_TRIPLE", this_host_triple());
+        cmd.env("RUSTUP_OVERRIDE_HOST_TUPLE", this_host_triple());
 
         // These are used in some installation tests that unset RUSTUP_HOME/CARGO_HOME
         cmd.env("HOME", self.homedir.to_string_lossy().to_string());


### PR DESCRIPTION
Redoing https://github.com/rust-lang/rustup/pull/4668 a piece at a time