### PR TITLE
Allow `update` to proceed even if a file/dir in the old toolchain is missing

### DIFF
--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -206,15 +206,7 @@ fn remove_file_that_not_exists() {
     let cx = DistContext::new(None).unwrap();
     let mut tx = cx.transaction();
 
-    let err = tx.remove_file("c", PathBuf::from("foo")).unwrap_err();
-
-    match err.downcast_ref::<RustupError>() {
-        Some(RustupError::ComponentMissingFile { name, path }) => {
-            assert_eq!(name, "c");
-            assert_eq!(path.clone(), PathBuf::from("foo"));
-        }
-        _ => panic!(),
-    }
+    tx.remove_file("c", PathBuf::from("foo")).unwrap();
 }
 
 #[test]
@@ -252,15 +244,7 @@ fn remove_dir_that_not_exists() {
     let cx = DistContext::new(None).unwrap();
     let mut tx = cx.transaction();
 
-    let err = tx.remove_dir("c", PathBuf::from("foo")).unwrap_err();
-
-    match err.downcast_ref::<RustupError>() {
-        Some(RustupError::ComponentMissingDir { name, path }) => {
-            assert_eq!(name, "c");
-            assert_eq!(path.clone(), PathBuf::from("foo"));
-        }
-        _ => panic!(),
-    }
+    tx.remove_dir("c", PathBuf::from("foo")).unwrap();
 }
 
 #[test]

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use anyhow::{Context, anyhow};
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::{
     dist::{prefix::InstallPrefix, temp},
@@ -110,11 +110,11 @@ impl Transaction {
         let abs_path = self.prefix.abs_path(&relpath);
         let backup = self.tmp_cx.new_file()?;
         if !utils::path_exists(&abs_path) {
-            return Err(RustupError::ComponentMissingFile {
-                name: component.to_owned(),
-                path: relpath,
-            }
-            .into());
+            // If the file doesn't exist, that's fine, since we would just be deleting it anyway
+            warn!(
+                "failure removing component '{component}', directory does not exist: '{relpath:?}'",
+            );
+            return Ok(());
         }
 
         utils::rename("component", &abs_path, &backup, self.permit_copy_rename)?;
@@ -129,11 +129,11 @@ impl Transaction {
         let abs_path = self.prefix.abs_path(&relpath);
         let backup = self.tmp_cx.new_directory()?;
         if !utils::path_exists(&abs_path) {
-            return Err(RustupError::ComponentMissingDir {
-                name: component.to_owned(),
-                path: relpath,
-            }
-            .into());
+            // If the dir doesn't exist, that's fine, since we would just be deleting it anyway
+            warn!(
+                "failure removing component '{component}', directory does not exist: '{relpath:?}'",
+            );
+            return Ok(());
         }
 
         utils::rename(

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -42,10 +42,6 @@ pub enum RustupError {
     IncompletePartialFile,
     #[error("component download failed for {0}")]
     ComponentDownloadFailed(String),
-    #[error("failure removing component '{name}', directory does not exist: '{}'", .path.display())]
-    ComponentMissingDir { name: String, path: PathBuf },
-    #[error("failure removing component '{name}', directory does not exist: '{}'", .path.display())]
-    ComponentMissingFile { name: String, path: PathBuf },
     #[error("could not create {name} directory: '{}'", .path.display())]
     CreatingDirectory { name: &'static str, path: PathBuf },
     #[error("invalid toolchain name: '{0}'")]


### PR DESCRIPTION
Resolves: https://github.com/rust-lang/rustup/issues/1480

If a file doesn't exist, the outcome is identical to deleting it (from the user's perspective), so it shouldn't prevent `rustup update` from proceeding.