### PR TITLE
fix(cli/self-update): stop emitting cargo metadata in `warn_if_default_linker_missing()`

### DIFF
--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -744,6 +744,7 @@ fn warn_if_default_linker_missing(process: &Process) {
         // Fill in some dummy settings for `Build`/`Tool` to be able to properly
         // give us the metadata we want
         cc::Build::new()
+            .cargo_metadata(false)
             .opt_level(0)
             .target(&tuple)
             .host(&tuple)


### PR DESCRIPTION
Closes #5059.

Because the output varies from platform to platform, and the influence being purely cosmetic, it is quite tricky to do a full regression test I think?

The regression itself is from the migration to cc-rs in #4807 so many thanks for @ermakov0's pointers.