### PR TITLE
Avoid printing a warning about `settings.toml` on a fresh install

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -596,7 +596,7 @@ pub(crate) async fn install(
         .is_none_or(|s| s != "yes")
     {
         check_existence_of_rustc_or_cargo_in_path(no_prompt, cfg.process)?;
-        check_existence_of_settings_file(cfg.process)?;
+        check_existence_of_settings_file(cfg)?;
     }
 
     #[cfg(unix)]
@@ -738,13 +738,26 @@ fn check_existence_of_rustc_or_cargo_in_path(no_prompt: bool, process: &Process)
     Ok(())
 }
 
-fn check_existence_of_settings_file(process: &Process) -> Result<()> {
-    let rustup_dir = process.rustup_home()?;
+fn check_existence_of_settings_file(cfg: &Cfg<'_>) -> Result<()> {
+    let rustup_dir = cfg.process.rustup_home()?;
     let settings_file_path = rustup_dir.join("settings.toml");
-    if utils::path_exists(&settings_file_path) {
-        warn!("It looks like you have an existing rustup settings file at:");
-        warn!("{}", settings_file_path.display());
-        warn!("Rustup will install the default toolchain as specified in the settings file,");
+    if !utils::path_exists(&settings_file_path) {
+        return Ok(());
+    }
+    let settings_toolchain = cfg
+        .settings_file
+        .with(|s| Ok(s.default_toolchain.clone()))?;
+    // If there is already a non-empty `settings.toml` file (e.g., not a fresh install),
+    // then we warn the user that there was an already configured default toolchain.
+    let Some(default_toolchain) = settings_toolchain else {
+        return Ok(());
+    };
+    warn!("it looks like you have an existing rustup settings file at:");
+    warn!("{}", settings_file_path.display());
+    let inferred =
+        PartialToolchainDesc::from_str("stable")?.resolve(&cfg.get_default_host_triple()?)?;
+    if default_toolchain != inferred.to_string() {
+        warn!("rustup will install the default toolchain as specified in the settings file,");
         warn!("instead of the one inferred from the default host triple.");
     }
     Ok(())

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -659,7 +659,7 @@ version = "12""#,
         .is_ok()
         .with_stderr(snapbox::str![[r#"
 ...
-warn: It looks like you have an existing rustup settings file at:
+warn: it looks like you have an existing rustup settings file at:
 ...
 "#]]);
 }


### PR DESCRIPTION
Fixes (partially) #4744.

Now, in a fresh install, a warning about an already-existing `setting.toml` file is not printed.

Feedback on the wording of the comment is appreciated.