### PR TITLE
fix(ci/freebsd): install ca certs to prevent certificate-related issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1361,7 +1361,7 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo \
+          pkg install -y git gmake bash sudo ca_root_nss \
             `# The following packages are required by 'aws-lc-rs':` \
             cmake-core llvm-devel-lite rust-bindgen-cli
         run: |
@@ -1393,7 +1393,7 @@ jobs:
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo \
+          pkg install -y git gmake bash sudo ca_root_nss \
             `# The following packages are required by 'aws-lc-rs':` \
             cmake-core llvm-devel-lite rust-bindgen-cli
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.25"
+version = "1.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52f4c29e2a68ac30c9087e1b772dc9f44a2b66ed44edf2266cf2be9b03dafc1"
+checksum = "4735e9cbde5aac84a5ce588f6b23a90b9b0b528f6c5a8db8a4aff300463a0839"
 dependencies = [
  "cc",
  "libc",
@@ -2179,6 +2179,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "libc",
+ "libz-sys",
  "opener",
  "openssl",
  "openssl-src",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,12 @@ features = [
 ]
 version = "0.61"
 
+# HACK: Temporarily pinned due to `zlib` regression, to be removed when
+# <https://github.com/madler/zlib/issues/1168> is resolved.
+# See: <https://github.com/rust-lang/rustup/issues/4760>
+[target.'cfg(target_os = "freebsd")'.dependencies]
+libz-sys = "=1.1.24"
+
 [dev-dependencies]
 enum-map = "2.5.0"
 http-body-util = "0.1.0"

--- a/ci/actions-templates/freebsd-builds-template.yaml
+++ b/ci/actions-templates/freebsd-builds-template.yaml
@@ -22,7 +22,7 @@ jobs: # skip-main skip-stable
         usesh: true
         copyback: false
         prepare: |
-          pkg install -y git gmake bash sudo \
+          pkg install -y git gmake bash sudo ca_root_nss \
             `# The following packages are required by 'aws-lc-rs':` \
             cmake-core llvm-devel-lite rust-bindgen-cli
         run: |


### PR DESCRIPTION
Basically we are reproducing https://github.com/rust-lang/rustup/pull/3810 here. Not really sure if this is enough to have FreeBSD CI running again...

Closes #4749, also closes #4760, both without touching the gist.

OTOH this won't be closing https://github.com/rust-lang/rustup/issues/4751 since we are pinning onto the old FreeBSD version now.