### PR TITLE
Display the full names of targets not matching the host target tuple

### DIFF
--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -87,6 +87,15 @@ impl Manifest {
             &component.pkg
         }
     }
+
+    pub(crate) fn display_name(&self, component: &Component, host_target: &TargetTuple) -> String {
+        match &component.target {
+            Some(component_target) if *host_target == *component_target => {
+                self.short_name(component).to_owned()
+            }
+            _ => self.name(component),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -167,7 +167,11 @@ impl Manifestation {
             .iter()
             // The same as the component name's length used in `ComponentBinary::new`
             // As it's used for status output
-            .map(|component| new_manifest.short_name(component).len())
+            .map(|component| {
+                new_manifest
+                    .display_name(component, &toolchain.target)
+                    .len()
+            })
             .max()
             .unwrap_or(0)
             .max(DEFAULT_MIN_NAME_WIDTH);
@@ -177,7 +181,13 @@ impl Manifestation {
             .components_to_install
             .into_iter()
             .filter_map(|component| {
-                ComponentBinary::new(component, &new_manifest, download_cfg, max_name_width)
+                ComponentBinary::new(
+                    component,
+                    &new_manifest,
+                    download_cfg,
+                    max_name_width,
+                    &toolchain.target,
+                )
             })
             .collect::<Result<Vec<_>>>()?;
 
@@ -766,6 +776,7 @@ impl<'a> ComponentBinary<'a> {
         manifest: &'a Manifest,
         download_cfg: &'a DownloadCfg<'a>,
         name_width: usize,
+        host_toolchain_target: &TargetTuple,
     ) -> Option<Result<Self>> {
         Some(Ok(ComponentBinary {
             binary: match manifest.binary(&component) {
@@ -773,7 +784,10 @@ impl<'a> ComponentBinary<'a> {
                 Ok(None) => return None,
                 Err(e) => return Some(Err(e)),
             },
-            status: download_cfg.status_for(manifest.short_name(&component).to_owned(), name_width),
+            status: download_cfg.status_for(
+                manifest.display_name(&component, host_toolchain_target),
+                name_width,
+            ),
             component,
             manifest,
             download_cfg,


### PR DESCRIPTION
Displays the target tuple when it doesn't match the host target tuple.

Example output:

```
info: downloading 7 components
                             cargo installed                       10.64 MiB (29.13 MiB/s, ETA: 0s)                                         
                            clippy installed                        4.58 MiB (27.97 MiB/s, ETA: 0s)                                         
                         rust-docs installed                       21.29 MiB (8.54 MiB/s, ETA: 0s))s)                                       
rust-std-aarch64-unknown-linux-gnu installed                       27.12 MiB (26.71 MiB/s, ETA: 0s)                                         
                          rust-std installed                       28.36 MiB (26.10 MiB/s, ETA: 0s)                                         
                             rustc installed                       76.47 MiB (30.56 MiB/s, ETA: 0s)                                         
                           rustfmt installed                        2.06 MiB                                                                info: default toolchain set to stable-x86_64-unknown-linux-gnu
```

Resolves #4884
