### PR TITLE
Provide --yes alias for -y flag consistently

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -44,7 +44,7 @@ Options:
           Set log level to 'DEBUG' if 'RUSTUP_LOG' is unset
   -q, --quiet
           Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset
-  -y
+  -y, --yes
           Disable confirmation prompt
       --default-host <DEFAULT_HOST>
           Choose a default host tuple
@@ -133,6 +133,11 @@ main() {
                 ;;
             --quiet)
                 RUSTUP_QUIET=yes
+                ;;
+            --yes)
+                # user wants to skip the prompt --
+                # we don't need /dev/tty
+                need_tty=no
                 ;;
             *)
                 OPTIND=1

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -556,7 +556,7 @@ enum SelfSubcmd {
     /// Uninstall rustup
     Uninstall {
         /// Disable confirmation prompt
-        #[arg(short = 'y')]
+        #[arg(short = 'y', long = "yes")]
         no_prompt: bool,
 
         /// Do not clean up the `PATH` environment variable

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -36,7 +36,7 @@ struct RustupInit {
     quiet: bool,
 
     /// Disable confirmation prompt
-    #[arg(short = 'y')]
+    #[arg(short = 'y', long = "yes")]
     no_prompt: bool,
 
     /// Choose a default host tuple

--- a/tests/suite/cli_rustup_init_ui/rustup_init_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_init_ui/rustup_init_help_flag.stdout.term.svg
@@ -42,7 +42,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan>
+    <tspan x="10px" y="226px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--yes</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>          Disable confirmation prompt</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
@@ -38,7 +38,7 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>          Disable progress output, set log level to 'WARN' if 'RUSTUP_LOG' is unset</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>  -y</tspan>
+    <tspan x="10px" y="226px"><tspan>  -y, --yes</tspan>
 </tspan>
     <tspan x="10px" y="244px"><tspan>          Disable confirmation prompt</tspan>
 </tspan>

--- a/tests/suite/cli_rustup_ui/rustup_self_cmd_uninstall_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_self_cmd_uninstall_cmd_help_flag.stdout.term.svg
@@ -30,7 +30,7 @@
 </tspan>
     <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan><tspan>                    Disable confirmation prompt</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-y</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--yes</tspan><tspan>             Disable confirmation prompt</tspan>
 </tspan>
     <tspan x="10px" y="136px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-modify-path</tspan><tspan>  Do not clean up the `PATH` environment variable</tspan>
 </tspan>


### PR DESCRIPTION
This alias was originally added in 7e1eeb92cae356527ac2327e322549419a2960d9. This applies that same alias to all places where -y is used to suppress a confirmation prompt. Specifically, that includes rustup-init, the downloader script and `rustup self uninstall`.
