### PR TITLE
refactor(test/mock-bin): extract generic environment variable echo option

### DIFF
--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -2,20 +2,28 @@
 //! `Components` and `DirectoryPackage` are the two sides of the
 //! installation / uninstallation process.
 
-use std::borrow::Cow;
-use std::convert::Infallible;
-use std::fmt;
-use std::io::BufWriter;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{
+    borrow::Cow,
+    convert::Infallible,
+    fmt,
+    io::BufWriter,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use anyhow::bail;
 
-use crate::dist::component::package::{INSTALLER_VERSION, VERSION_FILE};
-use crate::dist::component::transaction::Transaction;
-use crate::dist::prefix::InstallPrefix;
-use crate::errors::RustupError;
-use crate::utils;
+use crate::{
+    dist::{
+        component::{
+            package::{INSTALLER_VERSION, VERSION_FILE},
+            transaction::Transaction,
+        },
+        prefix::InstallPrefix,
+    },
+    errors::RustupError,
+    utils,
+};
 
 const COMPONENTS_FILE: &str = "components";
 

--- a/src/dist/component/package.rs
+++ b/src/dist/component/package.rs
@@ -2,23 +2,31 @@
 //! for installing from a directory or tarball to an installation
 //! prefix, represented by a `Components` instance.
 
-use std::collections::{HashMap, HashSet};
-use std::io::{self, BufRead, ErrorKind as IOErrorKind, Read};
-use std::mem;
-use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    io::{self, BufRead, ErrorKind as IOErrorKind, Read},
+    mem,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, anyhow, bail};
 use tar::EntryType;
 use tracing::warn;
 
-use crate::diskio::{ChunkWriter, CompletedIo, Executor, IO_CHUNK_SIZE, Item, Kind};
-use crate::dist::component::components::{ComponentPart, ComponentPartKind, Components};
-use crate::dist::component::transaction::Transaction;
-use crate::dist::manifest::CompressionKind;
-use crate::dist::temp;
-use crate::errors::RustupError;
-use crate::utils;
+use crate::{
+    diskio::{ChunkWriter, CompletedIo, Executor, IO_CHUNK_SIZE, Item, Kind},
+    dist::{
+        component::{
+            components::{ComponentPart, ComponentPartKind, Components},
+            transaction::Transaction,
+        },
+        manifest::CompressionKind,
+        temp,
+    },
+    errors::RustupError,
+    utils,
+};
 
 /// The current metadata revision used by rust-installer
 pub(crate) const INSTALLER_VERSION: &str = "3";

--- a/src/dist/component/tests.rs
+++ b/src/dist/component/tests.rs
@@ -1,10 +1,10 @@
-use std::fs;
-use std::io::Write;
-use std::path::PathBuf;
+use std::{fs, io::Write, path::PathBuf};
 
-use crate::errors::RustupError;
-use crate::test::DistContext;
-use crate::utils::{self, raw as utils_raw};
+use crate::{
+    errors::RustupError,
+    test::DistContext,
+    utils::{self, raw as utils_raw},
+};
 
 #[test]
 fn add_file() {

--- a/src/dist/component/transaction.rs
+++ b/src/dist/component/transaction.rs
@@ -9,17 +9,20 @@
 //! FIXME: This uses ensure_dir_exists in some places but rollback
 //! does not remove any dirs created by it.
 
-use std::fs::File;
-use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::{
+    fs::File,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use anyhow::{Context, anyhow};
 use tracing::{error, info};
 
-use crate::dist::prefix::InstallPrefix;
-use crate::dist::temp;
-use crate::errors::RustupError;
-use crate::utils;
+use crate::{
+    dist::{prefix::InstallPrefix, temp},
+    errors::RustupError,
+    utils,
+};
 
 /// A Transaction tracks changes to the file system, allowing them to
 /// be rolled back in case of an error. Instead of deleting or

--- a/src/dist/config.rs
+++ b/src/dist/config.rs
@@ -1,5 +1,4 @@
-use std::fmt;
-use std::str::FromStr;
+use std::{fmt, str::FromStr};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};

--- a/src/dist/download.rs
+++ b/src/dist/download.rs
@@ -1,10 +1,12 @@
-use std::borrow::Cow;
-use std::fs;
-use std::io::Read;
-use std::ops;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::{
+    borrow::Cow,
+    fs,
+    io::Read,
+    ops,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use anyhow::{Context, anyhow};
 use indicatif::{MultiProgress, ProgressBar, ProgressBarIter, ProgressDrawTarget, ProgressStyle};
@@ -12,13 +14,18 @@ use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 use url::Url;
 
-use crate::config::Cfg;
-use crate::dist::manifest::{Manifest, ManifestWithHash};
-use crate::dist::{Channel, DEFAULT_DIST_SERVER, ToolchainDesc, temp};
-use crate::download::{DownloadOptions, is_network_failure};
-use crate::errors::RustupError;
-use crate::process::Process;
-use crate::utils;
+use crate::{
+    config::Cfg,
+    dist::{
+        Channel, DEFAULT_DIST_SERVER, ToolchainDesc,
+        manifest::{Manifest, ManifestWithHash},
+        temp,
+    },
+    download::{DownloadOptions, is_network_failure},
+    errors::RustupError,
+    process::Process,
+    utils,
+};
 
 const UPDATE_HASH_LEN: usize = 20;
 

--- a/src/dist/manifest.rs
+++ b/src/dist/manifest.rs
@@ -297,8 +297,9 @@ impl Hash for Component {
 }
 
 mod component_target {
-    use super::TargetTuple;
     use serde::{Deserialize, Deserializer, Serializer};
+
+    use super::TargetTuple;
 
     pub fn serialize<S: Serializer>(
         target: &Option<TargetTuple>,
@@ -660,9 +661,10 @@ impl fmt::Display for ManifestVersion {
 
 #[cfg(test)]
 mod tests {
-    use crate::RustupError;
-    use crate::dist::TargetTuple;
-    use crate::dist::manifest::Manifest;
+    use crate::{
+        RustupError,
+        dist::{TargetTuple, manifest::Manifest},
+    };
 
     // Example manifest from https://public.etherpad-mozilla.org/p/Rust-infra-work-week
     static EXAMPLE: &str = include_str!("manifest/tests/channel-rust-nightly-example.toml");

--- a/src/dist/temp.rs
+++ b/src/dist/temp.rs
@@ -1,7 +1,9 @@
-use std::path::{Path, PathBuf};
-use std::{fmt, fs, ops};
+use std::{
+    fmt, fs, ops,
+    path::{Path, PathBuf},
+};
 
-pub(crate) use anyhow::Context as _;
+use anyhow::Context as _;
 use thiserror::Error as ThisError;
 use tracing::{debug, warn};
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,10 +1,3 @@
-use std::ffi::OsString;
-use std::fmt::Debug;
-use std::io;
-use std::io::IsTerminal;
-use std::num::NonZero;
-use std::path::PathBuf;
-use std::str::FromStr;
 #[cfg(feature = "test")]
 use std::{
     collections::HashMap,
@@ -14,7 +7,16 @@ use std::{
     sync::{Arc, Mutex},
     time::{Duration, Instant},
 };
-use std::{env, thread};
+use std::{
+    env,
+    ffi::{OsStr, OsString},
+    fmt::Debug,
+    io::{self, IsTerminal},
+    num::NonZero,
+    path::PathBuf,
+    str::FromStr,
+    thread,
+};
 
 use anstream::ColorChoice;
 use anyhow::{Context, bail};
@@ -58,7 +60,7 @@ impl Process {
 
         arg0.as_ref()
             .and_then(|a| a.file_stem())
-            .and_then(std::ffi::OsStr::to_str)
+            .and_then(OsStr::to_str)
             .map(String::from)
     }
 

--- a/src/test/dist.rs
+++ b/src/test/dist.rs
@@ -1,28 +1,33 @@
 //! Tools for building and working with the filesystem of a mock Rust
 //! distribution server, with v1 and v2 manifests.
 
-use std::collections::{BTreeMap, HashMap};
-use std::fs::{self, File};
-use std::io::{self, Read, Write};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, Mutex};
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs::{self, File},
+    io::{self, Read, Write},
+    path::{Path, PathBuf},
+    sync::{Arc, LazyLock, Mutex},
+};
 
 use url::Url;
 
-use super::clitools::hard_link;
-use super::mock::MockInstallerBuilder;
-use super::{CROSS_ARCH1, CROSS_ARCH2, MULTI_ARCH1, create_hash, this_host_tuple};
-use crate::dist::{
-    DEFAULT_DIST_SERVER, Profile, TargetTuple,
-    component::{Components, DirectoryPackage, Transaction},
-    manifest::{
-        Component, CompressionKind, HashedBinary, Manifest, ManifestVersion, Package,
-        PackageTargets, Renamed, TargetedPackage,
-    },
-    prefix::InstallPrefix,
-    temp,
+use super::{
+    CROSS_ARCH1, CROSS_ARCH2, MULTI_ARCH1, clitools::hard_link, create_hash,
+    mock::MockInstallerBuilder, this_host_tuple,
 };
-use crate::process::TestProcess;
+use crate::{
+    dist::{
+        DEFAULT_DIST_SERVER, Profile, TargetTuple,
+        component::{Components, DirectoryPackage, Transaction},
+        manifest::{
+            Component, CompressionKind, HashedBinary, Manifest, ManifestVersion, Package,
+            PackageTargets, Renamed, TargetedPackage,
+        },
+        prefix::InstallPrefix,
+        temp,
+    },
+    process::TestProcess,
+};
 
 pub struct DistContext {
     pub pkg_dir: tempfile::TempDir,

--- a/src/test/mock_bin_src.rs
+++ b/src/test/mock_bin_src.rs
@@ -90,29 +90,16 @@ fn main() {
                 writeln!(out, "{}", arg.to_string_lossy()).unwrap();
             }
         }
-        Some("--echo-path") => {
-            let mut out = io::stderr();
-            writeln!(out, "{}", std::env::var("PATH").unwrap()).unwrap();
-        }
-        Some("--echo-cargo-env") => {
-            let mut out = io::stderr();
-            if let Ok(cargo) = std::env::var("CARGO") {
-                writeln!(out, "{cargo}").unwrap();
-            } else {
-                panic!("CARGO environment variable not set");
-            }
+        Some("--echo-env") => {
+            let name = args.next().expect("--echo-env requires a variable name");
+            let value = env::var(&name).unwrap_or_else(|_| {
+                panic!("{} environment variable not set", name.to_string_lossy())
+            });
+            eprintln!("{value}");
         }
         Some("--echo-current-exe") => {
             let mut out = io::stderr();
             writeln!(out, "{}", std::env::current_exe().unwrap().display()).unwrap();
-        }
-        Some("--echo-rustup-toolchain-source") => {
-            let mut out = io::stderr();
-            if let Ok(rustup_toolchain_source) = std::env::var("RUSTUP_TOOLCHAIN_SOURCE") {
-                writeln!(out, "{rustup_toolchain_source}").unwrap();
-            } else {
-                panic!("RUSTUP_TOOLCHAIN_SOURCE environment variable not set");
-            }
         }
         arg => panic!("bad mock proxy commandline: {:?}", arg),
     }

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -422,7 +422,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
     let cargo_home_bin = cx.config.cargodir.join("bin");
     assert_ok_with_paths(
         cx.config
-            .expect(["cargo", "--echo-path"])
+            .expect(["cargo", "--echo-env", "PATH"])
             .await
             .extend_redactions([("[CARGO_HOME_BIN]", &cargo_home_bin)]),
         snapbox::str![[r#"
@@ -433,7 +433,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
 
     assert_ok_with_paths(
         cx.config
-            .expect_with_env(["cargo", "--echo-path"], [("PATH", "")])
+            .expect_with_env(["cargo", "--echo-env", "PATH"], [("PATH", "")])
             .await
             .extend_redactions([("[CARGO_HOME_BIN]", &cargo_home_bin)]),
         snapbox::str![[r#"
@@ -446,7 +446,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
     assert_ok_with_paths(
         cx.config
             .expect_with_env(
-                ["cargo", "--echo-path"],
+                ["cargo", "--echo-env", "PATH"],
                 [("PATH", &*cx.config.exedir.display().to_string())],
             )
             .await
@@ -466,7 +466,7 @@ async fn rustup_doesnt_prepend_path_unnecessarily() {
     assert_ok_with_paths(
         cx.config
             .expect_with_env(
-                ["cargo", "--echo-path"],
+                ["cargo", "--echo-env", "PATH"],
                 [(
                     "PATH",
                     std::env::join_paths([&cx.config.exedir, &cargo_home_bin])
@@ -1682,7 +1682,7 @@ async fn rustup_updates_cargo_env_if_proxy() {
 
     // If CARGO isn't set then we should not set it.
     cx.config
-        .expect(["cargo", "--echo-cargo-env"])
+        .expect(["cargo", "--echo-env", "CARGO"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...
@@ -1694,7 +1694,7 @@ CARGO environment variable not set[..]
     // If CARGO is set to a proxy then change it to the real CARGO path
     cx.config
         .expect_with_env(
-            ["cargo", "--echo-cargo-env"],
+            ["cargo", "--echo-env", "CARGO"],
             [("CARGO", &*proxy_path.display().to_string())],
         )
         .await

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -3457,7 +3457,7 @@ async fn rustup_toolchain_source_cli() {
         .await
         .is_ok();
     cx.config
-        .expect(["cargo", "+nightly", "--echo-rustup-toolchain-source"])
+        .expect(["cargo", "+nightly", "--echo-env", "RUSTUP_TOOLCHAIN_SOURCE"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...
@@ -3471,7 +3471,7 @@ async fn rustup_toolchain_source_env() {
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
         .expect_with_env(
-            ["cargo", "--echo-rustup-toolchain-source"],
+            ["cargo", "--echo-env", "RUSTUP_TOOLCHAIN_SOURCE"],
             [("RUSTUP_TOOLCHAIN", "nightly")],
         )
         .await
@@ -3490,7 +3490,7 @@ async fn rustup_toolchain_source_path_override() {
         .await
         .is_ok();
     cx.config
-        .expect(["cargo", "--echo-rustup-toolchain-source"])
+        .expect(["cargo", "--echo-env", "RUSTUP_TOOLCHAIN_SOURCE"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...
@@ -3505,7 +3505,7 @@ async fn rustup_toolchain_source_toolchain_file() {
     let toolchain_file = cx.config.current_dir().join("rust-toolchain.toml");
     raw::write_file(&toolchain_file, "[toolchain]\nchannel='nightly'").unwrap();
     cx.config
-        .expect(["cargo", "--echo-rustup-toolchain-source"])
+        .expect(["cargo", "--echo-env", "RUSTUP_TOOLCHAIN_SOURCE"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...
@@ -3522,7 +3522,7 @@ async fn rustup_toolchain_source_default() {
         .await
         .is_ok();
     cx.config
-        .expect(["cargo", "--echo-rustup-toolchain-source"])
+        .expect(["cargo", "--echo-env", "RUSTUP_TOOLCHAIN_SOURCE"])
         .await
         .with_stderr(snapbox::str![[r#"
 ...


### PR DESCRIPTION
This PR is mainly cherry-picked from https://github.com/rust-lang/rustup/pull/5056 as suggested in https://github.com/rust-lang/rustup/pull/5056#issuecomment-5570975890.

Also, since my project goal prototype branch will be modifying `dist` files a lot, I've used this opportunity to clean up the imports in `dist` as well.