### PR TITLE
dist: bump `rustup` version to v1.29.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2077,7 +2077,7 @@ dependencies = [
 
 [[package]]
 name = "rustup"
-version = "1.29.1"
+version = "1.29.2"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustup"
-version = "1.29.1"
+version = "1.29.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Manage multiple rust installations with ease"


### PR DESCRIPTION
This is the first step in the v1.29.2 release process using our new [release process](https://rust-lang.github.io/rustup/dev-guide/release-process.html#patch-version-bumps).
