### PR TITLE
fix(cli/rustup_mode)!: skip auto-installation in some `rustup` commands

### DIFF
--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -32,7 +32,7 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
         .skip(1 + toolchain.is_some() as usize)
         .collect();
 
-    let cfg = Cfg::from_env(current_dir, false, process)?;
+    let cfg = Cfg::from_env(current_dir, false, true, process)?;
     let (toolchain, source) = cfg
         .local_toolchain(match toolchain {
             Some(name) => Some((

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -301,6 +301,36 @@ fn update_toolchain_value_parser(s: &str) -> Result<PartialToolchainDesc> {
     })
 }
 
+impl RustupSubcmd {
+    fn allow_auto_install(&self) -> bool {
+        match self {
+            // These subcommands execute or rely on the active toolchain, so auto-installing it when
+            // missing may be reasonable depending on the user's decision.
+            #[cfg(not(windows))]
+            RustupSubcmd::Man { .. } => true,
+            RustupSubcmd::Doc { .. } | RustupSubcmd::Run { .. } => true,
+
+            // These subcommands don't require the active toolchain, so auto-installing it should be
+            // disabled to avoid surprises.
+            RustupSubcmd::Check { .. }
+            | RustupSubcmd::Completions { .. }
+            | RustupSubcmd::Component { .. }
+            | RustupSubcmd::Default { .. }
+            | RustupSubcmd::DumpTestament
+            | RustupSubcmd::Install { .. }
+            | RustupSubcmd::Override { .. }
+            | RustupSubcmd::Self_ { .. }
+            | RustupSubcmd::Set { .. }
+            | RustupSubcmd::Show { .. }
+            | RustupSubcmd::Target { .. }
+            | RustupSubcmd::Toolchain { .. }
+            | RustupSubcmd::Uninstall { .. }
+            | RustupSubcmd::Update { .. }
+            | RustupSubcmd::Which { .. } => false,
+        }
+    }
+}
+
 #[derive(Debug, Subcommand)]
 enum ShowSubcmd {
     /// Show the active toolchain
@@ -631,14 +661,19 @@ pub async fn main(
 
     update_console_filter(process, &console_filter, matches.quiet, matches.verbose);
 
-    let cfg = &mut Cfg::from_env(current_dir, matches.quiet, true, process)?;
-    cfg.toolchain_override = matches.plus_toolchain;
-
     let Some(subcmd) = matches.subcmd else {
         let help = Rustup::command().render_long_help();
         writeln!(process.stderr().lock(), "{}", help.ansi())?;
         return Ok(ExitCode::FAILURE);
     };
+
+    let cfg = &mut Cfg::from_env(
+        current_dir,
+        matches.quiet,
+        subcmd.allow_auto_install(),
+        process,
+    )?;
+    cfg.toolchain_override = matches.plus_toolchain;
 
     match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
@@ -1968,8 +2003,8 @@ fn output_completion_script(
 }
 
 async fn display_version(current_dir: PathBuf, process: &Process) -> Result<()> {
-    info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
-    let mut cfg = Cfg::from_env(current_dir, true, true, process)?;
+    info!("this is the version for the rustup toolchain manager, not the rustc compiler");
+    let mut cfg = Cfg::from_env(current_dir, true, false, process)?;
     cfg.toolchain_override = cfg
         .process
         .args()
@@ -1982,6 +2017,12 @@ async fn display_version(current_dir: PathBuf, process: &Process) -> Result<()> 
                 "the currently active `rustc` version is `{}`",
                 tc.rustc_version()
             ),
+            Err(RustupError::ToolchainNotInstalled {
+                name,
+                is_active: true,
+            }) => {
+                info!("the active toolchain `{name}` is not installed");
+            }
             Err(err) => error!("failed to display the current `rustc` version: {err}"),
         },
         Ok(None) => info!("no `rustc` is currently active"),

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -631,7 +631,7 @@ pub async fn main(
 
     update_console_filter(process, &console_filter, matches.quiet, matches.verbose);
 
-    let cfg = &mut Cfg::from_env(current_dir, matches.quiet, process)?;
+    let cfg = &mut Cfg::from_env(current_dir, matches.quiet, true, process)?;
     cfg.toolchain_override = matches.plus_toolchain;
 
     let Some(subcmd) = matches.subcmd else {
@@ -1974,7 +1974,7 @@ fn output_completion_script(
 
 async fn display_version(current_dir: PathBuf, process: &Process) -> Result<()> {
     info!("This is the version for the rustup toolchain manager, not the rustc compiler.");
-    let mut cfg = Cfg::from_env(current_dir, true, process)?;
+    let mut cfg = Cfg::from_env(current_dir, true, true, process)?;
     cfg.toolchain_override = cfg
         .process
         .args()

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1108,20 +1108,17 @@ async fn which(
 async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
+    let mut t = cfg.process.stdout();
+
     // Print host tuple
-    {
-        let t = cfg.process.stdout();
-        let mut t = t.lock();
-        writeln!(
-            t,
-            "{HEADER}Default host: {HEADER:#}{}",
-            cfg.default_host_tuple()?
-        )?;
-    }
+    writeln!(
+        t.lock(),
+        "{HEADER}Default host: {HEADER:#}{}",
+        cfg.default_host_tuple()?
+    )?;
 
     // Print rustup home directory
     {
-        let t = cfg.process.stdout();
         let mut t = t.lock();
         writeln!(
             t,
@@ -1162,73 +1159,64 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     };
 
     // show installed toolchains
-    {
-        let mut t = cfg.process.stdout();
+    print_header(&mut t, "installed toolchains")?;
 
-        print_header(&mut t, "installed toolchains")?;
+    let default_toolchain_name = cfg.get_default()?;
+    let last_index = installed_toolchains.len().wrapping_sub(1);
+    for (n, toolchain_name) in installed_toolchains.into_iter().enumerate() {
+        let is_default_toolchain = default_toolchain_name.as_ref() == Some(&toolchain_name);
+        let is_active_toolchain = active_toolchain_name == Some(&toolchain_name);
 
-        let default_toolchain_name = cfg.get_default()?;
-        let last_index = installed_toolchains.len().wrapping_sub(1);
-        for (n, toolchain_name) in installed_toolchains.into_iter().enumerate() {
-            let is_default_toolchain = default_toolchain_name.as_ref() == Some(&toolchain_name);
-            let is_active_toolchain = active_toolchain_name == Some(&toolchain_name);
+        let status_str = match (is_active_toolchain, is_default_toolchain) {
+            (true, true) => " (active, default)",
+            (true, false) => " (active)",
+            (false, true) => " (default)",
+            (false, false) => "",
+        };
 
-            let status_str = match (is_active_toolchain, is_default_toolchain) {
-                (true, true) => " (active, default)",
-                (true, false) => " (active)",
-                (false, true) => " (default)",
-                (false, false) => "",
-            };
+        let mut t = t.lock();
 
-            writeln!(t.lock(), "{toolchain_name}{CONTEXT}{status_str}{CONTEXT:#}")?;
+        writeln!(t, "{toolchain_name}{CONTEXT}{status_str}{CONTEXT:#}")?;
 
-            if verbose {
-                let toolchain = Toolchain::new(cfg, toolchain_name.into())?;
-                writeln!(
-                    cfg.process.stdout().lock(),
-                    "  {}\n  path: {}",
-                    toolchain.rustc_version(),
-                    toolchain.path().display()
-                )?;
-                if n != last_index {
-                    writeln!(cfg.process.stdout().lock())?;
-                }
+        if verbose {
+            let toolchain = Toolchain::new(cfg, toolchain_name.into())?;
+            writeln!(
+                t,
+                "  {}\n  path: {}",
+                toolchain.rustc_version(),
+                toolchain.path().display()
+            )?;
+            if n != last_index {
+                writeln!(t)?;
             }
         }
     }
 
     // show active toolchain
-    {
-        let mut t = cfg.process.stdout();
+    writeln!(t.lock())?;
 
-        writeln!(t.lock())?;
+    print_header(&mut t, "active toolchain")?;
 
-        print_header(&mut t, "active toolchain")?;
-
-        match active_toolchain_and_source {
-            Some((active_toolchain_name, active_source)) => {
-                let active_toolchain = Toolchain::with_source(
-                    cfg,
-                    active_toolchain_name.clone().into(),
-                    &active_source,
-                )?;
-                writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-                writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
-                if verbose {
-                    writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
-                    writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
-                }
-
-                // show installed targets for the active toolchain
-                writeln!(t.lock(), "installed targets:")?;
-
-                for target in active_toolchain_targets {
-                    writeln!(t.lock(), "  {target}")?;
-                }
+    match active_toolchain_and_source {
+        Some((active_toolchain_name, active_source)) => {
+            let active_toolchain =
+                Toolchain::with_source(cfg, active_toolchain_name.clone().into(), &active_source)?;
+            writeln!(t.lock(), "name: {}", active_toolchain.name())?;
+            writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
+            if verbose {
+                writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
+                writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
             }
-            None => {
-                writeln!(t.lock(), "no active toolchain")?;
+
+            // show installed targets for the active toolchain
+            writeln!(t.lock(), "installed targets:")?;
+
+            for target in active_toolchain_targets {
+                writeln!(t.lock(), "  {target}")?;
             }
+        }
+        None => {
+            writeln!(t.lock(), "no active toolchain")?;
         }
     }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1143,21 +1143,6 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
         .map(|atar| (&atar.0, &atar.1))
         .unzip();
 
-    let active_toolchain_targets = match active_toolchain_name {
-        Some(ToolchainName::Official(desc)) => DistributableToolchain::new(cfg, desc.clone())?
-            .components()?
-            .into_iter()
-            .filter_map(|c| {
-                (c.installed && c.component.short_name() == "rust-std")
-                    .then(|| c.component.target.expect("rust-std should have a target"))
-            })
-            .collect(),
-        Some(ToolchainName::Custom(name)) => {
-            Toolchain::new(cfg, LocalToolchainName::Named(name.into()))?.installed_targets()?
-        }
-        None => Vec::new(),
-    };
-
     // show installed toolchains
     print_header(&mut t, "installed toolchains")?;
 
@@ -1214,6 +1199,20 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
 
     // show installed targets for the active toolchain
     writeln!(t.lock(), "installed targets:")?;
+
+    let active_toolchain_targets = match active_toolchain_name {
+        ToolchainName::Official(desc) => DistributableToolchain::new(cfg, desc.clone())?
+            .components()?
+            .into_iter()
+            .filter_map(|c| {
+                (c.installed && c.component.short_name() == "rust-std")
+                    .then(|| c.component.target.expect("rust-std should have a target"))
+            })
+            .collect(),
+        ToolchainName::Custom(name) => {
+            Toolchain::new(cfg, LocalToolchainName::Named(name.into()))?.installed_targets()?
+        }
+    };
 
     for target in active_toolchain_targets {
         writeln!(t.lock(), "  {target}")?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1197,27 +1197,25 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
 
     print_header(&mut t, "active toolchain")?;
 
-    match active_toolchain_and_source {
-        Some((active_toolchain_name, active_source)) => {
-            let active_toolchain =
-                Toolchain::with_source(cfg, active_toolchain_name.clone().into(), &active_source)?;
-            writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-            writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
-            if verbose {
-                writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
-                writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
-            }
+    let Some((active_toolchain_name, active_source)) = active_toolchain_and_source else {
+        writeln!(t.lock(), "no active toolchain")?;
+        return Ok(ExitCode::SUCCESS);
+    };
 
-            // show installed targets for the active toolchain
-            writeln!(t.lock(), "installed targets:")?;
+    let active_toolchain =
+        Toolchain::with_source(cfg, active_toolchain_name.clone().into(), &active_source)?;
+    writeln!(t.lock(), "name: {}", active_toolchain.name())?;
+    writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
+    if verbose {
+        writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
+        writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;
+    }
 
-            for target in active_toolchain_targets {
-                writeln!(t.lock(), "  {target}")?;
-            }
-        }
-        None => {
-            writeln!(t.lock(), "no active toolchain")?;
-        }
+    // show installed targets for the active toolchain
+    writeln!(t.lock(), "installed targets:")?;
+
+    for target in active_toolchain_targets {
+        writeln!(t.lock(), "  {target}")?;
     }
 
     fn print_header(t: &mut ColorableTerminal, text: &str) -> Result<(), Error> {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1202,10 +1202,11 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
         return Ok(ExitCode::SUCCESS);
     };
 
+    writeln!(t.lock(), "name: {active_toolchain_name}")?;
+    writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
+
     let active_toolchain =
         Toolchain::with_source(cfg, active_toolchain_name.clone().into(), &active_source)?;
-    writeln!(t.lock(), "name: {}", active_toolchain.name())?;
-    writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
     if verbose {
         writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
         writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1190,8 +1190,17 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     writeln!(t.lock(), "name: {active_toolchain_name}")?;
     writeln!(t.lock(), "active because: {}", active_source.to_reason())?;
 
-    let active_toolchain =
-        Toolchain::with_source(cfg, active_toolchain_name.clone().into(), &active_source)?;
+    let active_toolchain = match Toolchain::new(cfg, active_toolchain_name.clone().into()) {
+        Ok(active_toolchain) => active_toolchain,
+        Err(
+            RustupError::ToolchainNotInstalled { .. } | RustupError::PathToolchainNotInstalled(..),
+        ) => {
+            info!("the active toolchain `{active_toolchain_name}` is not installed");
+            return Ok(ExitCode::SUCCESS);
+        }
+        Err(e) => return Err(e.into()),
+    };
+
     if verbose {
         writeln!(t.lock(), "compiler: {}", active_toolchain.rustc_version())?;
         writeln!(t.lock(), "path: {}", active_toolchain.path().display())?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1462,7 +1462,7 @@ mod tests {
             home.apply(&mut vars);
             let tp = TestProcess::with_vars(vars);
             let mut cfg =
-                Cfg::from_env(tp.process.current_dir().unwrap(), false, &tp.process).unwrap();
+                Cfg::from_env(tp.process.current_dir().unwrap(), false, true, &tp.process).unwrap();
 
             let opts = InstallOpts {
                 default_host_tuple: None,

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -130,6 +130,6 @@ pub async fn main(
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    let mut cfg = Cfg::from_env(current_dir, quiet, true, process)?;
+    let mut cfg = Cfg::from_env(current_dir, quiet, false, process)?;
     self_update::install(no_prompt, opts, &mut cfg).await
 }

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -130,6 +130,6 @@ pub async fn main(
         targets: &target.iter().map(|s| &**s).collect::<Vec<_>>(),
     };
 
-    let mut cfg = Cfg::from_env(current_dir, quiet, process)?;
+    let mut cfg = Cfg::from_env(current_dir, quiet, true, process)?;
     self_update::install(no_prompt, opts, &mut cfg).await
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,12 +246,21 @@ pub(crate) struct Cfg<'a> {
     pub quiet: bool,
     pub current_dir: PathBuf,
     pub process: &'a Process,
+
+    /// Allows the auto-installation of the active toolchain when it is missing.
+    ///
+    /// This flag should be set to `false` when auto-installation behavior is undesired, such as
+    /// when running `rustup component` and `rustup target` subcommands. In these cases, it has a
+    /// higher precedence than the `RUSTUP_AUTO_INSTALL` environment variable and the `rustup set
+    /// auto-install` setting.
+    pub allow_auto_install: bool,
 }
 
 impl<'a> Cfg<'a> {
     pub(crate) fn from_env(
         current_dir: PathBuf,
         quiet: bool,
+        allow_auto_install: bool,
         process: &'a Process,
     ) -> Result<Self> {
         // Set up the rustup home directory
@@ -316,6 +325,7 @@ impl<'a> Cfg<'a> {
             quiet,
             current_dir,
             process,
+            allow_auto_install,
         };
 
         // Run some basic checks against the constructed configuration
@@ -372,6 +382,10 @@ impl<'a> Cfg<'a> {
     }
 
     pub(crate) fn should_auto_install(&self) -> Result<bool> {
+        if !self.allow_auto_install {
+            return Ok(false);
+        }
+
         if let Ok(mode) = self.process.var("RUSTUP_AUTO_INSTALL") {
             Ok(mode != "0")
         } else {
@@ -958,6 +972,7 @@ impl Debug for Cfg<'_> {
             dist_root_url,
             quiet,
             current_dir,
+            allow_auto_install,
             process: _,
         } = self;
 
@@ -975,6 +990,7 @@ impl Debug for Cfg<'_> {
             .field("dist_root_url", dist_root_url)
             .field("quiet", quiet)
             .field("current_dir", current_dir)
+            .field("allow_auto_install", allow_auto_install)
             .finish()
     }
 }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -26,7 +26,7 @@ async fn version_mentions_rustc_version_confusion() {
         .await
         .with_stderr(snapbox::str![[r#"
 ...
-info: This is the version for the rustup toolchain manager, not the rustc compiler.
+info: this is the version for the rustup toolchain manager, not the rustc compiler
 ...
 "#]])
         .is_ok();
@@ -1383,11 +1383,11 @@ async fn which_asking_uninstalled_toolchain() {
     cx.config
         .expect(["rustup", "which", "--toolchain=nightly", "rustc"])
         .await
-        .with_stdout(snapbox::str![[r#"
-[..]/toolchains/nightly-[HOST_TUPLE]/bin/rustc[EXE]
-
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'nightly-[HOST_TUPLE]' is not installed
+...
 "#]])
-        .is_ok();
+        .is_err();
 }
 
 #[tokio::test]
@@ -1512,7 +1512,7 @@ active because: overridden by +toolchain on the command line
         .expect(["rustup", "+foo", "which", "rustc"])
         .await
         .with_stderr(snapbox::str![[r#"
-error: override toolchain 'foo' is not installed: the +toolchain on the command line specifies an uninstalled toolchain
+error:[..] toolchain 'foo' is not installed[..]
 
 "#]])
         .is_err();

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1218,14 +1218,21 @@ async fn show_toolchain_toolchain_file_override_not_installed() {
 Default host: [HOST_TUPLE]
 rustup home:  [RUSTUP_DIR]
 
+installed toolchains
+--------------------
+stable-[HOST_TUPLE] (default)
+
+active toolchain
+----------------
+name: nightly-[HOST_TUPLE]
+active because: overridden by '[TOOLCHAIN_FILE]'
 
 "#]])
         .with_stderr(snapbox::str![[r#"
-error: toolchain 'nightly-[HOST_TUPLE]' is not installed
-help: run `rustup toolchain install` to install it
+info: the active toolchain `nightly-[HOST_TUPLE]` is not installed
 
 "#]])
-        .is_err();
+        .is_ok();
 }
 
 #[tokio::test]
@@ -1254,22 +1261,9 @@ active toolchain
 ----------------
 name: nightly-[HOST_TUPLE]
 active because: directory override for '[..]'
-installed targets:
-  [HOST_TUPLE]
 
 "#]])
         .is_ok();
-    cx.config
-        .expect(["rustup", "component", "list", "--installed"])
-        .await
-        .is_ok()
-        .with_stdout(snapbox::str![[r#"
-cargo-[HOST_TUPLE]
-rust-docs-[HOST_TUPLE]
-rust-std-[HOST_TUPLE]
-rustc-[HOST_TUPLE]
-
-"#]]);
 }
 
 #[tokio::test]
@@ -1370,8 +1364,6 @@ active toolchain
 ----------------
 name: nightly-[HOST_TUPLE]
 active because: overridden by environment variable RUSTUP_TOOLCHAIN
-installed targets:
-  [HOST_TUPLE]
 
 "#]]);
 }

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1210,7 +1210,7 @@ async fn set_auto_install_disable() {
         .await
         .is_ok();
     cx.config
-        .expect(["rustup", "target", "list", "--toolchain=nightly"])
+        .expect(["cargo", "+nightly", "--version"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...
@@ -1220,7 +1220,7 @@ error: toolchain 'nightly-[HOST_TUPLE]' is not installed
         .is_err();
     cx.config
         .expect_with_env(
-            ["rustup", "target", "list", "--toolchain=nightly"],
+            ["cargo", "+nightly", "--version"],
             [("RUSTUP_AUTO_INSTALL", "0")],
         )
         .await
@@ -1233,7 +1233,7 @@ error: toolchain 'nightly-[HOST_TUPLE]' is not installed
     // The environment variable takes precedence over the setting.
     cx.config
         .expect_with_env(
-            ["rustup", "target", "list", "--toolchain=nightly"],
+            ["cargo", "+nightly", "--version"],
             [("RUSTUP_AUTO_INSTALL", "1")],
         )
         .await


### PR DESCRIPTION
Closes #4836 by making it possible to skip `should_auto_install` 's dynamic detection entirely.

Whether the skip should be applied can be predetermined during `clap` dispatch (at least for `rustup_mode.rs`), so the only remaining question seems to be where we would want to apply the skip.