### PR TITLE
Show setup hint when rustup has no default toolchain

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -48,7 +48,7 @@ use crate::{
         download::DownloadCfg,
         manifest::{Component, ComponentStatus, ManifestWithHash},
     },
-    errors::RustupError,
+    errors::{DEFAULT_STABLE_HINT, RustupError},
     install::{InstallMethod, UpdateStatus},
     process::{ColorableTerminal, Process},
     toolchain::{
@@ -327,6 +327,36 @@ impl RustupSubcmd {
             | RustupSubcmd::Uninstall { .. }
             | RustupSubcmd::Update { .. }
             | RustupSubcmd::Which { .. } => false,
+        }
+    }
+
+    /// Returns whether rustup should warn about having no default toolchain and no installed toolchains.
+    fn should_warn_empty_setup(&self) -> bool {
+        match self {
+            // These subcommands are not about toolchains, so the hint would be noise.
+            RustupSubcmd::Completions { .. }
+            | RustupSubcmd::DumpTestament
+            | RustupSubcmd::Self_ { .. } => false,
+
+            // For all other subcommands, the hint may be useful if rustup is still unusable after
+            // the command has completed.
+            RustupSubcmd::Check { .. }
+            | RustupSubcmd::Component { .. }
+            | RustupSubcmd::Default { .. }
+            | RustupSubcmd::Doc { .. }
+            | RustupSubcmd::Install { .. }
+            | RustupSubcmd::Override { .. }
+            | RustupSubcmd::Run { .. }
+            | RustupSubcmd::Set { .. }
+            | RustupSubcmd::Show { .. }
+            | RustupSubcmd::Target { .. }
+            | RustupSubcmd::Toolchain { .. }
+            | RustupSubcmd::Uninstall { .. }
+            | RustupSubcmd::Update { .. }
+            | RustupSubcmd::Which { .. } => true,
+
+            #[cfg(not(windows))]
+            RustupSubcmd::Man { .. } => true,
         }
     }
 }
@@ -675,7 +705,9 @@ pub async fn main(
     )?;
     cfg.toolchain_override = matches.plus_toolchain;
 
-    match subcmd {
+    let should_warn = subcmd.should_warn_empty_setup();
+
+    let exit_code = match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
         RustupSubcmd::Install { opts } => update(cfg, opts, true).await,
         RustupSubcmd::Uninstall { opts } => toolchain_remove(cfg, opts).await,
@@ -802,7 +834,13 @@ pub async fn main(
         RustupSubcmd::Completions { shell, command } => {
             output_completion_script(shell, command, process)
         }
+    }?;
+
+    if should_warn && cfg.list_toolchains()?.is_empty() && cfg.get_default()?.is_none() {
+        warn!("no toolchain installed and no default toolchain set\n{DEFAULT_STABLE_HINT}");
     }
+
+    Ok(exit_code)
 }
 
 async fn default_(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -18,6 +18,8 @@ use crate::{
     toolchain::{PathBasedToolchainName, ToolchainName},
 };
 
+pub(crate) const DEFAULT_STABLE_HINT: &str = "help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.";
+
 /// A type erasing thunk for the retry crate to permit use with anyhow. See <https://github.com/dtolnay/anyhow/issues/149>
 #[derive(Debug, ThisError)]
 #[error(transparent)]
@@ -131,8 +133,8 @@ pub enum RustupError {
     #[error("path '{0}' not found")]
     PathToolchainNotInstalled(PathBasedToolchainName),
     #[error(
-        "rustup could not choose a version of {0} to run, because one wasn't specified explicitly, and no default is configured.\n\
-        help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain."
+        "rustup could not choose a version of {0} to run, because one wasn't specified explicitly, and no default is configured.\n{hint}",
+        hint = DEFAULT_STABLE_HINT
     )]
     ToolchainNotSelected(String),
     #[error("{}", unknown_components_msg(.desc, .components))]

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -393,6 +393,8 @@ async fn remove_override_none() {
             .with_stderr(snapbox::str![[r#"
 info: no override toolchain for '[CWD]'
 info: you may use `--path <path>` option to remove override toolchain for a specific path
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
 
 "#]]);
     }
@@ -628,6 +630,8 @@ async fn default_none() {
         .is_ok()
         .with_stderr(snapbox::str![[r#"
 info: default toolchain unset
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
 
 "#]]);
 

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1030,6 +1030,8 @@ test
         .with_stderr(snapbox::str![[r#"
 info: uninstalling toolchain test
 info: toolchain test uninstalled
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
 
 "#]])
         .is_ok();

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -267,6 +267,8 @@ async fn rustup_no_channels() {
         .with_stderr(snapbox::str![[r#"
 info: no updatable toolchains installed
 info: cleaning up downloads & tmp directories
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
 
 "#]])
         .is_ok();
@@ -721,7 +723,11 @@ async fn show_home() {
 [RUSTUP_DIR]
 
 "#]])
-        .with_stderr(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
+
+"#]])
         .is_ok();
 }
 
@@ -744,7 +750,11 @@ active toolchain
 no active toolchain
 
 "#]])
-        .with_stderr(snapbox::str![[""]])
+        .with_stderr(snapbox::str![[r#"
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
+
+"#]])
         .is_ok();
 }
 


### PR DESCRIPTION
It intends to fix #4901 

This adds in `rustup` to print the default stable setup hint when a  rustup command finishes in an empty setup state: no installed toolchains and no configured default toolchain.

The hint reuses `DEFAULT_STABLE_HINT`:

```text
help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
```
Changes:
1. Extracted the default stable hint into `DEFAULT_STABLE_HINT`.
2. Added `RustupSubcmd::should_warn_empty_setup()` to decide which rustup commands may show the empty setup warning.
3. Added the warning after subcommand execution, so rustup checks the final state before printing the hint.
4. Skipped the warning for `DumpTestament`, `Self_`, and `Completion` as those commands are not related to toolchain state.
5. Updated CLI test expectations.

