### PR TITLE
Reject unknown rust-toolchain.toml keys

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,7 @@ enum OverrideFileConfigError {
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct OverrideFile {
     toolchain: ToolchainSection,
 }
@@ -51,6 +52,7 @@ impl OverrideFile {
 }
 
 #[derive(Debug, Default, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct ToolchainSection {
     channel: Option<String>,
     path: Option<PathBuf>,
@@ -1412,5 +1414,28 @@ channel = nightly
             result.unwrap_err().downcast::<OverrideFileConfigError>(),
             Ok(OverrideFileConfigError::Parsing)
         ));
+    }
+
+    #[test]
+    fn parse_toml_rejects_unknown_toolchain_key() {
+        let contents = r#"[toolchain]
+channnel = "nightly"
+"#;
+
+        let error = Cfg::parse_override_file(contents, ParseMode::OnlyToml).unwrap_err();
+        assert!(format!("{error:#}").contains("unknown field `channnel`"));
+    }
+
+    #[test]
+    fn parse_toml_rejects_unknown_top_level_key() {
+        let contents = r#"[toolchain]
+channel = "nightly"
+
+[rustup]
+version = 4
+"#;
+
+        let error = Cfg::parse_override_file(contents, ParseMode::OnlyToml).unwrap_err();
+        assert!(format!("{error:#}").contains("unknown field `rustup`"));
     }
 }


### PR DESCRIPTION
Reject unknown keys at both levels of `rust-toolchain.toml` deserialization.

This prevents misspellings such as `channnel = "nightly"` from being silently ignored and also rejects unsupported top-level sections. The TOML parser reports the unknown key and lists the supported fields, while valid and legacy toolchain files retain their existing behavior.

Fixes #2876.

Validation:

- RED/GREEN tests for an unknown `[toolchain]` key and an unknown top-level section
- all 13 `config::tests` parser tests pass with the `test` feature
- `cargo clippy --all-targets --features test -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

I also attempted the broader `--all-features` Clippy command. On this Windows host its optional vendored-OpenSSL lane requires a `perl` executable and stopped while configuring OpenSSL; the repository's normal Windows feature set above is green.
