### PR TITLE
fix: lock state and settings file updates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1134,7 +1134,7 @@ impl StateFile {
         if !utils::is_file(&self.path) {
             return Ok(State::default());
         }
-        let content = utils::read_file("state", &self.path)?;
+        let content = utils::read_locked_file("state", &self.path)?;
         State::parse(&content).with_context(|| RustupError::ParsingFile {
             name: "state",
             path: self.path.clone(),
@@ -1142,7 +1142,7 @@ impl StateFile {
     }
 
     fn store(&self, state: &State) -> Result<()> {
-        utils::write_file("state", &self.path, &state.stringify()?)?;
+        utils::write_locked_file("state", &self.path, &state.stringify()?)?;
         Ok(())
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,7 +29,7 @@ impl SettingsFile {
 
     fn write_settings(&self) -> Result<()> {
         let settings = self.cache.borrow();
-        utils::write_file(
+        utils::write_locked_file(
             "settings",
             &self.path,
             &settings.as_ref().unwrap().stringify()?,
@@ -44,7 +44,7 @@ impl SettingsFile {
             if b.is_none() {
                 drop(b);
                 *self.cache.borrow_mut() = Some(if utils::is_file(&self.path) {
-                    let content = utils::read_file("settings", &self.path)?;
+                    let content = utils::read_locked_file("settings", &self.path)?;
                     Settings::parse(&content).with_context(|| RustupError::ParsingFile {
                         name: "settings",
                         path: self.path.clone(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -87,8 +87,22 @@ pub fn read_file(name: &'static str, path: &Path) -> Result<String> {
     })
 }
 
+pub(crate) fn read_locked_file(name: &'static str, path: &Path) -> Result<String> {
+    raw::read_locked_file(path).with_context(|| RustupError::ReadingFile {
+        name,
+        path: PathBuf::from(path),
+    })
+}
+
 pub fn write_file(name: &'static str, path: &Path, contents: &str) -> Result<()> {
     raw::write_file(path, contents).with_context(|| RustupError::WritingFile {
+        name,
+        path: PathBuf::from(path),
+    })
+}
+
+pub(crate) fn write_locked_file(name: &'static str, path: &Path, contents: &str) -> Result<()> {
+    raw::write_locked_file(path, contents).with_context(|| RustupError::WritingFile {
         name,
         path: PathBuf::from(path),
     })

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -3,7 +3,7 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::io;
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 use std::str;
 
@@ -60,6 +60,21 @@ pub fn path_exists<P: AsRef<Path>>(path: P) -> bool {
     fs::metadata(path).is_ok()
 }
 
+pub(crate) fn read_locked_file(path: &Path) -> io::Result<String> {
+    let mut file = File::open(path)?;
+    file.lock_shared()?;
+
+    let size = file
+        .metadata()
+        .map(|metadata| usize::try_from(metadata.len()).unwrap_or(usize::MAX))
+        .ok();
+    let mut contents = String::new();
+    contents.try_reserve_exact(size.unwrap_or(0))?;
+    file.read_to_string(&mut contents)?;
+
+    Ok(contents)
+}
+
 pub(crate) fn random_string(length: usize) -> String {
     const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789_";
     let mut rng = rand::rng();
@@ -77,6 +92,24 @@ pub fn write_file(path: &Path, contents: &str) -> io::Result<()> {
 
     Write::write_all(&mut file, contents.as_bytes())?;
 
+    file.sync_data()?;
+
+    Ok(())
+}
+
+pub(crate) fn write_locked_file(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        // Truncation must happen after the exclusive lock is held.
+        .truncate(false)
+        .open(path)?;
+
+    file.lock()?;
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    Write::write_all(&mut file, contents.as_bytes())?;
     file.sync_data()?;
 
     Ok(())
@@ -348,5 +381,22 @@ pub(crate) mod windows {
             Ok(maybe_result)
         }
         inner(s.as_ref())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn locked_file_round_trip_truncates_previous_contents() -> io::Result<()> {
+        let temp_dir = tempfile::tempdir()?;
+        let path = temp_dir.path().join("state.toml");
+
+        write_locked_file(&path, "last_release_notified_secs = 123456\n")?;
+        write_locked_file(&path, "version = \"12\"\n")?;
+
+        assert_eq!(read_locked_file(&path)?, "version = \"12\"\n");
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Add locked read/write helpers for file contents.
- Use them for `state.toml` and `settings.toml` reads and writes.
- Cover locked write truncation with a unit test.

## Why

Fixes #4942. These files can be touched by concurrent rustup processes, so writes now take an exclusive lock before truncating and reads take a shared lock.

## Validation

- `cargo test --features test locked_file_round_trip_truncates_previous_contents` — passed
- `cargo test --features test settings::tests` — passed
- `cargo test --features test --test test_bonanza notify_release_hint` — passed
- `cargo check --all-targets --features test` — passed
- `cargo clippy --all-targets --features test -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- `git diff --check` — passed