### PR TITLE
Extend complete profile warning with a profile-switch suggestion

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -25,7 +25,9 @@ use crate::{
     utils::{self, ExitCode},
 };
 
-pub(crate) const WARN_COMPLETE_PROFILE: &str = "downloading with complete profile isn't recommended unless you are a developer of the rust language";
+pub(crate) const WARN_COMPLETE_PROFILE: &str = "\
+downloading with the `complete` profile is deprecated
+help: consider switching to the `default` profile with `rustup set profile default`";
 
 pub(crate) fn confirm(question: &str, default: bool, process: &Process) -> Result<bool> {
     write!(process.stdout().lock(), "{question} ")?;

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -498,7 +498,8 @@ async fn test_warn_if_complete_profile_is_used() {
         .await
         .with_stderr(snapbox::str![[r#"
 ...
-warn: downloading with complete profile isn't recommended unless you are a developer of the rust language
+warn: downloading with the `complete` profile is deprecated
+help: consider switching to the `default` profile with `rustup set profile default`
 ...
 "#]])
         .is_ok();

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -2467,7 +2467,8 @@ async fn test_warn_if_complete_profile_is_used() {
         .await
         .with_stderr(snapbox::str![[r#"
 ...
-warn: downloading with complete profile isn't recommended unless you are a developer of the rust language
+warn: downloading with the `complete` profile is deprecated
+help: consider switching to the `default` profile with `rustup set profile default`
 ...
 "#]])
         .is_err();


### PR DESCRIPTION
after adding a component (e.g. miri) on one toolchain, rustup try installing it on every other toolchain, failing with no explanation when unavailable there `rustup` error will now explain the cause and points to rustup set profile minimal.
