### PR TITLE
chore: inform triagebot of the contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributing documentation has moved to the **[rustup dev guide]**.
 
-[rustup dev guide]: https://rust-lang.github.io/rustup/dev-guide)
+[rustup dev guide]: https://rust-lang.github.io/rustup/dev-guide
 
 ## Before hacking on rustup
 

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -15,6 +15,8 @@ allow-unauthenticated = [
 ]
 
 [assign]
+contributing_url = "https://rust-lang.github.io/rustup/dev-guide"
+llm_policy_url = "https://rust-lang.github.io/rustup/dev-guide/#ai-policy"
 
 # Enable issue transfers within the org
 # Documentation at: https://forge.rust-lang.org/triagebot/transfer.html


### PR DESCRIPTION
As suggested by @Kobzol, this PR tries to make use of the new triagebot features: https://forge.rust-lang.org/triagebot/pr-assignment.html#additional-new-pr-trigger-options

~~I have decided to remove the pull request template accordingly since it seems to be conveying the same information as the above options here.~~