### PR TITLE
feat: support .env files in rustup home

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,6 +2059,7 @@ dependencies = [
  "clap-cargo",
  "clap_complete",
  "console",
+ "dotenvy",
  "effective-limits",
  "enum-map",
  "env_proxy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ clap = { version = "4", features = ["derive", "wrap_help", "string"] }
 clap-cargo = "0.19.0"
 clap_complete = { version = "4", features = ["unstable-dynamic"] }
 console = "0.16"
+dotenvy = "0.15.7"
 effective-limits = "0.5.5"
 enum-map = "3.0.0"
 env_proxy = { version = "0.4.1", optional = true }

--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -1,5 +1,15 @@
 # Environment variables
 
+Rustup loads environment variables from an optional `${RUSTUP_HOME}/.env`
+file before it initializes. Variables inherited from the invoking process take
+precedence over values in this file, so they can be used for one-off overrides.
+For example:
+
+```dotenv
+RUSTUP_DIST_SERVER=https://example.com/rust-static
+RUSTUP_TOOLCHAIN=stable
+```
+
 - `RUSTUP_LOG` (default: none). Enables Rustup's "custom logging mode". In this mode,
   the verbosity of Rustup's log lines can be specified with `tracing_subscriber`'s
   [directive syntax]. For example, set `RUSTUP_LOG=rustup=DEBUG` to receive log lines

--- a/doc/user-guide/src/environment-variables.md
+++ b/doc/user-guide/src/environment-variables.md
@@ -1,8 +1,6 @@
 # Environment variables
 
-Rustup loads environment variables from an optional `${RUSTUP_HOME}/.env`
-file before it initializes. Variables inherited from the invoking process take
-precedence over values in this file, so they can be used for one-off overrides.
+Rustup loads environment variables from an optional `${RUSTUP_HOME}/.env`.
 For example:
 
 ```dotenv

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -37,6 +37,7 @@ fn main() -> Result<ExitCode> {
     pre_rustup_main_init();
 
     let process = Process::os();
+    process.load_dotenv()?;
     let runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .worker_threads(process.io_thread_count()?.into())

--- a/src/process.rs
+++ b/src/process.rs
@@ -49,10 +49,6 @@ impl Process {
         Self::OsProcess(OsProcess::new())
     }
 
-    /// Loads environment variables from the rustup configuration directory.
-    ///
-    /// This must be called before starting any threads because the process
-    /// environment is mutated by `dotenvy`.
     pub fn load_dotenv(&self) -> Result<()> {
         let path = self.rustup_home()?.join(".env");
         match dotenvy::from_path(&path) {

--- a/src/process.rs
+++ b/src/process.rs
@@ -49,6 +49,20 @@ impl Process {
         Self::OsProcess(OsProcess::new())
     }
 
+    /// Loads environment variables from the rustup configuration directory.
+    ///
+    /// This must be called before starting any threads because the process
+    /// environment is mutated by `dotenvy`.
+    pub fn load_dotenv(&self) -> Result<()> {
+        let path = self.rustup_home()?.join(".env");
+        match dotenvy::from_path(&path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.not_found() => Ok(()),
+            Err(error) => Err(error)
+                .with_context(|| format!("failed to load environment file '{}'", path.display())),
+        }
+    }
+
     pub fn name(&self) -> Option<String> {
         let arg0 = match self.var("RUSTUP_FORCE_ARG0") {
             Ok(v) => Some(v),

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -4,14 +4,15 @@ use std::{
     env::consts::EXE_SUFFIX,
     fs,
     path::{Path, PathBuf},
+    process::Command,
 };
 
 use rustup::{
     env_var::RUST_RECURSION_COUNT_MAX,
     for_host,
     test::{
-        CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_tuple,
-        topical_doc_data,
+        Assert, CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, SanitizedOutput, Scenario,
+        this_host_tuple, topical_doc_data,
     },
     utils::raw,
 };
@@ -1414,6 +1415,64 @@ installed targets:
   [HOST_TUPLE]
 
 "#]]);
+}
+
+fn run_active_toolchain_subprocess(mut command: Command) -> Assert {
+    let output = command.output().unwrap();
+    Assert::new(SanitizedOutput {
+        status: output.status.code(),
+        stdout: String::from_utf8(output.stdout).unwrap(),
+        stderr: String::from_utf8(output.stderr).unwrap(),
+    })
+}
+
+#[tokio::test]
+async fn show_toolchain_env_from_dotenv() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "toolchain", "install", "nightly", "beta"])
+        .await
+        .is_ok();
+    fs::write(
+        cx.config.rustupdir.join(".env"),
+        "RUSTUP_TOOLCHAIN=nightly\n",
+    )
+    .unwrap();
+
+    let mut command = cx.config.cmd("rustup", ["show", "active-toolchain"]);
+    command.env_remove("RUSTUP_TOOLCHAIN");
+    run_active_toolchain_subprocess(command)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+nightly-[HOST_TUPLE] (overridden by environment variable RUSTUP_TOOLCHAIN)
+
+"#]])
+        .with_stderr(snapbox::str![[""]]);
+
+    let mut command = cx.config.cmd("rustup", ["show", "active-toolchain"]);
+    command.env("RUSTUP_TOOLCHAIN", "beta");
+    run_active_toolchain_subprocess(command)
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+beta-[HOST_TUPLE] (overridden by environment variable RUSTUP_TOOLCHAIN)
+
+"#]])
+        .with_stderr(snapbox::str![[""]]);
+}
+
+#[tokio::test]
+async fn invalid_dotenv_is_reported() {
+    let cx = CliTestContext::new(Scenario::None).await;
+    fs::write(cx.config.rustupdir.join(".env"), "invalid line\n").unwrap();
+
+    let mut command = cx.config.cmd("rustup", ["--version"]);
+    command.env_remove("RUSTUP_TOOLCHAIN");
+    let output = command.output().unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    assert!(!output.status.success());
+    assert!(stderr.contains("failed to load environment file"));
+    assert!(stderr.contains(".env"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Users can add rustup only envs in `${RUSTUP_HOME}/.env` without a global shell envs.

For example, users who need rustup to access the network through an HTTP proxy can add the following to `${RUSTUP_HOME}/.env`:
```dotenv
http_proxy=http://127.0.0.1:7890
```

> ## Summary
> - Load an optional `${RUSTUP_HOME}/.env` before initializing the Tokio runtime and tracing.
> - Preserve inherited process environment variables as higher-precedence one-off overrides.
> - Ignore a missing `.env` file while reporting read and parse errors with the file path.
> - Document the configuration and test loading, precedence, and invalid-file behavior.

