### PR TITLE
dist: bump `rustup` version to v1.30.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.29.0"
+version = "1.30.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup"
-version = "1.29.0"
+version = "1.30.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Manage multiple rust installations with ease"


### PR DESCRIPTION
This is the first step in the v1.30.0 release cycle using our newly in-test release process (https://rust-lang.github.io/rustup/dev-guide/release-process.html#minor-version-bumps).

## Task List

The following tasks must be done before merging this PR:

- [x] Create the `release/1.29` branch.
- Bump the patch version on that branch: https://github.com/rust-lang/rustup/pull/4835