### PR TITLE
Hint that a new Rust release may be available

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -44,7 +44,7 @@ use crate::{
     command, component_for_bin,
     config::{ActiveSource, Cfg},
     dist::{
-        AutoInstallMode, DistOptions, PartialToolchainDesc, Profile, TargetTuple,
+        DistOptions, PartialToolchainDesc, Profile, Switch, TargetTuple,
         download::DownloadCfg,
         manifest::{Component, ComponentStatus, ManifestWithHash},
     },
@@ -647,7 +647,13 @@ enum SetSubcmd {
     /// The auto toolchain install mode
     AutoInstall {
         #[arg(value_enum, default_value_t)]
-        auto_install_mode: AutoInstallMode,
+        auto_install_mode: Switch,
+    },
+
+    /// The new stable release hint mode
+    ReleaseHint {
+        #[arg(value_enum, default_value_t)]
+        release_hint_mode: Switch,
     },
 }
 
@@ -704,6 +710,12 @@ pub async fn main(
     cfg.toolchain_override = matches.plus_toolchain;
 
     let should_warn = subcmd.should_warn_empty_setup();
+
+    let should_notify = !matches.quiet
+        && !matches!(
+            subcmd,
+            RustupSubcmd::Update { .. } | RustupSubcmd::Install { .. }
+        );
 
     let exit_code = match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
@@ -828,6 +840,9 @@ pub async fn main(
             SetSubcmd::AutoInstall { auto_install_mode } => cfg
                 .set_auto_install(auto_install_mode)
                 .map(|_| ExitCode::SUCCESS),
+            SetSubcmd::ReleaseHint { release_hint_mode } => cfg
+                .set_release_hint(release_hint_mode)
+                .map(|_| ExitCode::SUCCESS),
         },
         RustupSubcmd::Completions { shell, command } => {
             output_completion_script(shell, command, process)
@@ -836,6 +851,10 @@ pub async fn main(
 
     if should_warn && cfg.list_toolchains()?.is_empty() && cfg.get_default()?.is_none() {
         warn!("no toolchain installed and no default toolchain set\n{DEFAULT_STABLE_HINT}");
+    }
+
+    if should_notify && let Err(e) = cfg.notify_release() {
+        warn!("could not check if there is a new Rust release: {e}");
     }
 
     Ok(exit_code)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,20 +1,20 @@
 use std::fmt::{self, Debug, Display};
 use std::io;
+use std::io::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
+use chrono::{DateTime, NaiveDate};
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 use tracing::{debug, info, trace, warn};
 
 use crate::{
     cli::{common, self_update::SelfUpdateMode},
-    dist::{
-        self, AutoInstallMode, DistOptions, PartialToolchainDesc, Profile, TargetTuple,
-        ToolchainDesc,
-    },
+    dist::{self, DistOptions, PartialToolchainDesc, Profile, Switch, TargetTuple, ToolchainDesc},
     errors::RustupError,
     fallback_settings::FallbackSettings,
     install::{InstallMethod, UpdateStatus},
@@ -417,12 +417,21 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn set_auto_install(&self, mode: AutoInstallMode) -> Result<()> {
+    pub(crate) fn set_auto_install(&self, mode: Switch) -> Result<()> {
         self.settings_file.with_mut(|s| {
             s.auto_install = Some(mode);
             Ok(())
         })?;
         info!("setting auto install mode to {}", mode.as_str());
+        Ok(())
+    }
+
+    pub(crate) fn set_release_hint(&self, mode: Switch) -> Result<()> {
+        self.settings_file.with_mut(|s| {
+            s.release_hint = Some(mode);
+            Ok(())
+        })?;
+        info!("setting release hint mode to {}", mode.as_str());
         Ok(())
     }
 
@@ -435,7 +444,7 @@ impl<'a> Cfg<'a> {
             Ok(mode != "0")
         } else {
             self.settings_file
-                .with(|s| Ok(s.auto_install != Some(AutoInstallMode::Disable)))
+                .with(|s| Ok(s.auto_install != Some(Switch::Disable)))
         }
     }
 
@@ -988,6 +997,64 @@ impl<'a> Cfg<'a> {
             LocalToolchainName::Path(p) => p.to_path_buf(),
         }
     }
+
+    /// Notifies a user with a hint whenever a new Rust release is available.
+    /// This is only shown at max once per day and only if not in proxy mode.
+    pub(crate) fn notify_release(&self) -> Result<()> {
+        if self.settings_file.with(|s| Ok(s.release_hint))? == Some(Switch::Disable) {
+            return Ok(());
+        }
+
+        let time_now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        // Limit notifications to at most once per day.
+        // This is checked before loading the manifest to avoid unnecessary disk I/O.
+        let last_notified = self
+            .state_file
+            .with(|s| Ok(s.last_release_notified_secs.unwrap_or(0)))?;
+        if time_now.saturating_sub(last_notified) < NOTIFY_INTERVAL_SECS {
+            return Ok(());
+        }
+
+        let default_host = self.default_host_tuple()?;
+        let stable_desc = PartialToolchainDesc::from_str("stable")?.resolve(&default_host)?;
+        let distributable = DistributableToolchain::new(self, stable_desc)
+            .map_err(|e| anyhow!("stable toolchain unavailable: {e}"))?;
+        let release_date_str = match distributable.get_manifestation() {
+            Ok(manifestation) => match manifestation.load_manifest() {
+                Ok(Some(manifest)) => manifest.date,
+                Ok(None) | Err(_) => FALLBACK_RELEASE_DATE.to_owned(),
+            },
+            Err(_) => FALLBACK_RELEASE_DATE.to_owned(),
+        };
+
+        let today = DateTime::from_timestamp(time_now as i64, 0)
+            .unwrap_or_default()
+            .date_naive();
+
+        let release_date = NaiveDate::parse_from_str(&release_date_str, "%Y-%m-%d")
+            .map_err(|e| anyhow!("could not parse release date '{}': {e}", release_date_str))?;
+
+        // Skip the hint if fewer than 6 weeks have passed since the last known release.
+        if (today - release_date).num_days() < RELEASE_CYCLE_DAYS {
+            return Ok(());
+        }
+
+        self.state_file.with_mut(|s| {
+            s.last_release_notified_secs = Some(time_now);
+            Ok(())
+        })?;
+
+        writeln!(
+            self.process.stderr().lock(),
+            "hint: a new stable Rust release is available, run `rustup update stable` to install it"
+        )?;
+
+        Ok(())
+    }
 }
 
 /// The root path of the release server, without the `/dist` suffix.
@@ -1137,6 +1204,10 @@ pub(crate) enum InstalledPath<'a> {
     File { name: &'static str, path: PathBuf },
     Dir { path: &'a Path },
 }
+
+const RELEASE_CYCLE_DAYS: i64 = 42;
+const NOTIFY_INTERVAL_SECS: u64 = 24 * 60 * 60;
+const FALLBACK_RELEASE_DATE: &str = "2026-04-17";
 
 #[cfg(test)]
 mod tests {

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use anyhow::{Context, Result, anyhow, bail};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
 use tracing::{debug, info, trace, warn};
 
@@ -278,6 +278,7 @@ pub(crate) struct Cfg<'a> {
     pub profile_override: Option<Profile>,
     pub rustup_dir: PathBuf,
     pub settings_file: SettingsFile,
+    state_file: StateFile,
     fallback_settings: Option<FallbackSettings>,
     pub toolchains_dir: PathBuf,
     update_hash_dir: PathBuf,
@@ -323,6 +324,8 @@ impl<'a> Cfg<'a> {
             }
         })?;
 
+        let state_file = StateFile::new(rustup_dir.join("state.toml"));
+
         // Centralised file for multi-user systems to provide admin/distributor set initial values.
         #[cfg(unix)]
         let fallback_settings = FallbackSettings::new(
@@ -355,6 +358,7 @@ impl<'a> Cfg<'a> {
             profile_override: None,
             rustup_dir,
             settings_file,
+            state_file,
             fallback_settings,
             toolchains_dir,
             update_hash_dir,
@@ -1012,6 +1016,7 @@ impl Debug for Cfg<'_> {
             profile_override,
             rustup_dir,
             settings_file,
+            state_file,
             fallback_settings,
             toolchains_dir,
             update_hash_dir,
@@ -1030,6 +1035,7 @@ impl Debug for Cfg<'_> {
             .field("profile_override", profile_override)
             .field("rustup_dir", rustup_dir)
             .field("settings_file", settings_file)
+            .field("state_file", state_file)
             .field("fallback_settings", fallback_settings)
             .field("toolchains_dir", toolchains_dir)
             .field("update_hash_dir", update_hash_dir)
@@ -1042,6 +1048,62 @@ impl Debug for Cfg<'_> {
             .field("current_dir", current_dir)
             .field("allow_auto_install", allow_auto_install)
             .finish()
+    }
+}
+
+/// Contrary to `settings.toml`, this file is not intended to be user-facing
+/// and is intended to merely persistently story rustup's internal state.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct StateFile {
+    path: PathBuf,
+}
+
+impl StateFile {
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn load(&self) -> Result<State> {
+        if !utils::is_file(&self.path) {
+            return Ok(State::default());
+        }
+        let content = utils::read_file("state", &self.path)?;
+        State::parse(&content).with_context(|| RustupError::ParsingFile {
+            name: "state",
+            path: self.path.clone(),
+        })
+    }
+
+    fn store(&self, state: &State) -> Result<()> {
+        utils::write_file("state", &self.path, &state.stringify()?)?;
+        Ok(())
+    }
+
+    fn with<T, F: FnOnce(&State) -> Result<T>>(&self, f: F) -> Result<T> {
+        f(&self.load()?)
+    }
+
+    fn with_mut<T, F: FnOnce(&mut State) -> Result<T>>(&self, f: F) -> Result<T> {
+        let mut state = self.load()?;
+        let result = f(&mut state)?;
+        self.store(&state)?;
+        Ok(result)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+struct State {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_release_notified_secs: Option<u64>,
+}
+
+impl State {
+    fn parse(data: &str) -> Result<Self> {
+        toml::from_str(data).context("error parsing state")
+    }
+
+    fn stringify(&self) -> Result<String> {
+        Ok(toml::to_string(self)?)
     }
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -815,13 +815,13 @@ impl fmt::Display for Profile {
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
-pub enum AutoInstallMode {
+pub enum Switch {
     #[default]
     Enable,
     Disable,
 }
 
-impl AutoInstallMode {
+impl Switch {
     pub(crate) fn as_str(&self) -> &'static str {
         match self {
             Self::Enable => "enable",
@@ -830,7 +830,7 @@ impl AutoInstallMode {
     }
 }
 
-impl ValueEnum for AutoInstallMode {
+impl ValueEnum for Switch {
     fn value_variants<'a>() -> &'a [Self] {
         &[Self::Enable, Self::Disable]
     }
@@ -844,7 +844,7 @@ impl ValueEnum for AutoInstallMode {
     }
 }
 
-impl FromStr for AutoInstallMode {
+impl FromStr for Switch {
     type Err = anyhow::Error;
 
     fn from_str(mode: &str) -> Result<Self> {
@@ -852,7 +852,7 @@ impl FromStr for AutoInstallMode {
             "enable" => Ok(Self::Enable),
             "disable" => Ok(Self::Disable),
             _ => Err(anyhow!(format!(
-                "unknown auto install mode: '{}'; valid modes are {}",
+                "unknown mode: '{}'; valid modes are {}",
                 mode,
                 Self::value_variants().iter().join(", ")
             ))),
@@ -860,7 +860,7 @@ impl FromStr for AutoInstallMode {
     }
 }
 
-impl fmt::Display for AutoInstallMode {
+impl fmt::Display for Switch {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use crate::cli::self_update::SelfUpdateMode;
-use crate::dist::{AutoInstallMode, Profile};
+use crate::dist::{Profile, Switch};
 use crate::errors::RustupError;
 use crate::utils;
 
@@ -95,7 +95,9 @@ pub struct Settings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_self_update: Option<SelfUpdateMode>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_install: Option<AutoInstallMode>,
+    pub auto_install: Option<Switch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_hint: Option<Switch>,
 }
 
 impl Settings {

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -15,9 +15,10 @@ use std::{
     process::Command,
     string::FromUtf8Error,
     sync::{Arc, LazyLock, RwLock, RwLockWriteGuard},
-    time::Instant,
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
+use chrono::{DateTime, Duration};
 use enum_map::{Enum, EnumMap, enum_map};
 use snapbox::{IntoData, RedactedValue, Redactions, assert_data_eq};
 use tempfile::TempDir;
@@ -553,6 +554,8 @@ pub enum Scenario {
     /// Three dates, v2 manifests, host and MULTI_ARCH1 in first, host only in second,
     /// host and MULTI_ARCH1 but no RLS in last
     MissingComponentMulti,
+    /// One recent date (within the last 6 weeks), v2 manifests
+    RecentStable,
 }
 
 impl Scenario {
@@ -641,6 +644,16 @@ impl Scenario {
                     .multi_arch()
                     .with_rls(RlsStatus::Unavailable),
             ],
+            Self::RecentStable => {
+                let now = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs();
+                let recent = (DateTime::from_timestamp(now as i64, 0).unwrap() - Duration::days(7))
+                    .format("%Y-%m-%d")
+                    .to_string();
+                vec![Release::stable("1.1.0", &recent)]
+            }
         };
 
         let vs = match self {
@@ -661,7 +674,8 @@ impl Scenario {
             | Self::HostGoesMissingBefore
             | Self::HostGoesMissingAfter
             | Self::MissingComponent
-            | Self::MissingComponentMulti => vec![MockManifestVersion::V2],
+            | Self::MissingComponentMulti
+            | Self::RecentStable => vec![MockManifestVersion::V2],
         };
 
         MockDistServer {
@@ -718,6 +732,7 @@ impl ConstState {
                 Scenario::SimpleV2 => RwLock::new(None),
                 Scenario::Unavailable => RwLock::new(None),
                 Scenario::UnavailableRls => RwLock::new(None),
+                Scenario::RecentStable => RwLock::new(None),
             },
         }
     }
@@ -946,6 +961,13 @@ impl CliTestContext {
         if scenario != Scenario::None {
             config.distdir = Some(config.test_dist_dir.path().to_path_buf());
         }
+
+        // Disable the new release hint by default to avoid extra
+        // output to be matched during the tests.
+        config
+            .expect(["rustup", "set", "release-hint", "disable"])
+            .await
+            .is_ok();
 
         Self { config, _test_dir }
     }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -880,6 +880,49 @@ installed targets:
   [HOST_TUPLE]
 
 "#]])
+        .is_ok();
+}
+
+#[tokio::test]
+async fn notify_release_hint_at_most_once_per_day() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "set", "release-hint", "enable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stderr(snapbox::str![[r#"
+hint: a new stable Rust release is available, run `rustup update stable` to install it
+
+"#]])
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stderr(snapbox::str![[""]])
+        .is_ok();
+}
+
+#[tokio::test]
+async fn notify_release_hint_skipped_for_recent_release() {
+    let cx = CliTestContext::new(Scenario::RecentStable).await;
+    cx.config
+        .expect(["rustup", "set", "release-hint", "enable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
         .with_stderr(snapbox::str![[""]])
         .is_ok();
 }

--- a/tests/suite/cli_rustup_ui/rustup_set_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_set_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="740px" height="272px" xmlns="http://www.w3.org/2000/svg">
+<svg width="740px" height="290px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -38,15 +38,17 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">auto-install</tspan><tspan>      The auto toolchain install mode</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>              Print this message or the help of the given subcommand(s)</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">release-hint</tspan><tspan>      The new stable release hint mode</tspan>
 </tspan>
-    <tspan x="10px" y="208px">
+    <tspan x="10px" y="208px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>              Print this message or the help of the given subcommand(s)</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan class="fg-bright-green bold">Options:</tspan>
+    <tspan x="10px" y="226px">
 </tspan>
-    <tspan x="10px" y="244px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
+    <tspan x="10px" y="244px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="262px">
+    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
+</tspan>
+    <tspan x="10px" y="280px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Closes #4846.

After a rustup command completes (excluding proxy commands), rustup checks whether a new Rust release is available.

To avoid introducing any additional overhead, this feature does not communicate with the release server.
Instead, it checks whether the stable toolchain manifest date is more than six weeks old.
Since Rust follows a regular and predictable release cadence, this should provide a sufficiently accurate indication that a new release is available.

When an outdated stable toolchain is detected, rustup prints a hint suggesting that the user may update their stable toolchain; this hint is shown at most once per day.
Users who prefer not to receive these hints can opt out with `rustup set release-hint false`.

I have run some benchmarks (100 iterations) for the `rustup show` command and observed no significant slowdown (1.1x) when we do not show the hint.
However, due to manifest parsing, there is a 1.4x slowdown when the hint is shown (once per day).

Feedback is appreciated on:
1. Whether this approach and its associated overhead are acceptable, or if we should take a different direction;
2. Which rustup commands should display this hint;
3. Whether relying on Rust’s regular release cadence, instead of contacting the release server, is acceptable;