### PR TITLE
feat(config): allow the default host to be overridden with `RUSTUP_DE…

### DIFF
--- a/doc/dev-guide/src/tips-and-tricks.md
+++ b/doc/dev-guide/src/tips-and-tricks.md
@@ -57,7 +57,8 @@ mean a download is tried a total of four times before failing out.
 ## `RUSTUP_BACKTRACE`
 
 By default while running tests, we unset some environment variables that will
-break our testing (like `RUSTUP_TOOLCHAIN`, `SHELL`, `ZDOTDIR`, `RUST_BACKTRACE`).
+break our testing (like `RUSTUP_TOOLCHAIN`, `RUSTUP_DEFAULT_HOST`, `SHELL`,
+`ZDOTDIR`, `RUST_BACKTRACE`).
 But if you want to debug locally, you may need backtrace. `RUSTUP_BACKTRACE`
 is used like `RUST_BACKTRACE` to enable backtraces of failed tests.
 

--- a/doc/user-guide/src/concepts/toolchains.md
+++ b/doc/user-guide/src/concepts/toolchains.md
@@ -42,6 +42,19 @@ inferred, so the above could be written:
 $ rustup toolchain install stable-msvc
 ```
 
+Elements that are still missing are taken from the default host, which is
+detected at installation time and can be changed with `rustup set
+default-host`. Since that setting lives in `rustup`'s [configuration], it is
+shared by every environment using the same `RUSTUP_HOME`; where the host ABI is
+instead a property of the current shell environment, as with the [MSYS2]
+environments on Windows, the [`RUSTUP_DEFAULT_HOST`] environment variable can
+override it. Either way, a host named in the toolchain specification wins.
+`rustup show` reports the default host in use and where it was taken from.
+
+[configuration]: ../configuration.md
+[MSYS2]: https://www.msys2.org/
+[`RUSTUP_DEFAULT_HOST`]: ../environment-variables.md
+
 Toolchain names that don't name a channel instead can be used to name [custom
 toolchains].
 

--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -14,6 +14,25 @@
   or invocations will fail. This can specify custom toolchains, installable
   toolchains, or the absolute path to a toolchain.
 
+- `RUSTUP_DEFAULT_HOST` (default: none). If set, overrides the configured
+  [default host] when a toolchain specification doesn't name a host, e.g. when
+  `1.87` is resolved to `1.87-x86_64-pc-windows-gnu`. Unlike `RUSTUP_TOOLCHAIN`,
+  this doesn't [override] the selected toolchain, so a `rust-toolchain.toml`
+  file that pins a channel keeps its say over the version. This is useful for
+  environments such as the [MSYS2] shells, which share a single `RUSTUP_HOME`
+  while requiring different host ABIs. While it is set, the configured default
+  host isn't consulted, so `rustup set default-host` warns that what it writes
+  won't take effect. `rustup show` reports which of the two is in use.
+
+  This variable only completes a toolchain name that doesn't already specify a
+  host. It has no effect on the [default toolchain] if that name specifies a
+  host explicitly, as it always did before rustup 1.30 (e.g.
+  `1.87-x86_64-pc-windows-msvc` rather than `1.87`) and may still if it was set
+  by an older rustup or with an explicit host on the command line. Run `rustup
+  default` to check: it prints the resolved name, so if the host shown doesn't
+  match this variable, run `rustup default <channel>` with a bare channel to
+  store it without one.
+
 - `RUSTUP_DIST_SERVER` (default: `https://static.rust-lang.org`). Sets the root
   URL for downloading static resources related to Rust. You can change this to
   instead use a local mirror, or to test the binaries from the staging
@@ -76,6 +95,9 @@
 
 [directive syntax]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html#directives
 [dc]: https://docs.docker.com/storage/storagedriver/overlayfs-driver/#modifying-files-or-directories
+[default host]: concepts/toolchains.md#toolchain-specification
+[default toolchain]: overrides.md#default-toolchain
+[MSYS2]: https://www.msys2.org/
 [override]: overrides.md
 [tracing viewer]: https://github.com/catapult-project/catapult/blob/master/tracing/README.md
 [rustup issue tracker]: https://github.com/rust-lang/rustup/issues

--- a/doc/user-guide/src/installation/windows.md
+++ b/doc/user-guide/src/installation/windows.md
@@ -31,6 +31,17 @@ For example, to choose the 64 bit GNU toolchain:
 $ rustup set default-host x86_64-pc-windows-gnu
 ```
 
+That setting is stored in `rustup`'s configuration and is therefore shared by
+every environment using the same `RUSTUP_HOME`. [MSYS2] instead provides
+several environments that expect different ABIs (e.g. `x86_64-pc-windows-gnu`
+in UCRT64 and `x86_64-pc-windows-gnullvm` in CLANG64) while sharing one home
+directory, so such an environment can set the [`RUSTUP_DEFAULT_HOST`]
+environment variable during its initialization to select its own default host:
+
+```console
+$ export RUSTUP_DEFAULT_HOST=x86_64-pc-windows-gnullvm
+```
+
 Since the MSVC ABI provides the best interoperation with other Windows
 software it is recommended for most purposes. The GNU toolchain is always
 available, even if you don't use it by default. Just install it with `rustup
@@ -58,6 +69,7 @@ targets with the same compiler.
 [Visual Studio]: https://visualstudio.microsoft.com/
 [GCC toolchain]: https://gcc.gnu.org/
 [MSYS2]: https://www.msys2.org/
+[`RUSTUP_DEFAULT_HOST`]: ../environment-variables.md
 [msvc-toolchain]: https://www.rust-lang.org/tools/install?platform_override=win
 [toolchain specification]: ../concepts/toolchains.md#toolchain-specification
 [msvc install]: windows-msvc.html

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -838,9 +838,7 @@ pub async fn main(
             SelfSubcmd::UpgradeData => cfg.upgrade_data().map(|_| ExitCode::SUCCESS),
         },
         RustupSubcmd::Set { subcmd } => match subcmd {
-            SetSubcmd::DefaultHost { host_tuple } => cfg
-                .set_default_host_tuple(host_tuple)
-                .map(|_| ExitCode::SUCCESS),
+            SetSubcmd::DefaultHost { host_tuple } => set_default_host(cfg, host_tuple),
             SetSubcmd::Profile { profile_name } => {
                 cfg.set_profile(profile_name).map(|_| ExitCode::SUCCESS)
             }
@@ -1211,11 +1209,12 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
 
     let t = cfg.process.stdout();
 
-    // Print host tuple
+    // Print host tuple and where it came from
+    let (default_host, default_host_source) = cfg.default_host_tuple_with_source()?;
     writeln!(
         t.lock(),
-        "{HEADER}Default host: {HEADER:#}{}",
-        cfg.default_host_tuple()?
+        "{HEADER}Default host: {HEADER:#}{default_host} ({})",
+        default_host_source.to_reason()
     )?;
 
     // Print rustup home directory
@@ -1743,6 +1742,16 @@ fn override_remove(cfg: &Cfg<'_>, path: Option<&Path>, nonexistent: bool) -> Res
                 );
             }
         }
+    }
+    Ok(ExitCode::SUCCESS)
+}
+
+fn set_default_host(cfg: &Cfg<'_>, host_tuple: String) -> Result<ExitCode> {
+    cfg.set_default_host_tuple(host_tuple)?;
+    if let Ok(env_host) = cfg.process.var("RUSTUP_DEFAULT_HOST") {
+        warn!(
+            "`RUSTUP_DEFAULT_HOST` is set to `{env_host}`: the default host setting will not have any effect while it remains set"
+        );
     }
     Ok(ExitCode::SUCCESS)
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -125,6 +125,28 @@ impl Display for ActiveSource {
     }
 }
 
+// Represents the source that determined the default host tuple.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DefaultHostSource {
+    /// Detected from the running process, falling back to rustup's own build target.
+    Detected,
+    /// The `RUSTUP_DEFAULT_HOST` environment variable.
+    Environment,
+    /// The `default_host_tuple` setting, written by `rustup set default-host`
+    /// or at installation time.
+    Settings,
+}
+
+impl DefaultHostSource {
+    pub(crate) fn to_reason(self) -> &'static str {
+        match self {
+            Self::Detected => "detected",
+            Self::Environment => "from env var RUSTUP_DEFAULT_HOST",
+            Self::Settings => "from settings.toml in rustup home",
+        }
+    }
+}
+
 /// Represents the result of an operation that may ensure the installation of a certain toolchain.
 #[derive(Clone, Debug)]
 pub(crate) struct EnsureInstalled<T> {
@@ -999,8 +1021,14 @@ impl<'a> Cfg<'a> {
 
     #[tracing::instrument(level = "trace", skip_all)]
     pub(crate) fn default_host_tuple(&self) -> Result<TargetTuple> {
+        Ok(self.default_host_tuple_with_source()?.0)
+    }
+
+    pub(crate) fn default_host_tuple_with_source(
+        &self,
+    ) -> Result<(TargetTuple, DefaultHostSource)> {
         self.settings_file
-            .with(|s| Ok(default_host_tuple(s, self.process)))
+            .with(|s| Ok(default_host_tuple_with_source(s, self.process)))
     }
 
     /// The path on disk of any concrete toolchain
@@ -1191,11 +1219,32 @@ impl State {
     }
 }
 
+/// The host tuple used to complete toolchain names that don't specify one.
 pub(crate) fn default_host_tuple(s: &Settings, process: &Process) -> TargetTuple {
-    s.default_host_tuple
-        .as_ref()
-        .map(TargetTuple::new)
-        .unwrap_or_else(|| TargetTuple::from_host_or_build(process))
+    default_host_tuple_with_source(s, process).0
+}
+
+/// The host tuple used to complete toolchain names that don't specify one,
+/// along with the source it was taken from.
+///
+/// The `RUSTUP_DEFAULT_HOST` environment variable takes precedence over the
+/// `default_host_tuple` setting, so that an execution environment (e.g. an
+/// MSYS2 shell) can select a host ABI without changing the configuration
+/// shared with the other environments using the same `RUSTUP_HOME`.
+pub(crate) fn default_host_tuple_with_source(
+    s: &Settings,
+    process: &Process,
+) -> (TargetTuple, DefaultHostSource) {
+    if let Ok(tuple) = process.var("RUSTUP_DEFAULT_HOST") {
+        (TargetTuple::new(tuple), DefaultHostSource::Environment)
+    } else if let Some(tuple) = &s.default_host_tuple {
+        (TargetTuple::new(tuple), DefaultHostSource::Settings)
+    } else {
+        (
+            TargetTuple::from_host_or_build(process),
+            DefaultHostSource::Detected,
+        )
+    }
 }
 
 fn no_toolchain_error(process: &Process) -> anyhow::Error {

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -792,6 +792,7 @@ async fn setup_test_state(test_dist_dir: TempDir) -> (TempDir, Config) {
         env::remove_var("RUSTUP_AUTO_INSTALL");
         env::remove_var("RUSTUP_UPDATE_ROOT");
         env::remove_var("RUSTUP_TOOLCHAIN");
+        env::remove_var("RUSTUP_DEFAULT_HOST");
         env::remove_var("SHELL");
         env::remove_var("ZDOTDIR");
         // clap does its own terminal colour probing, and that isn't

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -743,7 +743,7 @@ async fn install_defaults_to_default_host() {
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -771,7 +771,7 @@ installed targets:
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [CROSS_ARCH_I]
+Default host: [CROSS_ARCH_I] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -739,7 +739,7 @@ async fn show_toolchain_none() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -770,7 +770,7 @@ async fn show_toolchain_default() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -864,7 +864,7 @@ async fn show_multiple_toolchains() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -948,7 +948,7 @@ async fn show_multiple_targets() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1002,7 +1002,7 @@ async fn show_multiple_toolchains_and_targets() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1133,7 +1133,7 @@ async fn show_toolchain_override() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1174,7 +1174,7 @@ async fn show_toolchain_toolchain_file_override() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1224,7 +1224,7 @@ async fn show_toolchain_version_nested_file_override() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1268,7 +1268,7 @@ async fn show_toolchain_toolchain_file_override_not_installed() {
             ("[TOOLCHAIN_FILE]", &toolchain_file),
         ])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1304,7 +1304,7 @@ async fn show_toolchain_override_not_installed() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1381,7 +1381,7 @@ async fn show_toolchain_env() {
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1413,7 +1413,7 @@ async fn show_toolchain_env_not_installed() {
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1468,7 +1468,7 @@ async fn show_with_verbose() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", &cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -1642,7 +1642,7 @@ async fn set_default_host() {
         .await
         .with_stdout(snapbox::str![[r#"
 ...
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 ...
 "#]])
         .is_ok();
@@ -4123,7 +4123,7 @@ async fn show_custom_toolchain() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4173,7 +4173,7 @@ async fn show_custom_toolchain_without_components_file() {
         .await
         .extend_redactions([("[RUSTUP_DIR]", cx.config.rustupdir.to_string())])
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4305,7 +4305,7 @@ default_toolchain = "beta"
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4343,7 +4343,7 @@ default_toolchain = "beta"
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [CROSS_ARCH_I]
+Default host: [CROSS_ARCH_I] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4400,7 +4400,7 @@ default_toolchain = "beta-[HOST_TUPLE]"
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [HOST_TUPLE]
+Default host: [HOST_TUPLE] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4438,7 +4438,7 @@ default_toolchain = "beta-[HOST_TUPLE]"
         .extend_redactions(redactions)
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-Default host: [CROSS_ARCH_I]
+Default host: [CROSS_ARCH_I] (from settings.toml in rustup home)
 rustup home:  [RUSTUP_DIR]
 
 installed toolchains
@@ -4453,4 +4453,187 @@ installed targets:
   [HOST_TUPLE]
 
 "#]]);
+}
+
+// The `RUSTUP_DEFAULT_HOST` environment variable overrides the `default_host_tuple`
+// setting when completing a toolchain name that doesn't specify a host, without
+// modifying the settings shared with other environments.
+// See: https://github.com/rust-lang/rustup/issues/5024
+#[tokio::test]
+async fn default_host_env_completes_unqualified_toolchains() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let mut toml_redactions = snapbox::Redactions::new();
+    toml_redactions
+        .insert("[HOST_TUPLE]", this_host_tuple())
+        .unwrap();
+    let toml_assert = snapbox::Assert::new()
+        .action_env(snapbox::assert::DEFAULT_ACTION_ENV)
+        .redact_with(toml_redactions);
+
+    let redactions = [
+        ("[RUSTUP_DIR]", cx.config.rustupdir.to_string()),
+        ("[CROSS_ARCH_I]", CROSS_ARCH1.to_owned()),
+    ];
+
+    cx.config
+        .expect(["rustup", "default", "beta"])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect_with_env(
+            ["rustup", "show"],
+            [
+                ("RUSTUP_DEFAULT_HOST", CROSS_ARCH1),
+                ("RUSTUP_AUTO_INSTALL", "0"),
+            ],
+        )
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I] (from env var RUSTUP_DEFAULT_HOST)
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE]
+
+active toolchain
+----------------
+name: beta-[CROSS_ARCH_I]
+active because: it's the default toolchain
+
+"#]]);
+
+    // The override is not persisted, so other environments are unaffected.
+    let settings_file = &cx.config.rustupdir.join("settings.toml");
+    toml_assert.eq(
+        fs::read_to_string(settings_file).unwrap(),
+        snapbox::str![[r#"
+...
+default_host_tuple = "[HOST_TUPLE]"
+default_toolchain = "beta"
+...
+"#]],
+    );
+}
+
+// A toolchain name that specifies a host stays authoritative, so `RUSTUP_DEFAULT_HOST`
+// doesn't affect it.
+#[tokio::test]
+async fn default_host_env_doesnt_affect_qualified_toolchains() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let redactions = [
+        ("[RUSTUP_DIR]", cx.config.rustupdir.to_string()),
+        ("[CROSS_ARCH_I]", CROSS_ARCH1.to_owned()),
+    ];
+
+    cx.config
+        .expect(["rustup", "default", for_host!("beta-{}")])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect_with_env(
+            ["rustup", "show"],
+            [
+                ("RUSTUP_DEFAULT_HOST", CROSS_ARCH1),
+                ("RUSTUP_AUTO_INSTALL", "0"),
+            ],
+        )
+        .await
+        .extend_redactions(redactions)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I] (from env var RUSTUP_DEFAULT_HOST)
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+beta-[HOST_TUPLE] (active, default)
+
+active toolchain
+----------------
+name: beta-[HOST_TUPLE]
+active because: it's the default toolchain
+installed targets:
+  [HOST_TUPLE]
+
+"#]]);
+}
+
+// A `rust-toolchain.toml` file that pins a channel without a host is completed
+// with `RUSTUP_DEFAULT_HOST`.
+#[tokio::test]
+async fn default_host_env_completes_toolchain_file() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    let toolchain_file = cx.config.current_dir().join("rust-toolchain.toml");
+    raw::write_file(&toolchain_file, "[toolchain]\nchannel = \"nightly\"\n").unwrap();
+
+    cx.config
+        .expect_with_env(
+            ["rustup", "show"],
+            [
+                ("RUSTUP_DEFAULT_HOST", CROSS_ARCH1),
+                ("RUSTUP_AUTO_INSTALL", "0"),
+            ],
+        )
+        .await
+        .extend_redactions([
+            ("[RUSTUP_DIR]", cx.config.rustupdir.to_string()),
+            ("[CROSS_ARCH_I]", CROSS_ARCH1.to_owned()),
+        ])
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+Default host: [CROSS_ARCH_I] (from env var RUSTUP_DEFAULT_HOST)
+rustup home:  [RUSTUP_DIR]
+
+installed toolchains
+--------------------
+
+active toolchain
+----------------
+name: nightly-[CROSS_ARCH_I]
+active because: overridden by '[..]/rust-toolchain.toml'
+
+"#]]);
+}
+
+// While `RUSTUP_DEFAULT_HOST` is set, `rustup set default-host` writes a setting that
+// won't be consulted, so it says so.
+#[tokio::test]
+async fn set_default_host_warns_while_env_is_set() {
+    let cx = CliTestContext::new(Scenario::None).await;
+    cx.config
+        .expect_with_env(
+            ["rustup", "set", "default-host", &this_host_tuple()],
+            [("RUSTUP_DEFAULT_HOST", CROSS_ARCH1)],
+        )
+        .await
+        .extend_redactions([("[CROSS_ARCH_I]", CROSS_ARCH1)])
+        .is_ok()
+        .with_stderr(snapbox::str![[r#"
+warn: `RUSTUP_DEFAULT_HOST` is set to `[CROSS_ARCH_I]`: the default host setting will not have any effect while it remains set
+warn: no toolchain installed and no default toolchain set
+help: run 'rustup default stable' to download the latest stable release of Rust and set it as your default toolchain.
+
+"#]]);
+}
+
+// `RUSTUP_DEFAULT_HOST` must name a host that can be resolved against.
+#[tokio::test]
+async fn default_host_env_invalid_tuple() {
+    let cx = CliTestContext::new(Scenario::None).await;
+    cx.config
+        .expect_with_env(["rustup", "show"], [("RUSTUP_DEFAULT_HOST", "foo")])
+        .await
+        .with_stderr(snapbox::str![[r#"
+error: Provided host 'foo' couldn't be converted to partial tuple
+
+"#]])
+        .is_err();
 }

--- a/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_show_toolchain.stdout.term.svg
@@ -19,7 +19,7 @@
   <rect width="100%" height="100%" y="0" rx="4.5" class="bg" />
 
   <text xml:space="preserve" class="container fg">
-    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">Default host: </tspan><tspan>[HOST_TUPLE]</tspan>
+    <tspan x="10px" y="28px"><tspan class="fg-bright-green bold">Default host: </tspan><tspan>[HOST_TUPLE] (from settings.toml in rustup home)</tspan>
 </tspan>
     <tspan x="10px" y="46px"><tspan class="fg-bright-green bold">rustup home:  </tspan><tspan>[RUSTUP_DIR]</tspan>
 </tspan>


### PR DESCRIPTION
Delivers the suggested override in #5024.

Allow overriding the default host from env var RUSTUP_DEFAULT_HOST.  Allows for env-based global toolchain (msvc, gnu, gnullvm) selection while still respecting project-level channel selection.  Preferable to setting RUSTUP_TOOLCHAIN at the env level because that would pin channel/version across all projects.

This also documents the new env var and also updates 'rustup show' to unambiguously explain how the current default host has been derived.