### PR TITLE
fix(cli/help): fix wording in `rustup run --help`

### DIFF
--- a/src/cli/help.rs
+++ b/src/cli/help.rs
@@ -212,7 +212,7 @@ pub(crate) fn run_help() -> String {
 
     {LITERAL}$ cargo +nightly build{LITERAL:#}
 
-    {LITERAL}$ rustup run nightly cargo build{LITERAL:#}"
+    {LITERAL}$ rustup run --install nightly cargo build{LITERAL:#}"
     )
 }
 

--- a/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_run_cmd_help_flag.stdout.term.svg
@@ -72,7 +72,7 @@
 </tspan>
     <tspan x="10px" y="478px">
 </tspan>
-    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup run nightly cargo build</tspan>
+    <tspan x="10px" y="496px"><tspan>    </tspan><tspan class="fg-bright-cyan bold">$ rustup run --install nightly cargo build</tspan>
 </tspan>
     <tspan x="10px" y="514px">
 </tspan>


### PR DESCRIPTION
Closes #5004 by taking this suggestion:

> Replace rustup run nightly with rustup run --install nightly.
