### PR TITLE
feat(config)!: use unqualified names for `default_toolchain`

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -106,7 +106,9 @@ async fn run_rustup_inner(
             // rustup deletes its own exe
             cfg_select! {
                 windows => self_update::complete_windows_uninstall(process),
-                _ => unreachable!("Attempted to use Windows-specific code on a non-Windows platform. Aborting."),
+                _ => unreachable!(
+                    "Attempted to use Windows-specific code on a non-Windows platform. Aborting."
+                ),
             }
         }
         Some(n) => {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -887,13 +887,13 @@ async fn default_(
                 cfg.set_default(Some(&toolchain_name.into()))?;
             }
             MaybeResolvableToolchainName::Some(ResolvableToolchainName::Official(toolchain)) => {
-                let desc = toolchain.resolve(&cfg.default_host_tuple()?)?;
+                let desc = toolchain.clone().resolve(&cfg.default_host_tuple()?)?;
                 let status = cfg
                     .ensure_installed(&desc, vec![], vec![], None, force_non_host, true)
                     .await?
                     .status;
 
-                cfg.set_default(Some(&desc.clone().into()))?;
+                cfg.set_default(Some(&toolchain.into()))?;
 
                 writeln!(cfg.process.stdout().lock())?;
 
@@ -1091,7 +1091,7 @@ async fn update(
                     force_non_host,
                 )?;
             }
-            let desc = name.resolve(&cfg.default_host_tuple()?)?;
+            let desc = name.clone().resolve(&cfg.default_host_tuple()?)?;
 
             let components = opts.component.iter().map(|s| &**s).collect::<Vec<_>>();
             let targets = opts.target.iter().map(|s| &**s).collect::<Vec<_>>();
@@ -1134,7 +1134,7 @@ async fn update(
             if opts.default
                 || (cfg.get_default()?.is_none() && matches!(status, UpdateStatus::Installed))
             {
-                cfg.set_default(Some(&desc.into()))?;
+                cfg.set_default(Some(&name.into()))?;
             }
         }
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -272,7 +272,7 @@ impl InstallOpts<'_> {
 
             check_proxy_sanity(cfg.process, components, &desc)?;
 
-            cfg.set_default(Some(&desc.clone().into()))?;
+            cfg.set_default(Some(&partial_desc.into()))?;
             writeln!(cfg.process.stdout().lock())?;
             common::show_channel_update(cfg, PackageUpdate::Toolchain(desc), Ok(status))?;
         }

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -69,7 +69,6 @@ use crate::{
     process::Process,
     toolchain::{
         DistributableToolchain, MaybeOfficialToolchainName, ResolvableToolchainName, Toolchain,
-        ToolchainName,
     },
     utils::{self, ExitCode},
 };
@@ -252,7 +251,8 @@ impl InstallOpts<'_> {
 
         let (components, targets) = (self.components, self.targets);
         let toolchain = self.select_toolchain(cfg)?;
-        if let Some(desc) = toolchain {
+        if let Some(partial_desc) = toolchain {
+            let desc = partial_desc.clone().resolve(&cfg.default_host_tuple()?)?;
             let options =
                 DistOptions::new(components, targets, &desc, cfg.get_profile()?, true, cfg)?;
             let status = if Toolchain::exists(cfg, &desc.clone().into())? {
@@ -284,7 +284,7 @@ impl InstallOpts<'_> {
     /// This function first initializes the default profile and default host tuple in the
     /// configuration, then returns the toolchain that should be installed, or `None` if none is
     /// specified by the user.
-    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> Result<Option<ToolchainDesc>> {
+    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> Result<Option<PartialToolchainDesc>> {
         let Self {
             default_host_tuple,
             default_toolchain,
@@ -342,18 +342,14 @@ impl InstallOpts<'_> {
                         MaybeOfficialToolchainName::None => unreachable!(),
                         MaybeOfficialToolchainName::Some(n) => n,
                     };
-                    Some(toolchain_name.resolve(&cfg.default_host_tuple()?)?)
+                    Some(toolchain_name)
                 }
-                None => match cfg.get_default()? {
+                None => match cfg.get_default_resolvable()? {
                     // Default is installable
-                    Some(ToolchainName::Official(t)) => Some(t),
+                    Some(ResolvableToolchainName::Official(t)) => Some(t),
                     // Default is custom, presumably from a prior install. Do nothing.
-                    Some(ToolchainName::Custom(_)) => None,
-                    None => Some(
-                        "stable"
-                            .parse::<PartialToolchainDesc>()?
-                            .resolve(&cfg.default_host_tuple()?)?,
-                    ),
+                    Some(ResolvableToolchainName::Custom(_)) => None,
+                    None => Some(PartialToolchainDesc::from_str("stable")?),
                 },
             })
         } else {
@@ -1378,11 +1374,7 @@ mod tests {
             };
 
             assert_eq!(
-                "stable"
-                    .parse::<PartialToolchainDesc>()
-                    .unwrap()
-                    .resolve(&cfg.default_host_tuple().unwrap())
-                    .unwrap(),
+                "stable".parse::<PartialToolchainDesc>().unwrap(),
                 opts.select_toolchain(&mut cfg)
                     .unwrap() // result
                     .unwrap() // option

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -70,7 +70,6 @@ use crate::{
     settings::SettingsFile,
     toolchain::{
         DistributableToolchain, MaybeOfficialToolchainName, ResolvableToolchainName, Toolchain,
-        ToolchainName,
     },
     utils::{self, ExitCode},
 };
@@ -270,7 +269,8 @@ impl InstallOpts<'_> {
 
         let (components, targets) = (self.components, self.targets);
         let toolchain = self.select_toolchain(&mut cfg)?;
-        if let Some(desc) = toolchain {
+        if let Some(partial_desc) = toolchain {
+            let desc = partial_desc.clone().resolve(&cfg.default_host_tuple()?)?;
             let options =
                 DistOptions::new(components, targets, &desc, cfg.get_profile()?, true, &cfg)?;
             let status = if Toolchain::exists(&cfg, &desc.clone().into())? {
@@ -302,7 +302,7 @@ impl InstallOpts<'_> {
     /// This function first initializes the default profile and default host tuple in the
     /// configuration, then returns the toolchain that should be installed, or `None` if none is
     /// specified by the user.
-    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> Result<Option<ToolchainDesc>> {
+    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> Result<Option<PartialToolchainDesc>> {
         let Self {
             default_host_tuple,
             default_toolchain,
@@ -360,18 +360,14 @@ impl InstallOpts<'_> {
                         MaybeOfficialToolchainName::None => unreachable!(),
                         MaybeOfficialToolchainName::Some(n) => n,
                     };
-                    Some(toolchain_name.resolve(&cfg.default_host_tuple()?)?)
+                    Some(toolchain_name)
                 }
-                None => match cfg.get_default()? {
+                None => match cfg.get_default_resolvable()? {
                     // Default is installable
-                    Some(ToolchainName::Official(t)) => Some(t),
+                    Some(ResolvableToolchainName::Official(t)) => Some(t),
                     // Default is custom, presumably from a prior install. Do nothing.
-                    Some(ToolchainName::Custom(_)) => None,
-                    None => Some(
-                        "stable"
-                            .parse::<PartialToolchainDesc>()?
-                            .resolve(&cfg.default_host_tuple()?)?,
-                    ),
+                    Some(ResolvableToolchainName::Custom(_)) => None,
+                    None => Some(PartialToolchainDesc::from_str("stable")?),
                 },
             })
         } else {
@@ -1398,11 +1394,7 @@ mod tests {
             };
 
             assert_eq!(
-                "stable"
-                    .parse::<PartialToolchainDesc>()
-                    .unwrap()
-                    .resolve(&cfg.default_host_tuple().unwrap())
-                    .unwrap(),
+                "stable".parse::<PartialToolchainDesc>().unwrap(),
                 opts.select_toolchain(&mut cfg)
                     .unwrap() // result
                     .unwrap() // option

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -290,7 +290,7 @@ impl InstallOpts<'_> {
 
             check_proxy_sanity(cfg.process, components, &desc)?;
 
-            cfg.set_default(Some(&desc.clone().into()))?;
+            cfg.set_default(Some(&partial_desc.into()))?;
             writeln!(cfg.process.stdout().lock())?;
             common::show_channel_update(&cfg, PackageUpdate::Toolchain(desc), Ok(status))?;
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -384,7 +384,7 @@ impl<'a> Cfg<'a> {
         Ok(cfg)
     }
 
-    pub(crate) fn set_default(&self, toolchain: Option<&ToolchainName>) -> Result<()> {
+    pub(crate) fn set_default(&self, toolchain: Option<&ResolvableToolchainName>) -> Result<()> {
         self.settings_file.with_mut(|s| {
             s.default_toolchain = toolchain.map(|t| t.to_string());
             Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -900,10 +900,24 @@ impl<'a> Cfg<'a> {
         })
     }
 
-    /// Get the configured default toolchain.
-    /// If none is configured, returns None
-    /// If a bad toolchain name is configured, errors.
+    /// Gets the configured default toolchain name in its resolved form, if any.
+    ///
+    /// This is essentially [`Cfg::get_default_resolvable()`] with an extra resolution step.
     pub(crate) fn get_default(&self) -> Result<Option<ToolchainName>> {
+        let Some(toolchain) = self.get_default_resolvable()? else {
+            return Ok(None);
+        };
+        Ok(Some(toolchain.resolve(&self.default_host_tuple()?)?))
+    }
+
+    /// Gets the configured default toolchain name in its unresolved form, if any.
+    ///
+    /// # Errors
+    ///
+    /// This function returns an error if:
+    /// - The configuration file is invalid.
+    /// - The configuration file contains an illegal default toolchain name.
+    pub(crate) fn get_default_resolvable(&self) -> Result<Option<ResolvableToolchainName>> {
         let user_opt = self.settings_file.with(|s| Ok(s.default_toolchain.clone()));
         let toolchain_maybe_str = if let Some(fallback_settings) = &self.fallback_settings {
             match user_opt {
@@ -913,11 +927,10 @@ impl<'a> Cfg<'a> {
         } else {
             user_opt
         }?;
-        toolchain_maybe_str
-            .map(|s| ResolvableToolchainName::from_str(&s))
-            .transpose()?
-            .map(|t| t.resolve(&self.default_host_tuple()?))
-            .transpose()
+        let Some(toolchain) = &toolchain_maybe_str else {
+            return Ok(None);
+        };
+        Ok(Some(ResolvableToolchainName::from_str(toolchain)?))
     }
 
     /// List all the installed toolchains: that is paths in the toolchain dir

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -296,6 +296,18 @@ impl ResolvableLocalToolchainName {
     }
 }
 
+impl From<PartialToolchainDesc> for ResolvableToolchainName {
+    fn from(value: PartialToolchainDesc) -> Self {
+        Self::Official(value)
+    }
+}
+
+impl From<CustomToolchainName> for ResolvableToolchainName {
+    fn from(value: CustomToolchainName) -> Self {
+        Self::Custom(value)
+    }
+}
+
 impl FromStr for ResolvableLocalToolchainName {
     type Err = InvalidName;
 

--- a/src/toolchain/names.rs
+++ b/src/toolchain/names.rs
@@ -252,6 +252,18 @@ impl ResolvableLocalToolchainName {
     }
 }
 
+impl From<PartialToolchainDesc> for ResolvableToolchainName {
+    fn from(value: PartialToolchainDesc) -> Self {
+        Self::Official(value)
+    }
+}
+
+impl From<CustomToolchainName> for ResolvableToolchainName {
+    fn from(value: CustomToolchainName) -> Self {
+        Self::Custom(value)
+    }
+}
+
 impl FromStr for ResolvableLocalToolchainName {
     type Err = InvalidName;
 

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -23,7 +23,7 @@ async fn update_once() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 4 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]]);
     cx.config
@@ -322,7 +322,7 @@ async fn default() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 4 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]]);
     cx.config

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -743,14 +743,12 @@ rustup home:  [RUSTUP_DIR]
 
 installed toolchains
 --------------------
-beta-[HOST_TUPLE] (active, default)
+beta-[HOST_TUPLE]
 
 active toolchain
 ----------------
-name: beta-[HOST_TUPLE]
+name: beta-[CROSS_ARCH_I]
 active because: it's the default toolchain
-installed targets:
-  [HOST_TUPLE]
 
 "#]]);
 }

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -4,7 +4,9 @@ use std::env::consts::EXE_SUFFIX;
 use std::io::Write;
 use std::process::Stdio;
 
-use rustup::test::{Assert, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple};
+use rustup::test::{
+    Assert, CROSS_ARCH1, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple,
+};
 #[cfg(windows)]
 use rustup::test::{RegistryGuard, USER_PATH};
 use rustup::utils::raw;
@@ -683,5 +685,72 @@ async fn install_warns_if_default_linker_missing() {
 warn: no default linker ([CC_TOOL]) was found in your PATH
 warn: many Rust crates require a system C toolchain to build
 ...
+"#]]);
+}
+
+// https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058868560
+#[tokio::test]
+async fn install_defaults_to_default_host() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
+
+    cx.config
+        .expect([
+            "rustup-init",
+            "-y",
+            "--no-modify-path",
+            "--default-toolchain=beta",
+        ])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [HOST_TUPLE]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#""#]]);
+
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
 "#]]);
 }

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -776,14 +776,12 @@ rustup home:  [RUSTUP_DIR]
 
 installed toolchains
 --------------------
-beta-[HOST_TUPLE] (active, default)
+beta-[HOST_TUPLE]
 
 active toolchain
 ----------------
-name: beta-[HOST_TUPLE]
+name: beta-[CROSS_ARCH_I]
 active because: it's the default toolchain
-installed targets:
-  [HOST_TUPLE]
 
 "#]]);
 }

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -5,7 +5,9 @@ use std::fs;
 use std::io::Write;
 use std::process::Stdio;
 
-use rustup::test::{Assert, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple};
+use rustup::test::{
+    Assert, CROSS_ARCH1, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple,
+};
 use rustup::utils::raw;
 
 fn run_input(config: &Config, args: &[&str], input: &str) -> Assert {
@@ -717,4 +719,71 @@ Current installation options:
 
     assert!(!settings_file.exists());
     assert!(!rustupdir.exists());
+}
+
+// https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058868560
+#[tokio::test]
+async fn install_defaults_to_default_host() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
+
+    cx.config
+        .expect([
+            "rustup-init",
+            "-y",
+            "--no-modify-path",
+            "--default-toolchain=beta",
+        ])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [HOST_TUPLE]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#""#]]);
+
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -4264,3 +4264,65 @@ fn nightly_manifest_path(cx: &CliTestContext) -> PathBuf {
         .join("rustlib")
         .join("multirust-channel-manifest.toml")
 }
+
+// https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058814392
+#[tokio::test]
+async fn default_stores_qualified_toolchains() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
+
+    cx.config
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [HOST_TUPLE]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#""#]]);
+
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+}

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -290,7 +290,7 @@ async fn default() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 4 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]])
         .is_ok();
@@ -327,7 +327,7 @@ async fn default_override() {
         .await
         .with_stderr(snapbox::str![[r#"
 info: using existing install for stable-[HOST_TUPLE]
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 info: note that the toolchain 'nightly-[HOST_TUPLE]' is currently in use (directory override for '[..]')
 
 "#]])
@@ -4032,7 +4032,7 @@ async fn custom_toolchain_with_components_toolchains_profile_does_not_err() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 2 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]])
         .is_ok();
@@ -4267,7 +4267,7 @@ fn nightly_manifest_path(cx: &CliTestContext) -> PathBuf {
 
 // https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058814392
 #[tokio::test]
-async fn default_stores_qualified_toolchains() {
+async fn default_stores_unqualified_toolchains() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
 
@@ -4315,14 +4315,12 @@ rustup home:  [RUSTUP_DIR]
 
 installed toolchains
 --------------------
-beta-[HOST_TUPLE] (active, default)
+beta-[HOST_TUPLE]
 
 active toolchain
 ----------------
-name: beta-[HOST_TUPLE]
+name: beta-[CROSS_ARCH_I]
 active because: it's the default toolchain
-installed targets:
-  [HOST_TUPLE]
 
 "#]]);
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -290,7 +290,7 @@ async fn default() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 4 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]])
         .is_ok();
@@ -327,7 +327,7 @@ async fn default_override() {
         .await
         .with_stderr(snapbox::str![[r#"
 info: using existing install for stable-[HOST_TUPLE]
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 info: note that the toolchain 'nightly-[HOST_TUPLE]' is currently in use (directory override for '[..]')
 
 "#]])
@@ -4032,7 +4032,7 @@ async fn custom_toolchain_with_components_toolchains_profile_does_not_err() {
 info: syncing channel updates for nightly-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.3.0 (hash-nightly-2)
 info: downloading 2 components
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 
 "#]])
         .is_ok();
@@ -4267,7 +4267,7 @@ fn nightly_manifest_path(cx: &CliTestContext) -> PathBuf {
 
 // https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058814392
 #[tokio::test]
-async fn default_stores_qualified_toolchains() {
+async fn default_stores_unqualified_toolchains() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
 
     let mut toml_redactions = snapbox::Redactions::new();
@@ -4294,7 +4294,7 @@ async fn default_stores_qualified_toolchains() {
         snapbox::str![[r#"
 ...
 default_host_tuple = "[HOST_TUPLE]"
-default_toolchain = "beta-[HOST_TUPLE]"
+default_toolchain = "beta"
 ...
 "#]],
     );
@@ -4332,7 +4332,7 @@ installed targets:
         snapbox::str![[r#"
 ...
 default_host_tuple = "[CROSS_ARCH_I]"
-default_toolchain = "beta-[HOST_TUPLE]"
+default_toolchain = "beta"
 ...
 "#]],
     );
@@ -4348,14 +4348,12 @@ rustup home:  [RUSTUP_DIR]
 
 installed toolchains
 --------------------
-beta-[HOST_TUPLE] (active, default)
+beta-[HOST_TUPLE]
 
 active toolchain
 ----------------
-name: beta-[HOST_TUPLE]
+name: beta-[CROSS_ARCH_I]
 active because: it's the default toolchain
-installed targets:
-  [HOST_TUPLE]
 
 "#]]);
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -4264,3 +4264,195 @@ fn nightly_manifest_path(cx: &CliTestContext) -> PathBuf {
         .join("rustlib")
         .join("multirust-channel-manifest.toml")
 }
+
+// https://github.com/rust-lang/rustup/issues/3651#issuecomment-5058814392
+#[tokio::test]
+async fn default_stores_qualified_toolchains() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let mut toml_redactions = snapbox::Redactions::new();
+    toml_redactions
+        .insert("[HOST_TUPLE]", this_host_tuple())
+        .unwrap();
+    toml_redactions
+        .insert("[CROSS_ARCH_I]", CROSS_ARCH1)
+        .unwrap();
+    let toml_assert = snapbox::Assert::new()
+        .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
+        .redact_with(toml_redactions);
+
+    let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
+
+    cx.config
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+
+    let settings_file = &cx.config.rustupdir.join("settings.toml");
+    toml_assert.eq(
+        fs::read_to_string(settings_file).unwrap(),
+        snapbox::str![[r#"
+...
+default_host_tuple = "[HOST_TUPLE]"
+default_toolchain = "beta-[HOST_TUPLE]"
+...
+"#]],
+    );
+
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [HOST_TUPLE]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#""#]]);
+
+    toml_assert.eq(
+        fs::read_to_string(settings_file).unwrap(),
+        snapbox::str![[r#"
+...
+default_host_tuple = "[CROSS_ARCH_I]"
+default_toolchain = "beta-[HOST_TUPLE]"
+...
+"#]],
+    );
+
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+}
+
+// When running `rustup default` with a fully qualified toolchain name, the resolution of the
+// default toolchain will not be influenced by the change in the default host tuple.
+// See: https://github.com/rust-lang/rustup/pull/4947#issuecomment-5255553287
+#[tokio::test]
+async fn default_stores_qualified_toolchains_on_demand() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let mut toml_redactions = snapbox::Redactions::new();
+    toml_redactions
+        .insert("[HOST_TUPLE]", this_host_tuple())
+        .unwrap();
+    toml_redactions
+        .insert("[CROSS_ARCH_I]", CROSS_ARCH1)
+        .unwrap();
+    let toml_assert = snapbox::Assert::new()
+        .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
+        .redact_with(toml_redactions);
+
+    let redactions = [("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())];
+
+    cx.config
+        .expect(["rustup", "default", for_host!("beta-{}")])
+        .await
+        .is_ok();
+
+    let settings_file = &cx.config.rustupdir.join("settings.toml");
+    toml_assert.eq(
+        fs::read_to_string(settings_file).unwrap(),
+        snapbox::str![[r#"
+...
+default_host_tuple = "[HOST_TUPLE]"
+default_toolchain = "beta-[HOST_TUPLE]"
+...
+"#]],
+    );
+
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [HOST_TUPLE]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#""#]]);
+
+    toml_assert.eq(
+        fs::read_to_string(settings_file).unwrap(),
+        snapbox::str![[r#"
+...
+default_host_tuple = "[CROSS_ARCH_I]"
+default_toolchain = "beta-[HOST_TUPLE]"
+...
+"#]],
+    );
+
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_AUTO_INSTALL", "0")])
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I]
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+}

--- a/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_default.stderr.term.svg
@@ -23,7 +23,7 @@
 </tspan>
     <tspan x="10px" y="64px"><tspan class="bold">info:</tspan><tspan> downloading 4 components</tspan>
 </tspan>
-    <tspan x="10px" y="82px"><tspan class="bold">info:</tspan><tspan> default toolchain set to nightly-[HOST_TUPLE]</tspan>
+    <tspan x="10px" y="82px"><tspan class="bold">info:</tspan><tspan> default toolchain set to nightly</tspan>
 </tspan>
     <tspan x="10px" y="100px">
 </tspan>

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -74,7 +74,7 @@ async fn install_bins_to_cargo_home() {
 info: syncing channel updates for stable-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
 info: downloading 4 components
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 
 "#]])
         .is_ok();
@@ -118,7 +118,7 @@ async fn proxies_are_relative_symlinks() {
 info: syncing channel updates for stable-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
 info: downloading 4 components
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 ...
 "#]])
         .is_ok();
@@ -974,7 +974,7 @@ async fn reinstall_specifying_different_toolchain() {
         .await
         .with_stderr(snapbox::str![[r#"
 ...
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 ...
 "#]])
         .is_ok();

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -72,7 +72,7 @@ async fn install_bins_to_cargo_home() {
 info: syncing channel updates for stable-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
 info: downloading 4 components
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 
 "#]])
         .is_ok();
@@ -114,7 +114,7 @@ async fn proxies_are_relative_symlinks() {
 info: syncing channel updates for stable-[HOST_TUPLE]
 info: latest update on 2015-01-02 for version 1.1.0 (hash-stable-1.1.0)
 info: downloading 4 components
-info: default toolchain set to stable-[HOST_TUPLE]
+info: default toolchain set to stable
 ...
 "#]])
         .is_ok();
@@ -975,7 +975,7 @@ async fn reinstall_specifying_different_toolchain() {
         .await
         .with_stderr(snapbox::str![[r#"
 ...
-info: default toolchain set to nightly-[HOST_TUPLE]
+info: default toolchain set to nightly
 ...
 "#]])
         .is_ok();


### PR DESCRIPTION
Stacked on https://github.com/rust-lang/rustup/pull/4950 and https://github.com/rust-lang/rustup/pull/4991.

Closes #3651.
Closes #4945.

### Problem Description

The original problem as seen in both #3651 and #4945 is the following:

> For now, `rustup default <toolchain>` resolves the full toolchain name from `<toolchain>`, which could be a function of `default_host_tuple`, and then stores that in `settings.toml`.
_#4945_

... this is notably problematic because the value of `default_toolchain` is inappropriately coupled with the value of the default host at the wrong moment: not the moment of running any `rustup` command, but the last execution of `rustup default` (whether manually by running that very command, or implicitly upon `rustup-init`):

> This has made the config file hostile to cross-platform dotfile management, since one may want to use the `stable` toolchain specific to the default host tuple of that platform.
_https://github.com/rust-lang/rustup/issues/4945#issue-4836038407_

> i have a stable-x86_64-pc-windows-gnu toolchain as my default [..] i want it to be `-msvc` instead so i can use windbg (i don't have gdb installed). i ran `rustup set default-host x86_64-pc-windows-msvc`, which succeeded, but did not install any toolchains or change the default:
_https://github.com/rust-lang/rustup/issues/3651#issue-2103220226_

### Proposed Solution

This PR makes rustup use unqualified names such as `stable` instead of fully qualified names such as `stable-aarch64-apple-darwin` for the `default_toolchain` field in the `settings.toml` file.

### Impact

#### Compatibility

This change is breaking exactly because the determination of the default toolchain will change to reflect the change of the default host tuple.

However, the user can always get the old behavior by specifying the fully qualified name when running `rustup default` (such as `rustup default stable-aarch64-apple-darwin`), in the rare case that they would like to decouple the default toolchain from the default host tuple.

For users with an existing `settings.toml`, manually running `rustup default stable` or similar commands should be necessary for them to get the new behavior.

#### Performance

As discussed in https://github.com/rust-lang/rustup/issues/4945#issuecomment-4956813676, since the default host tuple is resolved at the beginning of `rustup`'s execution, this change has introduced no extra I/O operations, and thus the performance impact is negligible.

### Validation

Validated through:

- Local testing.
- A specific test case that reflects @jyn514's original use case as described in https://github.com/rust-lang/rustup/issues/3651.
- Another specific test case that explicitly asserts backwards compatibility with existing `settings.toml` format with a fully qualified `default_toolchain` name.