### PR TITLE
feat(errors): guess toolchain typo in `RustupError::ToolchainNotInstalled`

### DIFF
--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -1,9 +1,6 @@
-#![allow(clippy::large_enum_variant)]
 #![allow(dead_code)]
 
-use std::io;
-use std::path::PathBuf;
-use std::sync::LazyLock;
+use std::{io, path::PathBuf, sync::LazyLock};
 
 use regex::Regex;
 use strsim::damerau_levenshtein;

--- a/src/cli/errors.rs
+++ b/src/cli/errors.rs
@@ -1,9 +1,5 @@
-#![allow(dead_code)]
+use std::{io, path::PathBuf};
 
-use std::{io, path::PathBuf, sync::LazyLock};
-
-use regex::Regex;
-use strsim::damerau_levenshtein;
 use thiserror::Error as ThisError;
 
 #[derive(ThisError, Debug)]
@@ -16,35 +12,4 @@ pub enum CliError {
     ReadDirError { p: PathBuf, source: io::Error },
     #[error("failure during windows uninstall")]
     WindowsUninstallMadness,
-}
-
-fn maybe_suggest_toolchain(bad_name: &str) -> String {
-    let bad_name = &bad_name.to_ascii_lowercase();
-    static VALID_CHANNELS: &[&str] = &["stable", "beta", "nightly"];
-    static NUMBERED: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[0-9]+\.[0-9]+$").unwrap());
-    if NUMBERED.is_match(bad_name) {
-        return format!(". Toolchain numbers tend to have three parts, e.g. {bad_name}.0");
-    }
-
-    // Suggest only for very small differences
-    // High number can result in inaccurate suggestions for short queries e.g. `rls`
-    const MAX_DISTANCE: usize = 3;
-
-    let mut scored: Vec<_> = VALID_CHANNELS
-        .iter()
-        .filter_map(|s| {
-            let distance = damerau_levenshtein(bad_name, s);
-            if distance <= MAX_DISTANCE {
-                Some((distance, s))
-            } else {
-                None
-            }
-        })
-        .collect();
-    scored.sort();
-    if scored.is_empty() {
-        String::new()
-    } else {
-        format!(". Did you mean '{}'?", scored[0].1)
-    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::large_enum_variant)]
 
-use std::ffi::OsString;
-use std::fmt::{Debug, Write as FmtWrite};
-use std::io;
-use std::io::Write;
-use std::path::PathBuf;
+use std::{
+    ffi::OsString,
+    fmt::{Debug, Write as FmtWrite},
+    io::{self, Write},
+    path::PathBuf,
+};
 
 use platforms::Platform;
 use thiserror::Error as ThisError;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::large_enum_variant)]
 
 use std::{
+    borrow::Cow,
     ffi::OsString,
     fmt::{Debug, Write as FmtWrite},
     io::{self, Write},
@@ -120,11 +121,14 @@ pub enum RustupError {
     ToolchainNotInstallable(String),
     #[error(
         "toolchain '{name}' is not installed{}",
-        if let ToolchainName::Official(t) = name {
-            let t = if *is_active { "" } else { &format!(" {t}") };
-            format!("\nhelp: run `rustup toolchain install{t}` to install it")
-        } else {
-            String::new()
+        match name {
+            ToolchainName::Official(t) => {
+                let t = if *is_active { "" } else { &format!(" {t}") };
+                Cow::Owned(format!(
+                    "\nhelp: run `rustup toolchain install{t}` to install it",
+                ))
+            }
+            ToolchainName::Custom(t) => maybe_suggest_toolchain(t),
         },
     )]
     ToolchainNotInstalled {
@@ -189,6 +193,30 @@ fn suggest_message(suggestion: &Option<String>) -> String {
         format!("; did you mean '{suggestion}'?")
     } else {
         String::new()
+    }
+}
+
+fn maybe_suggest_toolchain(bad_name: &str) -> Cow<'static, str> {
+    if bad_name.bytes().all(|b| b".0123456789".contains(&b)) {
+        return Cow::Borrowed("\nhelp: official versioned channels take the form X.Y or X.Y.Z");
+    }
+
+    // Suggest only for very small differences
+    // High number can result in inaccurate suggestions for short queries e.g. `rls`
+    const MAX_DISTANCE: usize = 3;
+
+    let bad_name = &bad_name.to_lowercase();
+    let suggestion = ["stable", "beta", "nightly"]
+        .into_iter()
+        .filter_map(|s| {
+            let distance = strsim::damerau_levenshtein(bad_name, s);
+            (distance <= MAX_DISTANCE).then_some((distance, s))
+        })
+        .max();
+
+    match suggestion {
+        Some((_, s)) => Cow::Owned(format!("\nhelp: did you mean '{s}'?")),
+        None => Cow::Borrowed("\nhelp: maybe you have mistyped the toolchain name?"),
     }
 }
 

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -617,7 +617,7 @@ async fn default_custom_not_installed_toolchain() {
         .is_err()
         .with_stderr(snapbox::str![[r#"
 error: toolchain 'nightly-2016-03-1' is not installed
-
+...
 "#]]);
 }
 
@@ -823,7 +823,7 @@ async fn undefined_linked_toolchain() {
         .with_stdout(snapbox::str![[""]])
         .with_stderr(snapbox::str![[r#"
 error: toolchain 'bogus' is not installed
-
+...
 "#]]);
 }
 

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1554,7 +1554,7 @@ active because: overridden by +toolchain on the command line
         .await
         .with_stderr(snapbox::str![[r#"
 error:[..] toolchain 'foo' is not installed[..]
-
+...
 "#]])
         .is_err();
     cx.config

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -309,6 +309,40 @@ rustc-[HOST_TUPLE]
 }
 
 #[tokio::test]
+async fn default_typo_guess() {
+    let cx = CliTestContext::new(Scenario::SimpleV2).await;
+    cx.config
+        .expect(["rustup", "default", "fable"])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'fable' is not installed
+help: did you mean 'stable'?
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "default", "1.23.4."])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain '1.23.4.' is not installed
+help: official versioned channels take the form X.Y or X.Y.Z
+
+"#]]);
+
+    cx.config
+        .expect(["rustup", "default", "invalid-toolchain"])
+        .await
+        .is_err()
+        .with_stderr(snapbox::str![[r#"
+error: toolchain 'invalid-toolchain' is not installed
+help: maybe you have mistyped the toolchain name?
+
+"#]]);
+}
+
+#[tokio::test]
 async fn default_override() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config


### PR DESCRIPTION
Closes #3317 by adapting a dead function to guess what the user meant when the toolchain name has a typo.
