### PR TITLE
docs(contributing): improve visibility of contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing to rustup
+
+Contributing documentation has moved to the **[rustup dev guide]**.
+
+[rustup dev guide]: https://rust-lang.github.io/rustup/dev-guide)
+
+## Before hacking on rustup
+
+We encourage people to discuss their design before hacking on code. Typically,
+you [file an issue] or start a thread on the [Zulip channel] before submitting
+a pull request.
+
+[file an issue]: https://github.com/rust-lang/rustup/issues
+[Zulip channel]: https://rust-lang.zulipchat.com/#narrow/channel/490103-t-rustup
+
+## AI/LLM usage policy
+
+Please refer to the [specific section] in the rustup dev guide.
+
+[specific section]: https://rust-lang.github.io/rustup/dev-guide/#ai-policy

--- a/doc/dev-guide/src/index.md
+++ b/doc/dev-guide/src/index.md
@@ -66,8 +66,8 @@ your own words. This includes the pull request body and responses to questions. 
 reviewed the PR yourself before submitting it for review to the maintainers. Do not copy responses
 from the AI when replying to questions from maintainers. As an exception, issues marked as `E-easy`
 are meant for new contributors as a learning opportunity; the use of an LLM when submitting PR for
-such issues is disallowed except without explicit permission from the team. Failure to comply may
-result in the PR being closed directly without further notice.
+such issues is only allowed with explicit permission from the team. Failure to comply may result
+in the PR being closed directly without further notice.
 
 If you wish to include context from an interaction with AI in your comments, it must be in a
 quote block (using `>`) and disclosed as such. It must be accompanied by human commentary


### PR DESCRIPTION
As reported by @steffahn and suggested by @teor2345 in a [Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/546943-all.2Fprivate/topic/Other.20teams.20adopting.20the.20LLM.20policy/near/616436189), this PR tries to improve visibility and readability of contribution guidelines by:

- Refining the wording of the LLM policy;
- Adding a conventional `CONTRIBUTING.md` that simply forwards to other links we have now.
