### PR TITLE
docs: update `CHANGELOG` for v1.29.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,69 @@
 # Changelog
 
+## [1.29.1] - 2026-XX-YY
+
+This new patch release has brought some minor improvements and fixes over the previous one.
+
+The headlines of this release are:
+
+- Concurrency in certain `rustup` operations has been further improved:
+  - When running `rustup update`, rustup will first check for possible updates in parallel. [pr#4752]
+  - When running `rustup component add` with multiple components, they will be installed concurrently. [pr#4790]
+
+- Implicit installation of the active toolchain in `rustup-init` and `rustup` invocations has
+  been deprecated when deemed unnecessary and will now produce a warning. [pr#4840]
+  - Please see our
+    [blog post](https://blog.rust-lang.org/inside-rust/2026/07/03/rustup-update-1.30/#refining-the-implicit-installation-behavior)
+    for more details regarding this change.
+
+- Installing `i686-pc-windows-*` host toolchain on 64-bit Windows now requires `--force-non-host`. [pr#4935]
+
+- A bug has been fixed which might cause Windows installation to fail when using `rustup-init.sh`. [pr#4756]
+
+- "Target **triple**" has been renamed to "target **tuple**" across the project to reflect the
+  [new terminology](https://github.com/rust-lang/rust/pull/125579/changes/a26450cf81d67d68d3c6157579f8d968349129e7).
+  [pr#4743] [pr#4827] [pr#4834]
+
+In addition, rustup now officially supports `aarch64-pc-windows-gnullvm` as a host platform. [pr#4523]
+
+[1.29.1]: https://github.com/rust-lang/rustup/releases/tag/1.29.1
+[pr#4523]: https://github.com/rust-lang/rustup/pull/4523
+[pr#4743]: https://github.com/rust-lang/rustup/pull/4743
+[pr#4752]: https://github.com/rust-lang/rustup/pull/4752
+[pr#4756]: https://github.com/rust-lang/rustup/pull/4756
+[pr#4790]: https://github.com/rust-lang/rustup/pull/4790
+[pr#4827]: https://github.com/rust-lang/rustup/pull/4827
+[pr#4834]: https://github.com/rust-lang/rustup/pull/4834
+[pr#4840]: https://github.com/rust-lang/rustup/pull/4840
+[pr#4935]: https://github.com/rust-lang/rustup/pull/4935
+
+### Detailed changes
+
+* use 'tuple' instead of 'triple' for env overrides by @tshepang in https://github.com/rust-lang/rustup/pull/4743
+* Avoid printing a warning about `settings.toml` on a fresh install by @FranciscoTGouveia in https://github.com/rust-lang/rustup/pull/4746
+* fix(rustup-init/sh): prevent passing `--default-host` twice by @rami3l in https://github.com/rust-lang/rustup/pull/4756
+* fix(cli/proxy-mode): stop enforcing `quiet: true` by @rami3l in https://github.com/rust-lang/rustup/pull/4762
+* Fix zsh completion showing all PATH entries for +toolchain arg by @simonhkswan in https://github.com/rust-lang/rustup/pull/4763
+* fix(dist/manifestation): use full toolchain name in `Update::unavailable_components()` by @rami3l in https://github.com/rust-lang/rustup/pull/4767
+* self\_update: show path to executable in case of updater failure by @djc in https://github.com/rust-lang/rustup/pull/4781
+* chore: Rename `Component::name_in_manifest` and `short_name_in_manifest` method to `name` and `short_name` by @Cloud0310 in https://github.com/rust-lang/rustup/pull/4778
+* Fix install message misalignment by @Cloud0310 in https://github.com/rust-lang/rustup/pull/4768
+* fix: Reduce flickering by using `set_move_cursor` by @ChrisDenton in https://github.com/rust-lang/rustup/pull/4786
+* Run a parallel pre-check before updating toolchains by @FranciscoTGouveia in https://github.com/rust-lang/rustup/pull/4752
+* Allow rustup component add to install multiple components in one update by @Inconnu08 in https://github.com/rust-lang/rustup/pull/4790
+* fix(dist/manifestation): fix log format when installing exactly 2 components by @rami3l in https://github.com/rust-lang/rustup/pull/4798
+* Use `cc-rs` to detect the default linker, instead of assuming `cc` by @jamesmunns in https://github.com/rust-lang/rustup/pull/4807
+* Make component removal best-effort and preserve single-error behavior by @Inconnu08 in https://github.com/rust-lang/rustup/pull/4797
+* Only show post-install instructions for currently installed shells by @ryankopf in https://github.com/rust-lang/rustup/pull/4806
+* test(dist/manifest): use the reordered fixture in `manifest_serialized_with_sorted_keys` by @cachebag in https://github.com/rust-lang/rustup/pull/4822
+* Improve error message for incomplete toolchains by @Inconnu08 in https://github.com/rust-lang/rustup/pull/4819
+* fix: rename partially "Triple" to "Tuple" to reflect the new terminology by @motorailgun in https://github.com/rust-lang/rustup/pull/4827
+* dist(release/1.29): backport patches, pt. 1 by @rami3l in https://github.com/rust-lang/rustup/pull/4867
+* feat(cli/rustup-mode): warn about auto-installation in some subcommands by @rami3l in https://github.com/rust-lang/rustup/pull/4895
+* chore(deps): update `curl` by @rami3l in https://github.com/rust-lang/rustup/pull/4928
+* dist(release/1.29): backport patches, pt. 2 by @rami3l in https://github.com/rust-lang/rustup/pull/4927
+* dist(release/1.29): backport patches, pt. 3 by @rami3l in https://github.com/rust-lang/rustup/pull/4939
+
 ## [1.29.0] - 2026-03-05
 
 This new release of rustup comes with significant changes.

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -33,7 +33,7 @@ RUSTUP_QUIET=no
 # NOTICE: If you change anything here, please make the same changes in setup_mode.rs
 usage() {
     cat <<EOF
-rustup-init 1.29.0 (d243d7d4e 2026-03-04)
+rustup-init 1.29.0 (50cdda979 2026-07-02)
 
 The installer for rustup
 

--- a/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_init_ui/rustup_init_sh_help_flag.stdout.term.svg
@@ -16,7 +16,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan>rustup-init 1.29.0 (d243d7d4e 2026-03-04)</tspan>
+    <tspan x="10px" y="28px"><tspan>rustup-init 1.29.0 (50cdda979 2026-07-02)</tspan>
 </tspan>
     <tspan x="10px" y="46px">
 </tspan>


### PR DESCRIPTION
Part of #4862.

Following our new [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#cutting-a-new-release), this is the (only) PR required for the 1.29.1 **beta** release.