### PR TITLE
Add aarch64-unknown-freebsd

### DIFF
--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -24,6 +24,7 @@ jobs: # skip-main skip-pr skip-stable
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
           - aarch64-unknown-linux-musl     # skip-pr skip-main
+          - aarch64-unknown-freebsd        # skip-pr skip-main skip-stable
           - powerpc64-unknown-linux-gnu    # skip-pr
           - x86_64-unknown-linux-musl      # skip-pr
           - i686-unknown-linux-gnu         # skip-pr skip-main

--- a/ci/cloudfront-invalidation.txt
+++ b/ci/cloudfront-invalidation.txt
@@ -11,6 +11,8 @@ rustup/dist/aarch64-unknown-linux-gnu/rustup-init
 rustup/dist/aarch64-unknown-linux-gnu/rustup-init.sha256
 rustup/dist/aarch64-unknown-linux-musl/rustup-init
 rustup/dist/aarch64-unknown-linux-musl/rustup-init.sha256
+rustup/dist/aarch64-unknown-freebsd/rustup-init
+rustup/dist/aarch64-unknown-freebsd/rustup-init.sha256
 rustup/dist/arm-linux-androideabi/rustup-init
 rustup/dist/arm-linux-androideabi/rustup-init.sha256
 rustup/dist/arm-unknown-linux-gnueabi/rustup-init

--- a/ci/docker/aarch64-unknown-freebsd/Dockerfile
+++ b/ci/docker/aarch64-unknown-freebsd/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust-aarch64-unknown-freebsd
+
+# Building `aws-lc-rs` for FreeBSD on Linux depends on `gcc-multilib`, `libclang` and `bindgen`.
+# See: https://aws.github.io/aws-lc-rs/requirements/linux
+RUN apt-get update && apt-get install -qy gcc-multilib libclang-dev
+
+ENV CC_aarch64_unknown_freebsd=aarch64-unknown-freebsd14-clang \
+    CARGO_TARGET_AARCH64_UNKNOWN_FREEBSD_LINKER=aarch64-unknown-freebsd14-clang

--- a/ci/fetch-rust-docker.bash
+++ b/ci/fetch-rust-docker.bash
@@ -23,6 +23,7 @@ LOCAL_DOCKER_TAG="rust-$TARGET"
 case "$TARGET" in
   aarch64-unknown-linux-gnu)       image=dist-aarch64-linux ;;
   aarch64-unknown-linux-musl)      image=dist-arm-linux-musl ;;
+  aarch64-unknown-freebsd)         image=dist-aarch64-freebsd ;;
   arm-unknown-linux-gnueabi)       image=dist-arm-linux-gnueabi ;;
   arm-unknown-linux-gnueabihf)     image=dist-armhf-linux ;;
   armv7-unknown-linux-gnueabihf)   image=dist-armv7-linux ;;

--- a/doc/user-guide/src/installation/other.md
+++ b/doc/user-guide/src/installation/other.md
@@ -117,6 +117,8 @@ You can manually download `rustup-init` for a given target from
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-gnu/rustup-init.sha256)
 - [aarch64-unknown-linux-musl](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-musl/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-unknown-linux-musl/rustup-init.sha256)
+- [aarch64-unknown-freebsd](https://static.rust-lang.org/rustup/dist/aarch64-unknown-freebsd/rustup-init)
+  - [sha256 file](https://static.rust-lang.org/rustup/dist/aarch64-unknown-freebsd/rustup-init.sha256)
 - [arm-linux-androideabi](https://static.rust-lang.org/rustup/dist/arm-linux-androideabi/rustup-init)
   - [sha256 file](https://static.rust-lang.org/rustup/dist/arm-linux-androideabi/rustup-init.sha256)
 - [arm-unknown-linux-gnueabi](https://static.rust-lang.org/rustup/dist/arm-unknown-linux-gnueabi/rustup-init)

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -524,6 +524,7 @@ impl TargetTuple {
                 (b"Darwin", b"i686") => Some("i686-apple-darwin"),
                 (b"FreeBSD", b"x86_64") => Some("x86_64-unknown-freebsd"),
                 (b"FreeBSD", b"i686") => Some("i686-unknown-freebsd"),
+                (b"FreeBSD", b"aarch64") => Some("aarch64-unknown-freebsd"),
                 (b"OpenBSD", b"x86_64") => Some("x86_64-unknown-openbsd"),
                 (b"OpenBSD", b"i686") => Some("i686-unknown-openbsd"),
                 (b"NetBSD", b"x86_64") => Some("x86_64-unknown-netbsd"),


### PR DESCRIPTION
aarch64-unknown-freebsd is now a Tier 2 target with host tools. Add support for it in rustup.