### PR TITLE
refactor(test/clitools)!: refine semantics of `CliTestContext::kill_at()`

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -21,8 +21,6 @@ use futures_util::{
 use tokio::task::{JoinHandle, spawn_blocking};
 use tracing::{debug, info, warn};
 
-#[cfg(feature = "test")]
-use crate::test::checkpoint;
 use crate::{
     diskio::{Executor, IO_CHUNK_SIZE, get_executor, unpack_ram},
     dist::{
@@ -294,7 +292,9 @@ impl Manifestation {
         }
 
         #[cfg(feature = "test")]
-        checkpoint(download_cfg.process, "manifestation-update-before-metadata");
+        download_cfg
+            .process
+            .checkpoint("manifestation-update-before-metadata");
 
         // Install new distribution manifest
         let new_manifest_str = new_manifest.clone().stringify()?;

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -294,7 +294,7 @@ impl Manifestation {
         #[cfg(feature = "test")]
         download_cfg
             .process
-            .checkpoint("manifestation-update-before-metadata");
+            .checkpoint(CHECKPOINT_UPDATE_BEFORE_METADATA);
 
         // Install new distribution manifest
         let new_manifest_str = new_manifest.clone().stringify()?;
@@ -884,3 +884,6 @@ impl ComponentInstall {
         tx
     }
 }
+
+#[cfg(feature = "test")]
+pub const CHECKPOINT_UPDATE_BEFORE_METADATA: &str = "update-before-metadata";

--- a/src/process.rs
+++ b/src/process.rs
@@ -8,6 +8,7 @@ use std::str::FromStr;
 #[cfg(feature = "test")]
 use std::{
     collections::HashMap,
+    fs,
     io::Cursor,
     path::Path,
     sync::{Arc, Mutex},
@@ -25,7 +26,10 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 #[cfg(feature = "test")]
-use crate::cli::log;
+use crate::{
+    cli::log,
+    test::{CHECKPOINT_ENV, checkpoint_path},
+};
 
 mod file_source;
 mod terminal_source;
@@ -233,6 +237,29 @@ impl Process {
     pub fn concurrent_downloads(&self) -> Option<usize> {
         let s = self.var("RUSTUP_CONCURRENT_DOWNLOADS").ok()?;
         Some(NonZero::from_str(&s).ok()?.get())
+    }
+
+    /// Registers a testing checkpoint with the given name and parks the current thread.
+    ///
+    /// Usually, the current process will be killed by the test driver.
+    #[cfg(feature = "test")]
+    pub(crate) fn checkpoint(&self, name: &str) {
+        if self.var(CHECKPOINT_ENV).as_deref() != Ok(name) {
+            return;
+        }
+
+        let rustup_home = self
+            .rustup_home()
+            .expect("selected test checkpoint requires RUSTUP_HOME");
+        let test_root = rustup_home
+            .parent()
+            .expect("test RUSTUP_HOME must be inside the test root");
+        fs::write(checkpoint_path(test_root, name), name)
+            .expect("failed to write test checkpoint marker");
+
+        loop {
+            thread::park();
+        }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -12,6 +12,7 @@ use std::{
     io::Cursor,
     path::Path,
     sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 use std::{env, thread};
 
@@ -257,9 +258,14 @@ impl Process {
         fs::write(checkpoint_path(test_root, name), name)
             .expect("failed to write test checkpoint marker");
 
-        loop {
-            thread::park();
+        let start_time = Instant::now();
+        let max_wait = Duration::from_mins(5);
+        while start_time.elapsed() < max_wait {
+            thread::sleep(Duration::from_secs(10));
         }
+        panic!(
+            "test checkpoint '{name}' timed out after {max_wait:?} without being killed by the test driver",
+        );
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -28,7 +28,7 @@ pub use crate::cli::self_update::{RegistryGuard, RegistryValueId, USER_PATH, get
 
 mod clitools;
 pub use clitools::{
-    Assert, CliTestContext, Config, SanitizedOutput, Scenario, SelfUpdateTestContext,
+    Assert, CliTestContext, Config, ParkedChild, SanitizedOutput, Scenario, SelfUpdateTestContext,
     output_release_file, print_command, print_indented,
 };
 pub(super) mod dist;

--- a/src/test.rs
+++ b/src/test.rs
@@ -21,7 +21,7 @@ use anyhow::Result;
 use sha2::{Digest, Sha256};
 
 use crate::dist::TargetTuple;
-use crate::process::{Process, TestProcess};
+use crate::process::TestProcess;
 
 #[cfg(windows)]
 pub use crate::cli::self_update::{RegistryGuard, RegistryValueId, USER_PATH, get_path};
@@ -36,28 +36,7 @@ pub use dist::DistContext;
 pub(super) mod mock;
 pub use mock::{MockComponentBuilder, MockFile, MockInstallerBuilder};
 
-/// Signal that a selected test checkpoint has been reached, then wait for the
-/// test driver to terminate this process.
-pub(crate) fn checkpoint(process: &Process, name: &str) {
-    if process.var(CHECKPOINT_ENV).as_deref() != Ok(name) {
-        return;
-    }
-
-    let rustup_home = process
-        .rustup_home()
-        .expect("selected test checkpoint requires RUSTUP_HOME");
-    let test_root = rustup_home
-        .parent()
-        .expect("test RUSTUP_HOME must be inside the test root");
-    fs::write(checkpoint_path(test_root, name), name)
-        .expect("failed to write test checkpoint marker");
-
-    loop {
-        std::thread::park();
-    }
-}
-
-fn checkpoint_path(test_root: &Path, name: &str) -> PathBuf {
+pub fn checkpoint_path(test_root: &Path, name: &str) -> PathBuf {
     test_root.join(format!("rustup-checkpoint-{name}"))
 }
 
@@ -353,4 +332,4 @@ pub static MULTI_ARCH1: &str = "i686-unknown-linux-gnu";
 #[cfg(not(target_pointer_width = "64"))]
 static MULTI_ARCH1: &str = "x86_64-unknown-linux-gnu";
 
-const CHECKPOINT_ENV: &str = "RUSTUP_TEST_CHECKPOINT";
+pub const CHECKPOINT_ENV: &str = "RUSTUP_TEST_CHECKPOINT";

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -973,9 +973,8 @@ impl CliTestContext {
         Self { config, _test_dir }
     }
 
-    /// Run a rustup command until it reaches `checkpoint`, then terminate it
-    /// without giving destructors an opportunity to run.
-    pub fn kill_at_checkpoint(&self, mut command: Command, checkpoint: &str) -> ExitStatus {
+    /// Run a rustup command until it reaches `checkpoint` and terminate it.
+    pub fn kill_at<S: AsRef<OsStr>>(&self, checkpoint: &str, args: impl AsRef<[S]>) -> ExitStatus {
         let marker = checkpoint_path(&self.config.test_root_dir, checkpoint);
         if let Err(error) = fs::remove_file(&marker)
             && error.kind() != io::ErrorKind::NotFound
@@ -983,10 +982,28 @@ impl CliTestContext {
             panic!("failed to remove stale checkpoint marker: {error}");
         }
 
-        command.env(CHECKPOINT_ENV, checkpoint);
-        let mut child = command
-            .spawn()
-            .expect("failed to start command for checkpoint test");
+        let (program, args) = args
+            .as_ref()
+            .split_first()
+            .expect("args should not be empty");
+        let mut cmd = self.config.cmd(
+            program
+                .as_ref()
+                .to_str()
+                .expect("invalid UTF-8 in program name"),
+            args,
+        );
+        cmd.env(CHECKPOINT_ENV, checkpoint);
+
+        let mut child = {
+            // The lock covers the spawn itself. It must not be held while the
+            // child stays parked: a writer queued behind it would then block
+            // every command spawned in the meantime, including the ones a test
+            // wants to run against the parked process.
+            let _lock = CMD_LOCK.read().unwrap();
+            cmd.spawn()
+                .expect("failed to start command for checkpoint test")
+        };
 
         let deadline = Instant::now() + StdDuration::from_secs(10);
         loop {

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -12,7 +12,7 @@ use std::{
     mem,
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
-    process::{Command, ExitStatus},
+    process::{Child, Command, ExitStatus},
     string::FromUtf8Error,
     sync::{Arc, LazyLock, RwLock, RwLockWriteGuard},
     thread,
@@ -975,6 +975,18 @@ impl CliTestContext {
 
     /// Run a rustup command until it reaches `checkpoint` and terminate it.
     pub fn kill_at<S: AsRef<OsStr>>(&self, checkpoint: &str, args: impl AsRef<[S]>) -> ExitStatus {
+        self.spawn_at(checkpoint, args).kill()
+    }
+
+    /// Run a rustup command until it reaches `checkpoint` and keep it parked.
+    ///
+    /// This is useful in e.g. racing the paused operation from another process.
+    /// The returned guard kills the command when dropped.
+    pub fn spawn_at<S: AsRef<OsStr>>(
+        &self,
+        checkpoint: &str,
+        args: impl AsRef<[S]>,
+    ) -> ParkedChild {
         let marker = checkpoint_path(&self.config.test_root_dir, checkpoint);
         if let Err(error) = fs::remove_file(&marker)
             && error.kind() != io::ErrorKind::NotFound
@@ -995,41 +1007,39 @@ impl CliTestContext {
         );
         cmd.env(CHECKPOINT_ENV, checkpoint);
 
-        let mut child = {
+        let mut parked = {
             // The lock covers the spawn itself. It must not be held while the
             // child stays parked: a writer queued behind it would then block
             // every command spawned in the meantime, including the ones a test
             // wants to run against the parked process.
             let _lock = CMD_LOCK.read().unwrap();
-            cmd.spawn()
-                .expect("failed to start command for checkpoint test")
+            ParkedChild {
+                child: Some({
+                    cmd.spawn()
+                        .expect("failed to start command for checkpoint test")
+                }),
+            }
         };
 
         let deadline = Instant::now() + StdDuration::from_secs(10);
         loop {
             if matches!(fs::read_to_string(&marker), Ok(contents) if contents == checkpoint) {
-                break;
+                break parked;
             }
-            if let Some(status) = child
+            if let Some(status) = parked
+                .child
+                .as_mut()
+                .unwrap()
                 .try_wait()
                 .expect("failed to query checkpoint test command")
             {
                 panic!("command exited before reaching checkpoint {checkpoint:?}: {status}");
             }
             if Instant::now() >= deadline {
-                let _ = child.kill();
-                let _ = child.wait();
                 panic!("timed out waiting for checkpoint {checkpoint:?}");
             }
             thread::sleep(StdDuration::from_millis(10));
         }
-
-        child
-            .kill()
-            .expect("failed to terminate command at checkpoint");
-        child
-            .wait()
-            .expect("failed to reap command after checkpoint")
     }
 
     /// Move the dist server to the specified scenario and restore it
@@ -1105,6 +1115,38 @@ impl DerefMut for WorkDirGuard<'_> {
 impl Drop for WorkDirGuard<'_> {
     fn drop(&mut self) {
         self.inner.config.workdir.replace(mem::take(&mut self.prev));
+    }
+}
+
+/// A spawned rustup command parked at a checkpoint.
+///
+/// The spawned command is created by [`CliTestContext::spawn_at`] and killed on drop unless
+/// [`ParkedChild::kill`] was called first.
+#[must_use]
+pub struct ParkedChild {
+    child: Option<Child>,
+}
+
+impl ParkedChild {
+    /// Terminate and reap the parked command immediately.
+    pub fn kill(mut self) -> ExitStatus {
+        let mut child = self.child.take().unwrap();
+        child
+            .kill()
+            .expect("failed to terminate command at checkpoint");
+        child
+            .wait()
+            .expect("failed to reap command after checkpoint")
+    }
+}
+
+impl Drop for ParkedChild {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else {
+            return;
+        };
+        let _ = child.kill();
+        let _ = child.wait();
     }
 }
 

--- a/tests/suite/cli_crash.rs
+++ b/tests/suite/cli_crash.rs
@@ -3,9 +3,10 @@ use rustup::test::{CliTestContext, Scenario};
 #[tokio::test]
 async fn interrupted_install_can_be_retried() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
-    let command = cx.config.cmd("rustup", ["toolchain", "install", "nightly"]);
-
-    let status = cx.kill_at_checkpoint(command, "manifestation-update-before-metadata");
+    let status = cx.kill_at(
+        "manifestation-update-before-metadata",
+        ["rustup", "toolchain", "install", "nightly"],
+    );
     assert!(!status.success());
 
     cx.config

--- a/tests/suite/cli_crash.rs
+++ b/tests/suite/cli_crash.rs
@@ -1,10 +1,13 @@
-use rustup::test::{CliTestContext, Scenario};
+use rustup::{
+    dist::manifestation::CHECKPOINT_UPDATE_BEFORE_METADATA,
+    test::{CliTestContext, Scenario},
+};
 
 #[tokio::test]
 async fn interrupted_install_can_be_retried() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     let status = cx.kill_at(
-        "manifestation-update-before-metadata",
+        CHECKPOINT_UPDATE_BEFORE_METADATA,
         ["rustup", "toolchain", "install", "nightly"],
     );
     assert!(!status.success());


### PR DESCRIPTION
Refines #4963 before going further with e.g. #4965.

cc @cachebag 