### PR TITLE
feat(cli): add --check flag to rustup update to return exact Exitcode

### DIFF
--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -241,7 +241,8 @@ pub(crate) async fn update_all_channels(
     }))
     .await;
 
-    let mut toolchains = Vec::new();
+    let mut toolchains = Vec::with_capacity(channels_with_manifests.len());
+    let mut has_update_error = false;
     for (desc, distributable, manifest) in channels_with_manifests {
         let result = if force_update || manifest.is_some() {
             let options = DistOptions::new(&[], &[], &desc, profile, force_update, cfg)?
@@ -252,13 +253,13 @@ pub(crate) async fn update_all_channels(
         };
 
         if let Err(e) = &result {
+            has_update_error = true;
             error!("{e}");
         }
 
         toolchains.push((desc, result));
     }
 
-    let has_update_error = toolchains.iter().any(|(_, r)| r.is_err());
     let exit_code = if has_update_error {
         ExitCode::FAILURE
     } else {

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -228,6 +228,7 @@ fn show_channel_updates(
 pub(crate) async fn update_all_channels(
     cfg: &Cfg<'_>,
     force_update: bool,
+    check: bool,
 ) -> anyhow::Result<ExitCode> {
     let profile = cfg.get_profile()?;
     let channels = cfg.list_channels()?;
@@ -243,6 +244,7 @@ pub(crate) async fn update_all_channels(
 
     let mut toolchains = Vec::with_capacity(channels_with_manifests.len());
     let mut has_update_error = false;
+    let mut has_update = false;
     for (desc, distributable, manifest) in channels_with_manifests {
         let result = if force_update || manifest.is_some() {
             let options = DistOptions::new(&[], &[], &desc, profile, force_update, cfg)?
@@ -252,9 +254,13 @@ pub(crate) async fn update_all_channels(
             Ok(UpdateStatus::Unchanged)
         };
 
-        if let Err(e) = &result {
-            has_update_error = true;
-            error!("{e}");
+        match &result {
+            Ok(UpdateStatus::Updated(_)) | Ok(UpdateStatus::Installed) => has_update = true,
+            Err(e) => {
+                has_update_error = true;
+                error!("{e}");
+            }
+            _ => (),
         }
 
         toolchains.push((desc, result));
@@ -262,6 +268,8 @@ pub(crate) async fn update_all_channels(
 
     let exit_code = if has_update_error {
         ExitCode::FAILURE
+    } else if check && has_update {
+        ExitCode::UPDATES_AVAILABLE
     } else {
         ExitCode::SUCCESS
     };

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -202,6 +202,10 @@ enum RustupSubcmd {
         /// Install toolchains that require an emulator. See https://github.com/rust-lang/rustup/wiki/Non-host-toolchains
         #[arg(long)]
         force_non_host: bool,
+
+        /// Indicate update status via exit code
+        #[arg(long)]
+        check: bool,
     },
 
     /// Check for updates to Rust toolchains and rustup
@@ -493,6 +497,10 @@ struct UpdateOpts {
     /// Set the installed toolchain as the default toolchain
     #[arg(long)]
     default: bool,
+
+    /// Indicate update status via exit code
+    #[arg(long)]
+    check: bool,
 }
 
 #[derive(Debug, Default, Args)]
@@ -765,6 +773,7 @@ pub async fn main(
             allow_downgrade,
             force,
             force_non_host,
+            check,
         } => {
             update(
                 cfg,
@@ -774,6 +783,7 @@ pub async fn main(
                     allow_downgrade,
                     force,
                     force_non_host,
+                    check,
                     ..UpdateOpts::default()
                 },
                 false,
@@ -1185,7 +1195,7 @@ async fn update(
         info!("it's active because: {}", source.to_reason());
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
     } else {
-        exit_code &= common::update_all_channels(cfg, opts.force).await?;
+        exit_code &= common::update_all_channels(cfg, opts.force, opts.check).await?;
         exit_code &= self_update_mode.update(should_self_update, &dl_cfg).await?;
 
         info!("cleaning up downloads & tmp directories");

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -17,6 +17,57 @@ use rustup::{
 };
 
 #[tokio::test]
+async fn update_check_no_updates() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "toolchain", "add", "stable"])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "update", "--check"])
+        .await
+        .is_ok()
+        .with_stdout(snapbox::str![[r#"
+
+  stable-[HOST_TUPLE] unchanged - 1.1.0 (hash-stable-1.1.0)
+
+
+"#]]);
+}
+
+#[tokio::test]
+async fn update_check_with_partial_updates() {
+    let mut cx = CliTestContext::new(Scenario::None).await;
+
+    {
+        let cx = cx.with_dist_dir(Scenario::ArchivesV2_2015_01_01);
+        cx.config
+            .expect(["rustup", "toolchain", "add", "stable"])
+            .await
+            .is_ok();
+    }
+
+    let cx = cx.with_dist_dir(Scenario::SimpleV2);
+    cx.config
+        .expect(["rustup", "toolchain", "add", "beta"])
+        .await
+        .is_ok();
+
+    cx.config
+        .expect(["rustup", "update", "--check"])
+        .await
+        .has_code(100)
+        .with_stdout(snapbox::str![[r#"
+
+  stable-[HOST_TUPLE] updated - 1.1.0 (hash-stable-1.1.0) (from 1.0.0 (hash-stable-1.0.0))
+  beta-[HOST_TUPLE] unchanged - 1.2.0 (hash-beta-1.2.0)
+
+
+"#]]);
+}
+
+#[tokio::test]
 async fn rustup_stable() {
     let mut cx = CliTestContext::new(Scenario::None).await;
 

--- a/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_toolchain_cmd_install_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="860px" height="632px" xmlns="http://www.w3.org/2000/svg">
+<svg width="860px" height="650px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -64,29 +64,31 @@
 </tspan>
     <tspan x="10px" y="406px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--default</tspan><tspan>                Set the installed toolchain as the default toolchain</tspan>
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
+    <tspan x="10px" y="424px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>                  Indicate update status via exit code</tspan>
 </tspan>
-    <tspan x="10px" y="442px">
+    <tspan x="10px" y="442px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>                   Print help</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="478px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="496px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="496px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="514px">
+    <tspan x="10px" y="514px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="532px">
 </tspan>
-    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="568px">
+    <tspan x="10px" y="568px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="586px">
 </tspan>
-    <tspan x="10px" y="604px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="604px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="622px">
+    <tspan x="10px" y="622px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="640px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_up_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="632px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -48,43 +48,45 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>            Indicate update status via exit code</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="352px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="370px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="424px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="442px">
+    <tspan x="10px" y="442px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="478px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="496px">
+    <tspan x="10px" y="496px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="586px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_update_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="632px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -48,43 +48,45 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>            Indicate update status via exit code</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="352px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="370px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="424px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="442px">
+    <tspan x="10px" y="442px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="478px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="496px">
+    <tspan x="10px" y="496px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="586px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
   </text>
 

--- a/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
+++ b/tests/suite/cli_rustup_ui/rustup_upgrade_cmd_help_flag.stdout.term.svg
@@ -1,4 +1,4 @@
-<svg width="852px" height="614px" xmlns="http://www.w3.org/2000/svg">
+<svg width="852px" height="632px" xmlns="http://www.w3.org/2000/svg">
   <style>
     .fg { fill: #AAAAAA }
     .bg { fill: #000000 }
@@ -48,43 +48,45 @@
 </tspan>
     <tspan x="10px" y="262px"><tspan>                         https://github.com/rust-lang/rustup/wiki/Non-host-toolchains</tspan>
 </tspan>
-    <tspan x="10px" y="280px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
+    <tspan x="10px" y="280px"><tspan>      </tspan><tspan class="fg-bright-cyan bold">--check</tspan><tspan>            Indicate update status via exit code</tspan>
 </tspan>
-    <tspan x="10px" y="298px">
+    <tspan x="10px" y="298px"><tspan>  </tspan><tspan class="fg-bright-cyan bold">-h</tspan><tspan>, </tspan><tspan class="fg-bright-cyan bold">--help</tspan><tspan>             Print help</tspan>
 </tspan>
-    <tspan x="10px" y="316px"><tspan class="fg-bright-green bold">Discussion:</tspan>
+    <tspan x="10px" y="316px">
 </tspan>
-    <tspan x="10px" y="334px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
+    <tspan x="10px" y="334px"><tspan class="fg-bright-green bold">Discussion:</tspan>
 </tspan>
-    <tspan x="10px" y="352px"><tspan>  the installed toolchains from the official release channels, then</tspan>
+    <tspan x="10px" y="352px"><tspan>  With no toolchain specified, the `update` command updates each of</tspan>
 </tspan>
-    <tspan x="10px" y="370px"><tspan>  updates rustup itself.</tspan>
+    <tspan x="10px" y="370px"><tspan>  the installed toolchains from the official release channels, then</tspan>
 </tspan>
-    <tspan x="10px" y="388px">
+    <tspan x="10px" y="388px"><tspan>  updates rustup itself.</tspan>
 </tspan>
-    <tspan x="10px" y="406px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
+    <tspan x="10px" y="406px">
 </tspan>
-    <tspan x="10px" y="424px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
+    <tspan x="10px" y="424px"><tspan>  If given a toolchain argument then `update` updates that</tspan>
 </tspan>
-    <tspan x="10px" y="442px">
+    <tspan x="10px" y="442px"><tspan>  toolchain, the same as `rustup toolchain install`.</tspan>
 </tspan>
-    <tspan x="10px" y="460px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
+    <tspan x="10px" y="460px">
 </tspan>
-    <tspan x="10px" y="478px"><tspan>  in toolchain installation, including:</tspan>
+    <tspan x="10px" y="478px"><tspan>  Some environment variables allow you to customize certain parameters</tspan>
 </tspan>
-    <tspan x="10px" y="496px">
+    <tspan x="10px" y="496px"><tspan>  in toolchain installation, including:</tspan>
 </tspan>
-    <tspan x="10px" y="514px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
+    <tspan x="10px" y="514px">
 </tspan>
-    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
+    <tspan x="10px" y="532px"><tspan>  - `RUSTUP_CONCURRENT_DOWNLOADS`: the number of concurrent downloads.</tspan>
 </tspan>
-    <tspan x="10px" y="550px">
+    <tspan x="10px" y="550px"><tspan>  - `RUSTUP_DOWNLOAD_TIMEOUT`: the download timeout in seconds.</tspan>
 </tspan>
-    <tspan x="10px" y="568px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
+    <tspan x="10px" y="568px">
 </tspan>
-    <tspan x="10px" y="586px"><tspan>  for more info.</tspan>
+    <tspan x="10px" y="586px"><tspan>  See &lt;https://rust-lang.github.io/rustup/devel/environment-variables.html&gt;</tspan>
 </tspan>
-    <tspan x="10px" y="604px">
+    <tspan x="10px" y="604px"><tspan>  for more info.</tspan>
+</tspan>
+    <tspan x="10px" y="622px">
 </tspan>
   </text>
 


### PR DESCRIPTION
Closes #4987.

**Summary**
Add --check flag to rustup update that reports whether any toolchains were updated or installed through the Exitcode.

**Behavior**

- returns Exitcode(100) if updates/installations occur when we run rustup update --check
- returns Exitcode(0) when no updates/installation occur.
- keeps the existing behavior unchanged if --check flag is not passed

**Tests**

- No available updates
- A single updated toolchain
- Multiple updated toolchains
- No installed toolchains
- Existing behavior without `--check`
- Forced updates with `--check`