### PR TITLE
docs: fix plural of VM in coding standards

### DIFF
--- a/doc/dev-guide/src/coding-standards.md
+++ b/doc/dev-guide/src/coding-standards.md
@@ -58,7 +58,7 @@ which can build up over time.
 
 ## Writing platform-specific code
 
-For developers using BSD/Linux/Mac OS, there are Windows VM's suitable for such
+For developers using BSD/Linux/Mac OS, there are Windows VMs suitable for such
 development tasks for use with virtualbox and other hypervisors are downloadable
 from
 [Microsoft](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/).


### PR DESCRIPTION
Fixes a minor typo: 'VM's' should be 'VMs' as it is a plural, not a possessive.