### PR TITLE
refactor(toolchain/distributable): return `EnsureInstalled<>` from `DistributableToolchain::install()`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1051,7 +1051,7 @@ async fn update(
                     }
                 }
                 Err(RustupError::ToolchainNotInstalled { .. }) => {
-                    DistributableToolchain::install(dist_opts).await?.0
+                    DistributableToolchain::install(dist_opts).await?.status
                 }
                 Err(e) => Err(e)?,
             };
@@ -1628,7 +1628,7 @@ async fn override_add(
             ToolchainName::Custom(_) => Err(e)?,
             ToolchainName::Official(desc) => {
                 let options = DistOptions::new(&[], &[], desc, cfg.get_profile()?, false, cfg)?;
-                let status = DistributableToolchain::install(options).await?.0;
+                let status = DistributableToolchain::install(options).await?.status;
                 writeln!(cfg.process.stdout().lock())?;
                 common::show_channel_update(
                     cfg,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1036,7 +1036,7 @@ async fn maybe_install_rust(opts: InstallOpts<'_>, cfg: &mut Cfg<'_>) -> Result<
                 .install(None)
                 .await?
         } else {
-            DistributableToolchain::install(options).await?.0
+            DistributableToolchain::install(options).await?.status
         };
 
         check_proxy_sanity(cfg.process, components, desc)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -862,9 +862,10 @@ impl<'a> Cfg<'a> {
             self,
         )?;
 
-        let (status, toolchain) = match DistributableToolchain::new(self, toolchain.clone()) {
+        Ok(match DistributableToolchain::new(self, toolchain.clone()) {
             Err(RustupError::ToolchainNotInstalled { .. }) => {
-                DistributableToolchain::install(options).await?
+                let tc = DistributableToolchain::install(options).await?;
+                EnsureInstalled::new(tc.inner.into(), tc.status)
             }
             Ok(distributable) => {
                 if verbose {
@@ -878,11 +879,10 @@ impl<'a> Cfg<'a> {
                 } else {
                     UpdateStatus::Unchanged
                 };
-                (status, distributable)
+                EnsureInstalled::new(distributable.into(), status)
             }
             Err(e) => return Err(e.into()),
-        };
-        Ok(EnsureInstalled::new(toolchain.into(), status))
+        })
     }
 
     /// Get the configured default toolchain.

--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -63,8 +63,8 @@ impl<'a> Toolchain<'a> {
                 ..
             }) if install_if_missing => {
                 let options = DistOptions::new(&[], &[], &desc, cfg.get_profile()?, true, cfg)?;
-                let tc = DistributableToolchain::install(options).await?.1.toolchain;
-                Ok(EnsureInstalled::new(tc, UpdateStatus::Installed))
+                let tc = DistributableToolchain::install(options).await?;
+                Ok(EnsureInstalled::new(tc.inner.into(), tc.status))
             }
             Err(e) => Err(e.into()),
         }

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -9,7 +9,7 @@ use platforms::Platform;
 
 use crate::{
     RustupError, component_for_bin,
-    config::{ActiveSource, Cfg},
+    config::{ActiveSource, Cfg, EnsureInstalled},
     dist::{
         DistOptions, PartialToolchainDesc, ToolchainDesc,
         config::Config,
@@ -18,7 +18,7 @@ use crate::{
         manifestation::{Changes, Manifestation},
         prefix::InstallPrefix,
     },
-    install::{InstallMethod, UpdateStatus},
+    install::InstallMethod,
 };
 
 use crate::errors::UnknownComponentInfo;
@@ -39,10 +39,13 @@ impl<'a> DistributableToolchain<'a> {
     #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
     pub(crate) async fn install(
         options: DistOptions<'a, '_>,
-    ) -> anyhow::Result<(UpdateStatus, Self)> {
+    ) -> anyhow::Result<EnsureInstalled<Self>> {
         let (cfg, toolchain) = (options.cfg, options.toolchain);
         let status = InstallMethod::Dist(options).install(None).await?;
-        Ok((status, Self::new(cfg, toolchain.clone())?))
+        Ok(EnsureInstalled::new(
+            Self::new(cfg, toolchain.clone())?,
+            status,
+        ))
     }
 
     pub(crate) async fn from_partial(


### PR DESCRIPTION
Follow-up of the refactoring part of #4859.