### PR TITLE
fix: reject unknown toolchain file keys

### DIFF
--- a/doc/user-guide/src/overrides.md
+++ b/doc/user-guide/src/overrides.md
@@ -114,6 +114,14 @@ issues with dependencies.
 
 ### Toolchain file settings
 
+| Setting | Supported since |
+|---------|-----------------|
+| `channel` | rustup 1.23.0 |
+| `components` | rustup 1.23.0 |
+| `targets` | rustup 1.23.0 |
+| `path` | rustup 1.24.0 |
+| `profile` | rustup 1.24.0 |
+
 #### channel
 
 The `channel` setting specifies which [toolchain] to use. The value is a

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ enum OverrideFileConfigError {
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct OverrideFile {
     toolchain: ToolchainSection,
 }
@@ -51,6 +52,7 @@ impl OverrideFile {
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct ToolchainSection {
     channel: Option<String>,
     path: Option<PathBuf>,
@@ -1412,5 +1414,31 @@ channel = nightly
             result.unwrap_err().downcast::<OverrideFileConfigError>(),
             Ok(OverrideFileConfigError::Parsing)
         ));
+    }
+
+    #[test]
+    fn parse_toml_unknown_toolchain_key() {
+        let contents = r#"[toolchain]
+channel = "nightly"
+channnel = "stable"
+"#;
+
+        let result = Cfg::parse_override_file(contents, ParseMode::Both);
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("unknown field `channnel`"), "{error}");
+    }
+
+    #[test]
+    fn parse_toml_unknown_top_level_key() {
+        let contents = r#"[toolchain]
+channel = "nightly"
+
+[future]
+key = "value"
+"#;
+
+        let result = Cfg::parse_override_file(contents, ParseMode::Both);
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("unknown field `future`"), "{error}");
     }
 }

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -3968,6 +3968,31 @@ error: rustup could not choose a version of rustc to run, because one wasn't spe
         .is_ok();
 }
 
+#[tokio::test]
+async fn rust_toolchain_toml_rejects_unknown_keys() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let cwd = cx.config.current_dir();
+    let toolchain_file = cwd.join("rust-toolchain.toml");
+    raw::write_file(
+        &toolchain_file,
+        "[toolchain]\nchannel = \"nightly\"\nchannnel = \"stable\"",
+    )
+    .unwrap();
+
+    cx.config
+        .expect(["rustup", "show", "active-toolchain"])
+        .await
+        .extend_redactions([("[CWD]", &cwd)])
+        .with_stderr(snapbox::str![[r#"
+...
+error: could not parse override file: '[CWD]/rust-toolchain.toml'[..]
+...
+unknown field `channnel`, expected one of `channel`, `path`, `components`, `targets`, `profile`[..]
+...
+"#]])
+        .is_err();
+}
+
 /// Ensures that `rust-toolchain.toml` files (with `.toml` extension) only allow TOML contents
 #[tokio::test]
 async fn only_toml_in_rust_toolchain_toml() {


### PR DESCRIPTION
## Summary

- reject unknown top-level and `[toolchain]` keys instead of silently ignoring them
- document the rustup release that introduced each supported setting

## Why

Misspelled or unsupported keys can otherwise leave rustup using a different toolchain configuration than the file appears to request.

Closes #2876

## Validation

- `cargo test --features=test parse_toml_unknown --lib`
- `cargo test --features=test --test test_bonanza rust_toolchain_toml`
- `cargo clippy --all-targets --features=test -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`