### PR TITLE
Add `rustup doc --serve` to serve docs over local HTTP

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,9 @@ fs_at = "0.2.1"
 futures-util = "0.3.31"
 git-testament = "0.2"
 home = "0.5.4"
+http-body-util = "0.1.0"
+hyper = { version = "1.0", default-features = false, features = ["server", "http1"] }
+hyper-util = { version = "0.1.1", features = ["tokio"] }
 indicatif = "0.18"
 itertools = "0.15"
 libc = "0.2"
@@ -141,9 +144,6 @@ libz-sys = "=1.1.24"
 
 [dev-dependencies]
 enum-map = "3.0.0"
-http-body-util = "0.1.0"
-hyper = { version = "1.0", default-features = false, features = ["server", "http1"] }
-hyper-util = { version = "0.1.1", features = ["tokio"] }
 proptest = "1.1.0"
 rustls-webpki = { version = "0.103.3" }
 tokio-rustls = "0.26.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,7 @@
 #[macro_use]
 pub mod log;
 pub mod common;
+mod docs;
 pub mod errors;
 mod help;
 mod job;

--- a/src/cli/docs.rs
+++ b/src/cli/docs.rs
@@ -1,19 +1,41 @@
 //! `rustup doc` and `rustup man`: opening toolchain documentation and man pages.
+//!
+//! `rustup doc --serve` serves the documentation over a local HTTP server
+//! instead of opening it directly as a `file://` URL. Some browsers (e.g.
+//! Snap/Flatpak builds of Firefox or Brave) run in a sandbox that can't
+//! access `file://` URLs under `~/.rustup`; serving the same static files
+//! over `http://127.0.0.1` sidesteps that restriction entirely.
+//!
+//! The server binds to `127.0.0.1` only (never exposed on the network) and
+//! rejects any request path that would resolve outside the served directory.
 
 use std::{
     borrow::Cow,
+    convert::Infallible,
     io::Write as _,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
+    sync::Arc,
 };
 
 use anyhow::{Context, Result, anyhow};
 use clap::Args;
+use http_body_util::Full;
+use hyper::{
+    Request, Response, StatusCode,
+    body::{Bytes, Incoming},
+    header::{CONTENT_LENGTH, CONTENT_TYPE},
+    server::conn::http1,
+    service::service_fn,
+};
+use hyper_util::rt::TokioIo;
+use tokio::net::TcpListener;
 use tracing::info;
 
 use super::topical_doc;
 use crate::{
     config::{ActiveSource, Cfg},
     dist::{PartialToolchainDesc, manifest::ComponentStatus},
+    process::Process,
     toolchain::DistributableToolchain,
     utils::{self, ExitCode},
 };
@@ -162,6 +184,7 @@ impl DocPage {
 pub(crate) async fn doc(
     cfg: &Cfg<'_>,
     path_only: bool,
+    serve: bool,
     toolchain: Option<PartialToolchainDesc>,
     mut topic: Option<&str>,
     doc_page: &DocPage,
@@ -212,6 +235,12 @@ pub(crate) async fn doc(
         return Ok(ExitCode::SUCCESS);
     }
 
+    if serve {
+        let root = toolchain.doc_path("")?;
+        serve_and_open(root, &doc_path, fragment, cfg.process).await?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
     if let Some(name) = topic {
         writeln!(
             cfg.process.stderr().lock(),
@@ -246,4 +275,107 @@ pub(crate) async fn man(
         .status()
         .expect("failed to open man page");
     Ok(ExitCode::SUCCESS)
+}
+
+/// Blocks forever, accepting and serving connections until the process is
+/// killed by Ctrl-C.
+async fn serve_and_open(
+    root: PathBuf,
+    initial_path: &Path,
+    fragment: Option<&str>,
+    process: &Process,
+) -> Result<()> {
+    let listener = TcpListener::bind(("127.0.0.1", 0))
+        .await
+        .context("failed to bind local documentation server")?;
+    let addr = listener
+        .local_addr()
+        .context("failed to read local address")?;
+    let root = Arc::<Path>::from(root);
+
+    let mut url = format!(
+        "http://{addr}/{}",
+        initial_path.to_string_lossy().replace('\\', "/")
+    );
+    if let Some(fragment) = fragment {
+        url.push('#');
+        url.push_str(fragment);
+    }
+
+    writeln!(
+        process.stderr().lock(),
+        "Serving docs at {url} (press Ctrl-C to stop)"
+    )?;
+    utils::open_browser(&url)?;
+
+    loop {
+        let (stream, _) = match listener.accept().await {
+            Ok(accepted) => accepted,
+            Err(err) => {
+                tracing::warn!("doc server: failed to accept connection: {err}");
+                continue;
+            }
+        };
+        let io = TokioIo::new(stream);
+        let root = root.clone();
+        let svc = service_fn(move |req| serve(req, root.clone()));
+
+        tokio::spawn(async move {
+            if let Err(err) = http1::Builder::new().serve_connection(io, svc).await {
+                tracing::warn!("doc server: connection error: {err}");
+            }
+        });
+    }
+}
+
+async fn serve(
+    req: Request<Incoming>,
+    root: Arc<Path>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let request_path = req.uri().path().trim_start_matches('/');
+    let mut path = root.to_path_buf();
+    for segment in Path::new(request_path).components() {
+        match segment {
+            Component::Normal(part) => path.push(part),
+            _ => return Ok(not_found()),
+        }
+    }
+    if !path.starts_with(&root) {
+        return Ok(not_found());
+    }
+    if path.is_dir() {
+        path.push("index.html");
+    }
+
+    let Ok(contents) = tokio::fs::read(&path).await else {
+        return Ok(not_found());
+    };
+
+    let response = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            CONTENT_TYPE,
+            match path.extension().and_then(|ext| ext.to_str()) {
+                Some("html") => "text/html; charset=utf-8",
+                Some("css") => "text/css",
+                Some("js") => "text/javascript",
+                Some("svg") => "image/svg+xml",
+                Some("png") => "image/png",
+                Some("jpg" | "jpeg") => "image/jpeg",
+                Some("woff2") => "font/woff2",
+                Some("txt") => "text/plain; charset=utf-8",
+                _ => "application/octet-stream",
+            },
+        )
+        .header(CONTENT_LENGTH, contents.len())
+        .body(Full::new(Bytes::from(contents)))
+        .expect("building a static response can't fail");
+    Ok(response)
+}
+
+fn not_found() -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Full::new(Bytes::from_static(b"404 not found")))
+        .expect("building a static response can't fail")
 }

--- a/src/cli/docs.rs
+++ b/src/cli/docs.rs
@@ -1,0 +1,249 @@
+//! `rustup doc` and `rustup man`: opening toolchain documentation and man pages.
+
+use std::{
+    borrow::Cow,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, anyhow};
+use clap::Args;
+use tracing::info;
+
+use super::topical_doc;
+use crate::{
+    config::{ActiveSource, Cfg},
+    dist::{PartialToolchainDesc, manifest::ComponentStatus},
+    toolchain::DistributableToolchain,
+    utils::{self, ExitCode},
+};
+
+macro_rules! docs_data {
+    (
+        $(
+            $( #[$meta:meta] )*
+            ($ident:ident, $help:expr, $path:expr $(,)?)
+        ),+ $(,)?
+    ) => {
+        #[derive(Debug, Args)]
+        pub(crate) struct DocPage {
+            $(
+                #[doc = $help]
+                #[arg(long, group = "page")]
+                $( #[$meta] )*
+                $ident: bool,
+            )+
+        }
+
+        impl DocPage {
+            fn path_str(&self) -> Option<&'static str> {
+                $( if self.$ident { return Some($path); } )+
+                None
+            }
+        }
+    };
+}
+
+docs_data![
+    // flags can be used to open specific documents, e.g. `rustup doc --nomicon`
+    // tuple elements: document name used as flag, help message, document index path
+    (
+        alloc,
+        "The Rust core allocation and collections library",
+        "alloc/index.html"
+    ),
+    (
+        book,
+        "The Rust Programming Language book",
+        "book/index.html"
+    ),
+    (cargo, "The Cargo Book", "cargo/index.html"),
+    (clippy, "The Clippy Documentation", "clippy/index.html"),
+    (core, "The Rust Core Library", "core/index.html"),
+    (
+        edition_guide,
+        "The Rust Edition Guide",
+        "edition-guide/index.html"
+    ),
+    (
+        embedded_book,
+        "The Embedded Rust Book",
+        "embedded-book/index.html"
+    ),
+    (
+        error_codes,
+        "The Rust Error Codes Index",
+        "error_codes/index.html"
+    ),
+    (
+        nomicon,
+        "The Dark Arts of Advanced and Unsafe Rust Programming",
+        "nomicon/index.html"
+    ),
+    #[arg(long = "proc_macro")]
+    (
+        proc_macro,
+        "A support library for macro authors when defining new macros",
+        "proc_macro/index.html"
+    ),
+    (reference, "The Rust Reference", "reference/index.html"),
+    (releases, "Rust Release Notes", "releases.html"),
+    (
+        rust_by_example,
+        "A collection of runnable examples that illustrate various Rust concepts and standard libraries",
+        "rust-by-example/index.html"
+    ),
+    (
+        rustc,
+        "The compiler for the Rust programming language",
+        "rustc/index.html"
+    ),
+    (
+        rustc_docs,
+        "The API documentation for the Rust compiler and other toolchain components",
+        "rustc-docs/index.html"
+    ),
+    (
+        rustdoc,
+        "Documentation generator for Rust projects",
+        "rustdoc/index.html"
+    ),
+    (std, "Standard library API documentation", "std/index.html"),
+    (
+        style_guide,
+        "The Rust Style Guide",
+        "style-guide/index.html"
+    ),
+    (
+        test,
+        "Support code for rustc's built in unit-test and micro-benchmarking framework",
+        "test/index.html"
+    ),
+    (
+        unstable_book,
+        "The Unstable Book",
+        "unstable-book/index.html"
+    ),
+];
+
+impl DocPage {
+    fn path(&self) -> Option<&'static Path> {
+        self.path_str().map(Path::new)
+    }
+
+    fn name(&self) -> Option<&'static str> {
+        Some(self.path_str()?.rsplit_once('/')?.0)
+    }
+
+    fn resolve<'t>(&self, root: &Path, topic: &'t str) -> Option<(PathBuf, Option<&'t str>)> {
+        // Use `.parent()` to chop off the default top-level `index.html`.
+        let mut base = root.join(Path::new(self.path()?).parent()?);
+        base.extend(topic.split("::"));
+        let base_index_html = base.join("index.html");
+
+        if base_index_html.is_file() {
+            return Some((base_index_html, None));
+        }
+
+        let base_html = base.with_extension("html");
+        if base_html.is_file() {
+            return Some((base_html, None));
+        }
+
+        let parent_html = base.parent()?.with_extension("html");
+        if parent_html.is_file() {
+            return Some((parent_html, topic.rsplit_once("::").map(|(_, s)| s)));
+        }
+
+        None
+    }
+}
+
+pub(crate) async fn doc(
+    cfg: &Cfg<'_>,
+    path_only: bool,
+    toolchain: Option<PartialToolchainDesc>,
+    mut topic: Option<&str>,
+    doc_page: &DocPage,
+) -> Result<ExitCode> {
+    let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
+    let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
+
+    if let Ok(distributable) = DistributableToolchain::try_from(&toolchain)
+        && let [_] = distributable
+            .components()?
+            .into_iter()
+            .filter(|cstatus| cstatus.component.short_name() == "rust-docs" && !cstatus.installed)
+            .take(1)
+            .collect::<Vec<ComponentStatus>>()
+            .as_slice()
+    {
+        info!(
+            "`rust-docs` not installed in toolchain `{}`\nhelp: run `rustup component add --toolchain {} rust-docs` to install it",
+            distributable.desc(),
+            distributable.desc()
+        );
+        return Err(anyhow!(
+            "unable to view documentation which is not installed"
+        ));
+    };
+
+    let (doc_path, fragment) = match (topic, doc_page.name()) {
+        (Some(topic), Some(name)) => {
+            let (doc_path, fragment) = doc_page
+                .resolve(&toolchain.doc_path("")?, topic)
+                .context(format!("no document for {name} on {topic}"))?;
+            (Cow::Owned(doc_path), fragment)
+        }
+        (Some(topic), None) => {
+            let doc_path = topical_doc::local_path(&toolchain.doc_path("").unwrap(), topic)?;
+            (Cow::Owned(doc_path), None)
+        }
+        (None, name) => {
+            topic = name;
+            let doc_path = doc_page.path().unwrap_or_else(|| Path::new("index.html"));
+            (Cow::Borrowed(doc_path), None)
+        }
+    };
+
+    if path_only {
+        let doc_path = toolchain.doc_path(&doc_path)?;
+        writeln!(cfg.process.stdout().lock(), "{}", doc_path.display())?;
+        return Ok(ExitCode::SUCCESS);
+    }
+
+    if let Some(name) = topic {
+        writeln!(
+            cfg.process.stderr().lock(),
+            "Opening docs named `{name}` in your browser"
+        )?;
+    } else {
+        writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
+    }
+    toolchain.open_docs(&doc_path, fragment)?;
+    Ok(ExitCode::SUCCESS)
+}
+
+#[cfg(not(windows))]
+pub(crate) async fn man(
+    cfg: &Cfg<'_>,
+    command: &str,
+    toolchain: Option<PartialToolchainDesc>,
+) -> Result<ExitCode> {
+    let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
+    let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
+    let path = toolchain.man_path();
+    utils::assert_is_directory(&path)?;
+
+    let mut manpaths = std::ffi::OsString::from(path);
+    manpaths.push(":"); // prepend to the default MANPATH list
+    if let Some(path) = cfg.process.var_os("MANPATH") {
+        manpaths.push(path);
+    }
+    std::process::Command::new("man")
+        .env("MANPATH", manpaths)
+        .arg(command)
+        .status()
+        .expect("failed to open man page");
+    Ok(ExitCode::SUCCESS)
+}

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -232,7 +232,11 @@ pub(crate) fn doc_help() -> String {
   the default browser.
 
   By default, it opens the documentation index. Use the various
-  flags to open specific pieces of documentation."
+  flags to open specific pieces of documentation.
+
+  If your browser is sandboxed (e.g. installed via Snap or Flatpak) it
+  may be unable to open `file://` URLs under `~/.rustup`. Pass `--serve`
+  to serve the documentation over a local HTTP server instead."
     )
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -252,6 +252,11 @@ enum RustupSubcmd {
         #[arg(long)]
         path: bool,
 
+        /// Serve the documentation over a local HTTP server instead of
+        /// opening it directly as a `file://` URL
+        #[arg(long, conflicts_with = "path")]
+        serve: bool,
+
         #[arg(long, help = official_toolchain_arg_help())]
         toolchain: Option<PartialToolchainDesc>,
 
@@ -817,10 +822,11 @@ pub async fn main(
         RustupSubcmd::Which { command, toolchain } => which(cfg, &command, toolchain).await,
         RustupSubcmd::Doc {
             path,
+            serve,
             toolchain,
             topic,
             page,
-        } => docs::doc(cfg, path, toolchain, topic.as_deref(), &page).await,
+        } => docs::doc(cfg, path, serve, toolchain, topic.as_deref(), &page).await,
         #[cfg(not(windows))]
         RustupSubcmd::Man { command, toolchain } => docs::man(cfg, &command, toolchain).await,
         RustupSubcmd::Self_ { subcmd } => match subcmd {

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anstream::ColorChoice;
 use anstyle::Style;
-use anyhow::{Context, Error, Result, anyhow};
+use anyhow::{Error, Result, anyhow};
 use clap::{
     Args, CommandFactory, Parser, Subcommand, ValueEnum,
     builder::{PossibleValue, ValueHint},
@@ -29,6 +29,7 @@ use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 use crate::{
     cli::{
         common::{self, PackageUpdate, update_console_filter},
+        docs,
         errors::CliError,
         help::{
             check_help, completions_help, default_help, doc_help, install_help,
@@ -39,14 +40,13 @@ use crate::{
             update_help,
         },
         self_update::{self, SelfUpdateMode, check_rustup_update},
-        topical_doc,
     },
     command, component_for_bin,
     config::{ActiveSource, Cfg},
     dist::{
         DistOptions, PartialToolchainDesc, Profile, Switch, TargetTuple,
         download::DownloadCfg,
-        manifest::{Component, ComponentStatus, ManifestWithHash},
+        manifest::{Component, ManifestWithHash},
     },
     errors::{DEFAULT_STABLE_HINT, RustupError},
     install::{InstallMethod, UpdateStatus},
@@ -259,7 +259,7 @@ enum RustupSubcmd {
         topic: Option<String>,
 
         #[command(flatten)]
-        page: DocPage,
+        page: docs::DocPage,
     },
 
     /// View the man page for a given command
@@ -820,9 +820,9 @@ pub async fn main(
             toolchain,
             topic,
             page,
-        } => doc(cfg, path, toolchain, topic.as_deref(), &page).await,
+        } => docs::doc(cfg, path, toolchain, topic.as_deref(), &page).await,
         #[cfg(not(windows))]
-        RustupSubcmd::Man { command, toolchain } => man(cfg, &command, toolchain).await,
+        RustupSubcmd::Man { command, toolchain } => docs::man(cfg, &command, toolchain).await,
         RustupSubcmd::Self_ { subcmd } => match subcmd {
             SelfSubcmd::Update => self_update::update(cfg).await,
             SelfSubcmd::Uninstall {
@@ -1738,236 +1738,6 @@ fn override_remove(cfg: &Cfg<'_>, path: Option<&Path>, nonexistent: bool) -> Res
             }
         }
     }
-    Ok(ExitCode::SUCCESS)
-}
-
-macro_rules! docs_data {
-    (
-        $(
-            $( #[$meta:meta] )*
-            ($ident:ident, $help:expr, $path:expr $(,)?)
-        ),+ $(,)?
-    ) => {
-        #[derive(Debug, Args)]
-        struct DocPage {
-            $(
-                #[doc = $help]
-                #[arg(long, group = "page")]
-                $( #[$meta] )*
-                $ident: bool,
-            )+
-        }
-
-        impl DocPage {
-            fn path_str(&self) -> Option<&'static str> {
-                $( if self.$ident { return Some($path); } )+
-                None
-            }
-        }
-    };
-}
-
-docs_data![
-    // flags can be used to open specific documents, e.g. `rustup doc --nomicon`
-    // tuple elements: document name used as flag, help message, document index path
-    (
-        alloc,
-        "The Rust core allocation and collections library",
-        "alloc/index.html"
-    ),
-    (
-        book,
-        "The Rust Programming Language book",
-        "book/index.html"
-    ),
-    (cargo, "The Cargo Book", "cargo/index.html"),
-    (clippy, "The Clippy Documentation", "clippy/index.html"),
-    (core, "The Rust Core Library", "core/index.html"),
-    (
-        edition_guide,
-        "The Rust Edition Guide",
-        "edition-guide/index.html"
-    ),
-    (
-        embedded_book,
-        "The Embedded Rust Book",
-        "embedded-book/index.html"
-    ),
-    (
-        error_codes,
-        "The Rust Error Codes Index",
-        "error_codes/index.html"
-    ),
-    (
-        nomicon,
-        "The Dark Arts of Advanced and Unsafe Rust Programming",
-        "nomicon/index.html"
-    ),
-    #[arg(long = "proc_macro")]
-    (
-        proc_macro,
-        "A support library for macro authors when defining new macros",
-        "proc_macro/index.html"
-    ),
-    (reference, "The Rust Reference", "reference/index.html"),
-    (releases, "Rust Release Notes", "releases.html"),
-    (
-        rust_by_example,
-        "A collection of runnable examples that illustrate various Rust concepts and standard libraries",
-        "rust-by-example/index.html"
-    ),
-    (
-        rustc,
-        "The compiler for the Rust programming language",
-        "rustc/index.html"
-    ),
-    (
-        rustc_docs,
-        "The API documentation for the Rust compiler and other toolchain components",
-        "rustc-docs/index.html"
-    ),
-    (
-        rustdoc,
-        "Documentation generator for Rust projects",
-        "rustdoc/index.html"
-    ),
-    (std, "Standard library API documentation", "std/index.html"),
-    (
-        style_guide,
-        "The Rust Style Guide",
-        "style-guide/index.html"
-    ),
-    (
-        test,
-        "Support code for rustc's built in unit-test and micro-benchmarking framework",
-        "test/index.html"
-    ),
-    (
-        unstable_book,
-        "The Unstable Book",
-        "unstable-book/index.html"
-    ),
-];
-
-impl DocPage {
-    fn path(&self) -> Option<&'static Path> {
-        self.path_str().map(Path::new)
-    }
-
-    fn name(&self) -> Option<&'static str> {
-        Some(self.path_str()?.rsplit_once('/')?.0)
-    }
-
-    fn resolve<'t>(&self, root: &Path, topic: &'t str) -> Option<(PathBuf, Option<&'t str>)> {
-        // Use `.parent()` to chop off the default top-level `index.html`.
-        let mut base = root.join(Path::new(self.path()?).parent()?);
-        base.extend(topic.split("::"));
-        let base_index_html = base.join("index.html");
-
-        if base_index_html.is_file() {
-            return Some((base_index_html, None));
-        }
-
-        let base_html = base.with_extension("html");
-        if base_html.is_file() {
-            return Some((base_html, None));
-        }
-
-        let parent_html = base.parent()?.with_extension("html");
-        if parent_html.is_file() {
-            return Some((parent_html, topic.rsplit_once("::").map(|(_, s)| s)));
-        }
-
-        None
-    }
-}
-
-async fn doc(
-    cfg: &Cfg<'_>,
-    path_only: bool,
-    toolchain: Option<PartialToolchainDesc>,
-    mut topic: Option<&str>,
-    doc_page: &DocPage,
-) -> Result<ExitCode> {
-    let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
-    let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
-
-    if let Ok(distributable) = DistributableToolchain::try_from(&toolchain)
-        && let [_] = distributable
-            .components()?
-            .into_iter()
-            .filter(|cstatus| cstatus.component.short_name() == "rust-docs" && !cstatus.installed)
-            .take(1)
-            .collect::<Vec<ComponentStatus>>()
-            .as_slice()
-    {
-        info!(
-            "`rust-docs` not installed in toolchain `{}`\nhelp: run `rustup component add --toolchain {} rust-docs` to install it",
-            distributable.desc(),
-            distributable.desc()
-        );
-        return Err(anyhow!(
-            "unable to view documentation which is not installed"
-        ));
-    };
-
-    let (doc_path, fragment) = match (topic, doc_page.name()) {
-        (Some(topic), Some(name)) => {
-            let (doc_path, fragment) = doc_page
-                .resolve(&toolchain.doc_path("")?, topic)
-                .context(format!("no document for {name} on {topic}"))?;
-            (Cow::Owned(doc_path), fragment)
-        }
-        (Some(topic), None) => {
-            let doc_path = topical_doc::local_path(&toolchain.doc_path("").unwrap(), topic)?;
-            (Cow::Owned(doc_path), None)
-        }
-        (None, name) => {
-            topic = name;
-            let doc_path = doc_page.path().unwrap_or_else(|| Path::new("index.html"));
-            (Cow::Borrowed(doc_path), None)
-        }
-    };
-
-    if path_only {
-        let doc_path = toolchain.doc_path(&doc_path)?;
-        writeln!(cfg.process.stdout().lock(), "{}", doc_path.display())?;
-        return Ok(ExitCode::SUCCESS);
-    }
-
-    if let Some(name) = topic {
-        writeln!(
-            cfg.process.stderr().lock(),
-            "Opening docs named `{name}` in your browser"
-        )?;
-    } else {
-        writeln!(cfg.process.stderr().lock(), "Opening docs in your browser")?;
-    }
-    toolchain.open_docs(&doc_path, fragment)?;
-    Ok(ExitCode::SUCCESS)
-}
-
-#[cfg(not(windows))]
-async fn man(
-    cfg: &Cfg<'_>,
-    command: &str,
-    toolchain: Option<PartialToolchainDesc>,
-) -> Result<ExitCode> {
-    let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
-    let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
-    let path = toolchain.man_path();
-    utils::assert_is_directory(&path)?;
-
-    let mut manpaths = std::ffi::OsString::from(path);
-    manpaths.push(":"); // prepend to the default MANPATH list
-    if let Some(path) = cfg.process.var_os("MANPATH") {
-        manpaths.push(path);
-    }
-    std::process::Command::new("man")
-        .env("MANPATH", manpaths)
-        .arg(command)
-        .status()
-        .expect("failed to open man page");
     Ok(ExitCode::SUCCESS)
 }
 

--- a/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_doc_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="835px" height="830px" xmlns="http://www.w3.org/2000/svg">
+<svg width="844px" height="938px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -42,73 +42,85 @@
 </tspan>
     <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--path</tspan><tspan>                   Only print the path to the documentation</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--serve</tspan><tspan>                  Serve the documentation over a local HTTP server instead of opening</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>                               information see `rustup help toolchain`</tspan>
+    <tspan x="10px" y="244px"><tspan>                               it directly as a `file://` URL</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--alloc</tspan><tspan>                  The Rust core allocation and collections library</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--toolchain</tspan><tspan class="fg-cyan"> </tspan><tspan class="fg-cyan">&lt;TOOLCHAIN&gt;</tspan><tspan>  Toolchain name, such as 'stable', 'nightly', or '1.8.0'. For more</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--book</tspan><tspan>                   The Rust Programming Language book</tspan>
+    <tspan x="10px" y="280px"><tspan>                               information see `rustup help toolchain`</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--cargo</tspan><tspan>                  The Cargo Book</tspan>
+    <tspan x="10px" y="298px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--alloc</tspan><tspan>                  The Rust core allocation and collections library</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--clippy</tspan><tspan>                 The Clippy Documentation</tspan>
+    <tspan x="10px" y="316px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--book</tspan><tspan>                   The Rust Programming Language book</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--core</tspan><tspan>                   The Rust Core Library</tspan>
+    <tspan x="10px" y="334px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--cargo</tspan><tspan>                  The Cargo Book</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition-guide</tspan><tspan>          The Rust Edition Guide</tspan>
+    <tspan x="10px" y="352px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--clippy</tspan><tspan>                 The Clippy Documentation</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--embedded-book</tspan><tspan>          The Embedded Rust Book</tspan>
+    <tspan x="10px" y="370px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--core</tspan><tspan>                   The Rust Core Library</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--error-codes</tspan><tspan>            The Rust Error Codes Index</tspan>
+    <tspan x="10px" y="388px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--edition-guide</tspan><tspan>          The Rust Edition Guide</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--nomicon</tspan><tspan>                The Dark Arts of Advanced and Unsafe Rust Programming</tspan>
+    <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--embedded-book</tspan><tspan>          The Embedded Rust Book</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--proc_macro</tspan><tspan>             A support library for macro authors when defining new macros</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--error-codes</tspan><tspan>            The Rust Error Codes Index</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--reference</tspan><tspan>              The Rust Reference</tspan>
+    <tspan x="10px" y="442px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--nomicon</tspan><tspan>                The Dark Arts of Advanced and Unsafe Rust Programming</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--releases</tspan><tspan>               Rust Release Notes</tspan>
+    <tspan x="10px" y="460px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--proc_macro</tspan><tspan>             A support library for macro authors when defining new macros</tspan>
 </tspan>
-    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rust-by-example</tspan><tspan>        A collection of runnable examples that illustrate various Rust</tspan>
+    <tspan x="10px" y="478px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--reference</tspan><tspan>              The Rust Reference</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>                               concepts and standard libraries</tspan>
+    <tspan x="10px" y="496px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--releases</tspan><tspan>               Rust Release Notes</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc</tspan><tspan>                  The compiler for the Rust programming language</tspan>
+    <tspan x="10px" y="514px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rust-by-example</tspan><tspan>        A collection of runnable examples that illustrate various Rust</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc-docs</tspan><tspan>             The API documentation for the Rust compiler and other toolchain</tspan>
+    <tspan x="10px" y="532px"><tspan>                               concepts and standard libraries</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>                               components</tspan>
+    <tspan x="10px" y="550px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc</tspan><tspan>                  The compiler for the Rust programming language</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustdoc</tspan><tspan>                Documentation generator for Rust projects</tspan>
+    <tspan x="10px" y="568px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustc-docs</tspan><tspan>             The API documentation for the Rust compiler and other toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--std</tspan><tspan>                    Standard library API documentation</tspan>
+    <tspan x="10px" y="586px"><tspan>                               components</tspan>
 </tspan>
-    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--style-guide</tspan><tspan>            The Rust Style Guide</tspan>
+    <tspan x="10px" y="604px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--rustdoc</tspan><tspan>                Documentation generator for Rust projects</tspan>
 </tspan>
-    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan>                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
+    <tspan x="10px" y="622px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--std</tspan><tspan>                    Standard library API documentation</tspan>
 </tspan>
-    <tspan x="10px" y="640px"><tspan>                               framework</tspan>
+    <tspan x="10px" y="640px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--style-guide</tspan><tspan>            The Rust Style Guide</tspan>
 </tspan>
-    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unstable-book</tspan><tspan>          The Unstable Book</tspan>
+    <tspan x="10px" y="658px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--test</tspan><tspan>                   Support code for rustc's built in unit-test and micro-benchmarking</tspan>
 </tspan>
-    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="676px"><tspan>                               framework</tspan>
 </tspan>
-    <tspan x="10px" y="694px">
+    <tspan x="10px" y="694px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--unstable-book</tspan><tspan>          The Unstable Book</tspan>
 </tspan>
-    <tspan x="10px" y="712px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="712px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="730px"><tspan>  Opens the documentation for the currently active toolchain with</tspan>
+    <tspan x="10px" y="730px">
 </tspan>
-    <tspan x="10px" y="748px"><tspan>  the default browser.</tspan>
+    <tspan x="10px" y="748px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="766px">
+    <tspan x="10px" y="766px"><tspan>  Opens the documentation for the currently active toolchain with</tspan>
 </tspan>
-    <tspan x="10px" y="784px"><tspan>  By default, it opens the documentation index. Use the various</tspan>
+    <tspan x="10px" y="784px"><tspan>  the default browser.</tspan>
 </tspan>
-    <tspan x="10px" y="802px"><tspan>  flags to open specific pieces of documentation.</tspan>
+    <tspan x="10px" y="802px">
 </tspan>
-    <tspan x="10px" y="820px">
+    <tspan x="10px" y="820px"><tspan>  By default, it opens the documentation index. Use the various</tspan>
+</tspan>
+    <tspan x="10px" y="838px"><tspan>  flags to open specific pieces of documentation.</tspan>
+</tspan>
+    <tspan x="10px" y="856px">
+</tspan>
+    <tspan x="10px" y="874px"><tspan>  If your browser is sandboxed (e.g. installed via Snap or Flatpak) it</tspan>
+</tspan>
+    <tspan x="10px" y="892px"><tspan>  may be unable to open `file://` URLs under `~/.rustup`. Pass `--serve`</tspan>
+</tspan>
+    <tspan x="10px" y="910px"><tspan>  to serve the documentation over a local HTTP server instead.</tspan>
+</tspan>
+    <tspan x="10px" y="928px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## The Problem
`rustup doc` currently opens the local Rust documentation as `file://` URLs using the system's default browser, but sandbox browsers are unable to access the documentation. The browser opens, just to display an "Access denied" error

## This PR
Adds an opt-in `--serve` flag. So instead of building a `file://` URL, `rustup doc --serve` opens an `http://127.0.0.1:<port>/...`
URL instead, which can be accessed by a sandboxed browser. Default `rustup doc` behavior is completely unchanged.

## Design decisions
- Bind only to `127.0.0.1` on an ephemeral port.
- Serve the  documentation directory as root so it keeps the relative links/CSS/JS/search working
- Reject path traversal attempts (`..` or absolute paths) to keep requests confined to the doc root.
- Keep the server running until the user exits with `Ctrl+C`. Did not go with any idle timeouts because a timeout would be arbitrary and could interrupt reading.
- Promote `hyper` (`server` + `http1`) from a dev-dependency to a dependency. Although `reqwest` already depends on `hyper`, that only exposes its client-side functionality internally, so a direct dependency is required to use the server APIs. `Cargo.lock` adds no new packages, and the release binary grows from **14,001,792** to **14,204,752** bytes (**+198.2 KiB**, **+1.45%**).
- I did think of automatic fallback but `rustup` can tell whether the browser was launched, but not whether it successfully rendered the documentation.

## Testing
- `cargo build` and `cargo clippy --all-targets --features test` pass cleanly.
- `cargo test --features test download::tests`: 5/5 tests pass.
- Manual: Verified `rustup doc --serve` and `rustup doc --serve std::vec`. Docs, assets, and relative links load correctly, invalid paths return 404, and Ctrl-C stops the server and releases the port.

Fixes #4975