### PR TITLE
chore(settings): rename triple to tuple

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -913,9 +913,7 @@ impl<'a> Cfg<'a> {
         // if the supplied tuple is insufficient / bad.
         PartialToolchainDesc::from_str("stable")?.resolve(&TargetTuple::new(host_tuple.clone()))?;
         self.settings_file.with_mut(|s| {
-            // TODO: Support default_host_tuple in settings while keeping default_host_triple
-            // for backwards compatibility.
-            s.default_host_triple = Some(host_tuple);
+            s.default_host_tuple = Some(host_tuple);
             Ok(())
         })
     }
@@ -995,7 +993,7 @@ impl Debug for Cfg<'_> {
 }
 
 fn default_host_tuple(s: &Settings, process: &Process) -> TargetTuple {
-    s.default_host_triple
+    s.default_host_tuple
         .as_ref()
         .map(TargetTuple::new)
         .unwrap_or_else(|| TargetTuple::from_host_or_build(process))

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -82,7 +82,8 @@ impl SettingsFile {
 pub struct Settings {
     pub version: MetadataVersion,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub default_host_triple: Option<String>,
+    #[serde(alias = "default_host_triple")]
+    pub default_host_tuple: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_toolchain: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -232,7 +233,19 @@ default_host_triple = "stable-aarch64-apple-darwin"
 "#;
         let settings = Settings::parse(raw).unwrap();
         assert_eq!(
-            settings.default_host_triple,
+            settings.default_host_tuple,
+            Some("stable-aarch64-apple-darwin".to_owned())
+        );
+    }
+
+    #[test]
+    fn deserialize_default_host_tuple() {
+        let raw = r#"version = "12"
+default_host_tuple = "stable-aarch64-apple-darwin"
+"#;
+        let settings = Settings::parse(raw).unwrap();
+        assert_eq!(
+            settings.default_host_tuple,
             Some("stable-aarch64-apple-darwin".to_owned())
         );
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -224,4 +224,16 @@ profile = "default"
 
 [overrides]
 "#;
+
+    #[test]
+    fn deserialize_default_host_triple() {
+        let raw = r#"version = "12"
+default_host_triple = "stable-aarch64-apple-darwin"
+"#;
+        let settings = Settings::parse(raw).unwrap();
+        assert_eq!(
+            settings.default_host_triple,
+            Some("stable-aarch64-apple-darwin".to_owned())
+        );
+    }
 }


### PR DESCRIPTION
Should resolve #4826 (I believe, finally).

This PR renames `Settings.default_host_triple` to `default_host_tuple`. Old settings toml still can be parsed through serde's alias.