### PR TITLE
docs: fix diskio comment wording

### DIFF
--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -80,7 +80,7 @@ pub(crate) enum FileBuffer {
 }
 
 impl FileBuffer {
-    /// All the buffers space to be re-used when the last reference to it is dropped.
+    /// All the buffers space to be reused when the last reference to it is dropped.
     pub(crate) fn clear(&mut self) {
         if let FileBuffer::Threaded(contents) = self {
             contents.clear()


### PR DESCRIPTION
## Summary
- fix `re-used` in a source comment in `diskio`

## Related issue
- N/A (minor comment wording fix)

## Guideline alignment
- Followed https://github.com/rust-lang/rustup/blob/main/doc/dev-guide/src/index.md
- Change is limited to one source comment and does not affect behavior.

## Validation
- `git diff --check`