### PR TITLE
ci: powerpc64-unknown-linux-musl is now stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -913,6 +913,7 @@ jobs:
           - x86_64-unknown-netbsd          # skip-pr skip-main
           - x86_64-unknown-illumos         # skip-pr skip-main
           - powerpc-unknown-linux-gnu      # skip-pr skip-main
+          - powerpc64-unknown-linux-musl   # skip-pr skip-main
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-main
           - powerpc64le-unknown-linux-musl # skip-pr skip-main
           - s390x-unknown-linux-gnu        # skip-pr skip-main

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -34,7 +34,7 @@ jobs: # skip-main skip-pr skip-stable
           - x86_64-unknown-netbsd          # skip-pr skip-main
           - x86_64-unknown-illumos         # skip-pr skip-main
           - powerpc-unknown-linux-gnu      # skip-pr skip-main
-          - powerpc64-unknown-linux-musl   # skip-pr skip-main skip-stable
+          - powerpc64-unknown-linux-musl   # skip-pr skip-main
           - powerpc64le-unknown-linux-gnu  # skip-pr skip-main
           - powerpc64le-unknown-linux-musl # skip-pr skip-main
           - s390x-unknown-linux-gnu        # skip-pr skip-main


### PR DESCRIPTION
As requested in https://github.com/rust-lang/rustup/pull/4688#pullrequestreview-3705544168 (cc @rami3l)