### PR TITLE
Fix has_local to not search PATH for external 'local' command

### DIFF
--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -14,6 +14,7 @@
 # mksh has this alias by default.
 has_local() {
     # shellcheck disable=SC2034  # deliberately unused
+    # shellcheck disable=SC1007  # PATH= is an intentional command prefix, not a bare assignment
     PATH= local _has_local
 }
 

--- a/rustup-init.sh
+++ b/rustup-init.sh
@@ -14,7 +14,7 @@
 # mksh has this alias by default.
 has_local() {
     # shellcheck disable=SC2034  # deliberately unused
-    local _has_local
+    PATH= local _has_local
 }
 
 has_local 2>/dev/null || alias local=typeset


### PR DESCRIPTION
### Problem

`has_local()` in `rustup-init.sh` is used to detect whether the shell has a builtin `local` keyword. On shells that lack it, the function falls through and the script aliases `local` to `typeset`.

However, if the shell has no builtin `local` *and* an executable named `local` happens to exist somewhere in `$PATH`, that external command would be found and used instead — making `has_local` return success incorrectly. Any subsequent `local` usage would then invoke that external command rather than the `typeset` alias.

### Fix

Set `PATH=` before the `local` call inside `has_local`. This prevents the shell from searching `$PATH` for a `local` executable: on shells with a builtin `local` the call succeeds as before, and on shells without it the call correctly fails even if an external `local` exists in `$PATH`.

```sh
has_local() {
    # shellcheck disable=SC2034  # deliberately unused
    PATH= local _has_local
}
```

Fixes #5009