### PR TITLE
ci(macos): trust `aws/tap` when installing `aws-cli`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1257,6 +1257,7 @@ jobs:
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/main')
         run: |
+          brew trust aws/tap
           brew install --overwrite awscli
           which aws
           aws --version
@@ -1388,6 +1389,7 @@ jobs:
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/main')
         run: |
+          brew trust aws/tap
           brew install --overwrite awscli
           which aws
           aws --version

--- a/ci/actions-templates/macos-builds-template.yaml
+++ b/ci/actions-templates/macos-builds-template.yaml
@@ -99,6 +99,7 @@ jobs: # skip-x86_64 skip-aarch64
       - name: Ensure that awscli is installed
         if: github.event_name == 'push' && matrix.mode == 'release' && (github.ref == 'refs/heads/stable' || github.ref == 'refs/heads/main')
         run: |
+          brew trust aws/tap
           brew install --overwrite awscli
           which aws
           aws --version


### PR DESCRIPTION
This resolves the following warning when issuing `brew install aws-cli`:

```console
Warning: The following taps are not trusted:
  aws/tap

Homebrew is currently ignoring formulae, casks and commands from these taps because tap trust is required.
```
_https://github.com/rust-lang/rustup/actions/runs/32144945612/job/95833501841#step:17:12_

See <https://docs.brew.sh/Tap-Trust> for more information.

