### PR TITLE
docs(dev-guide): reapply abandoned changes from #4970

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
-Before submitting a PR, please familiarize yourself with the
+<!-- Before submitting a PR, please familiarize yourself with the
 [developer guide]([CONTRIBUTING.md](https://rust-lang.github.io/rustup/dev-guide/index.html)),
-including the AI policy and style guide.
+including the AI policy and style guide. -->

--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -64,7 +64,10 @@ If you are opening an issue, you should be able to describe the problem in your 
 If you are opening a pull request, you are expected to be able to explain the proposed changes in
 your own words. This includes the pull request body and responses to questions. Make sure you have
 reviewed the PR yourself before submitting it for review to the maintainers. Do not copy responses
-from the AI when replying to questions from maintainers.
+from the AI when replying to questions from maintainers. As an exception, issues marked as `E-easy`
+are meant for new contributors as a learning opportunity; the use of an LLM when submitting PR for
+such issues is disallowed except without explicit permission from the team. Failure to comply may
+result in the PR being closed directly without further notice.
 
 If you wish to include context from an interaction with AI in your comments, it must be in a
 quote block (using `>`) and disclosed as such. It must be accompanied by human commentary


### PR DESCRIPTION
In GHMQ, any operation on the topic branch after enqueuing is considered a no-op, so what we have on our `main` branch is an older version of that document.

<img width="502" height="147" alt="image" src="https://github.com/user-attachments/assets/d3ea9fd8-f3f6-4ed6-9cf0-1e5301915951" />

 This PR has thus reapplied what has been abandoned in #4970.