### PR TITLE
ci(linux/x64-musl): install missing libc dependencies

### DIFF
--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -5,6 +5,7 @@ COPY ci/docker/scripts/sccache.bash /scripts/
 RUN \
   apt-get update && \
   apt-get install -qy \
+    libc6-dev \
     musl-dev \
     musl-tools \
     curl \


### PR DESCRIPTION
The upgrade to Ubuntu 26.04 LTS might have caused some changes in package organization and structure, thus a part of the external build dependencies are since gone.

Fix verified in https://github.com/rust-lang/rustup/actions/runs/24939235073/job/73030021918?pr=4831.