### PR TITLE
Align shell setup comments in rustup’s install message

### DIFF
--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -91,9 +91,10 @@ pub(crate) fn build_source_env_lines(process: &Process) -> String {
             groups.push((src, vec![shell.name()]));
         }
     }
+    let src_width = groups.iter().map(|(src, _)| src.len()).max().unwrap_or(0);
     groups
         .into_iter()
-        .map(|(src, names)| format!("    {}  # For {}\n", src, names.join("/")))
+        .map(|(src, names)| format!(" {:<src_width$} # For {}\n", src, names.join("/")))
         .collect()
 }
 


### PR DESCRIPTION
This fixes the spacing in the shell setup instructions so the `# For ...` comments stay aligned for all shells, including Nushell.

The issue became visible after PR #4701 changed the Nushell env path, which made the final message look misaligned:

```text
This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
source "~/.cargo/env.nu"  # For nushell
source "$HOME/.cargo/env.tcsh"  # For tcsh
```

With this change, it is aligned correctly:

```text
This is usually done by running one of the following (note the leading DOT):
. "$HOME/.cargo/env"            # For sh/bash/zsh/ash/dash/pdksh
source "$HOME/.cargo/env.fish"  # For fish
source "~/.cargo/env.nu"        # For nushell
source "$HOME/.cargo/env.tcsh"  # For tcsh
```

The fix computes the display width of the source path and uses it for formatting the final message.
