### PR TITLE
fix: rename partially "Triple" to "Tuple" to reflect the new terminology (pt.3)

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -511,15 +511,15 @@ pub(crate) fn ignorable_error(
 pub(crate) fn check_non_host_toolchain(
     toolchain: String,
     host_arch: &TargetTuple,
-    target_triple: &TargetTuple,
+    target_tuple: &TargetTuple,
     force_non_host: bool,
 ) -> Result<()> {
-    if force_non_host || host_arch.can_run(target_triple)? {
+    if force_non_host || host_arch.can_run(target_tuple)? {
         return Ok(());
     }
     Err(RustupError::ToolchainIncompatible {
         toolchain,
-        target_triple: target_triple.clone(),
+        target_tuple: target_tuple.clone(),
     }
     .into())
 }

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -99,7 +99,7 @@ pub(crate) fn toolchain_help() -> String {
     {PLACEHOLDER}<versioned>     = <major.minor>|<major.minor.patch>{PLACEHOLDER:#}
     {PLACEHOLDER}<prerelease>    = beta[.<number>]{PLACEHOLDER:#}
     {PLACEHOLDER}<date>          = YYYY-MM-DD{PLACEHOLDER:#}
-    {PLACEHOLDER}<host>          = <target-triple>{PLACEHOLDER:#}
+    {PLACEHOLDER}<host>          = <target-tuple>{PLACEHOLDER:#}
 
   'channel' is a named release channel, a major and minor version
   number such as `1.42`, or a fully specified version number, such

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -36,7 +36,7 @@ pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result
     let (toolchain, source) = cfg
         .local_toolchain(match toolchain {
             Some(name) => Some((
-                name.resolve(&cfg.get_default_host_triple()?)?,
+                name.resolve(&cfg.default_host_tuple()?)?,
                 ActiveSource::CommandLine,
             )),
             None => None,

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -752,7 +752,7 @@ pub async fn main(
         },
         RustupSubcmd::Set { subcmd } => match subcmd {
             SetSubcmd::DefaultHost { host_triple } => cfg
-                .set_default_host_triple(host_triple)
+                .set_default_host_tuple(host_triple)
                 .map(|_| ExitCode::SUCCESS),
             SetSubcmd::Profile { profile_name } => {
                 cfg.set_profile(profile_name).map(|_| ExitCode::SUCCESS)
@@ -1108,7 +1108,7 @@ async fn which(
 async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
-    // Print host triple
+    // Print host tuple
     {
         let t = cfg.process.stdout();
         let mut t = t.lock();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -787,7 +787,7 @@ async fn default_(
                 cfg.set_default(Some(&toolchain_name.into()))?;
             }
             MaybeResolvableToolchainName::Some(ResolvableToolchainName::Official(toolchain)) => {
-                let desc = toolchain.resolve(&cfg.get_default_host_triple()?)?;
+                let desc = toolchain.resolve(&cfg.default_host_tuple()?)?;
                 let status = cfg
                     .ensure_installed(&desc, vec![], vec![], None, force_non_host, true)
                     .await?
@@ -992,7 +992,7 @@ async fn update(
                     force_non_host,
                 )?;
             }
-            let desc = name.resolve(&cfg.get_default_host_triple()?)?;
+            let desc = name.resolve(&cfg.default_host_tuple()?)?;
 
             let components = opts.component.iter().map(|s| &**s).collect::<Vec<_>>();
             let targets = opts.target.iter().map(|s| &**s).collect::<Vec<_>>();
@@ -1060,7 +1060,7 @@ async fn run(
     command: Vec<String>,
     install: bool,
 ) -> Result<ExitStatus> {
-    let toolchain = toolchain.resolve(&cfg.get_default_host_triple()?)?;
+    let toolchain = toolchain.resolve(&cfg.default_host_tuple()?)?;
     let toolchain = Toolchain::from_local(toolchain, install, cfg).await?;
     let cmd = toolchain.command(&command[0])?;
     command::run_command_for_dir(cmd, &command[0], &command[1..])
@@ -1074,7 +1074,7 @@ async fn which(
     let (toolchain, _) = cfg
         .local_toolchain(match toolchain {
             Some(name) => Some((
-                name.resolve(&cfg.get_default_host_triple()?)?.into(),
+                name.resolve(&cfg.default_host_tuple()?)?.into(),
                 ActiveSource::CommandLine, // From --toolchain option
             )),
             None => None,
@@ -1115,7 +1115,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
         writeln!(
             t,
             "{HEADER}Default host: {HEADER:#}{}",
-            cfg.get_default_host_triple()?
+            cfg.default_host_tuple()?
         )?;
     }
 
@@ -1387,7 +1387,7 @@ async fn target_remove(
 
     for target in targets {
         let target = TargetTuple::new(target);
-        let default_target = cfg.get_default_host_triple()?;
+        let default_target = cfg.default_host_tuple()?;
         if target == default_target {
             warn!(
                 "removing the default host target; proc-macros and build scripts might no longer build"
@@ -1562,7 +1562,7 @@ async fn toolchain_remove(cfg: &mut Cfg<'_>, opts: UninstallOpts) -> Result<Exit
         .map(|(it, _)| it);
 
     for toolchain_name in &opts.toolchain {
-        let toolchain_name = toolchain_name.resolve(&cfg.get_default_host_triple()?)?;
+        let toolchain_name = toolchain_name.resolve(&cfg.default_host_tuple()?)?;
 
         if active_toolchain
             .as_ref()
@@ -1591,7 +1591,7 @@ async fn override_add(
     toolchain: ResolvableToolchainName,
     path: Option<&Path>,
 ) -> Result<ExitCode> {
-    let toolchain_name = toolchain.resolve(&cfg.get_default_host_triple()?)?;
+    let toolchain_name = toolchain.resolve(&cfg.default_host_tuple()?)?;
     match Toolchain::new(cfg, (&toolchain_name).into()) {
         Ok(_) => {}
         Err(e @ RustupError::ToolchainNotInstalled { .. }) => match &toolchain_name {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -122,7 +122,7 @@ impl InstallOpts<'_> {
         if let Some(default_host_tuple) = &default_host_tuple {
             // Set host tuple now as it will affect resolution of toolchain_str
             info!("setting default host tuple to {}", default_host_tuple);
-            cfg.set_default_host_triple(default_host_tuple.to_owned())?;
+            cfg.set_default_host_tuple(default_host_tuple.to_owned())?;
         } else {
             info!("default host tuple is {}", cfg.default_host_tuple()?);
         }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -124,7 +124,7 @@ impl InstallOpts<'_> {
             info!("setting default host tuple to {}", default_host_tuple);
             cfg.set_default_host_triple(default_host_tuple.to_owned())?;
         } else {
-            info!("default host tuple is {}", cfg.get_default_host_triple()?);
+            info!("default host tuple is {}", cfg.default_host_tuple()?);
         }
 
         let user_specified_something = default_toolchain.is_some()
@@ -164,7 +164,7 @@ impl InstallOpts<'_> {
                         MaybeOfficialToolchainName::None => unreachable!(),
                         MaybeOfficialToolchainName::Some(n) => n,
                     };
-                    Some(toolchain_name.resolve(&cfg.get_default_host_triple()?)?)
+                    Some(toolchain_name.resolve(&cfg.default_host_tuple()?)?)
                 }
                 None => match cfg.get_default()? {
                     // Default is installable
@@ -174,7 +174,7 @@ impl InstallOpts<'_> {
                     None => Some(
                         "stable"
                             .parse::<PartialToolchainDesc>()?
-                            .resolve(&cfg.get_default_host_triple()?)?,
+                            .resolve(&cfg.default_host_tuple()?)?,
                     ),
                 },
             })
@@ -736,8 +736,7 @@ fn check_existence_of_settings_file(cfg: &Cfg<'_>) -> Result<()> {
     };
     warn!("it looks like you have an existing rustup settings file at:");
     warn!("{}", settings_file_path.display());
-    let inferred =
-        PartialToolchainDesc::from_str("stable")?.resolve(&cfg.get_default_host_triple()?)?;
+    let inferred = PartialToolchainDesc::from_str("stable")?.resolve(&cfg.default_host_tuple()?)?;
     if default_toolchain != inferred.to_string() {
         warn!("rustup will install the default toolchain as specified in the settings file,");
         warn!("instead of the one inferred from the default host tuple.");
@@ -1479,7 +1478,7 @@ mod tests {
                 "stable"
                     .parse::<PartialToolchainDesc>()
                     .unwrap()
-                    .resolve(&cfg.get_default_host_triple().unwrap())
+                    .resolve(&cfg.default_host_tuple().unwrap())
                     .unwrap(),
                 opts.install(&mut cfg)
                     .unwrap() // result

--- a/src/config.rs
+++ b/src/config.rs
@@ -895,7 +895,7 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    pub(crate) fn set_default_host_triple(&self, host_triple: String) -> Result<()> {
+    pub(crate) fn set_default_host_tuple(&self, host_triple: String) -> Result<()> {
         // Ensure that the provided host_triple is capable of resolving
         // against the 'stable' toolchain.  This provides early errors
         // if the supplied triple is insufficient / bad.

--- a/src/config.rs
+++ b/src/config.rs
@@ -144,7 +144,7 @@ impl OverrideCfg {
     fn from_file(cfg: &Cfg<'_>, file: OverrideFile) -> Result<Self> {
         let toolchain_name = match (file.toolchain.channel, file.toolchain.path) {
             (Some(name), None) => {
-                ResolvableToolchainName::try_from(name)?.resolve(&cfg.get_default_host_triple()?)?
+                ResolvableToolchainName::try_from(name)?.resolve(&cfg.default_host_tuple()?)?
             }
             (None, Some(path)) => {
                 if file.toolchain.targets.is_some()
@@ -288,9 +288,8 @@ impl<'a> Cfg<'a> {
         let update_hash_dir = rustup_dir.join("update-hashes");
         let download_dir = rustup_dir.join("downloads");
 
-        // Figure out get_default_host_triple before Config is populated
-        let default_host_triple =
-            settings_file.with(|s| Ok(get_default_host_triple(s, process)))?;
+        // Figure out default_host_tuple before Config is populated
+        let default_host_triple = settings_file.with(|s| Ok(default_host_tuple(s, process)))?;
         // Environment override
         let env_override = match process.var_opt("RUSTUP_TOOLCHAIN")? {
             Some(tc) => {
@@ -323,7 +322,7 @@ impl<'a> Cfg<'a> {
         // For now, that means simply checking that 'stable' can resolve
         // for the current configuration.
         ResolvableToolchainName::try_from("stable")?.resolve(
-            &cfg.get_default_host_triple()
+            &cfg.default_host_tuple()
                 .context("Unable parse configuration")?,
         )?;
 
@@ -483,7 +482,7 @@ impl<'a> Cfg<'a> {
             .map(|(desc, source)| {
                 anyhow::Ok((
                     LocalToolchainName::Named(ToolchainName::Official(
-                        desc.resolve(&self.get_default_host_triple()?)?,
+                        desc.resolve(&self.default_host_tuple()?)?,
                     )),
                     source,
                 ))
@@ -529,7 +528,7 @@ impl<'a> Cfg<'a> {
         let override_config: Option<(OverrideCfg, ActiveSource)> =
             // First check +toolchain override from the command line
             if let Some(name) = &self.toolchain_override {
-                let override_config = name.resolve(&self.get_default_host_triple()?)?.into();
+                let override_config = name.resolve(&self.default_host_tuple()?)?.into();
                 Some((override_config, ActiveSource::CommandLine))
             }
             // Then check the RUSTUP_TOOLCHAIN environment variable
@@ -574,7 +573,7 @@ impl<'a> Cfg<'a> {
                 // have an unresolved name. I'm just preserving pre-existing
                 // behaviour by choosing ResolvableToolchainName here.
                 let toolchain_name = ResolvableToolchainName::try_from(name)?
-                    .resolve(&get_default_host_triple(settings, self.process))?;
+                    .resolve(&default_host_tuple(settings, self.process))?;
                 let override_cfg = toolchain_name.into();
                 return Ok(Some((override_cfg, source)));
             }
@@ -632,7 +631,7 @@ impl<'a> Cfg<'a> {
                                 toolchain_file.display()
                             )
                         })?;
-                    let default_host_triple = get_default_host_triple(settings, self.process);
+                    let default_host_triple = default_host_tuple(settings, self.process);
                     // Do not permit architecture/os selection in channels as
                     // these are host specific and toolchain files are portable.
                     if let ResolvableToolchainName::Official(name) = &toolchain_name
@@ -839,7 +838,7 @@ impl<'a> Cfg<'a> {
         toolchain_maybe_str
             .map(ResolvableToolchainName::try_from)
             .transpose()?
-            .map(|t| t.resolve(&self.get_default_host_triple()?))
+            .map(|t| t.resolve(&self.default_host_tuple()?))
             .transpose()
     }
 
@@ -909,9 +908,9 @@ impl<'a> Cfg<'a> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn get_default_host_triple(&self) -> Result<TargetTuple> {
+    pub(crate) fn default_host_tuple(&self) -> Result<TargetTuple> {
         self.settings_file
-            .with(|s| Ok(get_default_host_triple(s, self.process)))
+            .with(|s| Ok(default_host_tuple(s, self.process)))
     }
 
     /// The path on disk of any concrete toolchain
@@ -980,7 +979,7 @@ impl Debug for Cfg<'_> {
     }
 }
 
-fn get_default_host_triple(s: &Settings, process: &Process) -> TargetTuple {
+fn default_host_tuple(s: &Settings, process: &Process) -> TargetTuple {
     s.default_host_triple
         .as_ref()
         .map(TargetTuple::new)

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -106,12 +106,12 @@ pub enum RustupError {
     RunningCommand { name: OsString },
     #[error(
         "toolchain '{toolchain}' may not be able to run on this system\n\
-        note: to build software for that platform, try `rustup target add {target_triple}` instead\n\
+        note: to build software for that platform, try `rustup target add {target_tuple}` instead\n\
         note: add the `--force-non-host` flag to install the toolchain anyway"
     )]
     ToolchainIncompatible {
         toolchain: String,
-        target_triple: TargetTuple,
+        target_tuple: TargetTuple,
     },
     #[error("toolchain '{0}' is not installable")]
     ToolchainNotInstallable(String),

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -874,7 +874,7 @@ async fn setup_test_state(test_dist_dir: TempDir) -> (TempDir, Config) {
     hard_link(&rustup_path, rls_path).unwrap();
     hard_link(&rustup_path, rust_lldb_path).unwrap();
 
-    // Make sure the host triple matches the build triple. Otherwise testing a 32-bit build of
+    // Make sure the host tuple matches the build tuple. Otherwise testing a 32-bit build of
     // rustup on a 64-bit machine will fail, because the tests do not have the host detection
     // functionality built in.
     config

--- a/src/test/dist.rs
+++ b/src/test/dist.rs
@@ -189,24 +189,24 @@ impl Release {
 
         if self.channel == "stable" {
             // Same for v1 manifests. These are just the installers.
-            let host_triple = this_host_tuple();
+            let host_tuple = this_host_tuple();
 
             hard_link(
                 path.join(format!(
                     "dist/{}/rust-stable-{}.tar.gz",
-                    self.date, host_triple
+                    self.date, host_tuple
                 )),
-                path.join(format!("dist/rust-{}-{}.tar.gz", self.version, host_triple)),
+                path.join(format!("dist/rust-{}-{}.tar.gz", self.version, host_tuple)),
             )
             .unwrap();
             hard_link(
                 path.join(format!(
                     "dist/{}/rust-stable-{}.tar.gz.sha256",
-                    self.date, host_triple
+                    self.date, host_tuple
                 )),
                 path.join(format!(
                     "dist/rust-{}-{}.tar.gz.sha256",
-                    self.version, host_triple
+                    self.version, host_tuple
                 )),
             )
             .unwrap();
@@ -289,49 +289,49 @@ impl MockChannel {
         version_hash: &str,
         rls: RlsStatus,
         multi_arch: bool,
-        swap_triples: bool,
+        swap_tuples: bool,
     ) -> Self {
         // Build the mock installers
-        let host_triple = if swap_triples {
+        let host_tuple = if swap_tuples {
             MULTI_ARCH1.to_owned()
         } else {
             this_host_tuple()
         };
-        let std = MockInstallerBuilder::std(&host_triple);
-        let rustc = MockInstallerBuilder::rustc(&host_triple, version, version_hash);
+        let std = MockInstallerBuilder::std(&host_tuple);
+        let rustc = MockInstallerBuilder::rustc(&host_tuple, version, version_hash);
         let cargo = MockInstallerBuilder::cargo(version, version_hash);
         let rust_docs = MockInstallerBuilder::rust_doc();
         let rust = MockInstallerBuilder::combined(&[&std, &rustc, &cargo, &rust_docs]);
         let cross_std1 = MockInstallerBuilder::cross_std(CROSS_ARCH1, date);
         let cross_std2 = MockInstallerBuilder::cross_std(CROSS_ARCH2, date);
         let rust_src = MockInstallerBuilder::rust_src();
-        let rust_analysis = MockInstallerBuilder::rust_analysis(&host_triple);
+        let rust_analysis = MockInstallerBuilder::rust_analysis(&host_tuple);
 
         // Convert the mock installers to mock package definitions for the
         // mock dist server
         let mut all = MockChannelContent::default();
         all.std.extend(vec![
-            (std, host_triple.clone()),
+            (std, host_tuple.clone()),
             (cross_std1, CROSS_ARCH1.to_string()),
             (cross_std2, CROSS_ARCH2.to_string()),
         ]);
-        all.rustc.push((rustc, host_triple.clone()));
-        all.cargo.push((cargo, host_triple.clone()));
+        all.rustc.push((rustc, host_tuple.clone()));
+        all.cargo.push((cargo, host_tuple.clone()));
 
         if rls != RlsStatus::Unavailable {
             let rls = MockInstallerBuilder::rls(version, version_hash, rls.pkg_name());
-            all.rls.push((rls, host_triple.clone()));
+            all.rls.push((rls, host_tuple.clone()));
         } else {
             all.rls.push((
                 MockInstallerBuilder { components: vec![] },
-                host_triple.clone(),
+                host_tuple.clone(),
             ));
         }
 
-        all.docs.push((rust_docs, host_triple.clone()));
+        all.docs.push((rust_docs, host_tuple.clone()));
         all.src.push((rust_src, "*".to_string()));
         all.analysis.push((rust_analysis, "*".to_string()));
-        all.combined.push((rust, host_triple));
+        all.combined.push((rust, host_tuple));
 
         if multi_arch {
             let std = MockInstallerBuilder::std(MULTI_ARCH1);
@@ -340,21 +340,23 @@ impl MockChannel {
             let rust_docs = MockInstallerBuilder::rust_doc();
             let rust = MockInstallerBuilder::combined(&[&std, &rustc, &cargo, &rust_docs]);
 
-            let triple = MULTI_ARCH1.to_string();
-            all.std.push((std, triple.clone()));
-            all.rustc.push((rustc, triple.clone()));
-            all.cargo.push((cargo, triple.clone()));
+            let target_tuple = MULTI_ARCH1.to_string();
+            all.std.push((std, target_tuple.clone()));
+            all.rustc.push((rustc, target_tuple.clone()));
+            all.cargo.push((cargo, target_tuple.clone()));
 
             if rls != RlsStatus::Unavailable {
                 let rls = MockInstallerBuilder::rls(version, version_hash, rls.pkg_name());
-                all.rls.push((rls, triple.clone()));
+                all.rls.push((rls, target_tuple.clone()));
             } else {
-                all.rls
-                    .push((MockInstallerBuilder { components: vec![] }, triple.clone()));
+                all.rls.push((
+                    MockInstallerBuilder { components: vec![] },
+                    target_tuple.clone(),
+                ));
             }
 
-            all.docs.push((rust_docs, triple.to_string()));
-            all.combined.push((rust, triple));
+            all.docs.push((rust_docs, target_tuple.to_string()));
+            all.combined.push((rust, target_tuple));
         }
 
         let all_std_archs: Vec<String> = all.std.iter().map(|(_, arch)| arch).cloned().collect();
@@ -365,8 +367,8 @@ impl MockChannel {
             let target_pkgs =
                 target_pkgs
                     .into_iter()
-                    .map(|(installer, triple)| MockTargetedPackage {
-                        target: triple,
+                    .map(|(installer, target_tuple)| MockTargetedPackage {
+                        target: target_tuple,
                         available: !installer.components.is_empty(),
                         components: vec![],
                         installer,
@@ -466,7 +468,7 @@ impl MockChannel {
         version: &str,
         version_hash: &str,
     ) -> Self {
-        let host_triple = this_host_tuple();
+        let host_tuple = this_host_tuple();
 
         let packages = [
             "cargo",
@@ -483,7 +485,7 @@ impl MockChannel {
                 name,
                 version: format!("{version} ({version_hash})"),
                 targets: vec![MockTargetedPackage {
-                    target: host_triple.clone(),
+                    target: host_tuple.clone(),
                     available: false,
                     components: vec![],
                     installer: MockInstallerBuilder { components: vec![] },
@@ -549,7 +551,7 @@ impl RlsStatus {
 // A single rust-installer package
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub(crate) struct MockPackage {
-    // rust, rustc, rust-std-$triple, rust-doc, etc.
+    // rust, rustc, rust-std-$tuple, rust-doc, etc.
     pub name: &'static str,
     pub version: String,
     pub targets: Vec<MockTargetedPackage>,

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -371,7 +371,7 @@ impl<'a> Toolchain<'a> {
             return Ok(None);
         }
 
-        let default_host_triple = self.cfg.get_default_host_triple()?;
+        let default_host_tuple = self.cfg.default_host_tuple()?;
         // XXX: This could actually consider all installed distributable
         // toolchains in principle.
         for fallback in ["nightly", "beta", "stable"] {

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -376,7 +376,7 @@ impl<'a> Toolchain<'a> {
         // toolchains in principle.
         for fallback in ["nightly", "beta", "stable"] {
             let resolved =
-                PartialToolchainDesc::from_str(fallback)?.resolve(&default_host_triple)?;
+                PartialToolchainDesc::from_str(fallback)?.resolve(&default_host_tuple)?;
             if let Ok(fallback) = DistributableToolchain::new(self.cfg, resolved) {
                 let cmd = fallback.create_fallback_command("cargo", self)?;
                 return Ok(Some(cmd));
@@ -595,7 +595,7 @@ impl<'a> Toolchain<'a> {
             .filter_map(|c| {
                 c.name()
                     .strip_prefix("rust-std-")
-                    .map(|triple| TargetTuple::new(triple.to_string()))
+                    .map(|tuple| TargetTuple::new(tuple.to_string()))
             })
             .collect())
     }

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -6,7 +6,7 @@
 //!
 //! `MaybeOfficialToolchainName` represents a toolchain passed to rustup-init:
 //! 'none' to select no toolchain to install, and otherwise a partial toolchain
-//! description - channel and optional triple and optional date.
+//! description - channel and optional target tuple and optional date.
 //!
 //! `ResolvableToolchainName` represents a toolchain name from a user. Either a
 //! partial toolchain description or a single path component that is not 'none'.
@@ -15,7 +15,7 @@
 //! for both custom and official names.
 //!
 //! `ToolchainName` is the result of resolving `ResolvableToolchainName` with a
-//! host triple, or parsing an installed toolchain name directly.
+//! host tuple, or parsing an installed toolchain name directly.
 //!
 //! `ResolvableLocalToolchainName` represents the values permittable in
 //! `RUSTUP_TOOLCHAIN`: resolved or not resolved official names, custom names,
@@ -487,19 +487,19 @@ mod tests {
         toolchain::names::{CustomToolchainName, ResolvableToolchainName, ToolchainName},
     };
 
-    fn partial_toolchain_desc_re() -> String {
-        let triple_re = format!(
+    fn partial_toolchain_desc_regex() -> String {
+        let tuple_regex = format!(
             r"(-({}))?(?:-({}))?(?:-({}))?",
             LIST_ARCHS.join("|"),
             LIST_OSES.join("|"),
             LIST_ENVS.join("|")
         );
-        r"(nightly|beta|stable|[0-9]{1}(\.(0|[1-9][0-9]{0,2}))(\.(0|[1-9][0-9]{0,1}))?(-beta(\.(0|[1-9][1-9]{0,1}))?)?)(-([0-9]{4}-[0-9]{2}-[0-9]{2}))?".to_owned() + &triple_re
+        r"(nightly|beta|stable|[0-9]{1}(\.(0|[1-9][0-9]{0,2}))(\.(0|[1-9][0-9]{0,1}))?(-beta(\.(0|[1-9][1-9]{0,1}))?)?)(-([0-9]{4}-[0-9]{2}-[0-9]{2}))?".to_owned() + &tuple_regex
     }
 
     prop_compose! {
         fn arb_partial_toolchain_desc()
-            (s in string_regex(&partial_toolchain_desc_re()).unwrap()) -> String {
+            (s in string_regex(&partial_toolchain_desc_regex()).unwrap()) -> String {
             s
         }
     }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -226,8 +226,8 @@ async fn subcommand_required_for_self() {
 
 #[tokio::test]
 async fn multi_host_smoke_test() {
-    // We cannot run this test if the current host triple is equal to the
-    // multi-arch triple, but this should never be the case.  Check that just
+    // We cannot run this test if the current host tuple is equal to the
+    // multi-arch tuple, but this should never be the case.  Check that just
     // to be sure.
     assert_ne!(this_host_tuple(), MULTI_ARCH1);
 

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1920,7 +1920,7 @@ async fn add_component() {
 }
 
 #[tokio::test]
-async fn add_component_by_target_triple() {
+async fn add_component_by_target_tuple() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect(["rustup", "default", "stable"])
@@ -1943,7 +1943,7 @@ async fn add_component_by_target_triple() {
 }
 
 #[tokio::test]
-async fn add_component_by_target_triple_renamed_from() {
+async fn add_component_by_target_tuple_renamed_from() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect(["rustup", "default", "nightly"])
@@ -1970,7 +1970,7 @@ rls-[HOST_TUPLE]
 }
 
 #[tokio::test]
-async fn add_component_by_target_triple_renamed_to() {
+async fn add_component_by_target_tuple_renamed_to() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect(["rustup", "default", "nightly"])
@@ -2064,15 +2064,15 @@ async fn remove_component() {
 }
 
 #[tokio::test]
-async fn remove_component_by_target_triple() {
-    let component_with_triple = format!("rust-std-{CROSS_ARCH1}");
+async fn remove_component_by_target_tuple() {
+    let component_with_tuple = format!("rust-std-{CROSS_ARCH1}");
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect(&["rustup", "default", "stable"])
         .await
         .is_ok();
     cx.config
-        .expect(&["rustup", "component", "add", &component_with_triple])
+        .expect(&["rustup", "component", "add", &component_with_tuple])
         .await
         .is_ok();
     let path = PathBuf::from(format!(
@@ -2081,7 +2081,7 @@ async fn remove_component_by_target_triple() {
     ));
     assert!(cx.config.rustupdir.has(&path));
     cx.config
-        .expect(&["rustup", "component", "remove", &component_with_triple])
+        .expect(&["rustup", "component", "remove", &component_with_tuple])
         .await
         .is_ok();
     assert!(!cx.config.rustupdir.has(path.parent().unwrap()));
@@ -2095,8 +2095,8 @@ async fn add_remove_multiple_components() {
         format!("lib/rustlib/{CROSS_ARCH1}/lib/libstd.rlib"),
         format!("lib/rustlib/{CROSS_ARCH2}/lib/libstd.rlib"),
     ];
-    let component_with_triple1 = format!("rust-std-{CROSS_ARCH1}");
-    let component_with_triple2 = format!("rust-std-{CROSS_ARCH2}");
+    let component_with_tuple1 = format!("rust-std-{CROSS_ARCH1}");
+    let component_with_tuple2 = format!("rust-std-{CROSS_ARCH2}");
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
@@ -2110,8 +2110,8 @@ async fn add_remove_multiple_components() {
             "add",
             "rust-src",
             "rust-analysis",
-            &component_with_triple1,
-            &component_with_triple2,
+            &component_with_tuple1,
+            &component_with_tuple2,
         ])
         .await
         .is_ok();
@@ -2126,8 +2126,8 @@ async fn add_remove_multiple_components() {
             "remove",
             "rust-src",
             "rust-analysis",
-            &component_with_triple1,
-            &component_with_triple2,
+            &component_with_tuple1,
+            &component_with_tuple2,
         ])
         .await
         .is_ok();

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_help_flag.stdout.term.svg
@@ -80,7 +80,7 @@
 </tspan>
     <tspan x="10px" y="550px"><tspan>    </tspan><tspan class="fg-cyan">&lt;date&gt;          = YYYY-MM-DD</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan">&lt;host&gt;          = &lt;target-triple&gt;</tspan>
+    <tspan x="10px" y="568px"><tspan>    </tspan><tspan class="fg-cyan">&lt;host&gt;          = &lt;target-tuple&gt;</tspan>
 </tspan>
     <tspan x="10px" y="586px">
 </tspan>


### PR DESCRIPTION
Partial effort to #4826. Siblings: #4827, #4834

This PR still does not do functionality changes and should be the last PR in this series without such changes (next PR will include user-facing changes.)