### PR TITLE
test(download): also scrub `HTTP_PROXY` in `scrub_env()`

### DIFF
--- a/src/download/tests.rs
+++ b/src/download/tests.rs
@@ -430,6 +430,7 @@ async fn scrub_env() -> tokio::sync::MutexGuard<'static, ()> {
     // mutex guard.
     unsafe {
         remove_var("http_proxy");
+        remove_var("HTTP_PROXY");
         remove_var("https_proxy");
         remove_var("HTTPS_PROXY");
         remove_var("ftp_proxy");


### PR DESCRIPTION
Trivial patch to address https://github.com/rust-lang/rustup/pull/4848#issuecomment-4397097306.

Also serves as a `jj` exercise for myself.