### PR TITLE
Display a different color for installed components during a toolchain install

### DIFF
--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -430,9 +430,10 @@ impl DownloadStatus {
     }
 
     pub(crate) fn installed(&self) {
+        self.progress.set_prefix("installed");
         self.progress.set_style(DownloadStatus::progress_style(
             self.name_width,
-            "installed {total_bytes:>31}",
+            "{prefix:.green.bold} {total_bytes:>31}",
         ));
         self.progress.finish();
     }


### PR DESCRIPTION
Closes #4870.

I decided to set a prefix for the `ProgressBar` since we were not using one before.
Looking at indicatif's documentation, this seemed like a reasonable way to style a specific portion of the `ProgressBar`.

Is there a more idiomatic approach to achieving this that I might be overlooking?

CC @djc 

---
I have left two screenshots below to illustrate this change.

Before:
<img width="619" height="254" alt="image" src="https://github.com/user-attachments/assets/7c450808-fa9c-488f-88c2-2daedacb1a0a" />


After:
<img width="622" height="254" alt="image" src="https://github.com/user-attachments/assets/81d5882a-9569-4e4a-8779-9712ea523b6b" />

NB: My terminal does not display the last message (regarding the installed toolchain) in bright green as it should.
