### PR TITLE
refactor: replace `cfg_if!{}` with `cfg_select!{}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,7 +2047,6 @@ dependencies = [
  "anstyle",
  "anyhow",
  "cc",
- "cfg-if 1.0.4",
  "chrono",
  "clap",
  "clap-cargo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ anstream = "1"
 anstyle = "1.0.11"
 anyhow = "1.0.69"
 cc = "1"
-cfg-if = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 clap = { version = "4", features = ["derive", "wrap_help", "string"] }
 clap-cargo = "0.18.3"

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -16,7 +16,6 @@
 use std::process::ExitCode;
 
 use anyhow::{Context, Result, anyhow};
-use cfg_if::cfg_if;
 // Public macros require availability of the internal symbols
 use rs_tracing::{
     close_trace_file, close_trace_file_internal, open_trace_file, trace_to_file_internal,
@@ -105,12 +104,9 @@ async fn run_rustup_inner(
         Some(n) if n.starts_with("rustup-gc-") => {
             // This is the final uninstallation stage on windows where
             // rustup deletes its own exe
-            cfg_if! {
-                if #[cfg(windows)] {
-                    self_update::complete_windows_uninstall(process)
-                } else {
-                    unreachable!("Attempted to use Windows-specific code on a non-Windows platform. Aborting.")
-                }
+            cfg_select! {
+                windows => self_update::complete_windows_uninstall(process),
+                _ => unreachable!("Attempted to use Windows-specific code on a non-Windows platform. Aborting."),
             }
         }
         Some(n) => {

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -43,7 +43,6 @@ use std::{fmt, fs};
 
 use anstyle::Style;
 use anyhow::{Context, Result, anyhow};
-use cfg_if::cfg_if;
 use clap::ValueEnum;
 use clap::builder::PossibleValue;
 use clap_cargo::style::{GOOD, WARN};
@@ -540,12 +539,9 @@ fn canonical_cargo_home(process: &Process) -> Result<Cow<'static, str>> {
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".cargo");
     Ok(if default_cargo_home == path {
-        cfg_if! {
-            if #[cfg(windows)] {
-                r"%USERPROFILE%\.cargo".into()
-            } else {
-                "$HOME/.cargo".into()
-            }
+        cfg_select! {
+            windows => r"%USERPROFILE%\.cargo".into(),
+            _ => "$HOME/.cargo".into(),
         }
     } else {
         path.to_string_lossy().into_owned().into()


### PR DESCRIPTION
This gets us one fewer external dependency.

There might more `cfg()`s here that can be written this way for better readability, but for now I'm just doing the direct replacements.