### PR TITLE
tests: remove `XDG_CONFIG_HOME` from env

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -798,6 +798,8 @@ async fn setup_test_state(test_dist_dir: TempDir) -> (TempDir, Config) {
         // trait-controllable, but it does honour the terminal. To avoid testing
         // claps code, lie about whatever terminal this process was started under.
         env::set_var("TERM", "dumb");
+        // Removed to avoid leaking the developer's environment into the test
+        env::remove_var("XDG_CONFIG_HOME");
 
         match env::var("RUSTUP_BACKTRACE") {
             Ok(val) => env::set_var("RUST_BACKTRACE", val),


### PR DESCRIPTION
A test calling `setup_test_state` inherits the environment of `cargo test`, which is the environment of the calling developer's shell.

Most variables are either already caught by the setup function or ignored by rustup alltogether, `XDG_CONFIG_HOME` was not, leading to a leaked file after running an affected test:

```bash
$ cat /Users/alexis/.config/fish/conf.d/rustup.fish
source "/Users/alexis/.local/cache/target-dirs/cargo/rustup/tests/running-test-d8M8Jq/rustup-cargoMfCGsJ/ch/env.fish"
```

so when opening a new shell after that:

```
source: Error encountered while sourcing file “/Users/alexis/.local/cache/target-dirs/cargo/rustup/tests/running-test-d8M8Jq/rustup-cargoMfCGsJ/ch/env.fish”:
source: No such file or directory
```

<!-- Before submitting a PR, please familiarize yourself with the
[developer guide]([CONTRIBUTING.md](https://rust-lang.github.io/rustup/dev-guide/index.html)),
including the AI policy and style guide. -->
