### PR TITLE
fix(dist): fix unexpected downgrades without `--allow-downgrade`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -190,6 +190,10 @@ enum RustupSubcmd {
         #[arg(long)]
         no_self_update: bool,
 
+        /// Allow downgrading the toolchain
+        #[arg(long)]
+        allow_downgrade: bool,
+
         /// Force an update, even if some components are missing
         #[arg(long)]
         force: bool,
@@ -750,6 +754,7 @@ pub async fn main(
         RustupSubcmd::Update {
             toolchain,
             no_self_update,
+            allow_downgrade,
             force,
             force_non_host,
         } => {
@@ -758,6 +763,7 @@ pub async fn main(
                 UpdateOpts {
                     toolchain,
                     no_self_update,
+                    allow_downgrade,
                     force,
                     force_non_host,
                     ..UpdateOpts::default()

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -17,7 +17,7 @@ use url::Url;
 use crate::{
     config::Cfg,
     dist::{
-        DEFAULT_DIST_SERVER, Profile, TargetTuple, ToolchainDesc,
+        DEFAULT_DIST_SERVER, DistOptions, Profile, TargetTuple, ToolchainDesc,
         download::{DownloadCfg, DownloadTracker},
         manifest::{Component, Manifest},
         manifestation::{Changes, Manifestation, UpdateStatus},
@@ -1534,25 +1534,13 @@ async fn v2_manifest_checksum_mismatch_surfaces_error() {
 
     let tp = TestProcess::new(env::current_dir().unwrap(), &["rustup"], vars, "");
     let cfg = Cfg::from_env(tp.process.current_dir().unwrap(), false, true, &tp.process).unwrap();
-    let dl_cfg = DownloadCfg::new(&cfg);
-    let update_hash = cfg.get_hash_file(&cx.toolchain, true).unwrap();
-    let mut fetched = String::new();
 
-    let err = super::super::try_update_from_dist_(
-        &dl_cfg,
-        &update_hash,
-        &cx.toolchain,
-        Some(Profile::Default),
-        &cx.prefix,
-        false,
-        &[],
-        &[],
-        &mut fetched,
-        &cfg,
-        None,
-    )
-    .await
-    .unwrap_err();
+    let mut fetched = String::new();
+    let err = DistOptions::new(&[], &[], &cx.toolchain, Profile::Default, false, &cfg)
+        .unwrap()
+        .try_update(None, &cx.prefix, &mut fetched, None)
+        .await
+        .unwrap_err();
 
     match err.downcast_ref::<RustupError>() {
         Some(RustupError::ChecksumFailed { .. }) => {}

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -1536,9 +1536,13 @@ async fn v2_manifest_checksum_mismatch_surfaces_error() {
     let cfg = Cfg::from_env(tp.process.current_dir().unwrap(), false, true, &tp.process).unwrap();
 
     let mut fetched = String::new();
-    let err = DistOptions::new(&[], &[], &cx.toolchain, Profile::Default, false, &cfg)
-        .unwrap()
-        .try_update(None, &cx.prefix, &mut fetched, None)
+    let dist_opts =
+        DistOptions::new(&[], &[], &cx.toolchain, Profile::Default, false, &cfg).unwrap();
+    let manifest_result = dist_opts
+        .dl_v2_manifest(&cx.prefix, dist_opts.toolchain)
+        .await;
+    let err = dist_opts
+        .try_update(None, &cx.prefix, &mut fetched, manifest_result)
         .await
         .unwrap_err();
 

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -1535,14 +1535,13 @@ async fn v2_manifest_checksum_mismatch_surfaces_error() {
     let tp = TestProcess::new(env::current_dir().unwrap(), &["rustup"], vars, "");
     let cfg = Cfg::from_env(tp.process.current_dir().unwrap(), false, true, &tp.process).unwrap();
 
-    let mut fetched = String::new();
     let dist_opts =
         DistOptions::new(&[], &[], &cx.toolchain, Profile::Default, false, &cfg).unwrap();
     let manifest_result = dist_opts
         .dl_v2_manifest(&cx.prefix, dist_opts.toolchain)
         .await;
     let err = dist_opts
-        .try_update(None, &cx.prefix, &mut fetched, manifest_result)
+        .try_update(None, &cx.prefix, manifest_result)
         .await
         .unwrap_err();
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -944,7 +944,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
     pub(crate) async fn install_into(
         &self,
         prefix: &InstallPrefix,
-        manifest: Option<ManifestWithHash>,
+        mut prefetched_manifest: Option<ManifestWithHash>,
     ) -> Result<Option<String>> {
         let fresh_install = !prefix.path().exists();
         // fresh_install means the toolchain isn't present, but hash_exists means there is a stray hash file
@@ -1003,16 +1003,12 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         };
 
         let mut toolchain = self.toolchain.clone();
-        let mut prefetched_manifest = manifest;
         let res = loop {
             let result = try_update_from_dist_(
                 &self.dl_cfg,
                 &self.update_hash,
                 &toolchain,
-                match self.exists {
-                    false => Some(self.profile),
-                    true => None,
-                },
+                (!self.exists).then_some(self.profile),
                 prefix,
                 self.force,
                 self.components,
@@ -1083,14 +1079,13 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
                 .unwrap();
 
             if try_next < last_manifest {
-                // Wouldn't be an update if we go further back than the user's current nightly.
-                if let Some(e) = first_err {
-                    break Err(e);
-                } else {
+                break match first_err {
+                    // Wouldn't be an update if we go further back than the currently installed toolchain.
+                    Some(e) => Err(e),
                     // In this case, all newer nightlies are missing, which means there are no
                     // updates, so the user is already at the latest nightly.
-                    break Ok(None);
-                }
+                    None => Ok(None),
+                };
             }
 
             toolchain.date = Some(try_next.format("%Y-%m-%d").to_string());

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1,12 +1,7 @@
 //! Installation from a Rust distribution server
 
 use std::{
-    collections::HashSet,
-    env, fmt,
-    io::Write,
-    ops::Deref,
-    path::{Path, PathBuf},
-    str::FromStr,
+    collections::HashSet, env, fmt, io::Write, ops::Deref, path::PathBuf, str::FromStr,
     sync::LazyLock,
 };
 
@@ -1004,20 +999,14 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
 
         let mut toolchain = self.toolchain.clone();
         let res = loop {
-            let result = try_update_from_dist_(
-                &self.dl_cfg,
-                &self.update_hash,
-                &toolchain,
-                (!self.exists).then_some(self.profile),
-                prefix,
-                self.force,
-                self.components,
-                self.targets,
-                &mut fetched,
-                self.cfg,
-                prefetched_manifest.take(),
-            )
-            .await;
+            let result = self
+                .try_update(
+                    Some(&toolchain),
+                    prefix,
+                    &mut fetched,
+                    prefetched_manifest.take(),
+                )
+                .await;
 
             let e = match result {
                 Ok(v) => break Ok(v),
@@ -1099,177 +1088,183 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
 
         res
     }
-}
 
-#[allow(clippy::too_many_arguments)]
-async fn try_update_from_dist_(
-    download: &DownloadCfg<'_>,
-    update_hash: &Path,
-    toolchain: &ToolchainDesc,
-    profile: Option<Profile>,
-    prefix: &InstallPrefix,
-    force_update: bool,
-    components: &[&str],
-    targets: &[&str],
-    fetched: &mut String,
-    cfg: &Cfg<'_>,
-    prefetched_manifest: Option<ManifestWithHash>,
-) -> Result<Option<String>> {
-    let toolchain_str = toolchain.to_string();
-    let manifestation = Manifestation::open(prefix.clone(), toolchain.target.clone())?;
+    pub(crate) async fn try_update(
+        &self,
+        toolchain: Option<&ToolchainDesc>,
+        prefix: &InstallPrefix,
+        fetched: &mut String,
+        prefetched_manifest: Option<ManifestWithHash>,
+    ) -> Result<Option<String>> {
+        let download = &self.dl_cfg;
+        let toolchain = toolchain.unwrap_or(self.toolchain);
+        let toolchain_str = toolchain.to_string();
+        let manifestation = Manifestation::open(prefix.clone(), toolchain.target.clone())?;
 
-    // TODO: Add a notification about which manifest version is going to be used
-    info!("syncing channel updates for {toolchain_str}");
-    let manifest_result = if prefetched_manifest.is_some() {
-        Ok(prefetched_manifest)
-    } else {
-        download
-            .dl_v2_manifest(
-                // Skip the update hash when the installed manifest is missing or when components
-                // or targets were requested, since either case still requires the channel manifest.
-                if prefix.dist_manifest().is_some() && components.is_empty() && targets.is_empty() {
-                    Some(update_hash)
-                } else {
-                    None
-                },
-                toolchain,
-                cfg,
-            )
-            .await
-    };
-    match manifest_result {
-        Ok(Some(ManifestWithHash { manifest: m, hash })) => {
-            match m.get_rust_version() {
-                Ok(version) => info!("latest update on {} for version {version}", m.date),
-                Err(_) => info!("latest update on {}", m.date),
-            }
-
-            let profile_components = match profile {
-                Some(profile) => m.get_profile_components(profile, &toolchain.target)?,
-                None => Vec::new(),
-            };
-
-            let mut all_components: HashSet<Component> = profile_components.into_iter().collect();
-
-            let rust_package = m.get_package("rust")?;
-            let rust_target_package = rust_package.get_target(Some(&toolchain.target.clone()))?;
-
-            for component in components {
-                let mut component =
-                    Component::new(component.to_string(), Some(toolchain.target.clone()), false);
-                if let Some(renamed) = m.rename_component(&component) {
-                    component = renamed;
-                }
-                // Look up the newly constructed/renamed component and ensure that
-                // if it's a wildcard component we note such, otherwise we end up
-                // exacerbating the problem we thought we'd fixed with #2087 and #2115
-                if let Some(c) = rust_target_package
-                    .components
-                    .iter()
-                    .find(|c| c.short_name() == component.short_name())
-                    && c.target.is_none()
-                {
-                    component = component.wildcard();
-                }
-                all_components.insert(component);
-            }
-
-            for &target in targets {
-                let tuple = TargetTuple::new(target);
-                all_components.insert(Component::new("rust-std".to_string(), Some(tuple), false));
-            }
-
-            let mut explicit_add_components: Vec<_> = all_components.into_iter().collect();
-            explicit_add_components.sort();
-
-            let changes = Changes {
-                explicit_add_components,
-                remove_components: Vec::new(),
-            };
-
-            fetched.clone_from(&m.date);
-
-            return match manifestation
-                .update(m, changes, force_update, download, toolchain, true)
+        // TODO: Add a notification about which manifest version is going to be used
+        info!("syncing channel updates for {toolchain_str}");
+        let manifest_result = if prefetched_manifest.is_some() {
+            Ok(prefetched_manifest)
+        } else {
+            download
+                .dl_v2_manifest(
+                    // Skip the update hash when the installed manifest is missing or when components
+                    // or targets were requested, since either case still requires the channel manifest.
+                    (prefix.dist_manifest().is_some()
+                        && self.components.is_empty()
+                        && self.targets.is_empty())
+                    .then_some(&self.update_hash),
+                    toolchain,
+                    self.cfg,
+                )
                 .await
-            {
-                Ok(status) => match status {
-                    UpdateStatus::Unchanged => Ok(None),
-                    UpdateStatus::Changed => Ok(Some(hash)),
-                },
-                // Check for the variant by reference before we downcast with ownership,
-                // otherwise we'll drop implicit context bundled up in the original anyhow::Error.
-                Err(err) => match err.downcast_ref::<RustupError>() {
-                    Some(RustupError::RequestedComponentsUnavailable { .. }) => {
-                        let Ok(RustupError::RequestedComponentsUnavailable {
-                            components,
-                            manifest,
-                            toolchain,
-                        }) = err.downcast::<RustupError>()
-                        else {
-                            unreachable!()
-                        };
-
-                        Err(anyhow!(DistError::ToolchainComponentsMissing(
-                            components, manifest, toolchain,
-                        )))
-                    }
-                    Some(_) | None => Err(err),
-                },
-            };
-        }
-        Ok(None) => return Ok(None),
-        Err(err) => {
-            match err.downcast_ref::<RustupError>() {
-                Some(RustupError::DownloadNotExists { .. }) => {
-                    // Proceed to try v1 as a fallback
-                    debug!("manifest not found; trying legacy manifest");
+        };
+        match manifest_result {
+            Ok(Some(ManifestWithHash { manifest: m, hash })) => {
+                match m.get_rust_version() {
+                    Ok(version) => info!("latest update on {} for version {version}", m.date),
+                    Err(_) => info!("latest update on {}", m.date),
                 }
-                // Includes `ChecksumFailed`: if the v2 manifest exists but its
-                // contents do not match the published `.sha256`, surface the
-                // integrity failure as an error rather than silently treating
-                // the toolchain as up to date. The v1 fallback path below
-                // already does the same.
-                _ => return Err(err),
+
+                let profile_components = match self.exists {
+                    true => Vec::new(),
+                    false => m.get_profile_components(self.profile, &toolchain.target)?,
+                };
+
+                let mut all_components: HashSet<Component> =
+                    profile_components.into_iter().collect();
+
+                let rust_package = m.get_package("rust")?;
+                let rust_target_package =
+                    rust_package.get_target(Some(&toolchain.target.clone()))?;
+
+                for &component in self.components {
+                    let mut component = Component::new(
+                        component.to_string(),
+                        Some(toolchain.target.clone()),
+                        false,
+                    );
+                    if let Some(renamed) = m.rename_component(&component) {
+                        component = renamed;
+                    }
+                    // Look up the newly constructed/renamed component and ensure that
+                    // if it's a wildcard component we note such, otherwise we end up
+                    // exacerbating the problem we thought we'd fixed with #2087 and #2115
+                    if let Some(c) = rust_target_package
+                        .components
+                        .iter()
+                        .find(|c| c.short_name() == component.short_name())
+                        && c.target.is_none()
+                    {
+                        component = component.wildcard();
+                    }
+                    all_components.insert(component);
+                }
+
+                for &target in self.targets {
+                    let tuple = TargetTuple::new(target);
+                    all_components.insert(Component::new(
+                        "rust-std".to_string(),
+                        Some(tuple),
+                        false,
+                    ));
+                }
+
+                let mut explicit_add_components: Vec<_> = all_components.into_iter().collect();
+                explicit_add_components.sort();
+
+                let changes = Changes {
+                    explicit_add_components,
+                    remove_components: Vec::new(),
+                };
+
+                fetched.clone_from(&m.date);
+
+                return match manifestation
+                    .update(m, changes, self.force, download, toolchain, true)
+                    .await
+                {
+                    Ok(status) => match status {
+                        UpdateStatus::Unchanged => Ok(None),
+                        UpdateStatus::Changed => Ok(Some(hash)),
+                    },
+                    // Check for the variant by reference before we downcast with ownership,
+                    // otherwise we'll drop implicit context bundled up in the original anyhow::Error.
+                    Err(err) => match err.downcast_ref::<RustupError>() {
+                        Some(RustupError::RequestedComponentsUnavailable { .. }) => {
+                            let Ok(RustupError::RequestedComponentsUnavailable {
+                                components,
+                                manifest,
+                                toolchain,
+                            }) = err.downcast::<RustupError>()
+                            else {
+                                unreachable!()
+                            };
+
+                            Err(anyhow!(DistError::ToolchainComponentsMissing(
+                                components, manifest, toolchain,
+                            )))
+                        }
+                        Some(_) | None => Err(err),
+                    },
+                };
+            }
+            Ok(None) => return Ok(None),
+            Err(err) => {
+                match err.downcast_ref::<RustupError>() {
+                    Some(RustupError::DownloadNotExists { .. }) => {
+                        // Proceed to try v1 as a fallback
+                        debug!("manifest not found; trying legacy manifest");
+                    }
+                    // Includes `ChecksumFailed`: if the v2 manifest exists but its
+                    // contents do not match the published `.sha256`, surface the
+                    // integrity failure as an error rather than silently treating
+                    // the toolchain as up to date. The v1 fallback path below
+                    // already does the same.
+                    _ => return Err(err),
+                }
             }
         }
-    }
 
-    // If the v2 manifest is not found then try v1
-    let manifest = match download.dl_v1_manifest(&cfg.dist_root_url, toolchain).await {
-        Ok(m) => m,
-        Err(err) => match err.downcast_ref::<RustupError>() {
-            Some(RustupError::ChecksumFailed { .. }) => return Err(err),
-            Some(RustupError::DownloadNotExists { .. }) => {
-                bail!(DistError::MissingReleaseForToolchain(
-                    toolchain.manifest_name()
-                ));
-            }
-            _ => {
-                return Err(err).with_context(|| {
-                    format!(
-                        "failed to download manifest for '{}'",
+        // If the v2 manifest is not found then try v1
+        let manifest = match download
+            .dl_v1_manifest(&self.cfg.dist_root_url, toolchain)
+            .await
+        {
+            Ok(m) => m,
+            Err(err) => match err.downcast_ref::<RustupError>() {
+                Some(RustupError::ChecksumFailed { .. }) => return Err(err),
+                Some(RustupError::DownloadNotExists { .. }) => {
+                    bail!(DistError::MissingReleaseForToolchain(
                         toolchain.manifest_name()
-                    )
-                });
-            }
-        },
-    };
+                    ));
+                }
+                _ => {
+                    return Err(err).with_context(|| {
+                        format!(
+                            "failed to download manifest for '{}'",
+                            toolchain.manifest_name()
+                        )
+                    });
+                }
+            },
+        };
 
-    let result = manifestation
-        .update_v1(&manifest, update_hash, download)
-        .await;
+        let result = manifestation
+            .update_v1(&manifest, &self.update_hash, download)
+            .await;
 
-    // inspect, determine what context to add, then process afterwards.
-    if let Err(e) = &result
-        && let Some(RustupError::DownloadNotExists { .. }) = e.downcast_ref::<RustupError>()
-    {
-        return result.with_context(|| {
-            format!("could not download nonexistent rust version `{toolchain_str}`")
-        });
+        // inspect, determine what context to add, then process afterwards.
+        if let Err(e) = &result
+            && let Some(RustupError::DownloadNotExists { .. }) = e.downcast_ref::<RustupError>()
+        {
+            return result.with_context(|| {
+                format!("could not download nonexistent rust version `{toolchain_str}`")
+            });
+        }
+
+        result
     }
-
-    result
 }
 
 fn date_from_manifest_date(date_str: &str) -> Option<NaiveDate> {

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1103,21 +1103,9 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
 
         // TODO: Add a notification about which manifest version is going to be used
         info!("syncing channel updates for {toolchain_str}");
-        let manifest_result = if prefetched_manifest.is_some() {
-            Ok(prefetched_manifest)
-        } else {
-            download
-                .dl_v2_manifest(
-                    // Skip the update hash when the installed manifest is missing or when components
-                    // or targets were requested, since either case still requires the channel manifest.
-                    (prefix.dist_manifest().is_some()
-                        && self.components.is_empty()
-                        && self.targets.is_empty())
-                    .then_some(&self.update_hash),
-                    toolchain,
-                    self.cfg,
-                )
-                .await
+        let manifest_result = match prefetched_manifest {
+            Some(m) => Ok(Some(m)),
+            None => self.dl_v2_manifest(prefix, toolchain).await,
         };
         match manifest_result {
             Ok(Some(ManifestWithHash { manifest: m, hash })) => {
@@ -1255,6 +1243,25 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         }
 
         result
+    }
+
+    async fn dl_v2_manifest(
+        &self,
+        prefix: &InstallPrefix,
+        toolchain: &ToolchainDesc,
+    ) -> Result<Option<ManifestWithHash>> {
+        self.dl_cfg
+            .dl_v2_manifest(
+                // Skip the update hash when the installed manifest is missing or when components
+                // or targets were requested, since either case still requires the channel manifest.
+                (prefix.dist_manifest().is_some()
+                    && self.components.is_empty()
+                    && self.targets.is_empty())
+                .then_some(&self.update_hash),
+                toolchain,
+                self.cfg,
+            )
+            .await
     }
 }
 

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -951,7 +951,6 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
             std::fs::remove_file(&self.update_hash)?;
         }
 
-        let mut fetched = String::new();
         let mut first_err = None;
         let backtrack = self.toolchain.channel == Channel::Nightly && self.toolchain.date.is_none();
         // We want to limit backtracking if we do not already have a toolchain
@@ -1035,7 +1034,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
             }
 
             let result = self
-                .try_update(Some(&toolchain), prefix, &mut fetched, manifest_result)
+                .try_update(Some(&toolchain), prefix, manifest_result)
                 .await;
             let e = match result {
                 Ok(v) => break Ok(v),
@@ -1110,7 +1109,6 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         &self,
         toolchain: Option<&ToolchainDesc>,
         prefix: &InstallPrefix,
-        fetched: &mut String,
         manifest_result: Result<Option<ManifestWithHash>>,
     ) -> Result<Option<String>> {
         let download = &self.dl_cfg;
@@ -1175,9 +1173,6 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
                     explicit_add_components,
                     remove_components: Vec::new(),
                 };
-
-                fetched.clone_from(&m.date);
-
                 return match manifestation
                     .update(m, changes, self.force, download, toolchain, true)
                     .await

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -999,15 +999,16 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
 
         let mut toolchain = self.toolchain.clone();
         let res = loop {
-            let result = self
-                .try_update(
-                    Some(&toolchain),
-                    prefix,
-                    &mut fetched,
-                    prefetched_manifest.take(),
-                )
-                .await;
+            // TODO: Add a notification about which manifest version is going to be used
+            info!("syncing channel updates for {toolchain}");
+            let manifest_result = match prefetched_manifest.take() {
+                Some(manifest) => Ok(Some(manifest)),
+                None => self.dl_v2_manifest(prefix, &toolchain).await,
+            };
 
+            let result = self
+                .try_update(Some(&toolchain), prefix, &mut fetched, manifest_result)
+                .await;
             let e = match result {
                 Ok(v) => break Ok(v),
                 Err(e) if !backtrack => break Err(e),
@@ -1094,19 +1095,12 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         toolchain: Option<&ToolchainDesc>,
         prefix: &InstallPrefix,
         fetched: &mut String,
-        prefetched_manifest: Option<ManifestWithHash>,
+        manifest_result: Result<Option<ManifestWithHash>>,
     ) -> Result<Option<String>> {
         let download = &self.dl_cfg;
         let toolchain = toolchain.unwrap_or(self.toolchain);
-        let toolchain_str = toolchain.to_string();
         let manifestation = Manifestation::open(prefix.clone(), toolchain.target.clone())?;
 
-        // TODO: Add a notification about which manifest version is going to be used
-        info!("syncing channel updates for {toolchain_str}");
-        let manifest_result = match prefetched_manifest {
-            Some(m) => Ok(Some(m)),
-            None => self.dl_v2_manifest(prefix, toolchain).await,
-        };
         match manifest_result {
             Ok(Some(ManifestWithHash { manifest: m, hash })) => {
                 match m.get_rust_version() {
@@ -1238,14 +1232,14 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
             && let Some(RustupError::DownloadNotExists { .. }) = e.downcast_ref::<RustupError>()
         {
             return result.with_context(|| {
-                format!("could not download nonexistent rust version `{toolchain_str}`")
+                format!("could not download nonexistent rust version `{toolchain}`")
             });
         }
 
         result
     }
 
-    async fn dl_v2_manifest(
+    pub(crate) async fn dl_v2_manifest(
         &self,
         prefix: &InstallPrefix,
         toolchain: &ToolchainDesc,

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -5,7 +5,7 @@ use std::{
     sync::LazyLock,
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow};
 use chrono::NaiveDate;
 use clap::{ValueEnum, builder::PossibleValue};
 use itertools::Itertools;
@@ -1227,28 +1227,19 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         }
 
         // If the v2 manifest is not found then try v1
-        let manifest = match download
+        let manifest = download
             .dl_v1_manifest(&self.cfg.dist_root_url, toolchain)
             .await
-        {
-            Ok(m) => m,
-            Err(err) => match err.downcast_ref::<RustupError>() {
-                Some(RustupError::ChecksumFailed { .. }) => return Err(err),
+            .map_err(|err| match err.downcast_ref::<RustupError>() {
+                Some(RustupError::ChecksumFailed { .. }) => err,
                 Some(RustupError::DownloadNotExists { .. }) => {
-                    bail!(DistError::MissingReleaseForToolchain(
-                        toolchain.manifest_name()
-                    ));
+                    DistError::MissingReleaseForToolchain(toolchain.manifest_name()).into()
                 }
-                _ => {
-                    return Err(err).with_context(|| {
-                        format!(
-                            "failed to download manifest for '{}'",
-                            toolchain.manifest_name()
-                        )
-                    });
-                }
-            },
-        };
+                _ => err.context(format!(
+                    "failed to download manifest for '{}'",
+                    toolchain.manifest_name()
+                )),
+            })?;
 
         let result = manifestation
             .update_v1(&manifest, &self.update_hash, download)

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1006,6 +1006,34 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
                 None => self.dl_v2_manifest(prefix, &toolchain).await,
             };
 
+            let try_date_str = match (&toolchain.date, &manifest_result) {
+                (Some(date), _) => Some(date),
+                (None, Ok(Some(m))) => Some(&m.manifest.date),
+                _ => None,
+            };
+
+            let try_date = match try_date_str {
+                Some(s) if let Some(d) = date_from_manifest_date(s) => Ok(d),
+                // Parsing error can only be a problem if we enter backtracking, so we delay the
+                // error until we actually need to try another date.
+                Some(s) => Err(format!("malformed manifest date `{s}`")),
+                None => Err(format!(
+                    "manifest date not found for toolchain `{toolchain}`"
+                )),
+            };
+
+            // Skip installation when the toolchain to be installed comes with a valid manifest date
+            // that is older than the oldest acceptable date.
+            if try_date.as_ref().is_ok_and(|date| date < &last_manifest) {
+                break match first_err {
+                    // Wouldn't be an update if we go further back than the currently installed toolchain.
+                    Some(e) => Err(e),
+                    // In this case, all newer nightlies are missing, which means there are no
+                    // updates, so the user is already at the latest nightly.
+                    None => Ok(None),
+                };
+            }
+
             let result = self
                 .try_update(Some(&toolchain), prefix, &mut fetched, manifest_result)
                 .await;
@@ -1062,22 +1090,10 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
             // the components that the user currently has installed. Let's try the previous
             // nightlies in reverse chronological order until we find a nightly that does,
             // starting at one date earlier than the current manifest's date.
-            let toolchain_date = toolchain.date.as_ref().unwrap_or(&fetched);
-            let try_next = date_from_manifest_date(toolchain_date)
-                .unwrap_or_else(|| panic!("Malformed manifest date: {toolchain_date:?}"))
+            let try_next = try_date
+                .unwrap_or_else(|e| panic!("{e}"))
                 .pred_opt()
                 .unwrap();
-
-            if try_next < last_manifest {
-                break match first_err {
-                    // Wouldn't be an update if we go further back than the currently installed toolchain.
-                    Some(e) => Err(e),
-                    // In this case, all newer nightlies are missing, which means there are no
-                    // updates, so the user is already at the latest nightly.
-                    None => Ok(None),
-                };
-            }
-
             toolchain.date = Some(try_next.format("%Y-%m-%d").to_string());
         };
 

--- a/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -38,51 +38,53 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>   Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>  Allow downgrading the toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>            Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>   Install toolchains that require an emulator. See</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -38,51 +38,53 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>   Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>  Allow downgrading the toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>            Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>   Install toolchains that require an emulator. See</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="596px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -38,51 +38,53 @@
 </tspan>
     <tspan x="10px" y="172px"><tspan class="fg-bright-green bold">Options:</tspan>
 </tspan>
-    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>  Don't perform self update when running the `rustup update` command</tspan>
+    <tspan x="10px" y="190px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--no-self-update</tspan><tspan>   Don't perform self update when running the `rustup update` command</tspan>
 </tspan>
-    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>           Force an update, even if some components are missing</tspan>
+    <tspan x="10px" y="208px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--allow-downgrade</tspan><tspan>  Allow downgrading the toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>  Install toolchains that require an emulator. See</tspan>
+    <tspan x="10px" y="226px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force</tspan><tspan>            Force an update, even if some components are missing</tspan>
 </tspan>
-    <tspan x="10px" y="244px"><tspan>                        https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
+    <tspan x="10px" y="244px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--force-non-host</tspan><tspan>   Install toolchains that require an emulator. See</tspan>
 </tspan>
-    <tspan x="10px" y="262px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>            Print help</tspan>
+    <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px">
+    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="298px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="298px">
 </tspan>
-    <tspan x="10px" y="316px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="370px">
+    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="388px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="388px">
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="424px">
+    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="442px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="442px">
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="478px">
+    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="496px">
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="532px">
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="550px">
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="586px">
+    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="604px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -2620,6 +2620,58 @@ error: component 'rls' for target '[HOST_TUPLE]' is unavailable for download for
 }
 
 #[tokio::test]
+async fn update_allow_downgrade() {
+    let cx = CliTestContext::new(Scenario::MissingComponent).await;
+
+    cx.config.set_current_dist_date("2019-09-14");
+    cx.config
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-3)
+
+"#]])
+        .is_ok();
+
+    cx.config.set_current_dist_date("2019-09-13");
+    cx.config
+        .expect(["rustup", "toolchain", "install", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
+
+    cx.config
+        .expect([
+            "rustup",
+            "toolchain",
+            "install",
+            "nightly",
+            "--allow-downgrade",
+        ])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustc", "--version"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+1.37.0 (hash-nightly-2)
+
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
 async fn regression_2601() {
     // We're checking that we don't regress per #2601
     let cx = CliTestContext::new(Scenario::SimpleV2).await;

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -2646,7 +2646,7 @@ async fn update_allow_downgrade() {
         .expect(["rustc", "--version"])
         .await
         .with_stdout(snapbox::str![[r#"
-1.37.0 (hash-nightly-2)
+1.37.0 (hash-nightly-3)
 
 "#]])
         .is_ok();


### PR DESCRIPTION
Closes #5003.

Normally, when a toolchain is updated, the manifest date of the toolchain to be installed is compared to the current manifest date, so that `--allow-downgrade` can reject or allow potential downgrades accordingly.

However, there is a bug in the existing logic in that the  comparison is performed only _after_ the target toolchain is installed, which has effectively blocked all effects of `--allow-downgrade` _until the backtracking[^1] has started_, which is unfortunately never the case except for certain `nightly` builds. This seems to be the root cause of #5003.

[^1]: Rustup backtracks to older manifests to meet all component requirements. This is necessary because certain nightlies are allowed to not have the complete set of components.

This PR fixes this issue by comparing the manifest dates before the target toolchain is installed.