### PR TITLE
Add `--default` flag in `rustup toolchain install`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1059,7 +1059,6 @@ async fn update(
     let self_update_mode = SelfUpdateMode::from_cfg(cfg)?;
     let should_self_update = !opts.no_self_update;
     let force_non_host = opts.force_non_host;
-    let set_override = opts.r#override;
     cfg.profile_override = opts.profile;
 
     let cfg = &cfg;
@@ -1118,7 +1117,7 @@ async fn update(
                 Ok(status.clone()),
             )?;
 
-            if set_override {
+            if opts.r#override {
                 cfg.make_override(&cfg.current_dir, &desc.clone().into())?;
             }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -468,6 +468,10 @@ struct UpdateOpts {
     /// Set the installed toolchain as the override for the current directory
     #[arg(long)]
     r#override: bool,
+
+    /// Set the installed toolchain as the default toolchain
+    #[arg(long)]
+    default: bool,
 }
 
 #[derive(Debug, Default, Args)]
@@ -1121,7 +1125,9 @@ async fn update(
                 cfg.make_override(&cfg.current_dir, &desc.clone().into())?;
             }
 
-            if cfg.get_default()?.is_none() && matches!(status, UpdateStatus::Installed) {
+            if opts.default
+                || (cfg.get_default()?.is_none() && matches!(status, UpdateStatus::Installed))
+            {
                 cfg.set_default(Some(&desc.into()))?;
             }
         }

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="614px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="632px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -62,29 +62,31 @@
 </tspan>
     <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--override</tspan><tspan>               Set the installed toolchain as the override for the current directory</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--default</tspan><tspan>                Set the installed toolchain as the default toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="478px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="496px">
+    <tspan x="10px" y="496px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="586px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -768,6 +768,27 @@ async fn install_override_toolchain_from_version() {
 }
 
 #[tokio::test]
+async fn install_with_default_flag() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "toolchain", "install", "beta", "--default"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
 async fn override_overrides_default() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -789,6 +789,30 @@ async fn install_with_default_flag() {
 }
 
 #[tokio::test]
+async fn install_with_override_flag() {
+    let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
+    let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();
+    cx.config
+        .expect(["rustup", "default", "nightly"])
+        .await
+        .is_ok();
+
+    let cx = cx.change_dir(tempdir.path());
+    cx.config
+        .expect(["rustup", "toolchain", "install", "beta", "--override"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.2.0 (hash-beta-1.2.0)
+
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
 async fn override_overrides_default() {
     let mut cx = CliTestContext::new(Scenario::SimpleV2).await;
     let tempdir = tempfile::Builder::new().prefix("rustup").tempdir().unwrap();


### PR DESCRIPTION
Based on [#t-rustup > Reducing the need for setup-rust actions @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/490103-t-rustup/topic/Reducing.20the.20need.20for.20setup-rust.20actions/near/610697184).

Feedback on the wording of the doc comment for the new flag is welcome.