### PR TITLE
feat(openssl): strip unnessary openssl features

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -641,6 +641,7 @@ jobs:
           - armv7-unknown-linux-gnueabihf
           - aarch64-linux-android
           - aarch64-unknown-linux-gnu
+          - x86_64-linux-android           # skip-main
         include:
           - target: x86_64-unknown-linux-gnu
             run_tests: YES
@@ -1001,7 +1002,7 @@ jobs:
           - sparcv9-sun-solaris            # skip-pr skip-main
           - arm-linux-androideabi          # skip-pr skip-main
           - armv7-linux-androideabi        # skip-pr skip-main
-          - x86_64-linux-android           # skip-pr skip-main
+          - x86_64-linux-android           # skip-main
           - riscv64gc-unknown-linux-gnu    # skip-pr skip-main
           - riscv64gc-unknown-linux-musl   # skip-pr skip-main
           - loongarch64-unknown-linux-gnu  # skip-pr skip-main

--- a/ci/actions-templates/linux-builds-template.yaml
+++ b/ci/actions-templates/linux-builds-template.yaml
@@ -42,7 +42,7 @@ jobs: # skip-main skip-pr skip-stable
           - sparcv9-sun-solaris            # skip-pr skip-main
           - arm-linux-androideabi          # skip-pr skip-main
           - armv7-linux-androideabi        # skip-pr skip-main
-          - x86_64-linux-android           # skip-pr skip-main
+          - x86_64-linux-android           # skip-main
           - riscv64gc-unknown-linux-gnu    # skip-pr skip-main
           - riscv64gc-unknown-linux-musl   # skip-pr skip-main
           - loongarch64-unknown-linux-gnu  # skip-pr skip-main

--- a/ci/openssl-configure.sh
+++ b/ci/openssl-configure.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+configure=$1
+shift
+# `openssl-src` has no API for extra Configure arguments.
+exec perl "$configure" no-dtls no-sm2 no-sm3 no-sm4 no-srtp "$@"

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -19,16 +19,10 @@ if [ -n "$INSTALL_BINDGEN" ]; then
   export PATH="$CARGO_HOME/bin/bindgen-cli:$PATH"
 fi
 
-FEATURES=('--no-default-features')
-case "$TARGET" in
-  *-linux-android*) ;;
-  *)
-    FEATURES+=('--features' 'reqwest-native-tls')
-    case "$(uname -s)" in
-      *NT* ) ;; # Windows NT
-      * ) FEATURES+=('--features' 'vendored-openssl') ;;
-    esac
-    ;;
+FEATURES=('--no-default-features' '--features' 'reqwest-native-tls')
+case "$(uname -s)" in
+  *NT* ) ;; # Windows NT
+  * ) FEATURES+=('--features' 'vendored-openssl') ;;
 esac
 
 case "$TARGET" in

--- a/ci/run.bash
+++ b/ci/run.bash
@@ -22,7 +22,7 @@ fi
 FEATURES=('--no-default-features' '--features' 'reqwest-native-tls')
 case "$(uname -s)" in
   *NT* ) ;; # Windows NT
-  * ) FEATURES+=('--features' 'vendored-openssl') ;;
+  * ) FEATURES+=('--features' 'vendored-openssl'); export OPENSSL_SRC_PERL="$PWD/ci/openssl-configure.sh" ;;
 esac
 
 case "$TARGET" in


### PR DESCRIPTION
This fixes previous android ci/cd error, and further strips some of the openssl parts to improve build speed and size.

Also fixes #5007, allowing for future further reductions about openssl build.
