### PR TITLE
fix(dist/manifestation): fix log format when installing exactly 2 components

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -244,13 +244,12 @@ impl Manifestation {
         }
 
         if !components.is_empty() {
-            if components.len() > 2 {
-                info!("downloading {} components", components.len());
-            } else {
-                info!(
+            match &components[..] {
+                [c] => info!(
                     "downloading component {}",
-                    components[0].manifest.short_name(&components[0].component),
-                );
+                    c.manifest.short_name(&c.component),
+                ),
+                _ => info!("downloading {} components", components.len()),
             };
 
             let mut stream = InstallEvents::new(components.into_iter(), Arc::new(self));

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -3889,7 +3889,7 @@ async fn custom_toolchain_with_components_toolchains_profile_does_not_err() {
         .with_stderr(snapbox::str![[r#"
 info: syncing channel updates for nightly-[HOST_TRIPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
-info: downloading component cargo
+info: downloading 2 components
 info: default toolchain set to nightly-[HOST_TRIPLE]
 
 "#]])


### PR DESCRIPTION
Follow-up of https://github.com/rust-lang/rustup/pull/4790.

TLDR: During manual testing a very silly typo has surfaced 🐛