### PR TITLE
Fix documentation link to `no-self-update` feature

### DIFF
--- a/doc/user-guide/src/basics.md
+++ b/doc/user-guide/src/basics.md
@@ -30,7 +30,7 @@ info: downloading self-update
 
 ## Keeping `rustup` up to date
 
-If your `rustup` was built with the [no-self-update feature](https://github.com/rust-lang/rustup/blob/HEAD/Cargo.toml#L25), it can not update
+If your `rustup` was built with the [no-self-update feature](https://github.com/rust-lang/rustup/blob/HEAD/Cargo.toml#L29), it can not update
 itself. This is not the default, and only versions of `rustup` built with
 `--no-default-features`, or obtained from a third-party distributor who has
 disabled it (such as NixOS).


### PR DESCRIPTION
While reviewing #3051, I noticed that this link was deprecated.

That said, I would like to point out that whenever `Cargo.toml` is modified (specifically, if lines are added above the current location of `no-self-update`), the link will break again.
I am not sure if there is a reliable way to prevent this, but I wanted to highlight it as a potential issue going forward.