### PR TITLE
refactor(cli/rustup-mode): avoid redundant allocs in `target_add()`

### DIFF
--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1478,17 +1478,17 @@ async fn target_add(
     )
     .await?;
 
-    let components = distributable.components()?;
-    if targets.contains(&"all".to_string()) {
-        if targets.len() != 1 {
-            return Err(anyhow!(
-                "`rustup target add {}` includes `all`",
-                targets.join(" ")
-            ));
-        }
+    let all = targets.iter().any(|it| it == "all");
+    if all && targets.len() != 1 {
+        return Err(anyhow!(
+            "`rustup target add {}` includes `all`",
+            targets.join(" ")
+        ));
+    }
 
+    if all {
         targets.clear();
-        for component in components {
+        for component in distributable.components()? {
             if component.component.short_name() == "rust-std"
                 && component.available
                 && !component.installed

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1504,18 +1504,13 @@ async fn target_add(
     }
 
     distributable
-        .add_components(
-            targets
-                .into_iter()
-                .map(|target| {
-                    Component::new(
-                        "rust-std".to_string(),
-                        Some(TargetTuple::new(target)),
-                        false,
-                    )
-                })
-                .collect(),
-        )
+        .add_components(targets.into_iter().map(|target| {
+            Component::new(
+                "rust-std".to_string(),
+                Some(TargetTuple::new(target)),
+                false,
+            )
+        }))
         .await?;
 
     Ok(ExitCode::SUCCESS)
@@ -1613,7 +1608,8 @@ async fn component_add(
             components
                 .into_iter()
                 .map(|component| Component::try_new(&component, &distributable, target.as_ref()))
-                .collect::<anyhow::Result<_>>()?,
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter(),
         )
         .await?;
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1464,7 +1464,7 @@ async fn target_list(
 
 async fn target_add(
     cfg: &Cfg<'_>,
-    mut targets: Vec<String>,
+    targets: Vec<String>,
     toolchain: Option<PartialToolchainDesc>,
 ) -> anyhow::Result<ExitCode> {
     // XXX: long term move this error to cli ? the normal .into doesn't work
@@ -1487,20 +1487,14 @@ async fn target_add(
     }
 
     if all {
-        targets.clear();
-        for component in distributable.components()? {
-            if component.component.short_name() == "rust-std"
-                && component.available
-                && !component.installed
-            {
-                let target = component
-                    .component
-                    .target
-                    .as_ref()
-                    .expect("rust-std should have a target");
-                targets.push(target.to_string());
-            }
-        }
+        distributable
+            .add_components(distributable.components()?.into_iter().filter_map(|c| {
+                (c.available && !c.installed && c.component.short_name() == "rust-std")
+                    .then_some(c.component)
+            }))
+            .await?;
+
+        return Ok(ExitCode::SUCCESS);
     }
 
     distributable

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -65,7 +65,10 @@ impl<'a> DistributableToolchain<'a> {
         &self.desc
     }
 
-    pub(crate) async fn add_components(&self, components: Vec<Component>) -> anyhow::Result<()> {
+    pub(crate) async fn add_components(
+        &self,
+        components: impl Iterator<Item = Component>,
+    ) -> anyhow::Result<()> {
         let manifestation = self.get_manifestation()?;
         let manifest = self.get_manifest()?;
 
@@ -78,7 +81,7 @@ impl<'a> DistributableToolchain<'a> {
             .get(&self.desc.target)
             .expect("installed manifest should have a known target");
 
-        let mut validated_components = Vec::with_capacity(components.len());
+        let mut validated_components = Vec::with_capacity(components.size_hint().0);
 
         for mut component in components {
             if let Some(c) = manifest.rename_component(&component) {


### PR DESCRIPTION
Follow-up on a minor pre-existing issue discovered when reviewing #5042.

This patch avoids an extra `.to_string()` allocation and a redundant `into_iter() -> collect() -> into_iter()` round trip.