### PR TITLE
docs: fix disk buffer comment wording

### DIFF
--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -80,7 +80,7 @@ pub(crate) enum FileBuffer {
 }
 
 impl FileBuffer {
-    /// All the buffers space to be re-used when the last reference to it is dropped.
+    /// All the buffer space to be reused when the last reference to it is dropped.
     pub(crate) fn clear(&mut self) {
         if let FileBuffer::Threaded(contents) = self {
             contents.clear()


### PR DESCRIPTION
## Summary
- fix wording in a disk buffer comment

## Related issue
- N/A (trivial docs/comment fix)

## Guideline alignment
- reviewed the repository guidance in `README.md`
- kept the change to one source file comment with no behavior impact

## Validation
- `git diff --check`
