### PR TITLE
feat(config): warn user if auto-install is enabled, take 2

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1074,7 +1074,7 @@ async fn update(
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
     } else if ensure_active_toolchain {
         let (toolchain, source) = cfg.ensure_active_toolchain(force_non_host, true).await?;
-        info!("the active toolchain `{toolchain}` has been installed");
+        info!("the active toolchain `{}` has been installed", *toolchain);
         info!("it's active because: {}", source.to_reason());
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
     } else {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -826,7 +826,7 @@ async fn default_(
                 let status = cfg
                     .ensure_installed(&desc, vec![], vec![], None, force_non_host, true)
                     .await?
-                    .0;
+                    .status;
 
                 cfg.set_default(Some(&(&desc).into()))?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -542,7 +542,10 @@ impl<'a> Cfg<'a> {
         }
 
         match self.ensure_active_toolchain(true, false).await {
-            Ok(r) => Ok(Some(r)),
+            Ok(r) => {
+                let (tc, source) = r;
+                Ok(Some((tc.inner, source)))
+            }
             Err(e) => match e.downcast_ref::<RustupError>() {
                 Some(RustupError::ToolchainNotSelected(_)) => Ok(None),
                 _ => Err(e),
@@ -744,10 +747,8 @@ impl<'a> Cfg<'a> {
         match name {
             Some((tc, source)) => {
                 let install_if_missing = self.should_auto_install()?;
-                Ok((
-                    Toolchain::from_local(tc, install_if_missing, self).await?,
-                    source,
-                ))
+                let tc = Toolchain::from_local(tc, install_if_missing, self).await?;
+                Ok((tc.inner, source))
             }
             None => {
                 let (tc, source) = self
@@ -764,10 +765,10 @@ impl<'a> Cfg<'a> {
         &self,
         force_non_host: bool,
         verbose: bool,
-    ) -> Result<(LocalToolchainName, ActiveSource)> {
+    ) -> Result<(EnsureInstalled<LocalToolchainName>, ActiveSource)> {
         if let Some((override_config, source)) = self.find_override_config()? {
             let toolchain = override_config.clone().into_local_toolchain_name();
-            if let OverrideCfg::Official {
+            let status = if let OverrideCfg::Official {
                 toolchain,
                 components,
                 targets,
@@ -782,20 +783,24 @@ impl<'a> Cfg<'a> {
                     force_non_host,
                     verbose,
                 )
-                .await?;
+                .await?
+                .status
             } else {
                 Toolchain::with_source(self, toolchain.clone(), &source)?;
-            }
-            Ok((toolchain, source))
+                UpdateStatus::Unchanged
+            };
+            Ok((EnsureInstalled::new(toolchain, status), source))
         } else if let Some(toolchain) = self.get_default()? {
             let source = ActiveSource::Default;
-            if let ToolchainName::Official(desc) = &toolchain {
+            let status = if let ToolchainName::Official(desc) = &toolchain {
                 self.ensure_installed(desc, vec![], vec![], None, force_non_host, verbose)
-                    .await?;
+                    .await?
+                    .status
             } else {
                 Toolchain::with_source(self, toolchain.clone().into(), &source)?;
-            }
-            Ok((toolchain.into(), source))
+                UpdateStatus::Unchanged
+            };
+            Ok((EnsureInstalled::new(toolchain.into(), status), source))
         } else {
             Err(no_toolchain_error(self.process))
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,6 +141,24 @@ impl<T> EnsureInstalled<T> {
     }
 }
 
+impl<T: Display> EnsureInstalled<T> {
+    fn warn_auto_install(&self, process: &Process) {
+        // If we're already in a recursion, or we haven't just installed the active toolchain, then
+        // don't print the warning.
+        let recursions = process.var("RUST_RECURSION_COUNT");
+        if recursions.is_ok_and(|it| it != "0") || !matches!(self.status, UpdateStatus::Installed) {
+            return;
+        }
+
+        warn!(
+            "the missing active toolchain `{}` has been auto-installed",
+            self.inner,
+        );
+        warn!("this might cause rustup commands to take longer time to finish than expected");
+        info!("you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`");
+    }
+}
+
 impl<T> Deref for EnsureInstalled<T> {
     type Target = T;
 
@@ -544,6 +562,7 @@ impl<'a> Cfg<'a> {
         match self.ensure_active_toolchain(true, false).await {
             Ok(r) => {
                 let (tc, source) = r;
+                tc.warn_auto_install(self.process);
                 Ok(Some((tc.inner, source)))
             }
             Err(e) => match e.downcast_ref::<RustupError>() {
@@ -747,8 +766,10 @@ impl<'a> Cfg<'a> {
         match name {
             Some((tc, source)) => {
                 let install_if_missing = self.should_auto_install()?;
-                let tc = Toolchain::from_local(tc, install_if_missing, self).await?;
-                Ok((tc.inner, source))
+                let EnsureInstalled { inner: tc, status } =
+                    Toolchain::from_local(tc, install_if_missing, self).await?;
+                EnsureInstalled::new(tc.name(), status).warn_auto_install(self.process);
+                Ok((tc, source))
             }
             None => {
                 let (tc, source) = self

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Debug, Display};
 use std::io;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
@@ -121,6 +122,30 @@ impl Display for ActiveSource {
             Self::OverrideDb(_) => "path-override",
             Self::ToolchainFile(_) => "toolchain-file",
         })
+    }
+}
+
+/// Represents the result of an operation that may ensure the installation of a certain toolchain.
+#[derive(Clone, Debug)]
+pub(crate) struct EnsureInstalled<T> {
+    pub inner: T,
+    pub status: UpdateStatus,
+}
+
+impl<T> EnsureInstalled<T> {
+    pub fn new(toolchain: T, status: UpdateStatus) -> Self {
+        Self {
+            inner: toolchain,
+            status,
+        }
+    }
+}
+
+impl<T> Deref for EnsureInstalled<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -787,7 +812,7 @@ impl<'a> Cfg<'a> {
         profile: Option<Profile>,
         force_non_host: bool,
         verbose: bool,
-    ) -> Result<(UpdateStatus, Toolchain<'_>)> {
+    ) -> Result<EnsureInstalled<Toolchain<'_>>> {
         common::check_non_host_toolchain(
             toolchain.to_string(),
             &TargetTuple::from_host_or_build(self.process),
@@ -831,7 +856,7 @@ impl<'a> Cfg<'a> {
             }
             Err(e) => return Err(e.into()),
         };
-        Ok((status, toolchain.into()))
+        Ok(EnsureInstalled::new(toolchain.into(), status))
     }
 
     /// Get the configured default toolchain.

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -314,6 +314,12 @@ impl Config {
             "/bogus-config-file.toml",
         );
 
+        // Clear current recursion count to avoid messing up related logic
+        cmd.env("RUST_RECURSION_COUNT", "");
+
+        // Clear override for auto installation of active toolchain unless explicitly requested
+        cmd.env("RUSTUP_AUTO_INSTALL", "");
+
         // Pass `RUSTUP_CI` over to the test process in case it is required downstream
         if let Some(ci) = env::var_os("RUSTUP_CI") {
             cmd.env("RUSTUP_CI", ci);

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -21,13 +21,14 @@ use wait_timeout::ChildExt;
 
 use crate::{
     RustupError,
-    config::{ActiveSource, Cfg, InstalledPath},
+    config::{ActiveSource, Cfg, EnsureInstalled, InstalledPath},
     dist::{
         DistOptions, PartialToolchainDesc, TargetTuple,
         component::{Component, Components},
         prefix::InstallPrefix,
     },
-    env_var, install,
+    env_var,
+    install::{self, UpdateStatus},
     utils::{self, raw::open_dir_following_links},
 };
 
@@ -54,15 +55,16 @@ impl<'a> Toolchain<'a> {
         name: LocalToolchainName,
         install_if_missing: bool,
         cfg: &'a Cfg<'a>,
-    ) -> anyhow::Result<Toolchain<'a>> {
+    ) -> anyhow::Result<EnsureInstalled<Toolchain<'a>>> {
         match Self::new(cfg, name) {
-            Ok(tc) => Ok(tc),
+            Ok(tc) => Ok(EnsureInstalled::new(tc, UpdateStatus::Unchanged)),
             Err(RustupError::ToolchainNotInstalled {
                 name: ToolchainName::Official(desc),
                 ..
             }) if install_if_missing => {
                 let options = DistOptions::new(&[], &[], &desc, cfg.get_profile()?, true, cfg)?;
-                Ok(DistributableToolchain::install(options).await?.1.toolchain)
+                let tc = DistributableToolchain::install(options).await?.1.toolchain;
+                Ok(EnsureInstalled::new(tc, UpdateStatus::Installed))
             }
             Err(e) => Err(e.into()),
         }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -64,7 +64,7 @@ async fn rustc_with_bad_rustup_toolchain_env_var() {
         .expect_with_env(["rustc"], [("RUSTUP_TOOLCHAIN", "bogus")])
         .await
         .with_stderr(snapbox::str![[r#"
-error: override toolchain 'bogus' is not installed[..]
+error:[..] toolchain 'bogus' is not installed[..]
 
 "#]])
         .is_err();
@@ -1381,7 +1381,10 @@ async fn which_asking_uninstalled_toolchain() {
 "#]])
         .is_ok();
     cx.config
-        .expect(["rustup", "which", "--toolchain=nightly", "rustc"])
+        .expect_with_env(
+            ["rustup", "which", "--toolchain=nightly", "rustc"],
+            [("RUSTUP_AUTO_INSTALL", "1")],
+        )
         .await
         .with_stderr(snapbox::str![[r#"
 error: toolchain 'nightly-[HOST_TUPLE]' is not installed

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1749,3 +1749,49 @@ info: falling back to "[EXTERN_PATH]"
 "#]])
         .is_ok();
 }
+
+#[tokio::test]
+async fn warn_auto_install_on_proxy() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect_with_env(
+            ["rustc", "--version"],
+            [("RUSTUP_TOOLCHAIN", "stable"), ("RUSTUP_AUTO_INSTALL", "1")],
+        )
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.1.0 (hash-stable-1.1.0)
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+...
+warn: the missing active toolchain `stable-[HOST_TUPLE]` has been auto-installed
+warn: this might cause rustup commands to take longer time to finish than expected
+info: you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`
+...
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
+async fn warn_auto_install_on_rustup() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect_with_env(
+            ["rustup", "doc", "--path"],
+            [("RUSTUP_TOOLCHAIN", "stable"), ("RUSTUP_AUTO_INSTALL", "1")],
+        )
+        .await
+        .with_stdout(snapbox::str![[r#"
+[..]/toolchains/stable-[HOST_TUPLE]/share/doc/rust/html/index.html
+
+"#]])
+        .with_stderr(snapbox::str![[r#"
+...
+warn: the missing active toolchain `stable-[HOST_TUPLE]` has been auto-installed
+warn: this might cause rustup commands to take longer time to finish than expected
+info: you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`
+...
+"#]])
+        .is_ok();
+}

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1247,7 +1247,7 @@ async fn show_toolchain_override_not_installed() {
         .await
         .is_ok();
     cx.config
-        .expect(["rustup", "show"])
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "1")])
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
@@ -1349,7 +1349,13 @@ installed targets:
 async fn show_toolchain_env_not_installed() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
-        .expect_with_env(["rustup", "show"], [("RUSTUP_TOOLCHAIN", "nightly")])
+        .expect_with_env(
+            ["rustup", "show"],
+            [
+                ("RUSTUP_TOOLCHAIN", "nightly"),
+                ("RUSTUP_AUTO_INSTALL", "1"),
+            ],
+        )
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .is_ok()

--- a/tests/suite/cli_v1.rs
+++ b/tests/suite/cli_v1.rs
@@ -271,7 +271,7 @@ async fn remove_override_toolchain_err_handling() {
         .await
         .is_ok();
     cx.config
-        .expect(["rustc", "--version"])
+        .expect_with_env(["rustc", "--version"], [("RUSTUP_AUTO_INSTALL", "1")])
         .await
         .with_stdout(snapbox::str![[r#"
 1.2.0 (hash-beta-1.2.0)

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -478,7 +478,7 @@ async fn remove_override_toolchain_err_handling() {
         .await
         .is_ok();
     cx.config
-        .expect(["rustc", "--version"])
+        .expect_with_env(["rustc", "--version"], [("RUSTUP_AUTO_INSTALL", "1")])
         .await
         .with_stdout(snapbox::str![[r#"
 1.2.0 (hash-beta-1.2.0)
@@ -511,7 +511,7 @@ async fn file_override_toolchain_err_handling() {
     let toolchain_file = cwd.join("rust-toolchain");
     rustup::utils::raw::write_file(&toolchain_file, "beta").unwrap();
     cx.config
-        .expect(["rustc", "--version"])
+        .expect_with_env(["rustc", "--version"], [("RUSTUP_AUTO_INSTALL", "1")])
         .await
         .with_stdout(snapbox::str![[r#"
 1.2.0 (hash-beta-1.2.0)
@@ -553,7 +553,10 @@ error: toolchain 'beta-[HOST_TUPLE]' is not installed
 "#]])
         .is_err();
     cx.config
-        .expect(["rustc", "+beta", "--version"])
+        .expect_with_env(
+            ["rustc", "+beta", "--version"],
+            [("RUSTUP_AUTO_INSTALL", "1")],
+        )
         .await
         .with_stdout(snapbox::str![[r#"
 1.2.0 (hash-beta-1.2.0)

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -488,6 +488,9 @@ async fn remove_override_toolchain_err_handling() {
 info: syncing channel updates for beta-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.2.0 (hash-beta-1.2.0)
 info: downloading 4 components
+warn: the missing active toolchain `beta-[HOST_TUPLE]` has been auto-installed
+warn: this might cause rustup commands to take longer time to finish than expected
+info: you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`
 
 "#]])
         .is_ok();
@@ -521,6 +524,9 @@ async fn file_override_toolchain_err_handling() {
 info: syncing channel updates for beta-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.2.0 (hash-beta-1.2.0)
 info: downloading 4 components
+warn: the missing active toolchain `beta-[HOST_TUPLE]` has been auto-installed
+warn: this might cause rustup commands to take longer time to finish than expected
+info: you may opt out with `RUSTUP_AUTO_INSTALL=0` or `rustup set auto-install disable`
 
 "#]])
         .is_ok();


### PR DESCRIPTION
Alternative design for #4454.

Closes https://github.com/rust-lang/rustup/issues/4445.

~~Opening a draft early to collect CI errors, please don't review yet 🙏~~

This PR has minimized its dependencies on #4840 so hopefully it'll be easier to backport this to 1.29 as well.
Since #4840 is a breaking change, I'd still like to add some 1.29-exclusive deprecation warnings based on it (part of #4211).