### PR TITLE
dist: bump `rustup` version to v1.29.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,7 +2230,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.29.0"
+version = "1.29.1"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup"
-version = "1.29.0"
+version = "1.29.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Manage multiple rust installations with ease"


### PR DESCRIPTION
This is the first step in the v1.29.1 release process using our newly in-test release process (https://rust-lang.github.io/rustup/dev-guide/release-process.html#patch-version-bumps).

It also prepares for the v1.30.0 release process on `main` (https://github.com/rust-lang/rustup/pull/4832).

See also: https://github.com/rust-lang/blog.rust-lang.org/pull/1880