### PR TITLE
docs: improve the FileBuffer::clear doc comment wording

### DIFF
--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -80,7 +80,7 @@ pub(crate) enum FileBuffer {
 }
 
 impl FileBuffer {
-    /// All the buffers space to be re-used when the last reference to it is dropped.
+    /// Allows the buffer's space to be reused when the last reference to it is dropped.
     pub(crate) fn clear(&mut self) {
         if let FileBuffer::Threaded(contents) = self {
             contents.clear()


### PR DESCRIPTION
## Summary

- improve the `FileBuffer::clear` doc comment wording

## Related issue

- N/A (trivial comment-only fix)

## Guideline alignment

- no CONTRIBUTING guide or PR template was present in the repo root scan, so I kept this to a single-file comment-only fix on `main`

## Validation

- not run (comment-only change)
