### PR TITLE
chore(deps): remove pinned `openssl-src`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,9 +1479,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.4+3.5.4"
+version = "300.6.1+3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507b3792995dae9b0df8a1c1e3771e8418b7c2d9f0baeba32e6fe8b06c7cb72"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
 dependencies = [
  "cc",
 ]
@@ -2071,7 +2071,6 @@ dependencies = [
  "libz-sys",
  "opener",
  "openssl",
- "openssl-src",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -2423,7 +2422,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,6 @@ opener = "0.8.0"
 # rustup: this allows controlling the vendoring status without exposing the
 # presence of the download crate.
 openssl = { version = "0.10", optional = true }
-# HACK: Temporarily pinned due to ppc64 ELFv1/v2 ABI issue in 300.5.5, to be
-# removed when <https://github.com/openssl/openssl/issues/29815> lands.
-openssl-src = { version = "=300.5.4", optional = true }
 opentelemetry = { version = "0.32", optional = true }
 opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic"], optional = true }
 opentelemetry_sdk = { version = "0.32", features = ["rt-tokio"], optional = true }


### PR DESCRIPTION
The underlying issue has been resolved in OpenSSL v3.6.3: https://github.com/openssl/openssl/commit/7936b4c415ae0d27162bf2c6ef9a96d1e5ffb5a9

Supersedes https://github.com/rust-lang/rustup/pull/4938.