### PR TITLE
refactor(dist/manifest): extract `Component::std()`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,7 @@ version = "1.30.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Manage multiple rust installations with ease"
-homepage = "https://github.com/rust-lang/rustup"
 keywords = ["rustup", "multirust", "install", "proxy"]
-readme = "README.md"
 repository = "https://github.com/rust-lang/rustup"
 build = "build.rs"
 

--- a/src/cli/rustup_mode.rs
+++ b/src/cli/rustup_mode.rs
@@ -1498,13 +1498,11 @@ async fn target_add(
     }
 
     distributable
-        .add_components(targets.into_iter().map(|target| {
-            Component::new(
-                "rust-std".to_string(),
-                Some(TargetTuple::new(target)),
-                false,
-            )
-        }))
+        .add_components(
+            targets
+                .into_iter()
+                .map(|target| Component::std(TargetTuple::new(target))),
+        )
         .await?;
 
     Ok(ExitCode::SUCCESS)
@@ -1543,8 +1541,9 @@ async fn target_remove(
         if has_at_most_one_target {
             warn!("removing the last target; no build targets will be available");
         }
-        let new_component = Component::new("rust-std".to_string(), Some(target), false);
-        distributable.remove_component(new_component).await?;
+        distributable
+            .remove_component(Component::std(target))
+            .await?;
     }
 
     Ok(ExitCode::SUCCESS)

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -128,16 +128,16 @@ impl<P: Deref<Target = Path>> DirectoryPackage<P> {
             match part.kind {
                 ComponentPartKind::File => {
                     if self.copy {
-                        builder.copy_file(path.clone(), &src_path)?
+                        builder.copy_file(path, &src_path)?
                     } else {
-                        builder.move_file(path.clone(), &src_path)?
+                        builder.move_file(path, &src_path)?
                     }
                 }
                 ComponentPartKind::Dir => {
                     if self.copy {
-                        builder.copy_dir(path.clone(), &src_path)?
+                        builder.copy_dir(path, &src_path)?
                     } else {
-                        builder.move_dir(path.clone(), &src_path)?
+                        builder.move_dir(path, &src_path)?
                     }
                 }
                 _ => return Err(RustupError::CorruptComponent(name.to_owned()).into()),

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -552,6 +552,10 @@ impl Component {
         }
     }
 
+    pub fn std(target: TargetTuple) -> Self {
+        Self::new("rust-std".to_string(), Some(target), false)
+    }
+
     pub(crate) fn try_new(
         name: &str,
         distributable: &DistributableToolchain<'_>,

--- a/src/dist/manifestation/tests.rs
+++ b/src/dist/manifestation/tests.rs
@@ -751,16 +751,8 @@ async fn unavailable_components_is_target() {
 
     let cx = TestContext::new(Some(edit), GZOnly);
     let adds = [
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     // Update with rust-std
@@ -871,16 +863,8 @@ async fn update_preserves_extensions() {
     let cx = TestContext::new(None, GZOnly);
 
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     change_channel_date(&cx.url, "nightly", "2016-02-01");
@@ -921,16 +905,8 @@ async fn update_makes_no_changes_for_identical_manifest() {
 async fn add_extensions_for_initial_install() {
     let cx = TestContext::new(None, GZOnly);
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
@@ -950,16 +926,8 @@ async fn add_extensions_for_same_manifest() {
     cx.update_from_dist(&[], &[], false).await.unwrap();
 
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
@@ -984,16 +952,8 @@ async fn add_extensions_for_upgrade() {
     change_channel_date(&cx.url, "nightly", "2016-02-02");
 
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
@@ -1047,11 +1007,7 @@ async fn add_extensions_does_not_remove_other_components() {
     let cx = TestContext::new(None, GZOnly);
     cx.update_from_dist(&[], &[], false).await.unwrap();
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
@@ -1076,25 +1032,13 @@ async fn remove_extensions_for_initial_install() {
 async fn remove_extensions_for_same_manifest() {
     let cx = TestContext::new(None, GZOnly);
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&[], &removes, false).await.unwrap();
 
@@ -1114,27 +1058,15 @@ async fn remove_extensions_for_upgrade() {
     change_channel_date(&cx.url, "nightly", "2016-02-01");
 
     let adds = vec![
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-apple-darwin")),
-            false,
-        ),
-        Component::new(
-            "rust-std".to_string(),
-            Some(TargetTuple::new("i686-unknown-linux-gnu")),
-            false,
-        ),
+        Component::std(TargetTuple::new("i686-apple-darwin")),
+        Component::std(TargetTuple::new("i686-unknown-linux-gnu")),
     ];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
     change_channel_date(&cx.url, "nightly", "2016-02-02");
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&[], &removes, false).await.unwrap();
 
@@ -1232,11 +1164,7 @@ async fn remove_extension_not_installed() {
     let cx = TestContext::new(None, GZOnly);
     cx.update_from_dist(&[], &[], false).await.unwrap();
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&[], &removes, false).await.unwrap();
 }
@@ -1248,19 +1176,11 @@ fn remove_extensions_for_same_manifest_does_not_reinstall_other_components() {}
 #[tokio::test]
 async fn remove_extensions_does_not_remove_other_components() {
     let cx = TestContext::new(None, GZOnly);
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&[], &removes, false).await.unwrap();
 
@@ -1275,19 +1195,11 @@ async fn remove_extensions_does_not_hang_with_concurrent_downloads_override() {
         [("RUSTUP_CONCURRENT_DOWNLOADS".to_owned(), "2".to_owned())].into(),
     );
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&[], &removes, false).await.unwrap();
 
@@ -1299,27 +1211,15 @@ async fn add_and_remove_for_upgrade() {
     let cx = TestContext::new(None, GZOnly);
     change_channel_date(&cx.url, "nightly", "2016-02-01");
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-unknown-linux-gnu")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-unknown-linux-gnu"))];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
     change_channel_date(&cx.url, "nightly", "2016-02-02");
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-unknown-linux-gnu")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-unknown-linux-gnu"))];
 
     cx.update_from_dist(&adds, &removes, false).await.unwrap();
 
@@ -1337,25 +1237,13 @@ async fn add_and_remove_for_upgrade() {
 async fn add_and_remove() {
     let cx = TestContext::new(None, GZOnly);
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-unknown-linux-gnu")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-unknown-linux-gnu"))];
 
     cx.update_from_dist(&adds, &[], false).await.unwrap();
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-unknown-linux-gnu")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-unknown-linux-gnu"))];
 
     cx.update_from_dist(&adds, &removes, false).await.unwrap();
 
@@ -1374,17 +1262,9 @@ async fn add_and_remove_same_component() {
     let cx = TestContext::new(None, GZOnly);
     cx.update_from_dist(&[], &[], false).await.unwrap();
 
-    let adds = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let adds = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
-    let removes = vec![Component::new(
-        "rust-std".to_string(),
-        Some(TargetTuple::new("i686-apple-darwin")),
-        false,
-    )];
+    let removes = vec![Component::std(TargetTuple::new("i686-apple-darwin"))];
 
     cx.update_from_dist(&adds, &removes, false)
         .await

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -1159,11 +1159,7 @@ impl<'cfg, 'a> DistOptions<'cfg, 'a> {
 
                 for &target in self.targets {
                     let tuple = TargetTuple::new(target);
-                    all_components.insert(Component::new(
-                        "rust-std".to_string(),
-                        Some(tuple),
-                        false,
-                    ));
+                    all_components.insert(Component::std(tuple));
                 }
 
                 let mut explicit_add_components: Vec<_> = all_components.into_iter().collect();

--- a/src/test/mock.rs
+++ b/src/test/mock.rs
@@ -160,7 +160,7 @@ impl MockInstallerBuilder {
             let mut comp_file = OpenOptions::new()
                 .append(true)
                 .create(true)
-                .open(comp_file.clone())
+                .open(comp_file)
                 .unwrap();
             writeln!(comp_file, "{}", component.name).unwrap();
 


### PR DESCRIPTION
> [!NOTE]
> 
> This PR is generated by GitHub Copilot on GPT 5.6 Luna, with manual review and minor adjustments. 

Addresses the concern in https://github.com/rust-lang/rustup/pull/5054#pullrequestreview-5130129288.