### PR TITLE
feat(cli): add --check flag to rustup update for semantic exit codes

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -212,7 +212,10 @@ fn show_channel_updates(
     Ok(())
 }
 
-pub(crate) async fn update_all_channels(cfg: &Cfg<'_>, force_update: bool) -> Result<ExitCode> {
+pub(crate) async fn update_all_channels(
+    cfg: &Cfg<'_>,
+    force_update: bool,
+) -> Result<(ExitCode, bool)> {
     let profile = cfg.get_profile()?;
     let channels = cfg.list_channels()?;
 
@@ -249,6 +252,13 @@ pub(crate) async fn update_all_channels(cfg: &Cfg<'_>, force_update: bool) -> Re
         ExitCode::SUCCESS
     };
 
+    let any_updates = toolchains.iter().any(|(_, r)| {
+        matches!(
+            r,
+            Ok(UpdateStatus::Installed) | Ok(UpdateStatus::Updated(_))
+        )
+    });
+
     if toolchains.is_empty() {
         info!("no updatable toolchains installed");
     }
@@ -263,7 +273,7 @@ pub(crate) async fn update_all_channels(cfg: &Cfg<'_>, force_update: bool) -> Re
         show_channel_updates(cfg, t)?;
     }
 
-    Ok(exit_code)
+    Ok((exit_code, any_updates))
 }
 
 /// Print a list of items (targets or components) to stdout.

--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -62,7 +62,12 @@ pub(crate) fn update_help() -> String {
   If given a toolchain argument then `update` updates that
   toolchain, the same as `rustup toolchain install`.
 
-{TOOLCHAIN_INSTALL_HINT}"
+{TOOLCHAIN_INSTALL_HINT}
+
+{HEADER}Exit status (with --check):{HEADER:#}
+  {LITERAL}0{LITERAL:#}   No updates were applied; everything was already up to date.
+  {LITERAL}100{LITERAL:#} At least one toolchain was updated.
+  {LITERAL}1{LITERAL:#}   An error occurred."
     )
 }
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -193,6 +193,10 @@ enum RustupSubcmd {
         /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
         #[arg(long)]
         force_non_host: bool,
+
+        /// Set exit code to indicate whether udpates were applied
+        #[arg(long)]
+        check: bool,
     },
 
     /// Check for updates to Rust toolchains and rustup
@@ -728,7 +732,7 @@ pub async fn main(
 
     let exit_code = match subcmd {
         RustupSubcmd::DumpTestament => common::dump_testament(process),
-        RustupSubcmd::Install { opts } => update(cfg, opts, true).await,
+        RustupSubcmd::Install { opts } => update(cfg, opts, true, false).await,
         RustupSubcmd::Uninstall { opts } => toolchain_remove(cfg, opts).await,
         RustupSubcmd::Show { verbose, subcmd } => handle_epipe(match subcmd {
             None => show(cfg, verbose).await,
@@ -746,6 +750,7 @@ pub async fn main(
             no_self_update,
             force,
             force_non_host,
+            check,
         } => {
             update(
                 cfg,
@@ -757,11 +762,12 @@ pub async fn main(
                     ..UpdateOpts::default()
                 },
                 false,
+                check,
             )
             .await
         }
         RustupSubcmd::Toolchain { subcmd } => match subcmd {
-            ToolchainSubcmd::Install { opts } => update(cfg, opts, true).await,
+            ToolchainSubcmd::Install { opts } => update(cfg, opts, true, false).await,
             ToolchainSubcmd::List { verbose, quiet } => {
                 handle_epipe(common::list_toolchains(cfg, verbose, quiet).await)
             }
@@ -1062,8 +1068,10 @@ async fn update(
     cfg: &mut Cfg<'_>,
     opts: UpdateOpts,
     ensure_active_toolchain: bool,
+    check: bool,
 ) -> Result<ExitCode> {
     let mut exit_code = ExitCode::SUCCESS;
+    let mut any_updated = false;
 
     common::warn_if_host_is_emulated(cfg.process);
     let self_update_mode = SelfUpdateMode::from_cfg(cfg)?;
@@ -1120,6 +1128,10 @@ async fn update(
                 Err(e) => Err(e)?,
             };
 
+            if matches!(status, UpdateStatus::Installed | UpdateStatus::Updated(_)) {
+                any_updated = true;
+            }
+
             writeln!(cfg.process.stdout().lock())?;
             common::show_channel_update(
                 cfg,
@@ -1144,12 +1156,20 @@ async fn update(
         info!("it's active because: {}", source.to_reason());
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
     } else {
-        exit_code &= common::update_all_channels(cfg, opts.force).await?;
+        let (channels_exit, channels_updated) =
+            common::update_all_channels(cfg, opts.force).await?;
+        exit_code &= channels_exit;
+        any_updated = channels_updated;
+
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
 
         info!("cleaning up downloads & tmp directories");
         utils::delete_dir_contents_following_links(&cfg.download_dir);
         dl_cfg.tmp_cx.clean();
+    }
+
+    if check && exit_code == ExitCode::SUCCESS && any_updated {
+        return Ok(ExitCode::UPDATES_AVAILABLE);
     }
 
     Ok(exit_code)

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -306,6 +306,80 @@ nightly-[HOST_TUPLE] - update available: 1.2.0 (hash-nightly-1) -> 1.3.0 (hash-n
 }
 
 #[tokio::test]
+async fn update_check_no_updates() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "toolchain", "add", "stable"])
+        .await
+        .is_ok();
+    // Updating an already-current toolchain with --check should return 0
+    cx.config
+        .expect(["rustup", "update", "--check", "stable"])
+        .await
+        .is_ok();
+}
+
+#[tokio::test]
+async fn update_check_with_updates() {
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    // Updating an outdated toolchain with --check should return 100
+    cx.config
+        .expect(["rustup", "update", "--check", "stable"])
+        .await
+        .has_code(100);
+}
+
+#[tokio::test]
+async fn update_without_check_always_succeeds() {
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    // Without --check, update should return 0 even when updates occurred
+    cx.config
+        .expect(["rustup", "update", "stable"])
+        .await
+        .is_ok();
+}
+
+#[tokio::test]
+async fn update_check_all_channels() {
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable", "beta", "nightly"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    // update --check with no specific toolchain updates all and returns 100
+    cx.config
+        .expect(["rustup", "update", "--check"])
+        .await
+        .has_code(100);
+}
+
+#[tokio::test]
 async fn default() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config

--- a/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="704px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -46,43 +46,55 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>           Set exit code to indicate whether udpates were applied</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
+</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-bright-green bold">Exit status (with --check):</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">0</tspan><tspan>   No updates were applied; everything was already up to date.</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">100</tspan><tspan> At least one toolchain was updated.</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">1</tspan><tspan>   An error occurred.</tspan>
+</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="704px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -46,43 +46,55 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>           Set exit code to indicate whether udpates were applied</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
+</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-bright-green bold">Exit status (with --check):</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">0</tspan><tspan>   No updates were applied; everything was already up to date.</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">100</tspan><tspan> At least one toolchain was updated.</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">1</tspan><tspan>   An error occurred.</tspan>
+</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="704px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -46,43 +46,55 @@
 </tspan>
     <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>           Set exit code to indicate whether udpates were applied</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
+</tspan>
+    <tspan x="10px" y="622px"><tspan class="fg-bright-green bold">Exit status (with --check):</tspan>
+</tspan>
+    <tspan x="10px" y="640px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">0</tspan><tspan>   No updates were applied; everything was already up to date.</tspan>
+</tspan>
+    <tspan x="10px" y="658px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">100</tspan><tspan> At least one toolchain was updated.</tspan>
+</tspan>
+    <tspan x="10px" y="676px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">1</tspan><tspan>   An error occurred.</tspan>
+</tspan>
+    <tspan x="10px" y="694px">
 </tspan>
   </text>
 


### PR DESCRIPTION
## Summary

This adds a `--check` flag to `rustup update` that causes the command to set its exit code based on whether any toolchains were actually updated:

- `0`   — no updates were applied; everything was already up to date
- `100` — at least one toolchain was updated
- `1`   — an error occurred

Without `--check`, the behavior is unchanged (exit 0 on success regardless of whether updates occurred). This preserves backward compatibility for existing workflows.

The exit codes align with `rustup check` (#4681).

Closes #4987

## Changes

- Added `--check` flag to the `rustup update` subcommand
- Modified `update()` to track whether any toolchain's `UpdateStatus` was
  `Installed` or `Updated`, and return `ExitCode::UPDATES_AVAILABLE` (100)
  when `--check` is set and updates occurred
- Modified `update_all_channels()` to return whether any channel was updated
  alongside the existing exit code
- Added exit status documentation to `update_help()` in `help.rs`
- Added 4 integration tests covering: no updates (exit 0), with updates
  (exit 100), without --check (always exit 0), and all-channels update

## Test plan

- [ ] `cargo fmt --all --check` passes
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [ ] `cargo test --features=test` passes
- [ ] New tests `update_check_no_updates`, `update_check_with_updates`,
      `update_without_check_always_succeeds`, and `update_check_all_channels`
      all pass