### PR TITLE
chore(dist/manifestation): remove unused `Manifestation::uninstall()`

### DIFF
--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -323,35 +323,6 @@ impl Manifestation {
         Ok(UpdateStatus::Changed)
     }
 
-    #[cfg(test)]
-    pub(crate) fn uninstall(
-        &self,
-        manifest: &Manifest,
-        tmp_cx: Arc<temp::Context>,
-        permit_copy_rename: bool,
-    ) -> Result<()> {
-        let prefix = self.installation.prefix();
-
-        let mut tx = Transaction::new(prefix.clone(), tmp_cx, permit_copy_rename);
-
-        // Read configuration and delete it
-        let rel_config_path = prefix.rel_manifest_file(CONFIG_FILE);
-        let abs_config_path = prefix.path().join(&rel_config_path);
-        let config_str = utils::read_file("dist config", &abs_config_path)?;
-        let config = Config::parse(&config_str).with_context(|| RustupError::ParsingFile {
-            name: "config",
-            path: abs_config_path,
-        })?;
-        tx.remove_file("dist config", rel_config_path)?;
-
-        for component in config.components {
-            tx = self.uninstall_component(component, manifest, tx)?;
-        }
-        tx.commit();
-
-        Ok(())
-    }
-
     fn uninstall_component(
         &self,
         component: Component,

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -520,20 +520,6 @@ impl TestContext {
             .await
     }
 
-    fn uninstall(&self) -> Result<()> {
-        let trip = self.toolchain.target.clone();
-        let manifestation = Manifestation::open(self.prefix.clone(), trip)?;
-        let manifest = manifestation.load_manifest()?.unwrap();
-
-        manifestation.uninstall(
-            &manifest,
-            self.tmp_cx.clone(),
-            self.tp.process.permit_copy_rename(),
-        )?;
-
-        Ok(())
-    }
-
     fn stderr_line_contains(&self, needle: &str) -> bool {
         str::from_utf8(&self.tp.stderr())
             .unwrap()
@@ -563,31 +549,6 @@ async fn initial_install_xz() {
 #[tokio::test]
 async fn initial_install_zst() {
     initial_install(AddZStd).await;
-}
-
-#[tokio::test]
-async fn test_uninstall() {
-    let cx = TestContext::new(None, GZOnly);
-    cx.update_from_dist(&[], &[], false).await.unwrap();
-    cx.uninstall().unwrap();
-
-    assert!(!utils::path_exists(cx.prefix.path().join("bin/rustc")));
-    assert!(!utils::path_exists(
-        cx.prefix.path().join("lib/libstd.rlib")
-    ));
-}
-
-#[tokio::test]
-async fn uninstall_removes_config_file() {
-    let cx = TestContext::new(None, GZOnly);
-    cx.update_from_dist(&[], &[], false).await.unwrap();
-    assert!(utils::path_exists(
-        cx.prefix.manifest_file("multirust-config.toml")
-    ));
-    cx.uninstall().unwrap();
-    assert!(!utils::path_exists(
-        cx.prefix.manifest_file("multirust-config.toml")
-    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
I have found this function when writing my PoC for #988. It seems that this function is not used anywhere but is tested, it feels quite strange this way.

Looking at https://github.com/rust-lang/rustup/pull/3886 it seems that @djc has realized that this was dead code so he put `cfg(test)` on it. However the tests using this function seem to be doing nothing at all either...
