### PR TITLE
dist(release/1.29): backport patches, pt. 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,9 +150,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -160,14 +160,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -237,9 +238,9 @@ checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -320,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.5"
+version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
+checksum = "db8b397918185f0161ff3d6fcaa9e4bfc09b8367caf6e1d4a2848e5477ed027b"
 dependencies = [
  "clap",
 ]
@@ -389,9 +390,9 @@ checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -906,12 +907,9 @@ dependencies = [
 
 [[package]]
 name = "html-escape"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1ad449764d627e22bfd7cd5e8868264fc9236e07c752972b4080cd351cb476"
-dependencies = [
- "utf8-width",
-]
+checksum = "46c1ff2d1cbf39efe5af0900ced8a069b5e61557a17544eb0c4a50239937389e"
 
 [[package]]
 name = "http"
@@ -1171,9 +1169,9 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.18.5"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f007684f2e9727160da8b960ec161264703bfd1af084fd2e34d040c9a0dd4"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
  "portable-atomic",
@@ -1798,9 +1796,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -2031,9 +2029,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "zeroize",
 ]
@@ -2117,7 +2115,7 @@ dependencies = [
  "platforms",
  "proptest",
  "pulldown-cmark",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rayon",
  "regex",
  "remove_dir_all",
@@ -2538,9 +2536,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.51"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2558,9 +2556,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2619,7 +2617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -2934,12 +2932,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf8-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8_iter"
@@ -3404,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -667,13 +667,8 @@ impl TargetTuple {
         let ret = if partial_self.os != partial_other.os {
             false
         } else if partial_self.os.as_deref() == Some("pc-windows") {
-            // Windows is a special case here: we can run gnu and msvc on the same system,
-            // x86_64 can run i686, and aarch64 can run i686 through emulation
-            (partial_self.arch == partial_other.arch)
-                || (partial_self.arch.as_deref() == Some("x86_64")
-                    && partial_other.arch.as_deref() == Some("i686"))
-                || (partial_self.arch.as_deref() == Some("aarch64")
-                    && partial_other.arch.as_deref() == Some("i686"))
+            // Windows is a special case here: we can run gnu and msvc on the same system.
+            partial_self.arch == partial_other.arch
         } else {
             // For other OSes, for now, we assume other toolchains won't run
             false
@@ -1465,31 +1460,33 @@ mod tests {
                 &["i686-unknown-linux-gnu"],
             ),
             (
-                // On the other hand, 64 bit Windows
+                // On the other hand, Windows msvc
                 "x86_64-pc-windows-msvc",
-                // is compatible with 32 bit windows, and even gnu
-                &[
-                    "i686-pc-windows-msvc",
-                    "x86_64-pc-windows-gnu",
-                    "i686-pc-windows-gnu",
-                ],
+                // is compatible with Windows gnu
+                &["x86_64-pc-windows-gnu"],
                 // But is not compatible with Linux
-                &["x86_64-unknown-linux-gnu"],
-            ),
-            (
-                // Indeed, 64bit windows with the gnu toolchain
-                "x86_64-pc-windows-gnu",
-                // is compatible with the other windows platforms
                 &[
+                    "x86_64-unknown-linux-gnu",
+                    // or 32-bit Windows
                     "i686-pc-windows-msvc",
-                    "x86_64-pc-windows-gnu",
                     "i686-pc-windows-gnu",
                 ],
-                // But is not compatible with Linux despite also being gnu
-                &["x86_64-unknown-linux-gnu"],
             ),
             (
-                // However, 32bit Windows is not expected to be able to run
+                // And the Windows gnu toolchain
+                "x86_64-pc-windows-gnu",
+                // is compatible with Windows msvc
+                &["x86_64-pc-windows-msvc"],
+                // But is not compatible with Linux despite also being gnu
+                &[
+                    "x86_64-unknown-linux-gnu",
+                    // And is not compatible with 32-bit Windows
+                    "i686-pc-windows-msvc",
+                    "i686-pc-windows-gnu",
+                ],
+            ),
+            (
+                // 32bit Windows is not expected to be able to run
                 // 64bit windows
                 "i686-pc-windows-msvc",
                 &["i686-pc-windows-gnu"],


### PR DESCRIPTION
Part of https://github.com/rust-lang/rustup/issues/4862; continuation of https://github.com/rust-lang/rustup/pull/4927.