### PR TITLE
fix: Reduce flickering by using `set_move_cursor`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -844,6 +844,8 @@ async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
     if channels_len > 0 {
         let multi_progress_bars =
             MultiProgress::with_draw_target(cfg.process.progress_draw_target());
+        // Help avoid flickering by moving the cursor instead of clearing the line.
+        multi_progress_bars.set_move_cursor(true);
         let semaphore = Arc::new(Semaphore::new(concurrent_downloads));
         let channels = tokio_stream::iter(channels.into_iter()).map(|(name, distributable)| {
             let msg = format!("{bold}{name} - {bold:#}");

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -327,7 +327,8 @@ impl DownloadTracker {
         } else {
             ProgressDrawTarget::hidden()
         });
-
+        // Help avoid flickering by moving the cursor instead of clearing the line.
+        multi_progress_bars.set_move_cursor(true);
         Self {
             multi_progress_bars,
         }


### PR DESCRIPTION
Instead of clearing the line then writing the new line.

Fixes #4757 (hopefully)