### PR TITLE
style: qualify `anyhow::Result<>` everywhere

### DIFF
--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -15,7 +15,7 @@
 
 use std::process::ExitCode;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 // Public macros require availability of the internal symbols
 use rs_tracing::{
     close_trace_file, close_trace_file_internal, open_trace_file, trace_to_file_internal,
@@ -32,7 +32,7 @@ use rustup::is_proxyable_tools;
 use rustup::process::Process;
 use rustup::utils;
 
-fn main() -> Result<ExitCode> {
+fn main() -> anyhow::Result<ExitCode> {
     #[cfg(windows)]
     pre_rustup_main_init();
 
@@ -65,7 +65,7 @@ fn main() -> Result<ExitCode> {
 async fn run_rustup(
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,
-) -> Result<utils::ExitCode> {
+) -> anyhow::Result<utils::ExitCode> {
     if let Ok(dir) = process.var("RUSTUP_TRACE_DIR") {
         open_trace_file!(dir)?;
     }
@@ -80,7 +80,7 @@ async fn run_rustup(
 async fn run_rustup_inner(
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,
-) -> Result<utils::ExitCode> {
+) -> anyhow::Result<utils::ExitCode> {
     // Guard against infinite proxy recursion. This mostly happens due to
     // bugs in rustup.
     do_recursion_guard(process)?;
@@ -124,7 +124,7 @@ async fn run_rustup_inner(
     }
 }
 
-fn do_recursion_guard(process: &Process) -> Result<()> {
+fn do_recursion_guard(process: &Process) -> anyhow::Result<()> {
     let recursion_count = process
         .var("RUST_RECURSION_COUNT")
         .ok()

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -8,7 +8,7 @@ use std::sync::LazyLock;
 use std::{cmp, env};
 
 use anstyle::Style;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use clap_cargo::style::{CONTEXT, ERROR, UPDATE_ADDED, UPDATE_UNCHANGED, UPDATE_UPGRADED};
 use futures_util::future::join_all;
 use git_testament::{git_testament, render_testament};
@@ -29,7 +29,7 @@ pub(crate) const WARN_COMPLETE_PROFILE: &str = "\
 downloading with the `complete` profile is deprecated
 help: consider switching to the `default` profile with `rustup set profile default`";
 
-pub(crate) fn confirm(question: &str, default: bool, process: &Process) -> Result<bool> {
+pub(crate) fn confirm(question: &str, default: bool, process: &Process) -> anyhow::Result<bool> {
     write!(process.stdout().lock(), "{question} ")?;
     let _ = std::io::stdout().flush();
     let input = read_line(process)?;
@@ -52,7 +52,10 @@ pub(crate) enum Confirm {
     Advanced,
 }
 
-pub(crate) fn confirm_advanced(customized_install: bool, process: &Process) -> Result<Confirm> {
+pub(crate) fn confirm_advanced(
+    customized_install: bool,
+    process: &Process,
+) -> anyhow::Result<Confirm> {
     writeln!(process.stdout().lock())?;
     let first_option = match customized_install {
         true => "1) Proceed with selected options (default - just press enter)",
@@ -77,7 +80,11 @@ pub(crate) fn confirm_advanced(customized_install: bool, process: &Process) -> R
     Ok(r)
 }
 
-pub(crate) fn question_str(question: &str, default: &str, process: &Process) -> Result<String> {
+pub(crate) fn question_str(
+    question: &str,
+    default: &str,
+    process: &Process,
+) -> anyhow::Result<String> {
     writeln!(process.stdout().lock(), "{question} [{default}]")?;
     let _ = std::io::stdout().flush();
     let input = read_line(process)?;
@@ -91,7 +98,11 @@ pub(crate) fn question_str(question: &str, default: &str, process: &Process) -> 
     }
 }
 
-pub(crate) fn question_bool(question: &str, default: bool, process: &Process) -> Result<bool> {
+pub(crate) fn question_bool(
+    question: &str,
+    default: bool,
+    process: &Process,
+) -> anyhow::Result<bool> {
     let default_text = if default { "(Y/n)" } else { "(y/N)" };
     writeln!(process.stdout().lock(), "{question} {default_text}")?;
 
@@ -111,7 +122,7 @@ pub(crate) fn question_bool(question: &str, default: bool, process: &Process) ->
     }
 }
 
-pub(crate) fn read_line(process: &Process) -> Result<String> {
+pub(crate) fn read_line(process: &Process) -> anyhow::Result<String> {
     let stdin = process.stdin();
     let stdin = stdin.lock();
     let mut lines = stdin.lines();
@@ -126,8 +137,8 @@ pub(crate) fn read_line(process: &Process) -> Result<String> {
 pub(crate) fn show_channel_update(
     cfg: &Cfg<'_>,
     name: PackageUpdate,
-    updated: Result<UpdateStatus>,
-) -> Result<()> {
+    updated: anyhow::Result<UpdateStatus>,
+) -> anyhow::Result<()> {
     show_channel_updates(cfg, vec![(name, updated)])
 }
 
@@ -147,8 +158,8 @@ impl Display for PackageUpdate {
 
 fn show_channel_updates(
     cfg: &Cfg<'_>,
-    updates: Vec<(PackageUpdate, Result<UpdateStatus>)>,
-) -> Result<()> {
+    updates: Vec<(PackageUpdate, anyhow::Result<UpdateStatus>)>,
+) -> anyhow::Result<()> {
     let data = updates.into_iter().map(|(pkg, result)| {
         let (banner, style) = match &result {
             Ok(UpdateStatus::Installed) => ("installed", UPDATE_ADDED),
@@ -195,7 +206,7 @@ fn show_channel_updates(
     let t = cfg.process.stdout();
     let mut t = t.lock();
 
-    let data: Vec<_> = data.collect::<Result<_>>()?;
+    let data = data.collect::<anyhow::Result<Vec<_>>>()?;
     let max_width = data
         .iter()
         .fold(0, |a, &(_, _, width, _, _, _)| cmp::max(a, width));
@@ -214,7 +225,10 @@ fn show_channel_updates(
     Ok(())
 }
 
-pub(crate) async fn update_all_channels(cfg: &Cfg<'_>, force_update: bool) -> Result<ExitCode> {
+pub(crate) async fn update_all_channels(
+    cfg: &Cfg<'_>,
+    force_update: bool,
+) -> anyhow::Result<ExitCode> {
     let profile = cfg.get_profile()?;
     let channels = cfg.list_channels()?;
 
@@ -277,7 +291,7 @@ pub(super) fn list_items(
     installed_only: bool,
     quiet: bool,
     process: &Process,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let t = process.stdout();
     let mut t = t.lock();
     let bold = Style::new().bold();
@@ -291,7 +305,11 @@ pub(super) fn list_items(
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) async fn list_toolchains(cfg: &Cfg<'_>, verbose: bool, quiet: bool) -> Result<ExitCode> {
+pub(crate) async fn list_toolchains(
+    cfg: &Cfg<'_>,
+    verbose: bool,
+    quiet: bool,
+) -> anyhow::Result<ExitCode> {
     let toolchains = cfg.list_toolchains()?;
     if toolchains.is_empty() {
         writeln!(cfg.process.stdout().lock(), "no installed toolchains")?;
@@ -329,7 +347,7 @@ pub(crate) async fn list_toolchains(cfg: &Cfg<'_>, verbose: bool, quiet: bool) -
         is_active: bool,
         verbose: bool,
         quiet: bool,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         if quiet {
             writeln!(cfg.process.stdout().lock(), "{toolchain}")?;
             return Ok(());
@@ -364,7 +382,7 @@ pub(crate) async fn list_toolchains(cfg: &Cfg<'_>, verbose: bool, quiet: bool) -
     Ok(ExitCode::SUCCESS)
 }
 
-pub(crate) fn list_overrides(cfg: &Cfg<'_>) -> Result<ExitCode> {
+pub(crate) fn list_overrides(cfg: &Cfg<'_>) -> anyhow::Result<ExitCode> {
     let overrides = cfg.settings_file.with(|s| Ok(s.overrides.clone()))?;
 
     if overrides.is_empty() {
@@ -405,7 +423,7 @@ pub(crate) fn version() -> &'static str {
     &RENDERED
 }
 
-pub(crate) fn dump_testament(process: &Process) -> Result<ExitCode> {
+pub(crate) fn dump_testament(process: &Process) -> anyhow::Result<ExitCode> {
     use git_testament::GitModification::*;
     writeln!(
         process.stdout().lock(),
@@ -493,7 +511,7 @@ pub(crate) fn ignorable_error(
     error: &'static str,
     no_prompt: bool,
     process: &Process,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let error = anyhow!(error);
     report_error(&error, process);
     if no_prompt {
@@ -515,7 +533,7 @@ pub(crate) fn check_non_host_toolchain(
     host_arch: &TargetTuple,
     target_tuple: &TargetTuple,
     force_non_host: bool,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     if force_non_host || host_arch.can_run(target_tuple)? {
         return Ok(());
     }

--- a/src/cli/docs.rs
+++ b/src/cli/docs.rs
@@ -17,7 +17,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use clap::Args;
 use http_body_util::Full;
 use hyper::{
@@ -187,7 +187,7 @@ pub(crate) async fn doc(
     toolchain: Option<PartialToolchainDesc>,
     mut topic: Option<&str>,
     doc_page: &DocPage,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
     let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
 
@@ -254,7 +254,7 @@ pub(crate) async fn man(
     cfg: &Cfg<'_>,
     command: &str,
     toolchain: Option<PartialToolchainDesc>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
     let toolchain = cfg.toolchain_from_partial(toolchain).await?.0;
     let path = toolchain.man_path();
@@ -275,7 +275,11 @@ pub(crate) async fn man(
 
 /// Blocks forever, accepting and serving connections until the process is
 /// killed by Ctrl-C.
-async fn serve_and_open(root: PathBuf, initial_path: &Path, fragment: Option<&str>) -> Result<()> {
+async fn serve_and_open(
+    root: PathBuf,
+    initial_path: &Path,
+    fragment: Option<&str>,
+) -> anyhow::Result<()> {
     let listener = TcpListener::bind(("127.0.0.1", 0))
         .await
         .context("failed to bind local documentation server")?;
@@ -319,7 +323,7 @@ async fn serve_and_open(root: PathBuf, initial_path: &Path, fragment: Option<&st
 async fn serve(
     req: Request<Incoming>,
     root: Arc<Path>,
-) -> Result<Response<Full<Bytes>>, Infallible> {
+) -> anyhow::Result<Response<Full<Bytes>>, Infallible> {
     let request_path = req.uri().path().trim_start_matches('/');
     let mut path = root.to_path_buf();
     for segment in Path::new(request_path).components() {

--- a/src/cli/proxy_mode.rs
+++ b/src/cli/proxy_mode.rs
@@ -1,7 +1,5 @@
 use std::{path::PathBuf, process::ExitStatus, str::FromStr};
 
-use anyhow::Result;
-
 use crate::{
     cli::{job, self_update},
     command::run_command_for_dir,
@@ -11,7 +9,11 @@ use crate::{
 };
 
 #[tracing::instrument(level = "trace", skip(process))]
-pub async fn main(arg0: &str, current_dir: PathBuf, process: &Process) -> Result<ExitStatus> {
+pub async fn main(
+    arg0: &str,
+    current_dir: PathBuf,
+    process: &Process,
+) -> anyhow::Result<ExitStatus> {
     self_update::cleanup_self_updater(process)?;
 
     let _setup = job::setup();

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -13,7 +13,7 @@ use std::{
 
 use anstream::ColorChoice;
 use anstyle::Style;
-use anyhow::{Error, Result, anyhow};
+use anyhow::{Error, anyhow};
 use clap::{
     Args, CommandFactory, Parser, Subcommand, ValueEnum,
     builder::{PossibleValue, ValueHint},
@@ -66,7 +66,7 @@ use crate::{
 const TOOLCHAIN_OVERRIDE_ERROR: &str = "To override the toolchain using the 'rustup +toolchain' syntax, \
                         make sure to prefix the toolchain override with a '+'";
 
-fn handle_epipe(res: Result<ExitCode>) -> Result<ExitCode> {
+fn handle_epipe(res: anyhow::Result<ExitCode>) -> anyhow::Result<ExitCode> {
     match res {
         Err(e) => {
             let root = e.root_cause();
@@ -306,7 +306,7 @@ enum RustupSubcmd {
     },
 }
 
-fn update_toolchain_value_parser(s: &str) -> Result<PartialToolchainDesc> {
+fn update_toolchain_value_parser(s: &str) -> anyhow::Result<PartialToolchainDesc> {
     PartialToolchainDesc::from_str(s).inspect_err(|_| {
         if s == "self" {
             info!("if you meant to update rustup itself, use `rustup self update`");
@@ -679,7 +679,7 @@ pub async fn main(
     current_dir: PathBuf,
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let cfg = &mut Cfg::from_env(current_dir, true, false, process)?;
     clap_complete::CompleteEnv::with_factory(|| completion_command(cfg))
         .var("RUSTUP_COMPLETE")
@@ -906,7 +906,7 @@ async fn default_(
     cfg: &Cfg<'_>,
     toolchain: Option<MaybeResolvableToolchainName>,
     force_non_host: bool,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
     if let Some(toolchain) = toolchain {
@@ -951,7 +951,7 @@ async fn default_(
     Ok(ExitCode::SUCCESS)
 }
 
-async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> Result<ExitCode> {
+async fn check_updates(cfg: &Cfg<'_>, opts: CheckOpts) -> anyhow::Result<ExitCode> {
     let t = cfg.process.stdout();
     let use_colors = matches!(t.color_choice(), ColorChoice::Auto | ColorChoice::Always);
     let mut update_available = false;
@@ -1094,7 +1094,7 @@ async fn update(
     cfg: &mut Cfg<'_>,
     opts: UpdateOpts,
     ensure_active_toolchain: bool,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let mut exit_code = ExitCode::SUCCESS;
 
     common::warn_if_host_is_emulated(cfg.process);
@@ -1192,7 +1192,7 @@ async fn run(
     toolchain: ResolvableLocalToolchainName,
     command: Vec<String>,
     install: bool,
-) -> Result<ExitStatus> {
+) -> anyhow::Result<ExitStatus> {
     let toolchain = toolchain.resolve(&cfg.default_host_tuple()?)?;
     let toolchain = Toolchain::from_local(toolchain, install, cfg).await?;
     let cmd = toolchain.command(&command[0])?;
@@ -1203,7 +1203,7 @@ async fn which(
     cfg: &Cfg<'_>,
     binary: &str,
     toolchain: Option<ResolvableToolchainName>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let (toolchain, _) = cfg
         .local_toolchain(match toolchain {
             Some(name) => Some((
@@ -1238,7 +1238,7 @@ async fn which(
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
-async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
+async fn show(cfg: &Cfg<'_>, verbose: bool) -> anyhow::Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
     let t = cfg.process.stdout();
@@ -1372,7 +1372,7 @@ async fn show(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
-async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode> {
+async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> anyhow::Result<ExitCode> {
     match cfg.maybe_ensure_active_toolchain(None).await? {
         Some((toolchain_name, source)) => {
             let toolchain = Toolchain::with_source(cfg, toolchain_name, &source)?;
@@ -1403,7 +1403,7 @@ async fn show_active_toolchain(cfg: &Cfg<'_>, verbose: bool) -> Result<ExitCode>
 }
 
 #[tracing::instrument(level = "trace", skip_all)]
-fn show_rustup_home(cfg: &Cfg<'_>) -> Result<ExitCode> {
+fn show_rustup_home(cfg: &Cfg<'_>) -> anyhow::Result<ExitCode> {
     writeln!(cfg.process.stdout().lock(), "{}", cfg.rustup_dir.display())?;
     Ok(ExitCode::SUCCESS)
 }
@@ -1413,7 +1413,7 @@ async fn target_list(
     toolchain: Option<PartialToolchainDesc>,
     installed_only: bool,
     quiet: bool,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
 
     // If a toolchain is Distributable, we can assume it has a manifest and thus print all possible targets and the installed ones.
@@ -1447,7 +1447,7 @@ async fn target_add(
     cfg: &Cfg<'_>,
     mut targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     // XXX: long term move this error to cli ? the normal .into doesn't work
     // because Result here is the wrong sort and expression type ascription
     // isn't a feature yet.
@@ -1506,7 +1506,7 @@ async fn target_remove(
     cfg: &Cfg<'_>,
     targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let distributable = DistributableToolchain::from_partial(
         toolchain.map(|desc| (desc, ActiveSource::CommandLine)),
         cfg,
@@ -1547,7 +1547,7 @@ async fn component_list(
     toolchain: Option<PartialToolchainDesc>,
     installed_only: bool,
     quiet: bool,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
 
     // downcasting required because the toolchain files can name any toolchain
@@ -1580,7 +1580,7 @@ async fn component_add(
     components: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
     target: Option<String>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let distributable = DistributableToolchain::from_partial(
         toolchain.map(|desc| (desc, ActiveSource::CommandLine)),
         cfg,
@@ -1594,7 +1594,7 @@ async fn component_add(
             components
                 .into_iter()
                 .map(|component| Component::try_new(&component, &distributable, target.as_ref()))
-                .collect::<Result<_>>()?,
+                .collect::<anyhow::Result<_>>()?,
         )
         .await?;
 
@@ -1615,7 +1615,7 @@ async fn component_remove(
     components: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
     target: Option<String>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain = toolchain.map(|desc| (desc, ActiveSource::CommandLine));
     let distributable = DistributableToolchain::from_partial(toolchain, cfg).await?;
     let target = get_target(target, &distributable);
@@ -1623,7 +1623,7 @@ async fn component_remove(
     let parsed_components = components
         .iter()
         .map(|component| Component::try_new(component, &distributable, target.as_ref()))
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<anyhow::Result<Vec<_>>>()?;
 
     let mut unknown_components = Vec::new();
 
@@ -1653,7 +1653,11 @@ async fn component_remove(
     }
 }
 
-async fn toolchain_link(cfg: &Cfg<'_>, dest: &CustomToolchainName, src: &Path) -> Result<ExitCode> {
+async fn toolchain_link(
+    cfg: &Cfg<'_>,
+    dest: &CustomToolchainName,
+    src: &Path,
+) -> anyhow::Result<ExitCode> {
     cfg.ensure_toolchains_dir()?;
     let mut pathbuf = PathBuf::from(src);
 
@@ -1680,7 +1684,7 @@ async fn toolchain_link(cfg: &Cfg<'_>, dest: &CustomToolchainName, src: &Path) -
     Ok(ExitCode::SUCCESS)
 }
 
-async fn toolchain_remove(cfg: &Cfg<'_>, opts: UninstallOpts) -> Result<ExitCode> {
+async fn toolchain_remove(cfg: &Cfg<'_>, opts: UninstallOpts) -> anyhow::Result<ExitCode> {
     let default_toolchain = cfg.get_default().ok().flatten();
     let active_toolchain = cfg
         .maybe_ensure_active_toolchain(Some(false))
@@ -1718,7 +1722,7 @@ async fn override_add(
     cfg: &Cfg<'_>,
     toolchain: ResolvableToolchainName,
     path: Option<&Path>,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     let toolchain_name = toolchain.clone().resolve(&cfg.default_host_tuple()?)?;
     match Toolchain::new(cfg, toolchain_name.clone().into()) {
         Ok(_) => {}
@@ -1742,7 +1746,11 @@ async fn override_add(
     Ok(ExitCode::SUCCESS)
 }
 
-fn override_remove(cfg: &Cfg<'_>, path: Option<&Path>, nonexistent: bool) -> Result<ExitCode> {
+fn override_remove(
+    cfg: &Cfg<'_>,
+    path: Option<&Path>,
+    nonexistent: bool,
+) -> anyhow::Result<ExitCode> {
     let paths = if nonexistent {
         let list: Vec<_> = cfg.settings_file.with(|s| {
             Ok(s.overrides
@@ -1779,7 +1787,10 @@ fn override_remove(cfg: &Cfg<'_>, path: Option<&Path>, nonexistent: bool) -> Res
     Ok(ExitCode::SUCCESS)
 }
 
-fn set_auto_self_update(cfg: &Cfg<'_>, auto_self_update_mode: SelfUpdateMode) -> Result<ExitCode> {
+fn set_auto_self_update(
+    cfg: &Cfg<'_>,
+    auto_self_update_mode: SelfUpdateMode,
+) -> anyhow::Result<ExitCode> {
     if cfg!(feature = "no-self-update") {
         let mut args = cfg.process.args_os();
         let arg0 = args.next().map(PathBuf::from);
@@ -1828,7 +1839,7 @@ fn output_completion_script(
     shell: Shell,
     command: CompletionCommand,
     process: &Process,
-) -> Result<ExitCode> {
+) -> anyhow::Result<ExitCode> {
     match command {
         CompletionCommand::Rustup => {
             clap_complete::generate(
@@ -1867,7 +1878,7 @@ fn output_completion_script(
     Ok(ExitCode::SUCCESS)
 }
 
-async fn display_version(cfg: &mut Cfg<'_>) -> Result<()> {
+async fn display_version(cfg: &mut Cfg<'_>) -> anyhow::Result<()> {
     info!("this is the version for the rustup toolchain manager, not the rustc compiler");
     cfg.toolchain_override = cfg
         .process

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1859,9 +1859,7 @@ fn output_completion_script(
                 Shell::Zsh => "/share/zsh/site-functions/_cargo",
                 _ => {
                     return Err(anyhow!(
-                        "{} does not currently support completions for {}",
-                        command,
-                        shell
+                        "{command} does not currently support completions for {shell}"
                     ));
                 }
             };

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -43,7 +43,7 @@ use std::{
 };
 
 use anstyle::Style;
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use clap::{ValueEnum, builder::PossibleValue};
 use clap_cargo::style::{GOOD, WARN};
 use itertools::Itertools;
@@ -124,7 +124,7 @@ impl InstallOpts<'_> {
         no_prompt: bool,
         quiet: bool,
         process: &Process,
-    ) -> Result<ExitCode> {
+    ) -> anyhow::Result<ExitCode> {
         #[cfg_attr(not(unix), allow(unused_mut))]
         let mut exit_code = ExitCode::SUCCESS;
 
@@ -242,7 +242,7 @@ impl InstallOpts<'_> {
         current_dir: PathBuf,
         quiet: bool,
         process: &Process,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         install_bins(process)?;
 
         #[cfg(unix)]
@@ -302,7 +302,7 @@ impl InstallOpts<'_> {
     /// This function first initializes the default profile and default host tuple in the
     /// configuration, then returns the toolchain that should be installed, or `None` if none is
     /// specified by the user.
-    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> Result<Option<PartialToolchainDesc>> {
+    fn select_toolchain(self, cfg: &mut Cfg<'_>) -> anyhow::Result<Option<PartialToolchainDesc>> {
         let Self {
             default_host_tuple,
             default_toolchain,
@@ -378,7 +378,7 @@ impl InstallOpts<'_> {
     }
 
     // Interactive editing of the install options
-    fn customize(&mut self, process: &Process) -> Result<()> {
+    fn customize(&mut self, process: &Process) -> anyhow::Result<()> {
         writeln!(
             process.stdout().lock(),
             "I'm going to ask you the value of each of these installation options.\n\
@@ -422,7 +422,7 @@ impl InstallOpts<'_> {
         Ok(())
     }
 
-    fn validate(&self, process: &Process) -> Result<()> {
+    fn validate(&self, process: &Process) -> anyhow::Result<()> {
         common::warn_if_host_is_emulated(process);
 
         let host_tuple = self
@@ -474,7 +474,7 @@ pub enum SelfUpdateMode {
 }
 
 impl SelfUpdateMode {
-    pub(crate) fn from_cfg(cfg: &Cfg<'_>) -> Result<Self> {
+    pub(crate) fn from_cfg(cfg: &Cfg<'_>) -> anyhow::Result<Self> {
         if cfg.process.is_ci() {
             return Ok(Self::Disable);
         }
@@ -508,7 +508,7 @@ impl SelfUpdateMode {
         &self,
         should_self_update: bool,
         dl_cfg: &DownloadCfg<'_>,
-    ) -> Result<ExitCode> {
+    ) -> anyhow::Result<ExitCode> {
         if cfg!(feature = "no-self-update") {
             info!("self-update is disabled for this build of rustup");
             info!("any updates to rustup will need to be fetched with your system package manager");
@@ -563,7 +563,7 @@ impl ValueEnum for SelfUpdateMode {
 impl FromStr for SelfUpdateMode {
     type Err = anyhow::Error;
 
-    fn from_str(mode: &str) -> Result<Self> {
+    fn from_str(mode: &str) -> anyhow::Result<Self> {
         match mode {
             "enable" => Ok(Self::Enable),
             "disable" => Ok(Self::Disable),
@@ -594,7 +594,7 @@ fn update_root(process: &Process) -> String {
 
 /// `CARGO_HOME` suitable for display, possibly with $HOME
 /// substituted for the directory prefix
-fn canonical_cargo_home(process: &Process) -> Result<Cow<'static, str>> {
+fn canonical_cargo_home(process: &Process) -> anyhow::Result<Cow<'static, str>> {
     let path = process.cargo_home()?;
 
     let default_cargo_home = process
@@ -611,7 +611,7 @@ fn canonical_cargo_home(process: &Process) -> Result<Cow<'static, str>> {
     })
 }
 
-fn rustc_or_cargo_exists_in_path(process: &Process) -> Result<()> {
+fn rustc_or_cargo_exists_in_path(process: &Process) -> anyhow::Result<()> {
     // Ignore rustc and cargo if present in $HOME/.cargo/bin or a few other directories
     #[allow(clippy::ptr_arg)]
     fn ignore_paths(path: &PathBuf) -> bool {
@@ -635,7 +635,10 @@ fn rustc_or_cargo_exists_in_path(process: &Process) -> Result<()> {
     Ok(())
 }
 
-fn check_existence_of_rustc_or_cargo_in_path(no_prompt: bool, process: &Process) -> Result<()> {
+fn check_existence_of_rustc_or_cargo_in_path(
+    no_prompt: bool,
+    process: &Process,
+) -> anyhow::Result<()> {
     // Only the test runner should set this
     let skip_check = process.var_os("RUSTUP_INIT_SKIP_PATH_CHECK");
 
@@ -659,7 +662,7 @@ fn check_existence_of_rustc_or_cargo_in_path(no_prompt: bool, process: &Process)
     Ok(())
 }
 
-fn check_existence_of_settings_file(process: &Process) -> Result<()> {
+fn check_existence_of_settings_file(process: &Process) -> anyhow::Result<()> {
     let rustup_dir = process.rustup_home()?;
     let settings_file = SettingsFile::new(rustup_dir.join("settings.toml"));
     if !utils::path_exists(&settings_file.path) {
@@ -682,7 +685,7 @@ fn check_existence_of_settings_file(process: &Process) -> Result<()> {
     Ok(())
 }
 
-fn pre_install_msg(no_modify_path: bool, process: &Process) -> Result<String> {
+fn pre_install_msg(no_modify_path: bool, process: &Process) -> anyhow::Result<String> {
     let cargo_home = process.cargo_home()?;
     let cargo_home_bin = cargo_home.join("bin");
     let rustup_home = home::rustup_home()?;
@@ -768,7 +771,7 @@ fn warn_if_default_linker_missing(process: &Process) {
     }
 }
 
-fn install_bins(process: &Process) -> Result<()> {
+fn install_bins(process: &Process) -> anyhow::Result<()> {
     let bin_path = process.cargo_home()?.join("bin");
     let this_exe_path = utils::current_exe()?;
     let rustup_path = bin_path.join(format!("rustup{EXE_SUFFIX}"));
@@ -784,7 +787,7 @@ fn install_bins(process: &Process) -> Result<()> {
     install_proxies(process)
 }
 
-pub(crate) fn install_proxies(process: &Process) -> Result<()> {
+pub(crate) fn install_proxies(process: &Process) -> anyhow::Result<()> {
     install_proxies_with_opts(
         process,
         // HACK: On Windows CI machines, some Docker setups don't like symlinks, so we force hard
@@ -795,7 +798,7 @@ pub(crate) fn install_proxies(process: &Process) -> Result<()> {
     )
 }
 
-fn install_proxies_with_opts(process: &Process, force_hard_links: bool) -> Result<()> {
+fn install_proxies_with_opts(process: &Process, force_hard_links: bool) -> anyhow::Result<()> {
     let bin_path = process.cargo_home()?.join("bin");
     let rustup_path = bin_path.join(format!("rustup{EXE_SUFFIX}"));
 
@@ -897,7 +900,11 @@ fn install_proxies_with_opts(process: &Process, force_hard_links: bool) -> Resul
     Ok(())
 }
 
-fn check_proxy_sanity(process: &Process, components: &[&str], desc: &ToolchainDesc) -> Result<()> {
+fn check_proxy_sanity(
+    process: &Process,
+    components: &[&str],
+    desc: &ToolchainDesc,
+) -> anyhow::Result<()> {
     let bin_path = process.cargo_home()?.join("bin");
 
     // Sometimes linking a proxy produces an unpredictable result, where the proxy
@@ -928,7 +935,11 @@ fn check_proxy_sanity(process: &Process, components: &[&str], desc: &ToolchainDe
 /// 5. Try to remove $CARGO_HOME/bin directory if it's empty.
 /// 6. Upon successfully removing $CARGO_HOME/bin, clean up $PATH.
 /// 7. Try to remove $CARGO_HOME directory if it's empty.
-pub(crate) fn uninstall(no_prompt: bool, no_modify_path: bool, cfg: &Cfg<'_>) -> Result<ExitCode> {
+pub(crate) fn uninstall(
+    no_prompt: bool,
+    no_modify_path: bool,
+    cfg: &Cfg<'_>,
+) -> anyhow::Result<ExitCode> {
     if cfg!(feature = "no-self-update") {
         error!("self-uninstall is disabled for this build of rustup");
         error!("you should probably use your system package manager to uninstall rustup");
@@ -991,7 +1002,7 @@ pub(crate) fn uninstall(no_prompt: bool, no_modify_path: bool, cfg: &Cfg<'_>) ->
 /// This removes non-`bin` entries in `$CARGO_HOME`, removes rustup tool links and executable from
 /// `$CARGO_HOME/bin`, then removes `$CARGO_HOME/bin` and `$CARGO_HOME` only if they are empty.
 /// Nonempty directories are left in place.
-fn clean_cargo_home(no_modify_path: bool, process: &Process) -> Result<()> {
+fn clean_cargo_home(no_modify_path: bool, process: &Process) -> anyhow::Result<()> {
     let cargo_home = process.cargo_home()?;
     let cargo_bin = cargo_home.join("bin");
 
@@ -1082,12 +1093,12 @@ pub(crate) enum SelfUpdatePermission {
 }
 
 #[cfg(windows)]
-pub(crate) fn self_update_permitted(_explicit: bool) -> Result<SelfUpdatePermission> {
+pub(crate) fn self_update_permitted(_explicit: bool) -> anyhow::Result<SelfUpdatePermission> {
     Ok(SelfUpdatePermission::Permit)
 }
 
 #[cfg(not(windows))]
-pub(crate) fn self_update_permitted(explicit: bool) -> Result<SelfUpdatePermission> {
+pub(crate) fn self_update_permitted(explicit: bool) -> anyhow::Result<SelfUpdatePermission> {
     // Detect if rustup is not meant to self-update
     let current_exe = env::current_exe()?;
     let current_exe_dir = current_exe.parent().expect("Rustup isn't in a directory‽");
@@ -1125,7 +1136,7 @@ pub(crate) fn self_update_permitted(explicit: bool) -> Result<SelfUpdatePermissi
 /// (and on windows this process will not be running to do it),
 /// rustup-init is stored in `$CARGO_HOME/bin`, and then deleted next
 /// time rustup runs.
-pub(crate) async fn update(cfg: &Cfg<'_>) -> Result<ExitCode> {
+pub(crate) async fn update(cfg: &Cfg<'_>) -> anyhow::Result<ExitCode> {
     common::warn_if_host_is_emulated(cfg.process);
 
     use SelfUpdatePermission::*;
@@ -1202,7 +1213,7 @@ fn parse_new_rustup_version(version: String) -> String {
     String::from(matched_version)
 }
 
-pub(crate) async fn prepare_update(dl_cfg: &DownloadCfg<'_>) -> Result<Option<PathBuf>> {
+pub(crate) async fn prepare_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Result<Option<PathBuf>> {
     let cargo_home = dl_cfg.process.cargo_home()?;
     let rustup_path = cargo_home.join(format!("bin{MAIN_SEPARATOR}rustup{EXE_SUFFIX}"));
     let setup_path = cargo_home.join(format!("bin{MAIN_SEPARATOR}rustup-init{EXE_SUFFIX}"));
@@ -1267,7 +1278,7 @@ pub(crate) async fn prepare_update(dl_cfg: &DownloadCfg<'_>) -> Result<Option<Pa
     Ok(Some(setup_path))
 }
 
-async fn get_available_rustup_version(dl_cfg: &DownloadCfg<'_>) -> Result<String> {
+async fn get_available_rustup_version(dl_cfg: &DownloadCfg<'_>) -> anyhow::Result<String> {
     let update_root = update_root(dl_cfg.process);
     let tempdir = tempfile::Builder::new()
         .prefix("rustup-update")
@@ -1330,7 +1341,7 @@ impl fmt::Display for SchemaVersion {
 }
 
 /// Returns whether an update was available
-pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> Result<bool> {
+pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> anyhow::Result<bool> {
     let t = dl_cfg.process.stdout();
     let mut t = t.lock();
     // Get current rustup version
@@ -1358,7 +1369,7 @@ pub(crate) async fn check_rustup_update(dl_cfg: &DownloadCfg<'_>) -> Result<bool
 }
 
 #[tracing::instrument(level = "trace")]
-pub(crate) fn cleanup_self_updater(process: &Process) -> Result<()> {
+pub(crate) fn cleanup_self_updater(process: &Process) -> anyhow::Result<()> {
     let cargo_home = process.cargo_home()?;
     let setup = cargo_home.join(format!("bin/rustup-init{EXE_SUFFIX}"));
 

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -26,7 +26,7 @@
 use std::borrow::Cow;
 use std::path::PathBuf;
 
-use anyhow::{Result, bail};
+use anyhow::bail;
 
 use super::utils;
 use crate::process::Process;
@@ -40,7 +40,7 @@ pub(crate) struct ShellScript {
 }
 
 // TODO: Update into a bytestring.
-fn cargo_home_str_with_home(home: &str, process: &Process) -> Result<Cow<'static, str>> {
+fn cargo_home_str_with_home(home: &str, process: &Process) -> anyhow::Result<Cow<'static, str>> {
     let path = process.cargo_home()?;
 
     let default_cargo_home = process
@@ -127,7 +127,7 @@ pub(crate) trait UnixShell {
         }
     }
 
-    fn cargo_home_str(&self, process: &Process) -> Result<Cow<'static, str>> {
+    fn cargo_home_str(&self, process: &Process) -> anyhow::Result<Cow<'static, str>> {
         #[cfg(windows)]
         let home = "%USERPROFILE%";
         #[cfg(not(windows))]
@@ -135,11 +135,11 @@ pub(crate) trait UnixShell {
         cargo_home_str_with_home(home, process)
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(r#". "{}/env""#, self.cargo_home_str(process)?))
     }
 
-    fn write_script(&self, script: &ShellScript, process: &Process) -> Result<()> {
+    fn write_script(&self, script: &ShellScript, process: &Process) -> anyhow::Result<()> {
         let home = process.cargo_home()?;
         let cargo_bin = format!("{}/bin", self.cargo_home_str(process)?);
         let env_name = home.join(script.name);
@@ -205,7 +205,7 @@ impl UnixShell for Bash {
 struct Zsh;
 
 impl Zsh {
-    fn zdotdir(process: &Process) -> Result<PathBuf> {
+    fn zdotdir(process: &Process) -> anyhow::Result<PathBuf> {
         use std::ffi::OsStr;
         use std::os::unix::ffi::OsStrExt;
 
@@ -305,7 +305,7 @@ impl UnixShell for Fish {
         }
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(
             r#"source "{}/env.fish""#,
             self.cargo_home_str(process)?
@@ -357,14 +357,14 @@ impl UnixShell for Nu {
         }
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(
             r#"source "{}/env.nu""#,
             self.cargo_home_str(process)?
         ))
     }
 
-    fn cargo_home_str(&self, process: &Process) -> Result<Cow<'static, str>> {
+    fn cargo_home_str(&self, process: &Process) -> anyhow::Result<Cow<'static, str>> {
         cargo_home_str_with_home("~", process)
     }
 }
@@ -414,7 +414,7 @@ impl UnixShell for Tcsh {
         }
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(
             r#"source "{}/env.tcsh""#,
             self.cargo_home_str(process)?
@@ -497,7 +497,7 @@ impl UnixShell for Pwsh {
         }
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(r#". "{}/env.ps1""#, self.cargo_home_str(process)?))
     }
 }
@@ -549,14 +549,14 @@ impl UnixShell for Xonsh {
         }
     }
 
-    fn source_string(&self, process: &Process) -> Result<String> {
+    fn source_string(&self, process: &Process) -> anyhow::Result<String> {
         Ok(format!(
             r#"source "{}/env.xsh""#,
             self.cargo_home_str(process)?
         ))
     }
 
-    fn cargo_home_str(&self, process: &Process) -> Result<Cow<'static, str>> {
+    fn cargo_home_str(&self, process: &Process) -> anyhow::Result<Cow<'static, str>> {
         cargo_home_str_with_home("$HOME", process)
     }
 }

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, bail};
 use tracing::{error, warn};
 
 use super::install_bins;
@@ -12,7 +12,10 @@ use crate::utils;
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because
 // sudo is configured not to change $HOME. Don't let that bogosity happen.
-pub(crate) fn do_anti_sudo_check(no_prompt: bool, process: &Process) -> Result<utils::ExitCode> {
+pub(crate) fn do_anti_sudo_check(
+    no_prompt: bool,
+    process: &Process,
+) -> anyhow::Result<utils::ExitCode> {
     pub(crate) fn home_mismatch(process: &Process) -> (bool, PathBuf, PathBuf) {
         let fallback = || (false, PathBuf::new(), PathBuf::new());
         // test runner should set this, nothing else
@@ -47,7 +50,7 @@ pub(crate) fn do_anti_sudo_check(no_prompt: bool, process: &Process) -> Result<u
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn do_remove_from_path(process: &Process) -> Result<()> {
+pub(crate) fn do_remove_from_path(process: &Process) -> anyhow::Result<()> {
     for sh in shell::get_available_shells(process) {
         let source_bytes = format!("{}\n", sh.source_string(process)?).into_bytes();
 
@@ -71,7 +74,7 @@ pub(crate) fn do_remove_from_path(process: &Process) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn do_add_to_path(process: &Process) -> Result<()> {
+pub(crate) fn do_add_to_path(process: &Process) -> anyhow::Result<()> {
     for sh in shell::get_available_shells(process) {
         let source_cmd = sh.source_string(process)?;
         let source_cmd_with_newline = format!("\n{source_cmd}");
@@ -100,7 +103,7 @@ pub(crate) fn do_add_to_path(process: &Process) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn do_write_env_files(process: &Process) -> Result<()> {
+pub(crate) fn do_write_env_files(process: &Process) -> anyhow::Result<()> {
     let mut written = vec![];
 
     for sh in shell::get_available_shells(process) {
@@ -117,7 +120,7 @@ pub(crate) fn do_write_env_files(process: &Process) -> Result<()> {
 
 /// Tell the upgrader to replace the rustup bins, then delete
 /// itself.
-pub(crate) fn run_update(setup_path: &Path, _process: &Process) -> Result<utils::ExitCode> {
+pub(crate) fn run_update(setup_path: &Path, _process: &Process) -> anyhow::Result<utils::ExitCode> {
     let status = Command::new(setup_path)
         .arg("--self-replace")
         .status()
@@ -133,13 +136,13 @@ pub(crate) fn run_update(setup_path: &Path, _process: &Process) -> Result<utils:
 /// This function is as the final step of a self-upgrade. It replaces
 /// `$CARGO_HOME/bin/rustup` with the running exe, and updates the
 /// links to it.
-pub(crate) fn self_replace(process: &Process) -> Result<utils::ExitCode> {
+pub(crate) fn self_replace(process: &Process) -> anyhow::Result<utils::ExitCode> {
     install_bins(process)?;
 
     Ok(utils::ExitCode(0))
 }
 
-fn remove_legacy_source_command(source_cmd: String, process: &Process) -> Result<()> {
+fn remove_legacy_source_command(source_cmd: String, process: &Process) -> anyhow::Result<()> {
     let cmd_bytes = source_cmd.into_bytes();
     for rc in shell::legacy_paths(process).filter(|rc| rc.is_file()) {
         let file = utils::read_file("rcfile", &rc)?;
@@ -166,7 +169,7 @@ fn find_exact_line(file: &[u8], line: &[u8]) -> Option<usize> {
         })
 }
 
-fn remove_legacy_paths(process: &Process) -> Result<()> {
+fn remove_legacy_paths(process: &Process) -> anyhow::Result<()> {
     // Before the work to support more kinds of shells, which was released in
     // version 1.23.0 of Rustup, we always inserted this line instead, which is
     // now considered legacy

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -7,7 +7,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use tracing::{info, warn};
 #[cfg(any(test, feature = "test"))]
 use windows_registry::Value;
@@ -24,14 +24,14 @@ use crate::download::DownloadOptions;
 use crate::process::{ColorableTerminal, Process};
 use crate::utils;
 
-pub(crate) fn ensure_prompt(process: &Process) -> Result<()> {
+pub(crate) fn ensure_prompt(process: &Process) -> anyhow::Result<()> {
     writeln!(process.stdout().lock(),)?;
     writeln!(process.stdout().lock(), "Press the Enter key to continue.")?;
     common::read_line(process)?;
     Ok(())
 }
 
-fn choice(max: u8, process: &Process) -> Result<Option<u8>> {
+fn choice(max: u8, process: &Process) -> anyhow::Result<Option<u8>> {
     write!(process.stdout().lock(), ">")?;
 
     let _ = std::io::stdout().flush();
@@ -46,7 +46,7 @@ fn choice(max: u8, process: &Process) -> Result<Option<u8>> {
     Ok(r)
 }
 
-pub(crate) fn choose_vs_install(process: &Process) -> Result<Option<VsInstallPlan>> {
+pub(crate) fn choose_vs_install(process: &Process) -> anyhow::Result<Option<VsInstallPlan>> {
     writeln!(
         process.stdout().lock(),
         "\n1) Quick install via the Visual Studio Community installer"
@@ -92,7 +92,7 @@ pub(super) async fn maybe_install_msvc(
     quiet: bool,
     opts: &InstallOpts<'_>,
     process: &Process,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let Some(plan) = do_msvc_check(opts, process) else {
         return Ok(());
     };
@@ -259,7 +259,7 @@ pub(crate) enum ContinueInstall {
 pub(crate) async fn try_install_msvc(
     opts: &InstallOpts<'_>,
     process: &Process,
-) -> Result<ContinueInstall> {
+) -> anyhow::Result<ContinueInstall> {
     // download the installer
     let visual_studio_url = utils::parse_url("https://aka.ms/vs/17/release/vs_community.exe")?;
 
@@ -350,7 +350,7 @@ fn has_windows_sdk_libs(process: &Process) -> bool {
 
 /// Run by rustup-gc-$num.exe to delete CARGO_HOME
 #[tracing::instrument(level = "trace")]
-pub fn complete_windows_uninstall(process: &Process) -> Result<utils::ExitCode> {
+pub fn complete_windows_uninstall(process: &Process) -> anyhow::Result<utils::ExitCode> {
     use std::process::Stdio;
 
     wait_for_parent()?;
@@ -375,7 +375,7 @@ pub fn complete_windows_uninstall(process: &Process) -> Result<utils::ExitCode> 
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn wait_for_parent() -> Result<()> {
+pub(crate) fn wait_for_parent() -> anyhow::Result<()> {
     use std::io;
     use std::mem;
     use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, WAIT_OBJECT_0};
@@ -447,12 +447,12 @@ pub(crate) fn wait_for_parent() -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn do_add_to_path(process: &Process) -> Result<()> {
+pub(crate) fn do_add_to_path(process: &Process) -> anyhow::Result<()> {
     let new_path = _with_path_cargo_home_bin(_add_to_path, process)?;
     _apply_new_path(new_path, process)
 }
 
-fn _apply_new_path(new_path: Option<HSTRING>, process: &Process) -> Result<()> {
+fn _apply_new_path(new_path: Option<HSTRING>, process: &Process) -> anyhow::Result<()> {
     use std::ptr;
     use windows_sys::Win32::Foundation::{LPARAM, WPARAM};
     use windows_sys::Win32::UI::WindowsAndMessaging::{
@@ -491,7 +491,7 @@ fn _apply_new_path(new_path: Option<HSTRING>, process: &Process) -> Result<()> {
 // Get the windows PATH variable out of the registry as a String. If
 // this returns None then the PATH variable is not a string and we
 // should not mess with it.
-fn get_windows_path_var(process: &Process) -> Result<Option<HSTRING>> {
+fn get_windows_path_var(process: &Process) -> anyhow::Result<Option<HSTRING>> {
     let environment = process
         .registry_environment_key()
         .context("Failed opening Environment key")?;
@@ -553,7 +553,7 @@ fn _remove_from_path(old_path: HSTRING, path_str: HSTRING) -> Option<HSTRING> {
     Some(HSTRING::from_wide(&new_path))
 }
 
-fn _with_path_cargo_home_bin<F>(f: F, process: &Process) -> Result<Option<HSTRING>>
+fn _with_path_cargo_home_bin<F>(f: F, process: &Process) -> anyhow::Result<Option<HSTRING>>
 where
     F: FnOnce(HSTRING, HSTRING) -> Option<HSTRING>,
 {
@@ -563,7 +563,7 @@ where
     Ok(windows_path.and_then(|old_path| f(old_path, HSTRING::from(path_str.as_path()))))
 }
 
-pub(crate) fn do_remove_from_path(process: &Process) -> Result<()> {
+pub(crate) fn do_remove_from_path(process: &Process) -> anyhow::Result<()> {
     let new_path = _with_path_cargo_home_bin(_remove_from_path, process)?;
     _apply_new_path(new_path, process)
 }
@@ -597,7 +597,7 @@ impl Process {
     }
 }
 
-fn rustup_uninstall_registry_key(process: &Process) -> Result<Key> {
+fn rustup_uninstall_registry_key(process: &Process) -> anyhow::Result<Key> {
     process
         .registry_key(RUSTUP_UNINSTALL_ENTRY, CURRENT_USER)
         .context("Failed creating uninstall key")
@@ -606,13 +606,13 @@ fn rustup_uninstall_registry_key(process: &Process) -> Result<Key> {
 pub(crate) fn update_uninstall_registry_display_version(
     version: &str,
     process: &Process,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     rustup_uninstall_registry_key(process)?
         .set_string("DisplayVersion", version)
         .context("Failed to set `DisplayVersion`")
 }
 
-pub(crate) fn add_uninstall_registry_entry(process: &Process) -> Result<()> {
+pub(crate) fn add_uninstall_registry_entry(process: &Process) -> anyhow::Result<()> {
     use std::path::PathBuf;
 
     let key = rustup_uninstall_registry_key(process)?;
@@ -642,7 +642,7 @@ pub(crate) fn add_uninstall_registry_entry(process: &Process) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn remove_uninstall_registry_entry(process: &Process) -> Result<()> {
+pub(crate) fn remove_uninstall_registry_entry(process: &Process) -> anyhow::Result<()> {
     match CURRENT_USER.remove_tree(process.registry_sub_key_path(RUSTUP_UNINSTALL_ENTRY)) {
         Ok(()) => Ok(()),
         Err(e) if e.code() == HRESULT::from_win32(ERROR_FILE_NOT_FOUND) => Ok(()),
@@ -650,7 +650,7 @@ pub(crate) fn remove_uninstall_registry_entry(process: &Process) -> Result<()> {
     }
 }
 
-pub(crate) fn run_update(setup_path: &Path, process: &Process) -> Result<utils::ExitCode> {
+pub(crate) fn run_update(setup_path: &Path, process: &Process) -> anyhow::Result<utils::ExitCode> {
     Command::new(setup_path)
         .arg("--self-replace")
         .spawn()
@@ -665,7 +665,7 @@ pub(crate) fn run_update(setup_path: &Path, process: &Process) -> Result<utils::
     Ok(utils::ExitCode(0))
 }
 
-pub(crate) fn self_replace(process: &Process) -> Result<utils::ExitCode> {
+pub(crate) fn self_replace(process: &Process) -> anyhow::Result<utils::ExitCode> {
     wait_for_parent()?;
     install_bins(process)?;
 
@@ -702,7 +702,7 @@ pub(crate) fn self_replace(process: &Process) -> Result<utils::ExitCode> {
 //
 // .. augmented with this SO answer
 // https://stackoverflow.com/questions/10319526/understanding-a-self-deleting-program-in-c
-pub(crate) fn spawn_uninstall_gc(no_modify_path: bool, process: &Process) -> Result<()> {
+pub(crate) fn spawn_uninstall_gc(no_modify_path: bool, process: &Process) -> anyhow::Result<()> {
     use std::io;
     use std::ptr;
     use std::thread;
@@ -787,7 +787,7 @@ const GC_MODIFY_PATH: &str = "RUSTUP_GC_MODIFY_PATH";
 pub const RUSTUP_REGISTRY_TEST_ID: &str = "RUSTUP_REGISTRY_TEST_ID";
 
 #[cfg(any(test, feature = "test"))]
-pub fn get_path(test_id: &str) -> Result<Option<Value>> {
+pub fn get_path(test_id: &str) -> anyhow::Result<Option<Value>> {
     USER_PATH.get(test_id, CURRENT_USER)
 }
 
@@ -805,7 +805,7 @@ pub struct RegistryValueId {
 
 #[cfg(any(test, feature = "test"))]
 impl RegistryValueId {
-    pub fn get(&self, test_id: &str, parent: &Key) -> Result<Option<Value>> {
+    pub fn get(&self, test_id: &str, parent: &Key) -> anyhow::Result<Option<Value>> {
         let mut options = parent.options();
         options.read().write().create().volatile();
         let sub_key = options.open(format!(r"RustupTest-{test_id}\{}", self.sub_key))?;
@@ -816,7 +816,7 @@ impl RegistryValueId {
         }
     }
 
-    pub fn set(&self, new: Option<&Value>, test_id: &str, parent: &Key) -> Result<()> {
+    pub fn set(&self, new: Option<&Value>, test_id: &str, parent: &Key) -> anyhow::Result<()> {
         let mut options = parent.options();
         options.read().write().create().volatile();
         let sub_key = options.open(format!(r"RustupTest-{test_id}\{}", self.sub_key))?;

--- a/src/cli/setup_mode.rs
+++ b/src/cli/setup_mode.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{Result, format_err};
+use anyhow::format_err;
 use clap::Parser;
 use tracing::warn;
 use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
@@ -79,7 +79,7 @@ pub async fn main(
     current_dir: PathBuf,
     process: &Process,
     console_filter: Handle<EnvFilter, Registry>,
-) -> Result<utils::ExitCode> {
+) -> anyhow::Result<utils::ExitCode> {
     use clap::error::ErrorKind;
 
     let RustupInit {

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 
 struct DocData<'a> {
     topic: &'a str,
@@ -18,14 +18,14 @@ fn index_html(doc: &DocData<'_>, wpath: &Path) -> Option<PathBuf> {
     }
 }
 
-fn dir_into_vec(dir: &Path) -> Result<Vec<OsString>> {
+fn dir_into_vec(dir: &Path) -> anyhow::Result<Vec<OsString>> {
     fs::read_dir(dir)
         .with_context(|| format!("Failed to read_dir {dir:?}"))?
         .map(|f| Ok(f?.file_name()))
         .collect()
 }
 
-fn search_path(doc: &DocData<'_>, wpath: &Path, keywords: &[&str]) -> Result<PathBuf> {
+fn search_path(doc: &DocData<'_>, wpath: &Path, keywords: &[&str]) -> anyhow::Result<PathBuf> {
     let dir = &doc.root.join(wpath);
     if dir.is_dir() {
         let entries = dir_into_vec(dir)?;
@@ -39,7 +39,7 @@ fn search_path(doc: &DocData<'_>, wpath: &Path, keywords: &[&str]) -> Result<Pat
     Err(anyhow!(format!("No document for '{}'", doc.topic)))
 }
 
-pub(crate) fn local_path(root: &Path, topic: &str) -> Result<PathBuf> {
+pub(crate) fn local_path(root: &Path, topic: &str) -> anyhow::Result<PathBuf> {
     // The ORDER of keywords_top is used for the default search and should not
     // be changed.
     // https://github.com/rust-lang/rustup/issues/2076#issuecomment-546613036

--- a/src/command.rs
+++ b/src/command.rs
@@ -5,7 +5,7 @@ use std::{
     process::{self, Command, ExitStatus},
 };
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 
 use crate::errors::RustupError;
 
@@ -14,7 +14,7 @@ pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
     mut cmd: Command,
     arg0: &str,
     args: &[S],
-) -> Result<ExitStatus> {
+) -> anyhow::Result<ExitStatus> {
     cmd.args(args);
 
     // FIXME rust-lang/rust#32254. It's not clear to me

--- a/src/config.rs
+++ b/src/config.rs
@@ -1062,7 +1062,7 @@ impl<'a> Cfg<'a> {
             .date_naive();
 
         let release_date = NaiveDate::parse_from_str(&release_date_str, "%Y-%m-%d")
-            .map_err(|e| anyhow!("could not parse release date '{}': {e}", release_date_str))?;
+            .map_err(|e| anyhow!("could not parse release date '{release_date_str}': {e}"))?;
 
         // Skip the hint if fewer than 6 weeks have passed since the last known release.
         if (today - release_date).num_days() < RELEASE_CYCLE_DAYS {

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, anyhow, bail};
 use chrono::{DateTime, NaiveDate};
 use serde::{Deserialize, Serialize};
 use thiserror::Error as ThisError;
@@ -188,7 +188,7 @@ enum OverrideCfg {
 }
 
 impl OverrideCfg {
-    fn from_file(cfg: &Cfg<'_>, file: OverrideFile) -> Result<Self> {
+    fn from_file(cfg: &Cfg<'_>, file: OverrideFile) -> anyhow::Result<Self> {
         let toolchain_name = match (file.toolchain.channel, file.toolchain.path) {
             (Some(name), None) => ResolvableToolchainName::from_str(&name)?,
             (None, Some(path)) => {
@@ -237,7 +237,10 @@ impl OverrideCfg {
         })
     }
 
-    fn into_local_toolchain_name(self, host_tuple: &TargetTuple) -> Result<LocalToolchainName> {
+    fn into_local_toolchain_name(
+        self,
+        host_tuple: &TargetTuple,
+    ) -> anyhow::Result<LocalToolchainName> {
         Ok(match self {
             Self::PathBased(path_based_name) => path_based_name.into(),
             Self::Custom(custom_name) => custom_name.into(),
@@ -304,7 +307,7 @@ impl<'a> Cfg<'a> {
         quiet: bool,
         allow_auto_install: bool,
         process: &'a Process,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         // Set up the rustup home directory
         let rustup_dir = process.rustup_home()?;
 
@@ -380,7 +383,10 @@ impl<'a> Cfg<'a> {
         Ok(cfg)
     }
 
-    pub(crate) fn set_default(&self, toolchain: Option<&ResolvableToolchainName>) -> Result<()> {
+    pub(crate) fn set_default(
+        &self,
+        toolchain: Option<&ResolvableToolchainName>,
+    ) -> anyhow::Result<()> {
         self.settings_file.with_mut(|s| {
             s.default_toolchain = toolchain.map(|t| t.to_string());
             Ok(())
@@ -394,7 +400,7 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn set_profile(&mut self, profile: Profile) -> Result<()> {
+    pub(crate) fn set_profile(&mut self, profile: Profile) -> anyhow::Result<()> {
         self.profile_override = None;
         self.settings_file.with_mut(|s| {
             s.profile = Some(profile);
@@ -404,7 +410,7 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn set_auto_self_update(&self, mode: SelfUpdateMode) -> Result<()> {
+    pub(crate) fn set_auto_self_update(&self, mode: SelfUpdateMode) -> anyhow::Result<()> {
         self.settings_file.with_mut(|s| {
             s.auto_self_update = Some(mode);
             Ok(())
@@ -413,7 +419,7 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn set_auto_install(&self, mode: Switch) -> Result<()> {
+    pub(crate) fn set_auto_install(&self, mode: Switch) -> anyhow::Result<()> {
         self.settings_file.with_mut(|s| {
             s.auto_install = Some(mode);
             Ok(())
@@ -422,7 +428,7 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn set_release_hint(&self, mode: Switch) -> Result<()> {
+    pub(crate) fn set_release_hint(&self, mode: Switch) -> anyhow::Result<()> {
         self.settings_file.with_mut(|s| {
             s.release_hint = Some(mode);
             Ok(())
@@ -431,7 +437,7 @@ impl<'a> Cfg<'a> {
         Ok(())
     }
 
-    pub(crate) fn should_auto_install(&self) -> Result<bool> {
+    pub(crate) fn should_auto_install(&self) -> anyhow::Result<bool> {
         if !self.allow_auto_install {
             return Ok(false);
         }
@@ -451,7 +457,7 @@ impl<'a> Cfg<'a> {
     // if there is no profile in the settings file. The last variant happens when
     // a user upgrades from a version of Rustup without profiles to a version of
     // Rustup with profiles.
-    pub(crate) fn get_profile(&self) -> Result<Profile> {
+    pub(crate) fn get_profile(&self) -> anyhow::Result<Profile> {
         if let Some(p) = self.profile_override {
             return Ok(p);
         }
@@ -468,7 +474,7 @@ impl<'a> Cfg<'a> {
         &self,
         desc: &ToolchainDesc,
         path: &'b Path,
-    ) -> Result<Vec<InstalledPath<'b>>> {
+    ) -> anyhow::Result<Vec<InstalledPath<'b>>> {
         Ok(vec![
             InstalledPath::File {
                 name: "update hash",
@@ -482,7 +488,7 @@ impl<'a> Cfg<'a> {
         &self,
         toolchain: &ToolchainDesc,
         create_parent: bool,
-    ) -> Result<PathBuf> {
+    ) -> anyhow::Result<PathBuf> {
         if create_parent {
             utils::ensure_dir_exists("update-hash", &self.update_hash_dir)?;
         }
@@ -491,7 +497,7 @@ impl<'a> Cfg<'a> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn upgrade_data(&self) -> Result<()> {
+    pub(crate) fn upgrade_data(&self) -> anyhow::Result<()> {
         let current_version = self.settings_file.with(|s| Ok(s.version))?;
         if current_version == MetadataVersion::default() {
             info!("nothing to upgrade: metadata version is already '{current_version}'");
@@ -531,7 +537,7 @@ impl<'a> Cfg<'a> {
         }
     }
 
-    pub(crate) fn find_default(&self) -> Result<Option<Toolchain<'_>>> {
+    pub(crate) fn find_default(&self) -> anyhow::Result<Option<Toolchain<'_>>> {
         Ok(self
             .get_default()?
             .map(|n| Toolchain::new(self, n.into()))
@@ -541,7 +547,7 @@ impl<'a> Cfg<'a> {
     pub(crate) async fn toolchain_from_partial(
         &self,
         toolchain: Option<(PartialToolchainDesc, ActiveSource)>,
-    ) -> Result<(Toolchain<'_>, ActiveSource)> {
+    ) -> anyhow::Result<(Toolchain<'_>, ActiveSource)> {
         let toolchain = toolchain
             .map(|(desc, source)| {
                 anyhow::Ok((
@@ -558,7 +564,7 @@ impl<'a> Cfg<'a> {
     pub(crate) async fn maybe_ensure_active_toolchain(
         &self,
         force_ensure: Option<bool>,
-    ) -> Result<Option<(LocalToolchainName, ActiveSource)>> {
+    ) -> anyhow::Result<Option<(LocalToolchainName, ActiveSource)>> {
         let should_ensure = if let Some(force) = force_ensure {
             force
         } else {
@@ -581,7 +587,9 @@ impl<'a> Cfg<'a> {
         }
     }
 
-    pub(crate) fn active_toolchain(&self) -> Result<Option<(LocalToolchainName, ActiveSource)>> {
+    pub(crate) fn active_toolchain(
+        &self,
+    ) -> anyhow::Result<Option<(LocalToolchainName, ActiveSource)>> {
         Ok(
             if let Some((override_config, source)) = self.find_override_config()? {
                 Some((
@@ -595,7 +603,7 @@ impl<'a> Cfg<'a> {
         )
     }
 
-    fn find_override_config(&self) -> Result<Option<(OverrideCfg, ActiveSource)>> {
+    fn find_override_config(&self) -> anyhow::Result<Option<(OverrideCfg, ActiveSource)>> {
         let override_config: Option<(OverrideCfg, ActiveSource)> =
             // First check +toolchain override from the command line
             if let Some(name) = &self.toolchain_override {
@@ -629,7 +637,7 @@ impl<'a> Cfg<'a> {
         &self,
         dir: &Path,
         settings: &Settings,
-    ) -> Result<Option<(OverrideCfg, ActiveSource)>> {
+    ) -> anyhow::Result<Option<(OverrideCfg, ActiveSource)>> {
         let mut dir = Some(dir);
 
         while let Some(d) = dir {
@@ -739,7 +747,7 @@ impl<'a> Cfg<'a> {
     fn parse_override_file<S: AsRef<str>>(
         contents: S,
         parse_mode: ParseMode,
-    ) -> Result<OverrideFile> {
+    ) -> anyhow::Result<OverrideFile> {
         let contents = contents.as_ref();
 
         match (contents.lines().count(), parse_mode) {
@@ -769,7 +777,7 @@ impl<'a> Cfg<'a> {
     pub(crate) async fn local_toolchain(
         &self,
         name: Option<(LocalToolchainName, ActiveSource)>,
-    ) -> Result<(Toolchain<'_>, ActiveSource)> {
+    ) -> anyhow::Result<(Toolchain<'_>, ActiveSource)> {
         match name {
             Some((tc, source)) => {
                 let install_if_missing = self.should_auto_install()?;
@@ -793,7 +801,7 @@ impl<'a> Cfg<'a> {
         &self,
         force_non_host: bool,
         verbose: bool,
-    ) -> Result<(EnsureInstalled<LocalToolchainName>, ActiveSource)> {
+    ) -> anyhow::Result<(EnsureInstalled<LocalToolchainName>, ActiveSource)> {
         if let Some((override_config, source)) = self.find_override_config()? {
             let default_host = self.default_host_tuple()?;
             let toolchain = override_config
@@ -848,7 +856,7 @@ impl<'a> Cfg<'a> {
         profile: Option<Profile>,
         force_non_host: bool,
         verbose: bool,
-    ) -> Result<EnsureInstalled<Toolchain<'_>>> {
+    ) -> anyhow::Result<EnsureInstalled<Toolchain<'_>>> {
         common::check_non_host_toolchain(
             toolchain.to_string(),
             &TargetTuple::from_host_or_build(self.process),
@@ -898,7 +906,7 @@ impl<'a> Cfg<'a> {
     /// Gets the configured default toolchain name in its resolved form, if any.
     ///
     /// This is essentially [`Cfg::get_default_resolvable()`] with an extra resolution step.
-    pub(crate) fn get_default(&self) -> Result<Option<ToolchainName>> {
+    pub(crate) fn get_default(&self) -> anyhow::Result<Option<ToolchainName>> {
         let Some(toolchain) = self.get_default_resolvable()? else {
             return Ok(None);
         };
@@ -912,7 +920,7 @@ impl<'a> Cfg<'a> {
     /// This function returns an error if:
     /// - The configuration file is invalid.
     /// - The configuration file contains an illegal default toolchain name.
-    pub(crate) fn get_default_resolvable(&self) -> Result<Option<ResolvableToolchainName>> {
+    pub(crate) fn get_default_resolvable(&self) -> anyhow::Result<Option<ResolvableToolchainName>> {
         let user_opt = self.settings_file.with(|s| Ok(s.default_toolchain.clone()));
         let toolchain_maybe_str = if let Some(fallback_settings) = &self.fallback_settings {
             match user_opt {
@@ -934,7 +942,7 @@ impl<'a> Cfg<'a> {
     /// - named with a valid resolved toolchain name
     /// Currently no notification of incorrect names or entry type is done.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn list_toolchains(&self) -> Result<Vec<ToolchainName>> {
+    pub(crate) fn list_toolchains(&self) -> anyhow::Result<Vec<ToolchainName>> {
         if utils::is_directory(&self.toolchains_dir) {
             let mut toolchains: Vec<_> = utils::read_dir("toolchains", &self.toolchains_dir)?
                 // TODO: this discards errors reading the directory, is that
@@ -954,7 +962,9 @@ impl<'a> Cfg<'a> {
         }
     }
 
-    pub(crate) fn list_channels(&self) -> Result<Vec<(ToolchainDesc, DistributableToolchain<'_>)>> {
+    pub(crate) fn list_channels(
+        &self,
+    ) -> anyhow::Result<Vec<(ToolchainDesc, DistributableToolchain<'_>)>> {
         self.list_toolchains()?
             .into_iter()
             .filter_map(|t| {
@@ -970,7 +980,7 @@ impl<'a> Cfg<'a> {
                     .map_err(Into::into)
                     .map(|t| (n.clone(), t))
             })
-            .collect::<Result<Vec<_>>>()
+            .collect::<anyhow::Result<Vec<_>>>()
     }
 
     /// Create an override for a toolchain
@@ -978,14 +988,14 @@ impl<'a> Cfg<'a> {
         &self,
         path: &Path,
         toolchain: &ResolvableToolchainName,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         self.settings_file.with_mut(|s| {
             s.add_override(path, toolchain.to_string());
             Ok(())
         })
     }
 
-    pub(crate) fn set_default_host_tuple(&self, host_tuple: String) -> Result<()> {
+    pub(crate) fn set_default_host_tuple(&self, host_tuple: String) -> anyhow::Result<()> {
         // Ensure that the provided host tuple is capable of resolving
         // against the 'stable' toolchain.  This provides early errors
         // if the supplied tuple is insufficient / bad.
@@ -997,7 +1007,7 @@ impl<'a> Cfg<'a> {
     }
 
     #[tracing::instrument(level = "trace", skip_all)]
-    pub(crate) fn default_host_tuple(&self) -> Result<TargetTuple> {
+    pub(crate) fn default_host_tuple(&self) -> anyhow::Result<TargetTuple> {
         self.settings_file
             .with(|s| Ok(default_host_tuple(s, self.process)))
     }
@@ -1012,7 +1022,7 @@ impl<'a> Cfg<'a> {
 
     /// Notifies a user with a hint whenever a new Rust release is available.
     /// This is only shown at max once per day and only if not in proxy mode.
-    pub(crate) fn notify_release(&self) -> Result<()> {
+    pub(crate) fn notify_release(&self) -> anyhow::Result<()> {
         if self.settings_file.with(|s| Ok(s.release_hint))? == Some(Switch::Disable) {
             return Ok(());
         }
@@ -1075,7 +1085,7 @@ impl<'a> Cfg<'a> {
 
 /// The root path of the release server, without the `/dist` suffix.
 /// By default, it points to [`dist::DEFAULT_DIST_SERVER`].
-fn dist_root_server(process: &Process) -> Result<String> {
+fn dist_root_server(process: &Process) -> anyhow::Result<String> {
     if let Some(s) = process.var_opt("RUSTUP_DIST_SERVER")? {
         trace!("`RUSTUP_DIST_SERVER` has been set to `{s}`");
         return Ok(s);
@@ -1146,7 +1156,7 @@ impl StateFile {
         Self { path }
     }
 
-    fn load(&self) -> Result<State> {
+    fn load(&self) -> anyhow::Result<State> {
         if !utils::is_file(&self.path) {
             return Ok(State::default());
         }
@@ -1157,16 +1167,16 @@ impl StateFile {
         })
     }
 
-    fn store(&self, state: &State) -> Result<()> {
+    fn store(&self, state: &State) -> anyhow::Result<()> {
         utils::write_locked_file("state", &self.path, &state.stringify()?)?;
         Ok(())
     }
 
-    fn with<T, F: FnOnce(&State) -> Result<T>>(&self, f: F) -> Result<T> {
+    fn with<T, F: FnOnce(&State) -> anyhow::Result<T>>(&self, f: F) -> anyhow::Result<T> {
         f(&self.load()?)
     }
 
-    fn with_mut<T, F: FnOnce(&mut State) -> Result<T>>(&self, f: F) -> Result<T> {
+    fn with_mut<T, F: FnOnce(&mut State) -> anyhow::Result<T>>(&self, f: F) -> anyhow::Result<T> {
         let mut state = self.load()?;
         let result = f(&mut state)?;
         self.store(&state)?;
@@ -1181,11 +1191,11 @@ struct State {
 }
 
 impl State {
-    fn parse(data: &str) -> Result<Self> {
+    fn parse(data: &str) -> anyhow::Result<Self> {
         toml::from_str(data).context("error parsing state")
     }
 
-    fn stringify(&self) -> Result<String> {
+    fn stringify(&self) -> anyhow::Result<String> {
         Ok(toml::to_string(self)?)
     }
 }

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -59,7 +59,6 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 use std::{fmt::Debug, fs::OpenOptions};
 
-use anyhow::Result;
 use tracing::{error, trace, warn};
 
 use crate::diskio::immediate::{FileState, IncrementalFileWriter};
@@ -238,7 +237,7 @@ impl Item {
         full_path: PathBuf,
         mode: u32,
         state: IncrementalFileState,
-    ) -> Result<(Self, Box<dyn ChunkWriter>)> {
+    ) -> anyhow::Result<(Self, Box<dyn ChunkWriter>)> {
         let (chunk_submit, content_callback) = state.incremental_file_channel(&full_path, mode)?;
         let result = Self {
             full_path,
@@ -270,7 +269,7 @@ impl IncrementalFileState {
         &self,
         path: &Path,
         mode: u32,
-    ) -> Result<(Box<dyn ChunkWriter>, IncrementalFile)> {
+    ) -> anyhow::Result<(Box<dyn ChunkWriter>, IncrementalFile)> {
         match self {
             Self::Threaded => {
                 let (tx, rx) = mpsc::channel::<FileBuffer>();

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 
-use anyhow::Result;
-
 use super::{Executor, Item, Kind, get_executor};
 use crate::process::TestProcess;
 use crate::test::test_dir;
@@ -16,7 +14,7 @@ impl Item {
     }
 }
 
-fn test_incremental_file(io_threads: &str) -> Result<()> {
+fn test_incremental_file(io_threads: &str) -> anyhow::Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());
@@ -85,7 +83,7 @@ fn test_incremental_file(io_threads: &str) -> Result<()> {
     Ok(())
 }
 
-fn test_complete_file(io_threads: &str) -> Result<()> {
+fn test_complete_file(io_threads: &str) -> anyhow::Result<()> {
     let work_dir = test_dir()?;
     let mut vars = HashMap::new();
     vars.insert("RUSTUP_IO_THREADS".to_string(), io_threads.to_string());

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -32,10 +32,7 @@ impl Components {
         if let Some(v) = c.read_version()?
             && v != INSTALLER_VERSION
         {
-            bail!(
-                "unsupported metadata version in existing installation: {}",
-                v
-            );
+            bail!("unsupported metadata version in existing installation: {v}");
         }
 
         Ok(c)

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -9,7 +9,7 @@ use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{Result, bail};
+use anyhow::bail;
 
 use crate::dist::component::package::{INSTALLER_VERSION, VERSION_FILE};
 use crate::dist::component::transaction::Transaction;
@@ -25,7 +25,7 @@ pub struct Components {
 }
 
 impl Components {
-    pub fn open(prefix: InstallPrefix) -> Result<Self> {
+    pub fn open(prefix: InstallPrefix) -> anyhow::Result<Self> {
         let c = Self { prefix };
 
         // Validate that the metadata uses a format we know
@@ -46,7 +46,7 @@ impl Components {
     fn rel_component_manifest(&self, name: &str) -> PathBuf {
         self.prefix.rel_manifest_file(&format!("manifest-{name}"))
     }
-    fn read_version(&self) -> Result<Option<String>> {
+    fn read_version(&self) -> anyhow::Result<Option<String>> {
         let p = self.prefix.manifest_file(VERSION_FILE);
         if utils::is_file(&p) {
             Ok(Some(utils::read_file(VERSION_FILE, &p)?.trim().to_string()))
@@ -54,7 +54,7 @@ impl Components {
             Ok(None)
         }
     }
-    fn write_version(&self, tx: &mut Transaction) -> Result<()> {
+    fn write_version(&self, tx: &mut Transaction) -> anyhow::Result<()> {
         tx.modify_file(self.prefix.rel_manifest_file(VERSION_FILE))?;
         utils::write_file(
             VERSION_FILE,
@@ -64,7 +64,7 @@ impl Components {
 
         Ok(())
     }
-    pub fn list(&self) -> Result<Vec<Component>> {
+    pub fn list(&self) -> anyhow::Result<Vec<Component>> {
         let path = self.prefix.abs_path(self.rel_components_file());
         if !utils::is_file(&path) {
             return Ok(Vec::new());
@@ -86,7 +86,7 @@ impl Components {
             tx,
         }
     }
-    pub fn find(&self, name: &str) -> Result<Option<Component>> {
+    pub fn find(&self, name: &str) -> anyhow::Result<Option<Component>> {
         let result = self.list()?;
         Ok(result.into_iter().find(|c| c.name() == name))
     }
@@ -103,35 +103,35 @@ pub(crate) struct ComponentBuilder {
 }
 
 impl ComponentBuilder {
-    pub(crate) fn copy_file(&mut self, path: PathBuf, src: &Path) -> Result<()> {
+    pub(crate) fn copy_file(&mut self, path: PathBuf, src: &Path) -> anyhow::Result<()> {
         self.parts.push(ComponentPart {
             kind: ComponentPartKind::File,
             path: path.clone(),
         });
         self.tx.copy_file(&self.name, path, src)
     }
-    pub(crate) fn copy_dir(&mut self, path: PathBuf, src: &Path) -> Result<()> {
+    pub(crate) fn copy_dir(&mut self, path: PathBuf, src: &Path) -> anyhow::Result<()> {
         self.parts.push(ComponentPart {
             kind: ComponentPartKind::Dir,
             path: path.clone(),
         });
         self.tx.copy_dir(&self.name, path, src)
     }
-    pub(crate) fn move_file(&mut self, path: PathBuf, src: &Path) -> Result<()> {
+    pub(crate) fn move_file(&mut self, path: PathBuf, src: &Path) -> anyhow::Result<()> {
         self.parts.push(ComponentPart {
             kind: ComponentPartKind::File,
             path: path.clone(),
         });
         self.tx.move_file(&self.name, path, src)
     }
-    pub(crate) fn move_dir(&mut self, path: PathBuf, src: &Path) -> Result<()> {
+    pub(crate) fn move_dir(&mut self, path: PathBuf, src: &Path) -> anyhow::Result<()> {
         self.parts.push(ComponentPart {
             kind: ComponentPartKind::Dir,
             path: path.clone(),
         });
         self.tx.move_dir(&self.name, path, src)
     }
-    pub(crate) fn finish(mut self) -> Result<Transaction> {
+    pub(crate) fn finish(mut self) -> anyhow::Result<Transaction> {
         // Write component manifest
         let path = self.components.rel_component_manifest(&self.name);
         let abs_path = self.components.prefix.abs_path(&path);
@@ -244,7 +244,7 @@ impl Component {
     pub(crate) fn name(&self) -> &str {
         &self.name
     }
-    pub(crate) fn parts(&self) -> Result<Vec<ComponentPart>> {
+    pub(crate) fn parts(&self) -> anyhow::Result<Vec<ComponentPart>> {
         let mut result = Vec::new();
         for line in utils::read_file("component", &self.manifest_file())?.lines() {
             result.push(
@@ -254,7 +254,7 @@ impl Component {
         }
         Ok(result)
     }
-    pub fn uninstall(&self, mut tx: Transaction) -> Result<Transaction> {
+    pub fn uninstall(&self, mut tx: Transaction) -> anyhow::Result<Transaction> {
         // Update components file
         let path = self.components.rel_components_file();
         let abs_path = self.components.prefix.abs_path(&path);

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -8,7 +8,7 @@ use std::mem;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, anyhow, bail};
 use tar::EntryType;
 use tracing::warn;
 
@@ -37,7 +37,7 @@ impl DirectoryPackage<temp::Dir> {
         kind: CompressionKind,
         temp_dir: temp::Dir,
         io_executor: Box<dyn Executor>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         match kind {
             CompressionKind::GZip => Self::from_tar(
                 flate2::bufread::GzDecoder::new(stream),
@@ -59,7 +59,7 @@ impl DirectoryPackage<temp::Dir> {
         stream: impl Read,
         temp_dir: temp::Dir,
         io_executor: Box<dyn Executor>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         let mut archive = tar::Archive::new(stream);
 
         // The rust-installer packages unpack to a directory called
@@ -73,7 +73,7 @@ impl DirectoryPackage<temp::Dir> {
 }
 
 impl<P: Deref<Target = Path>> DirectoryPackage<P> {
-    pub fn new(path: P, copy: bool) -> Result<Self> {
+    pub fn new(path: P, copy: bool) -> anyhow::Result<Self> {
         let file = utils::read_file("installer version", &path.join(VERSION_FILE))?;
         let v = file.trim();
         if v != INSTALLER_VERSION {
@@ -104,7 +104,7 @@ impl<P: Deref<Target = Path>> DirectoryPackage<P> {
         name: &str,
         short_name: Option<&str>,
         tx: Transaction,
-    ) -> Result<Transaction> {
+    ) -> anyhow::Result<Transaction> {
         let actual_name = if self.components.contains(name) {
             name
         } else if let Some(n) = short_name {
@@ -189,7 +189,7 @@ fn trigger_children(
     io_executor: &dyn Executor,
     directories: &mut HashMap<PathBuf, DirStatus>,
     op: CompletedIo,
-) -> Result<usize> {
+) -> anyhow::Result<usize> {
     let mut result = 0;
     if let CompletedIo::Item(item) = op
         && let Kind::Directory = item.kind
@@ -227,7 +227,7 @@ fn unpack_without_first_dir<R: Read>(
     archive: &mut tar::Archive<R>,
     path: &Path,
     mut io_executor: Box<dyn Executor>,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     let entries = archive.entries()?;
     let mut directories: HashMap<PathBuf, DirStatus> = HashMap::new();
     // Path is presumed to exist. Call it a precondition.
@@ -279,7 +279,7 @@ fn unpack_without_first_dir<R: Read>(
             directories: &mut HashMap<PathBuf, DirStatus>,
             mut sender_entry: Option<&mut SenderEntry<'_, R>>,
             full_path: P,
-        ) -> Result<bool> {
+        ) -> anyhow::Result<bool> {
             let mut result = sender_entry.is_none();
             for mut op in io_executor.completed().collect::<Vec<_>>() {
                 // TODO capture metrics

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use tracing::{error, info};
 
 use crate::dist::prefix::InstallPrefix;
@@ -66,7 +66,7 @@ impl Transaction {
     /// Add a file at a relative path to the install prefix. Returns a
     /// `File` that may be used to subsequently write the
     /// contents.
-    pub fn add_file(&mut self, component: &str, relpath: PathBuf) -> Result<File> {
+    pub fn add_file(&mut self, component: &str, relpath: PathBuf) -> anyhow::Result<File> {
         assert!(relpath.is_relative());
         let (item, file) = ChangedItem::add_file(&self.prefix, component, relpath)?;
         self.changes.push(item);
@@ -74,7 +74,12 @@ impl Transaction {
     }
 
     /// Copy a file to a relative path of the install prefix.
-    pub fn copy_file(&mut self, component: &str, relpath: PathBuf, src: &Path) -> Result<()> {
+    pub fn copy_file(
+        &mut self,
+        component: &str,
+        relpath: PathBuf,
+        src: &Path,
+    ) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = ChangedItem::dest_abs_path(&self.prefix, component, &relpath)?;
         utils::copy_file(src, &abs_path)?;
@@ -83,7 +88,12 @@ impl Transaction {
     }
 
     /// Recursively copy a directory to a relative path of the install prefix.
-    pub fn copy_dir(&mut self, component: &str, relpath: PathBuf, src: &Path) -> Result<()> {
+    pub fn copy_dir(
+        &mut self,
+        component: &str,
+        relpath: PathBuf,
+        src: &Path,
+    ) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = ChangedItem::dest_abs_path(&self.prefix, component, &relpath)?;
         utils::copy_dir(src, &abs_path)?;
@@ -92,7 +102,7 @@ impl Transaction {
     }
 
     /// Remove a file from a relative path to the install prefix.
-    pub fn remove_file(&mut self, component: &str, relpath: PathBuf) -> Result<()> {
+    pub fn remove_file(&mut self, component: &str, relpath: PathBuf) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = self.prefix.abs_path(&relpath);
         let backup = self.tmp_cx.new_file()?;
@@ -111,7 +121,7 @@ impl Transaction {
 
     /// Recursively remove a directory from a relative path of the
     /// install prefix.
-    pub fn remove_dir(&mut self, component: &str, relpath: PathBuf) -> Result<()> {
+    pub fn remove_dir(&mut self, component: &str, relpath: PathBuf) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = self.prefix.abs_path(&relpath);
         let backup = self.tmp_cx.new_directory()?;
@@ -135,7 +145,12 @@ impl Transaction {
 
     /// Create a new file with string contents at a relative path to
     /// the install prefix.
-    pub fn write_file(&mut self, component: &str, relpath: PathBuf, content: String) -> Result<()> {
+    pub fn write_file(
+        &mut self,
+        component: &str,
+        relpath: PathBuf,
+        content: String,
+    ) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let (item, mut file) = ChangedItem::add_file(&self.prefix, component, relpath.clone())?;
         utils::write_str(
@@ -152,7 +167,7 @@ impl Transaction {
     /// to it exists so that subsequent calls to `File::create` will succeed.
     ///
     /// This is used for arbitrarily manipulating a file.
-    pub fn modify_file(&mut self, relpath: PathBuf) -> Result<()> {
+    pub fn modify_file(&mut self, relpath: PathBuf) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = self.prefix.abs_path(&relpath);
         let backup = if utils::is_file(&abs_path) {
@@ -177,7 +192,7 @@ impl Transaction {
         component: &str,
         relpath: PathBuf,
         src: &Path,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = ChangedItem::dest_abs_path(&self.prefix, component, &relpath)?;
         utils::rename("component", src, &abs_path, self.permit_copy_rename)?;
@@ -186,7 +201,12 @@ impl Transaction {
     }
 
     /// Recursively move a directory to a relative path of the install prefix.
-    pub(crate) fn move_dir(&mut self, component: &str, relpath: PathBuf, src: &Path) -> Result<()> {
+    pub(crate) fn move_dir(
+        &mut self,
+        component: &str,
+        relpath: PathBuf,
+        src: &Path,
+    ) -> anyhow::Result<()> {
         assert!(relpath.is_relative());
         let abs_path = ChangedItem::dest_abs_path(&self.prefix, component, &relpath)?;
         utils::rename("component", src, &abs_path, self.permit_copy_rename)?;
@@ -231,7 +251,7 @@ enum ChangedItem {
 }
 
 impl ChangedItem {
-    fn roll_back(&self, prefix: &InstallPrefix, permit_copy_rename: bool) -> Result<()> {
+    fn roll_back(&self, prefix: &InstallPrefix, permit_copy_rename: bool) -> anyhow::Result<()> {
         use self::ChangedItem::*;
         match self {
             AddedFile(path) => utils::remove_file("component", &prefix.abs_path(path))?,
@@ -254,7 +274,11 @@ impl ChangedItem {
         }
         Ok(())
     }
-    fn dest_abs_path(prefix: &InstallPrefix, component: &str, relpath: &Path) -> Result<PathBuf> {
+    fn dest_abs_path(
+        prefix: &InstallPrefix,
+        component: &str,
+        relpath: &Path,
+    ) -> anyhow::Result<PathBuf> {
         let abs_path = prefix.abs_path(relpath);
         if utils::path_exists(&abs_path) {
             Err(anyhow!(RustupError::ComponentConflict {
@@ -268,7 +292,11 @@ impl ChangedItem {
             Ok(abs_path)
         }
     }
-    fn add_file(prefix: &InstallPrefix, component: &str, relpath: PathBuf) -> Result<(Self, File)> {
+    fn add_file(
+        prefix: &InstallPrefix,
+        component: &str,
+        relpath: PathBuf,
+    ) -> anyhow::Result<(Self, File)> {
         let abs_path = Self::dest_abs_path(prefix, component, &relpath)?;
         let file = File::create(&abs_path)
             .with_context(|| format!("error creating file '{}'", abs_path.display()))?;

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use super::manifest::Component;
@@ -14,11 +14,11 @@ pub struct Config {
 }
 
 impl Config {
-    pub(crate) fn parse(data: &str) -> Result<Self> {
+    pub(crate) fn parse(data: &str) -> anyhow::Result<Self> {
         toml::from_str(data).context("error parsing config")
     }
 
-    pub(crate) fn stringify(&self) -> Result<String> {
+    pub(crate) fn stringify(&self) -> anyhow::Result<String> {
         Ok(toml::to_string(&self)?)
     }
 }

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use indicatif::{MultiProgress, ProgressBar, ProgressBarIter, ProgressDrawTarget, ProgressStyle};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
@@ -54,7 +54,7 @@ impl<'a> DownloadCfg<'a> {
         url: &Url,
         hash: &str,
         status: &DownloadStatus,
-    ) -> Result<File> {
+    ) -> anyhow::Result<File> {
         utils::ensure_dir_exists("Download Directory", self.download_dir)?;
         let target_file = self.download_dir.join(Path::new(hash));
 
@@ -125,7 +125,7 @@ impl<'a> DownloadCfg<'a> {
         }
     }
 
-    pub(crate) fn clean(&self, hashes: &[impl AsRef<Path>]) -> Result<()> {
+    pub(crate) fn clean(&self, hashes: &[impl AsRef<Path>]) -> anyhow::Result<()> {
         for hash in hashes.iter() {
             let used_file = self.download_dir.join(hash);
             if self.download_dir.join(&used_file).exists() {
@@ -135,7 +135,7 @@ impl<'a> DownloadCfg<'a> {
         Ok(())
     }
 
-    async fn download_hash(&self, url: &str) -> Result<String> {
+    async fn download_hash(&self, url: &str) -> anyhow::Result<String> {
         let hash_url = utils::parse_url(&(url.to_owned() + ".sha256"))?;
         let hash_file = self.tmp_cx.new_file()?;
         DownloadOptions::try_from(self.process)?
@@ -150,7 +150,7 @@ impl<'a> DownloadCfg<'a> {
         update_hash: Option<&Path>,
         toolchain: &ToolchainDesc,
         cfg: &Cfg<'_>,
-    ) -> Result<Option<ManifestWithHash>> {
+    ) -> anyhow::Result<Option<ManifestWithHash>> {
         let manifest_url = toolchain.manifest_v2_url(&cfg.dist_root_url, self.process);
         match self
             .download_and_check(&manifest_url, update_hash, None, ".toml")
@@ -203,7 +203,7 @@ impl<'a> DownloadCfg<'a> {
         &self,
         dist_root: &str,
         toolchain: &ToolchainDesc,
-    ) -> Result<Vec<String>> {
+    ) -> anyhow::Result<Vec<String>> {
         let root_url = toolchain.package_dir(dist_root);
 
         if let Channel::Version(ver) = &toolchain.channel {
@@ -238,7 +238,7 @@ impl<'a> DownloadCfg<'a> {
         update_hash: Option<&Path>,
         status: Option<&DownloadStatus>,
         ext: &str,
-    ) -> Result<Option<(temp::File, String)>> {
+    ) -> anyhow::Result<Option<(temp::File, String)>> {
         let hash = self.download_hash(url_str).await?;
         let partial_hash: String = hash.chars().take(UPDATE_HASH_LEN).collect();
 
@@ -314,7 +314,7 @@ impl<'a> DownloadCfg<'a> {
         }
     }
 
-    pub(crate) fn url(&self, url: &str) -> Result<Url> {
+    pub(crate) fn url(&self, url: &str) -> anyhow::Result<Url> {
         match &*self.tmp_cx.dist_server {
             server if server != DEFAULT_DIST_SERVER => utils::parse_url(
                 &url.replace(DEFAULT_DIST_SERVER, self.tmp_cx.dist_server.as_str()),
@@ -444,7 +444,7 @@ impl DownloadStatus {
     }
 }
 
-fn file_hash(path: &Path) -> Result<String> {
+fn file_hash(path: &Path) -> anyhow::Result<String> {
     let mut hasher = Sha256::new();
     let mut downloaded = utils::buffered(path)?;
     let mut buf = vec![0; 32768];

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -19,7 +19,7 @@ use std::{
     str::FromStr,
 };
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, anyhow, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -297,7 +297,7 @@ impl Hash for Component {
 }
 
 mod component_target {
-    use super::{Result, TargetTuple};
+    use super::TargetTuple;
     use serde::{Deserialize, Deserializer, Serializer};
 
     pub fn serialize<S: Serializer>(
@@ -312,7 +312,7 @@ mod component_target {
 
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<Option<TargetTuple>, D::Error> {
+    ) -> anyhow::Result<Option<TargetTuple>, D::Error> {
         Ok(match Option::<String>::deserialize(deserializer)? {
             Some(s) if s != "*" => Some(TargetTuple::new(s)),
             _ => None,
@@ -321,7 +321,7 @@ mod component_target {
 }
 
 impl Manifest {
-    pub fn parse(data: &str) -> Result<Self> {
+    pub fn parse(data: &str) -> anyhow::Result<Self> {
         let mut manifest = toml::from_str::<Self>(data).context("error parsing manifest")?;
         for (from, to) in manifest.renames.iter() {
             manifest.reverse_renames.insert(to.to.clone(), from.clone());
@@ -331,11 +331,11 @@ impl Manifest {
         Ok(manifest)
     }
 
-    pub fn stringify(self) -> Result<String> {
+    pub fn stringify(self) -> anyhow::Result<String> {
         Ok(toml::to_string(&self)?)
     }
 
-    pub(super) fn binary(&self, component: &Component) -> Result<Option<&HashedBinary>> {
+    pub(super) fn binary(&self, component: &Component) -> anyhow::Result<Option<&HashedBinary>> {
         let package = self.get_package(component.short_name())?;
         let target_package = package.get_target(component.target.as_ref())?;
         // We prefer the first format in the list, since the parsing of the
@@ -343,17 +343,20 @@ impl Manifest {
         Ok(target_package.bins.first())
     }
 
-    pub fn get_package(&self, name: &str) -> Result<&Package> {
+    pub fn get_package(&self, name: &str) -> anyhow::Result<&Package> {
         self.packages
             .get(name)
             .ok_or_else(|| anyhow!(format!("package not found: '{name}'")))
     }
 
-    pub(crate) fn get_rust_version(&self) -> Result<&str> {
+    pub(crate) fn get_rust_version(&self) -> anyhow::Result<&str> {
         self.get_package("rust").map(|p| &*p.version)
     }
 
-    pub(crate) fn get_legacy_components(&self, target: &TargetTuple) -> Result<Vec<Component>> {
+    pub(crate) fn get_legacy_components(
+        &self,
+        target: &TargetTuple,
+    ) -> anyhow::Result<Vec<Component>> {
         // Build a profile from the components/extensions.
         let result = self
             .get_package("rust")?
@@ -370,7 +373,7 @@ impl Manifest {
         &self,
         profile: Profile,
         target: &TargetTuple,
-    ) -> Result<Vec<Component>> {
+    ) -> anyhow::Result<Vec<Component>> {
         // An older manifest with no profiles section.
         if self.profiles.is_empty() {
             return self.get_legacy_components(target);
@@ -398,7 +401,7 @@ impl Manifest {
         Ok(result)
     }
 
-    fn validate_targeted_package(&self, tpkg: &TargetedPackage) -> Result<()> {
+    fn validate_targeted_package(&self, tpkg: &TargetedPackage) -> anyhow::Result<()> {
         for c in tpkg.components.iter() {
             let cpkg = self.get_package(&c.pkg).with_context(|| {
                 RustupError::MissingPackageForComponent(self.short_name(c).to_owned())
@@ -410,7 +413,7 @@ impl Manifest {
         Ok(())
     }
 
-    fn validate(&self) -> Result<()> {
+    fn validate(&self) -> anyhow::Result<()> {
         // Every component mentioned must have an actual package to download
         for pkg in self.packages.values() {
             match &pkg.targets {
@@ -454,7 +457,7 @@ impl Manifest {
         &self,
         desc: &ToolchainDesc,
         config: &Config,
-    ) -> Result<Vec<ComponentStatus>> {
+    ) -> anyhow::Result<Vec<ComponentStatus>> {
         // Return all optional components of the "rust" package for the
         // toolchain's target tuple.
         let mut res = Vec::new();
@@ -502,7 +505,7 @@ impl Manifest {
 }
 
 impl Package {
-    pub fn get_target(&self, target: Option<&TargetTuple>) -> Result<&TargetedPackage> {
+    pub fn get_target(&self, target: Option<&TargetTuple>) -> anyhow::Result<&TargetedPackage> {
         match &self.targets {
             PackageTargets::Wildcard(tpkg) => Ok(tpkg),
             PackageTargets::Targeted(tpkgs) => {
@@ -553,7 +556,7 @@ impl Component {
         name: &str,
         distributable: &DistributableToolchain<'_>,
         fallback_target: Option<&TargetTuple>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         let manifest = distributable.get_manifest()?;
         for component_status in distributable.components()? {
             let component = component_status.component;

--- a/src/dist/manifestation.rs
+++ b/src/dist/manifestation.rs
@@ -13,7 +13,7 @@ use std::{
     vec,
 };
 
-use anyhow::{Context as _, Result, anyhow, bail};
+use anyhow::{Context as _, anyhow, bail};
 use futures_util::{
     Stream,
     stream::{FuturesUnordered, StreamExt},
@@ -55,7 +55,7 @@ impl Changes {
         self.explicit_add_components.iter()
     }
 
-    fn check_invariants(&self, config: &Option<Config>) -> Result<()> {
+    fn check_invariants(&self, config: &Option<Config>) -> anyhow::Result<()> {
         for component_to_add in self.iter_add_components() {
             if self.remove_components.contains(component_to_add) {
                 bail!("can't both add and remove components");
@@ -86,7 +86,7 @@ impl Manifestation {
     /// it will be created as needed. If there's an existing install
     /// then the rust-install installation format will be verified. A
     /// bad installer version is the only reason this will fail.
-    pub fn open(prefix: InstallPrefix, target_tuple: TargetTuple) -> Result<Self> {
+    pub fn open(prefix: InstallPrefix, target_tuple: TargetTuple) -> anyhow::Result<Self> {
         // TODO: validate the tuple with the existing install as well
         // as the metadata format of the existing install
         Ok(Self {
@@ -121,7 +121,7 @@ impl Manifestation {
         download_cfg: &DownloadCfg<'_>,
         toolchain: &ToolchainDesc,
         implicit_modify: bool,
-    ) -> Result<UpdateStatus> {
+    ) -> anyhow::Result<UpdateStatus> {
         // Some vars we're going to need a few times
         let prefix = self.installation.prefix();
         let rel_installed_manifest_path = prefix.rel_manifest_file(DIST_MANIFEST);
@@ -188,7 +188,7 @@ impl Manifestation {
                     &toolchain.target,
                 )
             })
-            .collect::<Result<Vec<_>>>()?;
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         const DEFAULT_CONCURRENT_DOWNLOADS: usize = 2;
         let concurrent_downloads = download_cfg
@@ -328,7 +328,7 @@ impl Manifestation {
         component: Component,
         manifest: &Manifest,
         mut tx: Transaction,
-    ) -> Result<Transaction> {
+    ) -> anyhow::Result<Transaction> {
         // For historical reasons, the rust-installer component
         // names are not the same as the dist manifest component
         // names. Some are just the component name some are the
@@ -351,7 +351,7 @@ impl Manifestation {
 
     // Read the config file. Config files are presently only created
     // for v2 installations.
-    pub(crate) fn read_config(&self) -> Result<Option<Config>> {
+    pub(crate) fn read_config(&self) -> anyhow::Result<Option<Config>> {
         let prefix = self.installation.prefix();
         let rel_config_path = prefix.rel_manifest_file(CONFIG_FILE);
         let config_path = prefix.path().join(rel_config_path);
@@ -369,7 +369,7 @@ impl Manifestation {
     }
 
     #[tracing::instrument(level = "trace")]
-    pub fn load_manifest(&self) -> Result<Option<Manifest>> {
+    pub fn load_manifest(&self) -> anyhow::Result<Option<Manifest>> {
         let prefix = self.installation.prefix();
         if let Some(old_manifest_path) = prefix.dist_manifest() {
             let manifest_str = utils::read_file("installed manifest", &old_manifest_path)?;
@@ -390,7 +390,7 @@ impl Manifestation {
         new_manifest: &[String],
         update_hash: &Path,
         dl_cfg: &DownloadCfg<'_>,
-    ) -> Result<Option<String>> {
+    ) -> anyhow::Result<Option<String>> {
         // If there's already a v2 installation then something has gone wrong
         if self.read_config()?.is_some() {
             return Err(anyhow!(
@@ -461,7 +461,7 @@ impl Manifestation {
         &self,
         config: &Option<Config>,
         mut tx: Transaction,
-    ) -> Result<Transaction> {
+    ) -> anyhow::Result<Transaction> {
         let installed_components = self.installation.list()?;
         let looks_like_v1 = config.is_none() && !installed_components.is_empty();
 
@@ -482,7 +482,7 @@ struct InstallEvents<'a, F> {
     components: vec::IntoIter<ComponentBinary<'a>>,
     cleanup_downloads: Vec<&'a str>,
     install_queue: VecDeque<ComponentInstall>,
-    installing: Option<JoinHandle<Result<Transaction>>>,
+    installing: Option<JoinHandle<anyhow::Result<Transaction>>>,
     downloads: FuturesUnordered<F>,
 }
 
@@ -519,8 +519,10 @@ impl<'a, F> InstallEvents<'a, F> {
     }
 }
 
-impl<'a, F: Future<Output = Result<(ComponentInstall, &'a str)>>> Stream for InstallEvents<'a, F> {
-    type Item = Result<Transaction>;
+impl<'a, F: Future<Output = anyhow::Result<(ComponentInstall, &'a str)>>> Stream
+    for InstallEvents<'a, F>
+{
+    type Item = anyhow::Result<Transaction>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.as_mut();
@@ -576,7 +578,7 @@ impl Update {
         new_manifest: &Manifest,
         changes: &Changes,
         config: &Option<Config>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         // The package to install.
         let rust_package = new_manifest.get_package("rust")?;
         let rust_target_package = rust_package.get_target(Some(&manifestation.target_tuple))?;
@@ -703,7 +705,7 @@ impl Update {
         &self,
         new_manifest: &Manifest,
         toolchain: &ToolchainDesc,
-    ) -> Result<()> {
+    ) -> anyhow::Result<()> {
         let mut unavailable_components: Vec<Component> = self
             .components_to_install
             .iter()
@@ -751,7 +753,7 @@ impl<'a> ComponentBinary<'a> {
         download_cfg: &'a DownloadCfg<'a>,
         name_width: usize,
         host_toolchain_target: &TargetTuple,
-    ) -> Option<Result<Self>> {
+    ) -> Option<anyhow::Result<Self>> {
         Some(Ok(ComponentBinary {
             binary: match manifest.binary(&component) {
                 Ok(Some(b)) => b,
@@ -768,7 +770,7 @@ impl<'a> ComponentBinary<'a> {
         }))
     }
 
-    async fn download(self, max_retries: usize) -> Result<(ComponentInstall, &'a str)> {
+    async fn download(self, max_retries: usize) -> anyhow::Result<(ComponentInstall, &'a str)> {
         use tokio_retry::{RetryIf, strategy::FixedInterval};
 
         let url = self.download_cfg.url(&self.binary.url)?;
@@ -823,7 +825,11 @@ struct ComponentInstall {
 }
 
 impl ComponentInstall {
-    fn install(self, tx: Transaction, manifestation: Arc<Manifestation>) -> Result<Transaction> {
+    fn install(
+        self,
+        tx: Transaction,
+        manifestation: Arc<Manifestation>,
+    ) -> anyhow::Result<Transaction> {
         // For historical reasons, the rust-installer component
         // names are not the same as the dist manifest component
         // names. Some are just the component name some are the

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -11,7 +11,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::{Result, anyhow};
+use anyhow::anyhow;
 use url::Url;
 
 use crate::{
@@ -381,7 +381,7 @@ async fn rename_component_new() {
     assert!(utils::path_exists(cx.prefix.path().join("bin/bonus")));
 }
 
-fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> Result<Url> {
+fn make_manifest_url(dist_server: &Url, toolchain: &ToolchainDesc) -> anyhow::Result<Url> {
     let url = format!(
         "{}/dist/channel-rust-{}.toml",
         dist_server, toolchain.channel
@@ -482,7 +482,7 @@ impl TestContext {
         add: &[Component],
         remove: &[Component],
         force: bool,
-    ) -> Result<UpdateStatus> {
+    ) -> anyhow::Result<UpdateStatus> {
         let dl_cfg = DownloadCfg {
             tmp_cx: self.tmp_cx.clone(),
             download_dir: &self.download_dir,

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -5,7 +5,7 @@ use std::{
     sync::LazyLock,
 };
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use chrono::NaiveDate;
 use clap::{ValueEnum, builder::PossibleValue};
 use itertools::Itertools;
@@ -134,7 +134,7 @@ struct ParsedToolchainDesc {
 
 impl FromStr for ParsedToolchainDesc {
     type Err = anyhow::Error;
-    fn from_str(desc: &str) -> Result<Self> {
+    fn from_str(desc: &str) -> anyhow::Result<Self> {
         // Note this regex gives you a guaranteed match of the channel (1)
         // and an optional match of the date (2) and target (3)
         static TOOLCHAIN_CHANNEL_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -201,7 +201,7 @@ pub struct PartialToolchainDesc {
 
 impl PartialToolchainDesc {
     /// Create a toolchain desc using input_host to fill in missing fields
-    pub(crate) fn resolve(self, input_host: &TargetTuple) -> Result<ToolchainDesc> {
+    pub(crate) fn resolve(self, input_host: &TargetTuple) -> anyhow::Result<ToolchainDesc> {
         let host = PartialTargetTuple::new(&input_host.0).ok_or_else(|| {
             anyhow!(format!(
                 "Provided host '{}' couldn't be converted to partial tuple",
@@ -248,7 +248,7 @@ impl PartialToolchainDesc {
 
 impl FromStr for PartialToolchainDesc {
     type Err = anyhow::Error;
-    fn from_str(name: &str) -> Result<Self> {
+    fn from_str(name: &str) -> anyhow::Result<Self> {
         let parsed: ParsedToolchainDesc = name.parse()?;
         let target = PartialTargetTuple::new(parsed.target.as_deref().unwrap_or(""));
 
@@ -339,7 +339,7 @@ impl ToolchainDesc {
 
 impl FromStr for ToolchainDesc {
     type Err = anyhow::Error;
-    fn from_str(name: &str) -> Result<Self> {
+    fn from_str(name: &str) -> anyhow::Result<Self> {
         let parsed: ParsedToolchainDesc = name.parse()?;
 
         if parsed.target.is_none() {
@@ -388,7 +388,7 @@ impl fmt::Display for Channel {
 
 impl FromStr for Channel {
     type Err = anyhow::Error;
-    fn from_str(chan: &str) -> Result<Self> {
+    fn from_str(chan: &str) -> anyhow::Result<Self> {
         match chan {
             "stable" => Ok(Self::Stable),
             "beta" => Ok(Self::Beta),
@@ -426,7 +426,7 @@ impl fmt::Display for PartialVersion {
 
 impl FromStr for PartialVersion {
     type Err = anyhow::Error;
-    fn from_str(ver: &str) -> Result<Self> {
+    fn from_str(ver: &str) -> anyhow::Result<Self> {
         // `semver::Comparator::from_str` supports an optional operator
         // (e.g. `=`, `>`, `>=`, `<`, `<=`, `~`, `^`, `*`) before the
         // partial version, so we should exclude that case first.
@@ -649,7 +649,7 @@ impl TargetTuple {
         Self::from_host(process).unwrap_or_else(Self::from_build)
     }
 
-    pub(crate) fn can_run(&self, other: &Self) -> Result<bool> {
+    pub(crate) fn can_run(&self, other: &Self) -> anyhow::Result<bool> {
         // Most trivial shortcut of all
         if self == other {
             return Ok(true);
@@ -788,7 +788,7 @@ impl ValueEnum for Profile {
 impl FromStr for Profile {
     type Err = anyhow::Error;
 
-    fn from_str(name: &str) -> Result<Self> {
+    fn from_str(name: &str) -> anyhow::Result<Self> {
         match name {
             "minimal" | "m" => Ok(Self::Minimal),
             "default" | "d" | "" => Ok(Self::Default),
@@ -842,7 +842,7 @@ impl ValueEnum for Switch {
 impl FromStr for Switch {
     type Err = anyhow::Error;
 
-    fn from_str(mode: &str) -> Result<Self> {
+    fn from_str(mode: &str) -> anyhow::Result<Self> {
         match mode {
             "enable" => Ok(Self::Enable),
             "disable" => Ok(Self::Disable),
@@ -889,7 +889,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         profile: Profile,
         force: bool,
         cfg: &'cfg Cfg<'cfg>,
-    ) -> Result<Self> {
+    ) -> anyhow::Result<Self> {
         Ok(Self {
             cfg,
             toolchain,
@@ -940,7 +940,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         &self,
         prefix: &InstallPrefix,
         mut prefetched_manifest: Option<ManifestWithHash>,
-    ) -> Result<Option<String>> {
+    ) -> anyhow::Result<Option<String>> {
         let fresh_install = !prefix.path().exists();
         // fresh_install means the toolchain isn't present, but hash_exists means there is a stray hash file
         if fresh_install && self.update_hash.exists() {
@@ -1109,8 +1109,8 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         &self,
         toolchain: Option<&ToolchainDesc>,
         prefix: &InstallPrefix,
-        manifest_result: Result<Option<ManifestWithHash>>,
-    ) -> Result<Option<String>> {
+        manifest_result: anyhow::Result<Option<ManifestWithHash>>,
+    ) -> anyhow::Result<Option<String>> {
         let download = &self.dl_cfg;
         let toolchain = toolchain.unwrap_or(self.toolchain);
         let manifestation = Manifestation::open(prefix.clone(), toolchain.target.clone())?;
@@ -1254,7 +1254,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
         &self,
         prefix: &InstallPrefix,
         toolchain: &ToolchainDesc,
-    ) -> Result<Option<ManifestWithHash>> {
+    ) -> anyhow::Result<Option<ManifestWithHash>> {
         self.dl_cfg
             .dl_v2_manifest(
                 // Skip the update hash when the installed manifest is missing or when components
@@ -1398,7 +1398,7 @@ mod tests {
     }
 
     #[test]
-    fn partial_version_from_str() -> Result<()> {
+    fn partial_version_from_str() -> anyhow::Result<()> {
         assert_eq!(
             PartialVersion::from_str("0.12")?,
             PartialVersion {

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::{fmt, fs, ops};
 
-pub(crate) use anyhow::{Context as _, Result};
+pub(crate) use anyhow::Context as _;
 use thiserror::Error as ThisError;
 use tracing::{debug, warn};
 
@@ -85,14 +85,14 @@ impl Context {
         }
     }
 
-    pub(crate) fn create_root(&self) -> Result<bool> {
+    pub(crate) fn create_root(&self) -> anyhow::Result<bool> {
         raw::ensure_dir_exists(&self.root_directory, |p| {
             debug!(path = %p.display(), "creating temp root");
         })
         .with_context(|| CreatingError::Root(PathBuf::from(&self.root_directory)))
     }
 
-    pub(crate) fn new_directory(&self) -> Result<Dir> {
+    pub(crate) fn new_directory(&self) -> anyhow::Result<Dir> {
         self.create_root()?;
 
         loop {
@@ -111,11 +111,11 @@ impl Context {
         }
     }
 
-    pub fn new_file(&self) -> Result<File> {
+    pub fn new_file(&self) -> anyhow::Result<File> {
         self.new_file_with_ext("", "")
     }
 
-    pub(crate) fn new_file_with_ext(&self, prefix: &str, ext: &str) -> Result<File> {
+    pub(crate) fn new_file_with_ext(&self, prefix: &str, ext: &str) -> anyhow::Result<File> {
         self.create_root()?;
 
         loop {

--- a/src/fallback_settings.rs
+++ b/src/fallback_settings.rs
@@ -2,7 +2,7 @@
 use std::{io, path::Path};
 
 #[cfg(unix)]
-use anyhow::{Context, Result};
+use anyhow::Context;
 use serde::Deserialize;
 
 #[cfg(unix)]
@@ -15,7 +15,7 @@ pub struct FallbackSettings {
 
 impl FallbackSettings {
     #[cfg(unix)]
-    pub(crate) fn new<P: AsRef<Path>>(path: P) -> Result<Option<Self>> {
+    pub(crate) fn new<P: AsRef<Path>>(path: P) -> anyhow::Result<Option<Self>> {
         // Users cannot fix issues with missing/unreadable/invalid centralised files, but logging isn't setup early so
         // we can't simply trap all errors and log diagnostics. Ideally we would, and then separate these into different
         // sorts of issues, logging messages about errors that should be fixed. Instead we trap some conservative errors

--- a/src/install.rs
+++ b/src/install.rs
@@ -2,7 +2,6 @@
 //! toolchains
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
 use tracing::debug;
 
 use crate::{
@@ -37,7 +36,10 @@ pub(crate) enum InstallMethod<'cfg, 'a> {
 impl InstallMethod<'_, '_> {
     // Install a toolchain
     #[tracing::instrument(level = "trace", err(level = "trace"), skip_all)]
-    pub(crate) async fn install(self, manifest: Option<ManifestWithHash>) -> Result<UpdateStatus> {
+    pub(crate) async fn install(
+        self,
+        manifest: Option<ManifestWithHash>,
+    ) -> anyhow::Result<UpdateStatus> {
         // Initialize rayon for use by the remove_dir_all crate limiting the number of threads.
         // This will error if rayon is already initialized but it's fine to ignore that.
         let _ = rayon::ThreadPoolBuilder::new()
@@ -82,7 +84,7 @@ impl InstallMethod<'_, '_> {
         }
     }
 
-    async fn run(&self, path: &Path, manifest: Option<ManifestWithHash>) -> Result<bool> {
+    async fn run(&self, path: &Path, manifest: Option<ManifestWithHash>) -> anyhow::Result<bool> {
         if path.exists() {
             // Don't uninstall first for Dist method
             match self {
@@ -153,6 +155,6 @@ impl InstallMethod<'_, '_> {
     }
 }
 
-pub(crate) fn uninstall(path: &Path) -> Result<()> {
+pub(crate) fn uninstall(path: &Path) -> anyhow::Result<()> {
     utils::remove_dir("install", path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 ))]
 #![recursion_limit = "1024"]
 
-use anyhow::{Result, anyhow};
+use anyhow::anyhow;
 use errors::RustupError;
 use itertools::{Itertools, chain};
 
@@ -32,7 +32,7 @@ pub static TOOLS: &[&str] = &[
 pub static DUP_TOOLS: &[&str] = &["rust-analyzer", "rustfmt", "cargo-fmt"];
 
 // If the given name is one of the tools we proxy.
-pub fn is_proxyable_tools(tool: &str) -> Result<()> {
+pub fn is_proxyable_tools(tool: &str) -> anyhow::Result<()> {
     if chain!(TOOLS, DUP_TOOLS).contains(&tool) {
         Ok(())
     } else {

--- a/src/process.rs
+++ b/src/process.rs
@@ -17,7 +17,7 @@ use std::{
 use std::{env, thread};
 
 use anstream::ColorChoice;
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, bail};
 use indicatif::ProgressDrawTarget;
 #[cfg(feature = "test")]
 use tracing::subscriber::DefaultGuard;
@@ -66,15 +66,15 @@ impl Process {
         home::env::home_dir_with_env(self)
     }
 
-    pub(crate) fn cargo_home(&self) -> Result<PathBuf> {
+    pub(crate) fn cargo_home(&self) -> anyhow::Result<PathBuf> {
         home::env::cargo_home_with_env(self).context("failed to determine cargo home")
     }
 
-    pub(crate) fn rustup_home(&self) -> Result<PathBuf> {
+    pub(crate) fn rustup_home(&self) -> anyhow::Result<PathBuf> {
         home::env::rustup_home_with_env(self).context("failed to determine rustup home dir")
     }
 
-    pub fn io_thread_count(&self) -> Result<IoThreadCount> {
+    pub fn io_thread_count(&self) -> anyhow::Result<IoThreadCount> {
         if let Ok(n) = self.var("RUSTUP_IO_THREADS") {
             let threads = usize::from_str(&n).context(
                 "invalid value in RUSTUP_IO_THREADS -- must be a natural number greater than zero",
@@ -95,14 +95,14 @@ impl Process {
         Ok(IoThreadCount::Default(count))
     }
 
-    pub(crate) fn unpack_ram(&self) -> Result<Option<usize>, env::VarError> {
+    pub(crate) fn unpack_ram(&self) -> anyhow::Result<Option<usize>, env::VarError> {
         Ok(match self.var_opt("RUSTUP_UNPACK_RAM")? {
             Some(budget) => usize::from_str(&budget).ok(),
             None => None,
         })
     }
 
-    pub fn var_opt(&self, key: &str) -> Result<Option<String>, env::VarError> {
+    pub fn var_opt(&self, key: &str) -> anyhow::Result<Option<String>, env::VarError> {
         match self.var(key) {
             Ok(val) => Ok(Some(val)),
             Err(env::VarError::NotPresent) => Ok(None),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
-use anyhow::{Context, Result};
+use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -27,7 +27,7 @@ impl SettingsFile {
         }
     }
 
-    fn write_settings(&self) -> Result<()> {
+    fn write_settings(&self) -> anyhow::Result<()> {
         let settings = self.cache.borrow();
         utils::write_locked_file(
             "settings",
@@ -37,7 +37,7 @@ impl SettingsFile {
         Ok(())
     }
 
-    fn read_settings(&self) -> Result<()> {
+    fn read_settings(&self) -> anyhow::Result<()> {
         let b = self.cache.borrow();
         if b.is_none() {
             drop(b);
@@ -54,14 +54,20 @@ impl SettingsFile {
         Ok(())
     }
 
-    pub(crate) fn with<T, F: FnOnce(&Settings) -> Result<T>>(&self, f: F) -> Result<T> {
+    pub(crate) fn with<T, F: FnOnce(&Settings) -> anyhow::Result<T>>(
+        &self,
+        f: F,
+    ) -> anyhow::Result<T> {
         self.read_settings()?;
 
         // Settings can no longer be None so it's OK to unwrap
         f(self.cache.borrow().as_ref().unwrap())
     }
 
-    pub(crate) fn with_mut<T, F: FnOnce(&mut Settings) -> Result<T>>(&self, f: F) -> Result<T> {
+    pub(crate) fn with_mut<T, F: FnOnce(&mut Settings) -> anyhow::Result<T>>(
+        &self,
+        f: F,
+    ) -> anyhow::Result<T> {
         self.read_settings()?;
 
         // Settings can no longer be None so it's OK to unwrap
@@ -121,11 +127,11 @@ impl Settings {
         self.overrides.get(&key).cloned()
     }
 
-    pub(crate) fn parse(data: &str) -> Result<Self> {
+    pub(crate) fn parse(data: &str) -> anyhow::Result<Self> {
         toml::from_str(data).context("error parsing settings")
     }
 
-    fn stringify(&self) -> Result<String> {
+    fn stringify(&self) -> anyhow::Result<String> {
         Ok(toml::to_string(self)?)
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -16,8 +16,6 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[cfg(test)]
-use anyhow::Result;
 use sha2::{Digest, Sha256};
 
 use crate::dist::TargetTuple;
@@ -250,9 +248,9 @@ impl fmt::Display for RustupHome {
 /// Create an isolated rustup home with no content, then call f with it, and
 /// delete it afterwards.
 #[cfg(test)]
-pub(super) fn with_rustup_home<F>(f: F) -> Result<()>
+pub(super) fn with_rustup_home<F>(f: F) -> anyhow::Result<()>
 where
-    F: FnOnce(&RustupHome) -> Result<()>,
+    F: FnOnce(&RustupHome) -> anyhow::Result<()>,
 {
     let test_dir = test_dir()?;
     let rustup_home = RustupHome::new_in(test_dir)?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,7 +8,7 @@ use std::ops::{BitAnd, BitAndAssign};
 use std::path::{Path, PathBuf};
 use std::process::ExitStatus;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, anyhow};
 use retry::delay::{Fibonacci, jitter};
 use retry::{OperationResult, retry};
 use tracing::{debug, info, warn};
@@ -70,7 +70,7 @@ impl From<ExitStatus> for ExitCode {
     }
 }
 
-pub fn ensure_dir_exists(name: &'static str, path: &Path) -> Result<bool> {
+pub fn ensure_dir_exists(name: &'static str, path: &Path) -> anyhow::Result<bool> {
     raw::ensure_dir_exists(path, |_| {
         debug!(name, path = %path.display(), "creating directory");
     })
@@ -80,35 +80,39 @@ pub fn ensure_dir_exists(name: &'static str, path: &Path) -> Result<bool> {
     })
 }
 
-pub fn read_file(name: &'static str, path: &Path) -> Result<String> {
+pub fn read_file(name: &'static str, path: &Path) -> anyhow::Result<String> {
     fs::read_to_string(path).with_context(|| RustupError::ReadingFile {
         name,
         path: PathBuf::from(path),
     })
 }
 
-pub(crate) fn read_locked_file(name: &'static str, path: &Path) -> Result<String> {
+pub(crate) fn read_locked_file(name: &'static str, path: &Path) -> anyhow::Result<String> {
     raw::read_locked_file(path).with_context(|| RustupError::ReadingFile {
         name,
         path: PathBuf::from(path),
     })
 }
 
-pub fn write_file(name: &'static str, path: &Path, contents: &str) -> Result<()> {
+pub fn write_file(name: &'static str, path: &Path, contents: &str) -> anyhow::Result<()> {
     raw::write_file(path, contents).with_context(|| RustupError::WritingFile {
         name,
         path: PathBuf::from(path),
     })
 }
 
-pub(crate) fn write_locked_file(name: &'static str, path: &Path, contents: &str) -> Result<()> {
+pub(crate) fn write_locked_file(
+    name: &'static str,
+    path: &Path,
+    contents: &str,
+) -> anyhow::Result<()> {
     raw::write_locked_file(path, contents).with_context(|| RustupError::WritingFile {
         name,
         path: PathBuf::from(path),
     })
 }
 
-pub(crate) fn append_file(name: &'static str, path: &Path, line: &str) -> Result<()> {
+pub(crate) fn append_file(name: &'static str, path: &Path, line: &str) -> anyhow::Result<()> {
     raw::append_file(path, line).with_context(|| RustupError::WritingFile {
         name,
         path: PathBuf::from(path),
@@ -120,14 +124,19 @@ pub(crate) fn write_line(
     mut file: impl Write,
     path: &Path,
     line: &str,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     writeln!(file, "{line}").with_context(|| RustupError::WritingFile {
         name,
         path: path.to_path_buf(),
     })
 }
 
-pub(crate) fn write_str(name: &'static str, file: &mut File, path: &Path, s: &str) -> Result<()> {
+pub(crate) fn write_str(
+    name: &'static str,
+    file: &mut File,
+    path: &Path,
+    s: &str,
+) -> anyhow::Result<()> {
     write!(file, "{s}").with_context(|| RustupError::WritingFile {
         name,
         path: path.to_path_buf(),
@@ -139,7 +148,7 @@ pub(crate) fn filter_file<F: FnMut(&str) -> bool>(
     src: &Path,
     dest: &Path,
     filter: F,
-) -> Result<usize> {
+) -> anyhow::Result<usize> {
     raw::filter_file(src, dest, filter).with_context(|| {
         format!(
             "could not copy {} file from '{}' to '{}'",
@@ -157,11 +166,11 @@ pub(crate) fn canonicalize_path(path: &Path) -> PathBuf {
     })
 }
 
-pub(crate) fn parse_url(url: &str) -> Result<Url> {
+pub(crate) fn parse_url(url: &str) -> anyhow::Result<Url> {
     Url::parse(url).with_context(|| format!("failed to parse url: {url}"))
 }
 
-pub(crate) fn assert_is_file(path: &Path) -> Result<()> {
+pub(crate) fn assert_is_file(path: &Path) -> anyhow::Result<()> {
     if !is_file(path) {
         Err(anyhow!(format!("not a file: '{}'", path.display())))
     } else {
@@ -169,7 +178,7 @@ pub(crate) fn assert_is_file(path: &Path) -> Result<()> {
     }
 }
 
-pub(crate) fn assert_is_directory(path: &Path) -> Result<()> {
+pub(crate) fn assert_is_directory(path: &Path) -> anyhow::Result<()> {
     if !is_directory(path) {
         Err(anyhow!(format!("not a directory: '{}'", path.display())))
     } else {
@@ -177,7 +186,7 @@ pub(crate) fn assert_is_directory(path: &Path) -> Result<()> {
     }
 }
 
-pub(crate) fn symlink_dir(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn symlink_dir(src: &Path, dest: &Path) -> anyhow::Result<()> {
     debug!(source = %src.display(), destination = %dest.display(), "linking directory");
     raw::symlink_dir(src, dest).with_context(|| {
         format!(
@@ -191,7 +200,7 @@ pub(crate) fn symlink_dir(src: &Path, dest: &Path) -> Result<()> {
 /// Attempts to symlink a file, falling back to hard linking if that fails.
 ///
 /// If `dest` already exists then it will be replaced.
-pub(crate) fn symlink_or_hardlink_file(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn symlink_or_hardlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     let _ = fs::remove_file(dest);
     // Use a relative symlink path if the src and dest are in the same directory.
     let symlink_target = if src.parent() == dest.parent() {
@@ -217,7 +226,7 @@ pub(crate) fn symlink_or_hardlink_file(src: &Path, dest: &Path) -> Result<()> {
     hardlink_file(src, dest)
 }
 
-pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
+pub fn hardlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     fs::hard_link(src, dest).with_context(|| RustupError::LinkingFile {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
@@ -225,7 +234,7 @@ pub fn hardlink_file(src: &Path, dest: &Path) -> Result<()> {
 }
 
 #[cfg(unix)]
-fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
+fn symlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     std::os::unix::fs::symlink(src, dest).with_context(|| RustupError::LinkingFile {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
@@ -233,14 +242,14 @@ fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
 }
 
 #[cfg(windows)]
-fn symlink_file(src: &Path, dest: &Path) -> Result<()> {
+fn symlink_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     std::os::windows::fs::symlink_file(src, dest).with_context(|| RustupError::LinkingFile {
         src: PathBuf::from(src),
         dest: PathBuf::from(dest),
     })
 }
 
-pub(crate) fn copy_dir(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn copy_dir(src: &Path, dest: &Path) -> anyhow::Result<()> {
     debug!(source = %src.display(), destination = %dest.display(), "copying directory");
     raw::copy_dir(src, dest).with_context(|| {
         format!(
@@ -253,18 +262,18 @@ pub(crate) fn copy_dir(src: &Path, dest: &Path) -> Result<()> {
 
 /// Copy a file from `src` to `dst`, preserving the symlink target if `src` is a symlink.
 /// This is the default behavior for component installation.
-pub(crate) fn copy_file(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn copy_file(src: &Path, dest: &Path) -> anyhow::Result<()> {
     copy_file_impl(src, dest, true)
 }
 
 /// Copy a file from `src` to `dst`, or if `src` is a symlink, create a new symlink
 /// at `dst` pointing to it.
 /// Used for self-update where we want to preserve the symlink to the original location.
-pub(crate) fn copy_file_symlink_to_source(src: &Path, dest: &Path) -> Result<()> {
+pub(crate) fn copy_file_symlink_to_source(src: &Path, dest: &Path) -> anyhow::Result<()> {
     copy_file_impl(src, dest, false)
 }
 
-fn copy_file_impl(src: &Path, dest: &Path, preserve_symlink: bool) -> Result<()> {
+fn copy_file_impl(src: &Path, dest: &Path, preserve_symlink: bool) -> anyhow::Result<()> {
     let metadata = fs::symlink_metadata(src).with_context(|| RustupError::ReadingFile {
         name: "metadata for",
         path: PathBuf::from(src),
@@ -292,7 +301,7 @@ fn copy_file_impl(src: &Path, dest: &Path, preserve_symlink: bool) -> Result<()>
     }
 }
 
-pub(crate) fn remove_dir(name: &'static str, path: &Path) -> Result<()> {
+pub(crate) fn remove_dir(name: &'static str, path: &Path) -> anyhow::Result<()> {
     debug!(name, path = %path.display(), "removing directory");
     raw::remove_dir(path).with_context(|| RustupError::RemovingDirectory {
         name,
@@ -300,7 +309,7 @@ pub(crate) fn remove_dir(name: &'static str, path: &Path) -> Result<()> {
     })
 }
 
-pub fn remove_file(name: &'static str, path: &Path) -> Result<()> {
+pub fn remove_file(name: &'static str, path: &Path) -> anyhow::Result<()> {
     // Most files we go to remove won't ever be in use. Some, like proxies, may
     // be for indefinite periods, and this will mean we are slower to error and
     // have the user fix the issue. Others, like the setup binary, are
@@ -322,7 +331,7 @@ pub fn remove_file(name: &'static str, path: &Path) -> Result<()> {
     })
 }
 
-pub(crate) fn ensure_file_removed(name: &'static str, path: &Path) -> Result<()> {
+pub(crate) fn ensure_file_removed(name: &'static str, path: &Path) -> anyhow::Result<()> {
     let result = remove_file(name, path);
     if let Err(err) = &result
         && let Some(retry::Error { error: e, .. }) = err.downcast_ref::<retry::Error<io::Error>>()
@@ -336,19 +345,19 @@ pub(crate) fn ensure_file_removed(name: &'static str, path: &Path) -> Result<()>
     })
 }
 
-pub(crate) fn read_dir(name: &'static str, path: &Path) -> Result<fs::ReadDir> {
+pub(crate) fn read_dir(name: &'static str, path: &Path) -> anyhow::Result<fs::ReadDir> {
     fs::read_dir(path).with_context(|| RustupError::ReadingDirectory {
         name,
         path: PathBuf::from(path),
     })
 }
 
-pub(crate) fn open_browser(path: impl AsRef<OsStr>) -> Result<()> {
+pub(crate) fn open_browser(path: impl AsRef<OsStr>) -> anyhow::Result<()> {
     opener::open_browser(path).context("couldn't open browser")
 }
 
 #[cfg(not(windows))]
-fn set_permissions(path: &Path, perms: fs::Permissions) -> Result<()> {
+fn set_permissions(path: &Path, perms: fs::Permissions) -> anyhow::Result<()> {
     fs::set_permissions(path, perms).map_err(|e| {
         RustupError::SettingPermissions {
             p: PathBuf::from(path),
@@ -358,7 +367,7 @@ fn set_permissions(path: &Path, perms: fs::Permissions) -> Result<()> {
     })
 }
 
-pub fn file_size(path: &Path) -> Result<u64> {
+pub fn file_size(path: &Path) -> anyhow::Result<u64> {
     Ok(fs::metadata(path)
         .with_context(|| RustupError::ReadingFile {
             name: "metadata for",
@@ -367,14 +376,14 @@ pub fn file_size(path: &Path) -> Result<u64> {
         .len())
 }
 
-pub(crate) fn make_executable(path: &Path) -> Result<()> {
+pub(crate) fn make_executable(path: &Path) -> anyhow::Result<()> {
     #[allow(clippy::unnecessary_wraps)]
     #[cfg(windows)]
-    fn inner(_: &Path) -> Result<()> {
+    fn inner(_: &Path) -> anyhow::Result<()> {
         Ok(())
     }
     #[cfg(not(windows))]
-    fn inner(path: &Path) -> Result<()> {
+    fn inner(path: &Path) -> anyhow::Result<()> {
         use std::os::unix::fs::PermissionsExt;
 
         let metadata = fs::metadata(path).map_err(|e| RustupError::SettingPermissions {
@@ -397,7 +406,7 @@ pub(crate) fn make_executable(path: &Path) -> Result<()> {
     inner(path)
 }
 
-pub fn current_exe() -> Result<PathBuf> {
+pub fn current_exe() -> anyhow::Result<PathBuf> {
     env::current_exe().context(RustupError::LocatingWorkingDir)
 }
 
@@ -411,7 +420,7 @@ pub(crate) fn format_path_for_display(path: &str) -> String {
 }
 
 #[cfg(target_os = "linux")]
-fn copy_and_delete(name: &'static str, src: &Path, dest: &Path) -> Result<()> {
+fn copy_and_delete(name: &'static str, src: &Path, dest: &Path) -> anyhow::Result<()> {
     // https://github.com/rust-lang/rustup/issues/1239
     // This uses std::fs::copy() instead of the faster std::fs::rename() to
     // avoid cross-device link errors.
@@ -433,7 +442,7 @@ pub fn rename(
     dest: &Path,
     #[allow(unused_variables)] // Only used on Linux
     permit_copy_rename: bool,
-) -> Result<()> {
+) -> anyhow::Result<()> {
     // https://github.com/rust-lang/rustup/issues/1870
     // 21 fib steps from 1 sums to ~28 seconds, hopefully more than enough
     // for our previous poor performance that avoided the race condition with
@@ -487,7 +496,7 @@ pub(crate) fn delete_dir_contents_following_links(dir_path: &Path) {
     }
 }
 
-pub(crate) fn buffered(path: &Path) -> Result<BufReader<File>, anyhow::Error> {
+pub(crate) fn buffered(path: &Path) -> anyhow::Result<BufReader<File>> {
     match File::open(path) {
         Ok(fh) => Ok(BufReader::with_capacity(8 * 1024 * 1024, fh)),
         Err(_) => Err(anyhow!(RustupError::ReadingFile {

--- a/tests/suite/static_roots.rs
+++ b/tests/suite/static_roots.rs
@@ -74,7 +74,7 @@ async fn store_static_roots() -> anyhow::Result<()> {
         for chunk in root_cert.chunks(20) {
             code.push_str("        ");
             for byte in chunk {
-                code.push_str(&format!("\\x{:02x}", byte));
+                code.push_str(&format!("\\x{byte:02x}"));
             }
             code.push_str("\\\n");
         }


### PR DESCRIPTION
> [!NOTE]
> 
> This PR is generated with GitHub Copilot on GPT 5.6 Luna, with manual review and minor modifications. 

As suggested in https://github.com/rust-lang/rustup/pull/5042#discussion_r3923920626, this patch qualifies all uses of `anyhow::Result<>` across the repo.