### PR TITLE
feat(cli/rustup-mode): add `rustup ci` subcommand

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 /// The CLI specific code lives in the cli module and sub-modules.
 #[macro_use]
 pub mod log;
+mod ci;
 pub mod common;
 mod docs;
 pub mod errors;

--- a/src/cli/ci.rs
+++ b/src/cli/ci.rs
@@ -1,0 +1,50 @@
+use std::{fmt, io::Write};
+
+use anyhow::Result;
+use clap::{ValueEnum, builder::PossibleValue};
+
+use crate::{config::Cfg, utils::ExitCode};
+
+pub(crate) fn problem_matcher(flavor: Flavor, cfg: &Cfg<'_>) -> Result<ExitCode> {
+    print_str(flavor.problem_matcher(), cfg)
+}
+
+fn print_str(s: &str, cfg: &Cfg<'_>) -> Result<ExitCode> {
+    let stdout = cfg.process.stdout();
+    write!(stdout.lock(), "{s}")?;
+    Ok(ExitCode::SUCCESS)
+}
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub(crate) enum Flavor {
+    Github,
+}
+
+impl Flavor {
+    fn problem_matcher(&self) -> &'static str {
+        match self {
+            Self::Github => include_str!("ci/matcher/github.json"),
+        }
+    }
+}
+
+impl ValueEnum for Flavor {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::Github]
+    }
+
+    fn to_possible_value<'a>(&self) -> Option<PossibleValue> {
+        Some(match self {
+            Self::Github => PossibleValue::new("github"),
+        })
+    }
+}
+
+impl fmt::Display for Flavor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.to_possible_value() {
+            Some(v) => write!(f, "{}", v.get_name()),
+            None => unreachable!(),
+        }
+    }
+}

--- a/src/cli/ci/matcher/github.json
+++ b/src/cli/ci/matcher/github.json
@@ -1,0 +1,44 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "rust-compiler",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*(warning|warn|error)(\\[(\\S*)\\])?(?:\\x1B\\[[0-9;]*[a-zA-Z])*: (.*?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "severity": 1,
+          "message": 4,
+          "code": 3
+        },
+        {
+          "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*\\s+(?:\\x1B\\[[0-9;]*[a-zA-Z])*-->\\s(?:\\x1B\\[[0-9;]*[a-zA-Z])*(\\S+):(\\d+):(\\d+)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+          "file": 1,
+          "line": 2,
+          "column": 3
+        }
+      ]
+    },
+    {
+      "owner": "rust-formatter",
+      "pattern": [
+        {
+          "regexp": "^(Diff in (\\S+)) at line (\\d+):",
+          "message": 1,
+          "file": 2,
+          "line": 3
+        }
+      ]
+    },
+    {
+      "owner": "rust-panic",
+      "pattern": [
+        {
+          "regexp": "^.*panicked\\s+at\\s+'(.*)',\\s+(.*):(\\d+):(\\d+)$",
+          "message": 1,
+          "file": 2,
+          "line": 3,
+          "column": 4
+        }
+      ]
+    }
+  ]
+}

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -32,6 +32,7 @@ use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 use crate::{
     cli::{
+        ci,
         common::{self, PackageUpdate, update_console_filter},
         docs,
         errors::CliError,
@@ -304,6 +305,13 @@ enum RustupSubcmd {
         #[arg(default_value = "rustup")]
         command: CompletionCommand,
     },
+
+    /// Generate CI-specific configurations
+    #[command(hide = true)]
+    Ci {
+        #[command(subcommand)]
+        subcmd: CiSubcmd,
+    },
 }
 
 fn update_toolchain_value_parser(s: &str) -> Result<PartialToolchainDesc> {
@@ -326,6 +334,7 @@ impl RustupSubcmd {
             // These subcommands don't require the active toolchain, so auto-installing it should be
             // disabled to avoid surprises.
             Self::Check { .. }
+            | Self::Ci { .. }
             | Self::Completions { .. }
             | Self::Component { .. }
             | Self::Default { .. }
@@ -347,7 +356,10 @@ impl RustupSubcmd {
     fn should_warn_empty_setup(&self) -> bool {
         match self {
             // These subcommands are not about toolchains, so the hint would be noise.
-            Self::Completions { .. } | Self::DumpTestament | Self::Self_ { .. } => false,
+            Self::Ci { .. }
+            | Self::Completions { .. }
+            | Self::DumpTestament
+            | Self::Self_ { .. } => false,
 
             // For all other subcommands, the hint may be useful if rustup is still unusable after
             // the command has completed.
@@ -674,6 +686,17 @@ enum SetSubcmd {
     },
 }
 
+#[derive(Debug, Subcommand)]
+#[command(arg_required_else_help = true, subcommand_required = true)]
+enum CiSubcmd {
+    /// Show the example problem matcher for the given CI flavor
+    #[command(alias = "matcher")]
+    ProblemMatcher {
+        #[arg(value_enum)]
+        flavor: ci::Flavor,
+    },
+}
+
 #[tracing::instrument(level = "trace", fields(args = format!("{:?}", process.args_os().collect::<Vec<_>>())), skip(process, console_filter))]
 pub async fn main(
     current_dir: PathBuf,
@@ -869,6 +892,9 @@ pub async fn main(
         RustupSubcmd::Completions { shell, command } => {
             output_completion_script(shell, command, process)
         }
+        RustupSubcmd::Ci { subcmd } => match subcmd {
+            CiSubcmd::ProblemMatcher { flavor } => ci::problem_matcher(flavor, cfg),
+        },
     }?;
 
     if should_warn && cfg.list_toolchains()?.is_empty() && cfg.get_default()?.is_none() {

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -536,6 +536,11 @@ fn rustup_upgrade_cmd_help_flag() {
 }
 
 #[test]
+fn rustup_ci_cmd_help_flag() {
+    test_help("rustup_ci_cmd_help_flag", &["ci", "--help"]);
+}
+
+#[test]
 fn rustup_which_cmd_help_flag() {
     test_help("rustup_which_cmd_help_flag", &["which", "--help"]);
 }

--- a/tests/suite/cli_rustup_ui/rustup_ci_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_ci_cmd_help_flag.stdout.term.svg
@@ -1,0 +1,47 @@
+<svg width="740px" height="218px" xmlns="http://www.w3.org/2000/svg">
+  <style>
+    .fg { fill: #AAAAAA }
+    .bg { fill: #000000 }
+    .fg-bright-cyan { fill: #55FFFF }
+    .fg-bright-green { fill: #55FF55 }
+    .fg-cyan { fill: #00AAAA }
+    .container {
+      padding: 0 10px;
+      line-height: 18px;
+    }
+    .bold { font-weight: bold; }
+    tspan {
+      font: 14px SFMono-Regular, Consolas, Liberation Mono, Menlo, monospace;
+      white-space: pre;
+      line-height: 18px;
+    }
+  </style>
+
+  <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
+
+  <text xml:space="preserve" class="container fg">
+    <tspan x="10px" y="28px"><tspan>Generate CI-specific configurations</tspan>
+</tspan>
+    <tspan x="10px" y="46px">
+</tspan>
+    <tspan x="10px" y="64px"><tspan class="fg-bright-green bold">Usage:</tspan><tspan> </tspan><tspan class="fg-bright-cyan bold">rustup[EXE] ci</tspan><tspan> </tspan><tspan class="fg-cyan">&lt;COMMAND&gt;</tspan>
+</tspan>
+    <tspan x="10px" y="82px">
+</tspan>
+    <tspan x="10px" y="100px"><tspan class="fg-bright-green bold">Commands:</tspan>
+</tspan>
+    <tspan x="10px" y="118px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">problem-matcher</tspan><tspan>  Show the example problem matcher for the given CI flavor</tspan>
+</tspan>
+    <tspan x="10px" y="136px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">help</tspan><tspan>             Print this message or the help of the given subcommand(s)</tspan>
+</tspan>
+    <tspan x="10px" y="154px">
+</tspan>
+    <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
+</tspan>
+    <tspan x="10px" y="190px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>  Print help</tspan>
+</tspan>
+    <tspan x="10px" y="208px">
+</tspan>
+  </text>
+
+</svg>


### PR DESCRIPTION
Part of #5011.

This first version has implemented a few main subcommands:

- ~~`rustup ci env`: prints a hardcoded `base.env` taken from https://github.com/rust-lang/rustup/issues/5011#issue-5122912890.~~
    - Retreated due to @epage's [concerns](https://github.com/rust-lang/rustup/issues/5011#issuecomment-5418097548).

- `rustup ci problem-matcher github`: prints a hardcoded problem matcher configuration for GitHub[^1].

[^1]: Taken from @r7kamura's solution (https://github.com/r7kamura/rust-problem-matchers/blob/7e46a19e8d2f3a44f97b551aee14a7b3cc18fcd0/.github/matchers.json) since it seems to be the most comprehensive of all.