### PR TITLE
docs: simplify the release-process wording

### DIFF
--- a/doc/dev-guide/src/release-process.md
+++ b/doc/dev-guide/src/release-process.md
@@ -98,7 +98,7 @@ and determine which `$BRANCH` you should be working on:
 
 Producing the final release artifacts is a bit involved because of the way
 rustup is distributed. Below is a list of things to be done in order to cut a
-new [b]eta release or an official [r]elease:
+new beta release or an official release:
 
 1. [b/r] Make sure that the desired version number for the new release
    `$VER_NUM` already exists in `$BRANCH`'s `Cargo.toml` file. Then in a new PR


### PR DESCRIPTION
## Summary

- simplify the release-process guide wording around beta and release

## Related issue

- N/A (trivial docs-only fix)

## Guideline alignment

- no CONTRIBUTING guide or PR template was present in the repo root scan, so I kept this to a single-file docs-only fix on `main`

## Validation

- not run (docs-only change)
