### PR TITLE
docs: fix the tracing guide wording

### DIFF
--- a/doc/dev-guide/src/tracing.md
+++ b/doc/dev-guide/src/tracing.md
@@ -118,6 +118,6 @@ Some good general heuristics:
   as these tend to help figure the puzzle of what-is-happening
 - Default to not instrumenting thin shim functions (or at least, only instrument
   them temporarily while figuring out the shape of a problem)
-- Be way of debug build timing - release optimisations make a huge difference,
+- Be aware of debug build timing - release optimisations make a huge difference,
   though debug is a lot faster to iterate on. If something isn't a problem in
   release don't pay it too much heed in debug.


### PR DESCRIPTION
## Summary

- fix a wording typo in the tracing guide's debug-build advice

## Related issue

- N/A (trivial docs-only fix)

## Guideline alignment

- no CONTRIBUTING guide or PR template was present in the repo root scan, so I kept this to a single-file docs-only fix on `main`

## Validation

- not run (docs-only change)
