### PR TITLE
test(clitools): refine error messages of exit code assertions

### DIFF
--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -187,19 +187,22 @@ impl Assert {
     }
 
     /// Asserts that the command exited with an ok status.
+    #[track_caller]
     pub fn is_ok(&self) -> &Self {
         self.has_code(0)
     }
 
     /// Asserts that the command exited with an error.
+    #[track_caller]
     pub fn is_err(&self) -> &Self {
-        assert_ne!(self.output.status, Some(0));
+        assert_ne!(self.output.status, Some(0), "unexpected command success");
         self
     }
 
     /// Asserts that the command exited with the specific code.
+    #[track_caller]
     pub fn has_code(&self, code: i32) -> &Self {
-        assert_eq!(self.output.status, Some(code));
+        assert_eq!(self.output.status, Some(code), "unexpected command failure");
         self
     }
 


### PR DESCRIPTION
From interactions with new contributors here I have realized that the source position in E2E tests are incorrect (from a DX perspective), and a plain `assert_eq!()` output without any explanation can be confusing at times.

So this simple patch aims to improve that experience by adding simple error messages and using the right positions:

Before:

```smalltalk
thread 'suite::cli_exact::update_once' (25194046) panicked at src/test/clitools.rs:202:9:
assertion `left == right` failed
  left: Some(1)
 right: Some(0)
```

After:

```smalltalk
thread 'suite::cli_exact::update_once' (25191171) panicked at tests/suite/cli_exact.rs:15:10:
assertion `left == right` failed: unexpected command failure
  left: Some(1)
 right: Some(0)
```

The position anchors like `tests/suite/cli_exact.rs:15:10` should be sufficient in guiding the developer to the failed assertion with a simple click on most IDEs.

This patch is a no-op when the tests pass, but IMHO it's a good DX improvement nonetheless.