### PR TITLE
self_update: show path to executable in case of updater failure

### DIFF
--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -129,7 +129,7 @@ pub(crate) fn run_update(setup_path: &Path) -> Result<utils::ExitCode> {
     let status = Command::new(setup_path)
         .arg("--self-replace")
         .status()
-        .context("unable to run updater")?;
+        .context(format!("unable to run updater ({})", setup_path.display()))?;
 
     if !status.success() {
         bail!("self-updated failed to replace rustup executable");


### PR DESCRIPTION
See #4777.