### PR TITLE
ci(docker/freebsd): bump `clang` version to `freebsd14`

### DIFF
--- a/ci/docker/x86_64-unknown-freebsd/Dockerfile
+++ b/ci/docker/x86_64-unknown-freebsd/Dockerfile
@@ -4,5 +4,5 @@ FROM rust-x86_64-unknown-freebsd
 # See: https://aws.github.io/aws-lc-rs/requirements/linux
 RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
 
-ENV CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd12-clang \
-    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd12-clang
+ENV CC_x86_64_unknown_freebsd=x86_64-unknown-freebsd14-clang \
+    CARGO_TARGET_X86_64_UNKNOWN_FREEBSD_LINKER=x86_64-unknown-freebsd14-clang


### PR DESCRIPTION
Resolves CI error on `main` (https://github.com/rust-lang/rustup/actions/runs/26989736967).

Fix verified with https://github.com/rust-lang/rustup/actions/runs/27098693247/job/79975395314?pr=4896.

Mirrors https://github.com/rust-lang/rust/pull/156607.