### PR TITLE
Fix zsh completion showing all PATH entries for +toolchain arg

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -13,7 +13,10 @@ use std::{
 use anstream::ColorChoice;
 use anstyle::Style;
 use anyhow::{Context, Error, Result, anyhow};
-use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum, builder::PossibleValue};
+use clap::{
+    Args, CommandFactory, Parser, Subcommand, ValueEnum,
+    builder::{PossibleValue, ValueHint},
+};
 use clap_cargo::style::{CONTEXT, ERROR, GOOD, HEADER, TRANSIENT, WARN};
 use clap_complete::Shell;
 use futures_util::stream::StreamExt;
@@ -97,6 +100,7 @@ struct Rustup {
     #[arg(
         name = "+toolchain",
         value_parser = plus_toolchain_value_parser,
+        value_hint = ValueHint::Other,
     )]
     plus_toolchain: Option<ResolvableToolchainName>,
 


### PR DESCRIPTION
## Problem

When using zsh completions generated by `rustup completions zsh`, typing `rustup <TAB>` shows every executable on `$PATH` alongside the actual rustup subcommands (`install`, `update`, `show`, etc.). This makes the completion menu nearly unusable — thousands of irrelevant entries mixed in with the ~15 real subcommand completions.

## How to reproduce

1. Generate zsh completions: `rustup completions zsh > _rustup`
2. Place `_rustup` on your `$fpath` and reload the shell (`exec zsh`)
3. Type `rustup ` and press `<TAB>`
4. Observe that all commands on `$PATH` appear in the completion list

## Cause

The `+toolchain` optional positional argument in `src/cli/rustup_mode.rs` is defined without a `value_hint`. When `clap_complete` generates zsh completions, arguments with no hint default to `ValueHint::Unknown`, which the zsh generator maps to the `_default` completion action ([source](https://github.com/clap-rs/clap/blob/master/clap_complete/src/aot/shells/zsh.rs#L407)):

```rust
ValueHint::Unknown => "_default",
```

This produces the following in the generated completion script:

```
'::+toolchain -- Release channel (e.g. +stable) or custom toolchain to set override:_default'
```

In zsh, `_default` is a catch-all completer that suggests files and commands on `$PATH`. Since this is an optional positional argument (`::` prefix), zsh offers these completions alongside the subcommand completions every time.

## Fix

This PR adds `value_hint = ValueHint::Other` to the `+toolchain` argument. In the zsh generator, `ValueHint::Other` maps to an empty string — no completion action — which prevents the PATH pollution. Rustup subcommand completions continue to work as expected.

## Future improvement

A more complete solution would be to provide dynamic completions for the `+toolchain` argument using `clap_complete`'s `ArgValueCompleter`, which could call `rustup toolchain list` at completion time to suggest installed toolchains. That would be a larger change involving adoption of `clap_complete`'s dynamic completion infrastructure, so this PR focuses on the minimal fix to eliminate the broken behavior.