### PR TITLE
ci: enable on all PR target branches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
   merge_group:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - main

--- a/ci/actions-templates/gen-workflows.sh
+++ b/ci/actions-templates/gen-workflows.sh
@@ -17,7 +17,7 @@ on:
   merge_group:
   pull_request:
     branches:
-      - "*"
+      - "**"
   push:
     branches:
       - main


### PR DESCRIPTION
Cherry picked from https://github.com/rust-lang/rustup/pull/4792, follow-up of https://github.com/rust-lang/rustup/pull/4774.

I wonder why this has been undiscovered for so long, probably we have never bothered to open PRs to branches other than `main`/`master`/`stable`?

Anyway, to match `release/1.29` and friends, you'll need `**`.