### PR TITLE
doc - fix minor typos

### DIFF
--- a/doc/dev-guide/src/tracing.md
+++ b/doc/dev-guide/src/tracing.md
@@ -59,7 +59,7 @@ receive log lines only from `rustup` itself with a max verbosity of `DEBUG`.
 ## Opentelemetry tracing
 
 The feature `otel` can be used when building rustup to turn on Opentelemetry
-tracing with an OLTP GRPC exporter.
+tracing with an OTLP gRPC exporter.
 
 This can be very useful for diagnosing performance or correctness issues in more
 complicated scenarios.
@@ -118,6 +118,6 @@ Some good general heuristics:
   as these tend to help figure the puzzle of what-is-happening
 - Default to not instrumenting thin shim functions (or at least, only instrument
   them temporarily while figuring out the shape of a problem)
-- Be way of debug build timing - release optimisations make a huge difference,
+- Be wary of debug build timing - release optimisations make a huge difference,
   though debug is a lot faster to iterate on. If something isn't a problem in
   release don't pay it too much heed in debug.


### PR DESCRIPTION
Fixing some minor typos for OTLP [1] which is OpenTelemetry Protocol and for gRPC

[1] https://opentelemetry.io/docs/specs/otlp/