### PR TITLE
feat(config)!: use unqualified names for dir override

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1160,7 +1160,7 @@ async fn update(
             )?;
 
             if opts.r#override {
-                cfg.make_override(&cfg.current_dir, &desc.clone().into())?;
+                cfg.make_override(&cfg.current_dir, &name.clone().into())?;
             }
 
             if opts.default
@@ -1719,7 +1719,7 @@ async fn override_add(
     toolchain: ResolvableToolchainName,
     path: Option<&Path>,
 ) -> Result<ExitCode> {
-    let toolchain_name = toolchain.resolve(&cfg.default_host_tuple()?)?;
+    let toolchain_name = toolchain.clone().resolve(&cfg.default_host_tuple()?)?;
     match Toolchain::new(cfg, toolchain_name.clone().into()) {
         Ok(_) => {}
         Err(e @ RustupError::ToolchainNotInstalled { .. }) => match &toolchain_name {
@@ -1738,7 +1738,7 @@ async fn override_add(
         Err(e) => Err(e)?,
     }
 
-    cfg.make_override(path.unwrap_or(&cfg.current_dir), &toolchain_name)?;
+    cfg.make_override(path.unwrap_or(&cfg.current_dir), &toolchain)?;
     Ok(ExitCode::SUCCESS)
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -636,12 +636,6 @@ impl<'a> Cfg<'a> {
             // First check the override database
             if let Some(name) = settings.dir_override(d) {
                 let source = ActiveSource::OverrideDb(d.to_owned());
-                // Note that `rustup override set` fully resolves it's input
-                // before writing to settings.toml, so resolving here may not
-                // be strictly necessary (could instead model as ToolchainName).
-                // However, settings.toml could conceivably be hand edited to
-                // have an unresolved name. I'm just preserving pre-existing
-                // behaviour by choosing ResolvableToolchainName here.
                 return Ok(Some((
                     ResolvableToolchainName::from_str(&name)?.into(),
                     source,
@@ -980,7 +974,11 @@ impl<'a> Cfg<'a> {
     }
 
     /// Create an override for a toolchain
-    pub(crate) fn make_override(&self, path: &Path, toolchain: &ToolchainName) -> Result<()> {
+    pub(crate) fn make_override(
+        &self,
+        path: &Path,
+        toolchain: &ResolvableToolchainName,
+    ) -> Result<()> {
         self.settings_file.with_mut(|s| {
             s.add_override(path, toolchain.to_string());
             Ok(())

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -352,7 +352,7 @@ async fn override_again() {
         .is_ok()
         .with_stdout(snapbox::str![[""]])
         .with_stderr(snapbox::str![[r#"
-info: override toolchain for [CWD] set to nightly-[HOST_TUPLE]
+info: override toolchain for [CWD] set to nightly
 
 "#]]);
 }
@@ -526,7 +526,7 @@ async fn list_overrides() {
         .extend_redactions([("[CWD]", cwd_formatted)])
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-[CWD]	nightly-[HOST_TUPLE]
+[CWD]	nightly             
 
 "#]])
         .with_stderr(snapbox::str![[""]]);
@@ -563,7 +563,7 @@ async fn list_overrides_with_nonexistent() {
         .extend_redactions([("[PATH]", path_formatted + " (not a directory)")])
         .is_ok()
         .with_stdout(snapbox::str![[r#"
-[PATH]	nightly-[HOST_TUPLE]
+[PATH]	nightly             
 
 
 "#]])

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1361,7 +1361,7 @@ async fn override_set_unset_with_path() {
         .await
         .extend_redactions([("[CWD]", cwd_str.to_string())])
         .with_stdout(snapbox::str![[r#"
-[CWD]	nightly-[HOST_TUPLE]
+[CWD]	nightly             
 
 "#]])
         .with_stderr(snapbox::str![[""]])
@@ -1387,7 +1387,7 @@ no overrides
 }
 
 #[tokio::test]
-async fn override_set_unqualified_doesnt_depend_on_default_host() {
+async fn override_set_unqualified_depends_on_default_host() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
 
     cx.config
@@ -1418,7 +1418,7 @@ active because: directory override for '[..]'
 ...
 active toolchain
 ----------------
-name: nightly-[HOST_TUPLE]
+name: nightly-[CROSS_ARCH_I]
 active because: directory override for '[..]'
 ...
 "#]])

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -1387,6 +1387,84 @@ no overrides
 }
 
 #[tokio::test]
+async fn override_set_unqualified_doesnt_depend_on_default_host() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    cx.config
+        .expect(["rustup", "override", "set", "nightly"])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+active toolchain
+----------------
+name: nightly-[HOST_TUPLE]
+active because: directory override for '[..]'
+...
+"#]])
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+active toolchain
+----------------
+name: nightly-[HOST_TUPLE]
+active because: directory override for '[..]'
+...
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
+async fn override_set_qualified_doesnt_depend_on_default_host() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+
+    cx.config
+        .expect(["rustup", "override", "set", for_host!("nightly-{}")])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+active toolchain
+----------------
+name: nightly-[HOST_TUPLE]
+active because: directory override for '[..]'
+...
+"#]])
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "set", "default-host", CROSS_ARCH1])
+        .await
+        .is_ok();
+    cx.config
+        .expect(["rustup", "show"])
+        .await
+        .with_stdout(snapbox::str![[r#"
+...
+active toolchain
+----------------
+name: nightly-[HOST_TUPLE]
+active because: directory override for '[..]'
+...
+"#]])
+        .is_ok();
+}
+
+#[tokio::test]
 async fn show_toolchain_env() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config


### PR DESCRIPTION
Prepares for https://github.com/rust-lang/rustup/issues/2868.

Previously, when reading from `settings.toml`, rustup accepts both qualified and unqualified toolchain names for dir overrides, however `rustup override set` only writes qualified names.

Essentially, this will case the same confusion as we have already had in https://github.com/rust-lang/rustup/issues/3651 where the user might tend to think that they have only pinned the channel with `rustup override set nightly`, but in reality the host tuple at that time has also been recorded.

This PR ensures the following user journey by mirroring the implementation of https://github.com/rust-lang/rustup/pull/4947:
- The user runs `rustup override set nightly`.
- The user switches to another default host tuple.
- This override will now qualify the `nightly` with the new default host tuple.

And the impact analysis from https://github.com/rust-lang/rustup/pull/4947#issue-4845607114 still applies, so I'll quote it below:

> ### Impact
> #### Compatibility
> This change is breaking exactly because the determination of the ~~default~~ override toolchain will change to reflect the change of the default host tuple.
> 
> However, the user can always get the old behavior by specifying the fully qualified name when running ~~`rustup default`~~ `rustup override set` (such as ~~`rustup default stable-aarch64-apple-darwin`~~ `rustup override set stable-aarch64-apple-darwin`), in the rare case that they would like to decouple the ~~default~~ override toolchain from the default host tuple.
> 
> For users with an existing `settings.toml`, manually running ~~`rustup default stable`~~ `rustup override set stable` or similar commands should be necessary for them to get the new behavior.
> 
> #### Performance
> As discussed in [#4945 (comment)](https://github.com/rust-lang/rustup/issues/4945#issuecomment-4956813676), since the default host tuple is resolved at the beginning of `rustup`'s execution, this change has introduced no extra I/O operations, and thus the performance impact is negligible.

PS: This change is also required for `rustup toolchain pin` to get the right value for dir overrides in #5042. Otherwise, we can only get a fully qualified toolchain name because that's the value it fetches from `settings.toml`, which means `--qualify` will behave differently just for dir overrides.
