### PR TITLE
ci(all-features): correct protoc's `semver` directive field for renovate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1512,10 +1512,11 @@ jobs:
         uses: actions/checkout@v6
       - name: Install rustup stable
         run: rustup toolchain install stable --profile minimal
+      # Protoc is an external dependency of the `otel` feature.
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         env:
-          # renovate: datasource=github-releases depName=protocolbuffers/protobuf versioning=semver
+          # renovate: datasource=github-releases depName=protocolbuffers/protobuf versioning=semver-coerced
           PROTOBUF_VERSION: "34.1"
         with:
           version: ${{ env.PROTOBUF_VERSION }}

--- a/ci/actions-templates/all-features-template.yaml
+++ b/ci/actions-templates/all-features-template.yaml
@@ -24,10 +24,11 @@ jobs: # skip-all
         uses: actions/checkout@v6
       - name: Install rustup stable
         run: rustup toolchain install stable --profile minimal
+      # Protoc is an external dependency of the `otel` feature.
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         env:
-          # renovate: datasource=github-releases depName=protocolbuffers/protobuf versioning=semver
+          # renovate: datasource=github-releases depName=protocolbuffers/protobuf versioning=semver-coerced
           PROTOBUF_VERSION: "34.1"
         with:
           version: ${{ env.PROTOBUF_VERSION }}


### PR DESCRIPTION
Clearly renovate [wasn't happy](https://developer.mend.io/github/rust-lang/rustup/-/job/8a5e5614-b946-48fc-ac62-47cc1c7364b8) about https://github.com/rust-lang/rustup/commit/dfc31fe32f67f5f105ab99267027810213fe4e97:

```json5
{
  currentValue: "34.1",
  datasource: "github-releases",
  depName: "protocolbuffers/protobuf",
  packageName: "protocolbuffers/protobuf",
  replaceString: '# renovate: datasource=github-releases depName=protocolbuffers/protobuf versioning=semver\n          PROTOBUF_VERSION: "34.1"\n',
  skipReason: "invalid-value",
  versioning: "semver",
  warnings: [],
  updates: [],
}
```

The most possible reason seems to be that `semver` actually means fully accurate semver and nothing else. Hopefully `semver-coerced` will make it happy again.

I also took the chance to clarify https://github.com/rust-lang/rustup/pull/4767#issuecomment-4109374859.

References:
- [Docs page](https://docs.renovatebot.com/modules/versioning/semver-coerced/)
- [GitHub Corpus](https://github.com/search?q=%22%23+renovate%3A+datasource%3Dgithub-releases+depName%3Dprotocolbuffers%2Fprotobuf+versioning%3Dsemver-coerced%22&type=code)