### PR TITLE
build(cargo): add `cargo` alias for `RUSTUP_FORCE_ARG0='rustup'`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 dev-install = "run -- --no-modify-path -y"
+run-rustup = ["run", "--config", "env.RUSTUP_FORCE_ARG0='rustup'"]

--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -10,8 +10,10 @@
 
 For developing on `rustup` itself, the easiest way is to run the development
 build on your current installation. This approach is best used for minor fixes
-or improvements. See the documentation for [`RUSTUP_FORCE_ARG0`] for more info.
+or improvements. See the documentation for [`cargo run-rustup`] and
+[`RUSTUP_FORCE_ARG0`] for more info.
 
+[`cargo run-rustup`]: tips-and-tricks.md#cargo-run-rustup
 [`RUSTUP_FORCE_ARG0`]: tips-and-tricks.md#rustup_force_arg0
 
 A more formal solution involves installing rustup into a temporary directory as

--- a/doc/dev-guide/src/tips-and-tricks.md
+++ b/doc/dev-guide/src/tips-and-tricks.md
@@ -1,21 +1,40 @@
 # Developer tips and tricks
 
-## `RUSTUP_FORCE_ARG0`
+## `cargo run-rustup`
 
-The environment variable `RUSTUP_FORCE_ARG0` can be used to get rustup to think
-it's a particular binary, rather than e.g. copying it, symlinking it or other
-tricks with exec. This is handy when testing particular code paths from cargo
-run.
+This is the easiest way to build rustup from source and test it against your
+current rustup installation. Compared to `cargo run` which executes
+`rustup-init`, `cargo run-rustup` runs `rustup` directly.
 
-For example, if you want to run `rustup show` with `cargo run`, you may execute:
+For example, if you want to run `rustup show`, you may execute:
 
 ```console
-> cargo run --config env.RUSTUP_FORCE_ARG0=\'rustup\' -- show
+> cargo run-rustup -- show
+```
+
+## `RUSTUP_FORCE_ARG0`
+
+Sometimes, you may want to test how rustup behaves when it's invoked with an
+executable name different from `rustup-init` and `rustup`, such as `rustc` or
+`cargo` when testing the proxy mode. In this case, `RUSTUP_FORCE_ARG0` can be
+used to force rustup into thinking it's being invoked with the given name.
+Similar to [`cargo run-rustup`], it directly runs on your existing rustup
+installation.
+
+For example, if you want to run `rustc --version`, you may execute:
+
+```console
+> cargo run --config env.RUSTUP_FORCE_ARG0=\'rustc\' -- --version
 ```
 
 This command passes the `RUSTUP_FORCE_ARG0` environment variable to the
 `rustup-init` binary without influencing the `cargo run` command itself,
 which is very important since `cargo` could also be a rustup proxy.
+
+In fact, [`cargo run-rustup`] is simply implemented as an alias of `cargo run
+--config env.RUSTUP_FORCE_ARG0=\'rustup\'`.
+
+[`cargo run-rustup`]: #cargo-run-rustup
 
 ## `RUSTUP_BACKTRACK_LIMIT`
 


### PR DESCRIPTION
Many thanks to @Cloud0310 for this idea.

Basically this crystalizes the [`RUSTUP_FORCE_ARG0='rustup'` trick](https://rust-lang.github.io/rustup/dev-guide/tips-and-tricks.html#rustup_force_arg0) into an alias subcommand `cargo run-rustup`, which I believe is a quite common action to be taken when playing with the project.

So far the value of `RUSTUP_FORCE_ARG0` is hardcoded to `'rustup'`, but I believe that would cover most use cases already (if there is a way to make it smarter while keeping this simple, please don't hesitate to help me out); if this turns out to be not enough, we can always add more as long as we are careful about choosing subcommand names.

Tested locally without issues:

```console
> cargo run-rustup -- show
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.42s
     Running `target/debug/rustup-init show`
Default host: aarch64-apple-darwin
rustup home: [redacted]

installed toolchains
--------------------
stable-aarch64-apple-darwin (active, default)
nightly-aarch64-apple-darwin
1.92.0-aarch64-apple-darwin

active toolchain
----------------
name: stable-aarch64-apple-darwin
active because: overridden by environment variable RUSTUP_TOOLCHAIN
installed targets:
  aarch64-apple-darwin
  x86_64-unknown-freebsd