### PR TITLE
Only create a URL when opening docs with URI fragments

### DIFF
--- a/src/toolchain.rs
+++ b/src/toolchain.rs
@@ -523,11 +523,21 @@ impl<'a> Toolchain<'a> {
         fragment: Option<&str>,
     ) -> anyhow::Result<()> {
         let relative = relative.as_ref();
-        let mut doc_url = Url::from_file_path(self.doc_path(relative)?)
-            .ok()
-            .with_context(|| anyhow!("invalid doc file absolute path `{}`", relative.display()))?;
-        doc_url.set_fragment(fragment);
-        utils::open_browser(doc_url.to_string())
+        let doc_path = self.doc_path(relative)?;
+        // HACK: If a fragment is needed then turn the path into a url
+        // We avoid doing this if a fragment isn't needed because
+        // `open_browser` can call `ShellExecuteW` on Windows which doesn't
+        // handle urls very well. See #5035.
+        if fragment.is_some() {
+            let mut doc_url = Url::from_file_path(&doc_path).ok().with_context(|| {
+                anyhow!("invalid doc file absolute path `{}`", relative.display())
+            })?;
+            doc_url.set_fragment(fragment);
+            utils::open_browser(doc_url.to_string())
+        } else {
+            // Otherwise use the filesystem path.
+            utils::open_browser(&doc_path)
+        }
     }
 
     /// Remove the toolchain from disk


### PR DESCRIPTION
`ShellExecuteW` does not handle urls very well so we try to avoid it as much as possible.

This is only a partial workaround for #5035 but it does allow new users basic access to the docs. I can implement a fuller fix but I'd want more time to test and evaluate the trade-offs so I think this is good to go in the meantime and I think this might be a good idea even if we do have a full fix (no point making a url if we don't have to).