### PR TITLE
hack(process/linux): enable `RUSTUP_PERMIT_COPY_RENAME` by default on CI

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -475,9 +475,7 @@ pub enum SelfUpdateMode {
 
 impl SelfUpdateMode {
     pub(crate) fn from_cfg(cfg: &Cfg<'_>) -> Result<Self> {
-        if cfg.process.var("CI").is_ok() && cfg.process.var("RUSTUP_CI").is_err() {
-            // If we're in CI (but not rustup's own CI, which wants to test this stuff!),
-            // disable automatic self updates.
+        if cfg.process.is_ci() {
             return Ok(Self::Disable);
         }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -147,6 +147,11 @@ impl Process {
     #[cfg(target_os = "linux")]
     pub fn permit_copy_rename(&self) -> bool {
         match self {
+            // HACK: On Linux CI machines, rustup is sometimes installed in a Docker image and we
+            // may hit OverlayFS restrictions that prevent renaming. Thus, we allow falling back to
+            // copying to avoid this issue.
+            // See: <https://github.com/dtolnay/rust-toolchain/pull/177>
+            _ if self.is_ci() => true,
             Self::OsProcess(_) => env::var_os("RUSTUP_PERMIT_COPY_RENAME").is_some(),
             #[cfg(feature = "test")]
             Self::TestProcess(p) => p.vars.contains_key("RUSTUP_PERMIT_COPY_RENAME"),

--- a/src/process.rs
+++ b/src/process.rs
@@ -126,6 +126,19 @@ impl Process {
         }
     }
 
+    /// Determines if the current process is running in a CI environment.
+    ///
+    /// # Note
+    ///
+    /// This function returns true iff the `CI` environment variable is set _and_ `RUSTUP_CI` is
+    /// not set.
+    ///
+    /// The `RUSTUP_CI` bit is required because it is set by rustup itself in test suites in
+    /// order to reproduce normal behavior even in a CI environment.
+    pub fn is_ci(&self) -> bool {
+        self.var("CI").is_ok() && self.var("RUSTUP_CI").is_err()
+    }
+
     #[cfg(not(target_os = "linux"))]
     pub fn permit_copy_rename(&self) -> bool {
         false


### PR DESCRIPTION
Addresses the concern raised in https://github.com/rust-lang/rustup/issues/5011#user-content-fn-1-d6ab2ff576a7d006325502f4a047667b. Mitigates:

- https://github.com/rust-lang/rustup/issues/4198
- https://github.com/rust-lang/rustup/issues/2949

## Background

One of the many cases where OverlayFS can break rustup's transactional semantics is when rustup is used in a CI environment conveniently placed in Docker containers, where `RUSTUP_PERMIT_COPY_RENAME=1` has been proven to be a viable workaround (https://github.com/rust-lang/rustup/issues/2949#issuecomment-2584968659, https://github.com/dtolnay/rust-toolchain/pull/177).

## Proposed Solution

This PR automatically enables `RUSTUP_PERMIT_COPY_RENAME` when `CI=1`.

The rationale is that Linux CI machines are quite common and wasting some disk spaces there should be more or less acceptable as long as more CI workflows pass. Hopefully, by limiting the hack to CI machines, this won't have a surprisingly large burst ratio.