### PR TITLE
fix(cli/proxy-mode): stop enforcing `quiet: true`

### DIFF
--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -32,7 +32,7 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .skip(1 + toolchain.is_some() as usize)
         .collect();
 
-    let cfg = Cfg::from_env(current_dir, true, process)?;
+    let cfg = Cfg::from_env(current_dir, false, process)?;
     let (toolchain, source) = cfg
         .local_toolchain(match toolchain {
             Some(name) => Some((


### PR DESCRIPTION
Closes #4761.

Not enforcing `--quiet` in `proxy_mode` will not cause any other problems, since if we track the usages of the `Cfg.quiet` flag, so far the only dependency chain I can find in the codebase is the following:

> `Cfg::local_toolchain()` -> `maybe_ensure_active_toolchain()` -> `ensure_active_toolchain()` -> `ensure_installed()` -> `DistOptions` -> `DownloadCfg` -> `DownloadTracker`

Since the difference is so subtle, no breakages has been detected since https://github.com/rust-lang/rustup/commit/63d63ea958236d5a72fb996235dbc81538e62459 until the progress bar was taken into consideration by the verbosity system in v1.29, meaning the flag could have had no impact at all before the fact.

Since the progress bar is intentionally not a visible part of the test snapshots, manual test is advised to make sure the fix is correct. As for myself, I have tested it immediately with a local build and everything looks okay.

cc @bjorn3 