### PR TITLE
fix(rustup-init/sh): prevent passing `--default-host` twice

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -174,6 +174,17 @@ main() {
         exit 1
     fi
 
+    # If a default host has been specified on the command line, we should
+    # revert our own override before calling the installer.
+    for arg in "$@"; do
+        case "$arg" in
+            --default-host|--default-host=*)
+                _default_host_override=
+                break
+                ;;
+        esac
+    done
+
     if [ "$need_tty" = "yes" ] && [ ! -t 0 ]; then
         # The installer is going to want to ask for confirmation by
         # reading stdin.  This script was piped into `sh` though and


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rustup/pull/4497, closes #4755.

My apologies for having misled you @cachebag on this one (I mistakenly thought rustup followed the GNU coreutils conventions, but should we adopt just that in rustup the binary instead?) 🙇 

@abr-egn Please feel free to test the patch locally if you have time 🙏 