### PR TITLE
ci(docker/android): stop building OpenSSL

### DIFF
--- a/ci/run.bash
+++ b/ci/run.bash
@@ -19,10 +19,16 @@ if [ -n "$INSTALL_BINDGEN" ]; then
   export PATH="$CARGO_HOME/bin/bindgen-cli:$PATH"
 fi
 
-FEATURES=('--no-default-features' '--features' 'reqwest-native-tls')
-case "$(uname -s)" in
-  *NT* ) ;; # Windows NT
-  * ) FEATURES+=('--features' 'vendored-openssl') ;;
+FEATURES=('--no-default-features')
+case "$TARGET" in
+  *-linux-android*) ;;
+  *)
+    FEATURES+=('--features' 'reqwest-native-tls')
+    case "$(uname -s)" in
+      *NT* ) ;; # Windows NT
+      * ) FEATURES+=('--features' 'vendored-openssl') ;;
+    esac
+    ;;
 esac
 
 case "$TARGET" in


### PR DESCRIPTION
Closes #4979 by not building OpenSSL for `*-linux-android` targets, as `reqwest-rustls-tls` should be enough for the task.

Fix verified in https://github.com/rust-lang/rustup/actions/runs/31479426119/job/93740694089?pr=4978.