### PR TITLE
www: align copy icon

### DIFF
--- a/www/rustup.css
+++ b/www/rustup.css
@@ -214,11 +214,12 @@ hr {
 }
 
 div.copy-icon {
-    transform: translateX(3px);
+    transform: translateX(2px);
 }
 
 div.copy-icon svg {
     fill: var(--body-color);
+    display: block;
 }
 
 button.copy-button:hover svg {


### PR DESCRIPTION
## Summary

This has been bothering me everytime I visit the rustup.rs website 

<img width="515" height="387" alt="image" src="https://github.com/user-attachments/assets/5344b546-923d-4f7d-be78-72df07dbf275" />

## Why
It's misaligned

## Validation
Check screenshot