### PR TITLE
style: reformat all sources and add CI checks

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,4 @@
 [alias]
 dev-install = "run -- --no-modify-path -y"
 run-rustup = ["run", "--config", "env.RUSTUP_FORCE_ARG0='rustup'"]
+xfmt = ["fmt", "--all", "--", "--config-path=.rustfmt.unstable.toml"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1548,7 +1548,7 @@ jobs:
           restore-keys: ${{ github.base_ref }}-${{ runner.os }}-cargo-clippy-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=rustfmt -c=clippy -y
+          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=clippy -y
       - name: Run the centos check within the docker image
         run: |
           docker run \
@@ -1578,7 +1578,8 @@ jobs:
           git diff --exit-code
       - name: Run Rust formatting checks
         run: |
-          cargo fmt --all --check
+          rustup toolchain install nightly --profile=minimal -c=rustfmt
+          cargo +nightly xfmt --check
       - name: Run cargo check and clippy
         run: |
           cargo check --all --all-targets --features test

--- a/.rustfmt.unstable.toml
+++ b/.rustfmt.unstable.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Crate"

--- a/ci/actions-templates/centos-fmt-clippy-template.yaml
+++ b/ci/actions-templates/centos-fmt-clippy-template.yaml
@@ -48,7 +48,7 @@ jobs: # skip-all
           restore-keys: ${{ github.base_ref }}-${{ runner.os }}-cargo-clippy-target-dir-${{ steps.cargo-target-cache.outputs.rust_hash }}-${{ hashFiles('**/Cargo.lock') }}
       - name: Install Rustup using ./rustup-init.sh
         run: |
-          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=rustfmt -c=clippy -y
+          sh ./rustup-init.sh --default-toolchain=stable --profile=minimal -c=clippy -y
       - name: Run the centos check within the docker image
         run: |
           docker run \
@@ -78,7 +78,8 @@ jobs: # skip-all
           git diff --exit-code
       - name: Run Rust formatting checks
         run: |
-          cargo fmt --all --check
+          rustup toolchain install nightly --profile=minimal -c=rustfmt
+          cargo +nightly xfmt --check
       - name: Run cargo check and clippy
         run: |
           cargo check --all --all-targets --features test

--- a/src/bin/rustup-init.rs
+++ b/src/bin/rustup-init.rs
@@ -20,17 +20,17 @@ use anyhow::{Context, anyhow};
 use rs_tracing::{
     close_trace_file, close_trace_file_internal, open_trace_file, trace_to_file_internal,
 };
-use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
-
-use rustup::cli::errors::CliError;
 #[cfg(windows)]
 use rustup::cli::self_update;
-use rustup::cli::{common, log, proxy_mode, rustup_mode, setup_mode};
-use rustup::env_var::RUST_RECURSION_COUNT_MAX;
-use rustup::errors::RustupError;
-use rustup::is_proxyable_tools;
-use rustup::process::Process;
-use rustup::utils;
+use rustup::{
+    cli::{common, errors::CliError, log, proxy_mode, rustup_mode, setup_mode},
+    env_var::RUST_RECURSION_COUNT_MAX,
+    errors::RustupError,
+    is_proxyable_tools,
+    process::Process,
+    utils,
+};
+use tracing_subscriber::{EnvFilter, Registry, reload::Handle};
 
 fn main() -> anyhow::Result<ExitCode> {
     #[cfg(windows)]

--- a/src/cli/common.rs
+++ b/src/cli/common.rs
@@ -1,11 +1,13 @@
 //! Just a dumping ground for cli stuff
 
-use std::fmt::Display;
-use std::fs;
-use std::io::{BufRead, Write};
-use std::path::Path;
-use std::sync::LazyLock;
-use std::{cmp, env};
+use std::{
+    cmp, env,
+    fmt::Display,
+    fs,
+    io::{BufRead, Write},
+    path::Path,
+    sync::LazyLock,
+};
 
 use anstyle::Style;
 use anyhow::{Context, anyhow};

--- a/src/cli/job.rs
+++ b/src/cli/job.rs
@@ -36,18 +36,20 @@ mod imp {
 
 #[cfg(windows)]
 mod imp {
-    use std::io;
-    use std::mem;
-    use std::ptr;
+    use std::{io, mem, ptr};
 
     use tracing::info;
-    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
-    use windows_sys::Win32::System::JobObjects::{
-        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
-        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
-        SetInformationJobObject,
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, HANDLE},
+        System::{
+            JobObjects::{
+                AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            },
+            Threading::GetCurrentProcess,
+        },
     };
-    use windows_sys::Win32::System::Threading::GetCurrentProcess;
 
     pub(crate) struct Setup {
         job: Handle,

--- a/src/cli/self_update.rs
+++ b/src/cli/self_update.rs
@@ -1385,11 +1385,14 @@ pub(crate) fn cleanup_self_updater(process: &Process) -> anyhow::Result<()> {
 mod tests {
     use std::collections::HashMap;
 
-    use crate::cli::self_update::InstallOpts;
-    use crate::config::Cfg;
-    use crate::dist::{PartialToolchainDesc, Profile};
-    use crate::test::{Env, test_dir, with_rustup_home};
-    use crate::{for_host, process::TestProcess};
+    use crate::{
+        cli::self_update::InstallOpts,
+        config::Cfg,
+        dist::{PartialToolchainDesc, Profile},
+        for_host,
+        process::TestProcess,
+        test::{Env, test_dir, with_rustup_home},
+    };
 
     #[test]
     fn default_toolchain_is_stable() {

--- a/src/cli/self_update/shell.rs
+++ b/src/cli/self_update/shell.rs
@@ -23,8 +23,7 @@
 //! 1) using a shell script that updates PATH if the path is not in PATH
 //! 2) sourcing this script (`. /path/to/script`) in any appropriate rc file
 
-use std::borrow::Cow;
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 
 use anyhow::bail;
 
@@ -206,8 +205,7 @@ struct Zsh;
 
 impl Zsh {
     fn zdotdir(process: &Process) -> anyhow::Result<PathBuf> {
-        use std::ffi::OsStr;
-        use std::os::unix::ffi::OsStrExt;
+        use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
         if matches!(process.var("SHELL"), Ok(sh) if sh.contains("zsh")) {
             match process.var("ZDOTDIR") {

--- a/src/cli/self_update/unix.rs
+++ b/src/cli/self_update/unix.rs
@@ -1,13 +1,16 @@
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use anyhow::{Context, bail};
 use tracing::{error, warn};
 
-use super::install_bins;
-use super::shell::{self, Posix, UnixShell};
-use crate::process::Process;
-use crate::utils;
+use super::{
+    install_bins,
+    shell::{self, Posix, UnixShell},
+};
+use crate::{process::Process, utils};
 
 // If the user is trying to install with sudo, on some systems this will
 // result in writing root-owned files to the user's home directory, because

--- a/src/cli/self_update/windows.rs
+++ b/src/cli/self_update/windows.rs
@@ -1,11 +1,13 @@
-use std::borrow::Cow;
-use std::env::{consts::EXE_SUFFIX, split_paths};
-use std::ffi::{OsStr, OsString};
-use std::fmt;
-use std::io::Write;
-use std::os::windows::ffi::OsStrExt;
-use std::path::Path;
-use std::process::Command;
+use std::{
+    borrow::Cow,
+    env::{consts::EXE_SUFFIX, split_paths},
+    ffi::{OsStr, OsString},
+    fmt,
+    io::Write,
+    os::windows::ffi::OsStrExt,
+    path::Path,
+    process::Command,
+};
 
 use anyhow::{Context, anyhow};
 use tracing::{info, warn};
@@ -15,14 +17,18 @@ use windows_registry::{CURRENT_USER, HSTRING, Key};
 use windows_result::WIN32_ERROR;
 use windows_sys::Win32::Foundation::{ERROR_FILE_NOT_FOUND, ERROR_INVALID_DATA};
 
-use super::super::errors::CliError;
-use super::common;
-use super::{InstallOpts, install_bins, report_error};
-use crate::cli::markdown::md;
-use crate::dist::TargetTuple;
-use crate::download::DownloadOptions;
-use crate::process::{ColorableTerminal, Process};
-use crate::utils;
+use crate::{
+    cli::{
+        common,
+        errors::CliError,
+        markdown::md,
+        self_update::{InstallOpts, install_bins, report_error},
+    },
+    dist::TargetTuple,
+    download::DownloadOptions,
+    process::{ColorableTerminal, Process},
+    utils,
+};
 
 pub(crate) fn ensure_prompt(process: &Process) -> anyhow::Result<()> {
     writeln!(process.stdout().lock(),)?;
@@ -376,15 +382,18 @@ pub fn complete_windows_uninstall(process: &Process) -> anyhow::Result<utils::Ex
 }
 
 pub(crate) fn wait_for_parent() -> anyhow::Result<()> {
-    use std::io;
-    use std::mem;
-    use windows_sys::Win32::Foundation::{CloseHandle, INVALID_HANDLE_VALUE, WAIT_OBJECT_0};
-    use windows_sys::Win32::Storage::FileSystem::SYNCHRONIZE;
-    use windows_sys::Win32::System::Diagnostics::ToolHelp::{
-        CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next, TH32CS_SNAPPROCESS,
-    };
-    use windows_sys::Win32::System::Threading::{
-        GetCurrentProcessId, INFINITE, OpenProcess, WaitForSingleObject,
+    use std::{io, mem};
+
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, INVALID_HANDLE_VALUE, WAIT_OBJECT_0},
+        Storage::FileSystem::SYNCHRONIZE,
+        System::{
+            Diagnostics::ToolHelp::{
+                CreateToolhelp32Snapshot, PROCESSENTRY32, Process32First, Process32Next,
+                TH32CS_SNAPPROCESS,
+            },
+            Threading::{GetCurrentProcessId, INFINITE, OpenProcess, WaitForSingleObject},
+        },
     };
 
     unsafe {
@@ -454,9 +463,12 @@ pub(crate) fn do_add_to_path(process: &Process) -> anyhow::Result<()> {
 
 fn _apply_new_path(new_path: Option<HSTRING>, process: &Process) -> anyhow::Result<()> {
     use std::ptr;
-    use windows_sys::Win32::Foundation::{LPARAM, WPARAM};
-    use windows_sys::Win32::UI::WindowsAndMessaging::{
-        HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutA, WM_SETTINGCHANGE,
+
+    use windows_sys::Win32::{
+        Foundation::{LPARAM, WPARAM},
+        UI::WindowsAndMessaging::{
+            HWND_BROADCAST, SMTO_ABORTIFHUNG, SendMessageTimeoutA, WM_SETTINGCHANGE,
+        },
     };
 
     let Some(new_path) = new_path else {
@@ -705,14 +717,15 @@ pub(crate) fn self_replace(process: &Process) -> anyhow::Result<utils::ExitCode>
 // .. augmented with this SO answer
 // https://stackoverflow.com/questions/10319526/understanding-a-self-deleting-program-in-c
 pub(crate) fn spawn_uninstall_gc(no_modify_path: bool, process: &Process) -> anyhow::Result<()> {
-    use std::io;
-    use std::ptr;
-    use std::thread;
-    use std::time::Duration;
-    use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE};
-    use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
-    use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_DELETE_ON_CLOSE, FILE_SHARE_DELETE, FILE_SHARE_READ, OPEN_EXISTING,
+    use std::{io, ptr, thread, time::Duration};
+
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, GENERIC_READ, INVALID_HANDLE_VALUE},
+        Security::SECURITY_ATTRIBUTES,
+        Storage::FileSystem::{
+            CreateFileW, FILE_FLAG_DELETE_ON_CLOSE, FILE_SHARE_DELETE, FILE_SHARE_READ,
+            OPEN_EXISTING,
+        },
     };
 
     // CARGO_HOME, hopefully empty except for bin/rustup.exe
@@ -835,14 +848,12 @@ impl RegistryValueId {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::os::windows::ffi::OsStringExt;
+    use std::{collections::HashMap, os::windows::ffi::OsStringExt};
 
     use windows_registry::Type;
 
     use super::*;
-    use crate::process::TestProcess;
-    use crate::test::test_id;
+    use crate::{process::TestProcess, test::test_id};
 
     fn test_process(test_id: &str) -> TestProcess {
         let vars: HashMap<String, String> = [

--- a/src/cli/topical_doc.rs
+++ b/src/cli/topical_doc.rs
@@ -1,6 +1,8 @@
-use std::ffi::OsString;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsString,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, anyhow};
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -35,9 +35,13 @@ pub(crate) fn run_command_for_dir<S: AsRef<OsStr> + Debug>(
 
     #[cfg(windows)]
     fn exec(cmd: &mut Command) -> io::Result<ExitStatus> {
-        use windows_sys::Win32::Foundation::{FALSE, TRUE};
-        use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
-        use windows_sys::core::BOOL;
+        use windows_sys::{
+            Win32::{
+                Foundation::{FALSE, TRUE},
+                System::Console::SetConsoleCtrlHandler,
+            },
+            core::BOOL,
+        };
 
         unsafe extern "system" fn ctrlc_handler(_: u32) -> BOOL {
             // Do nothing. Let the child process handle it.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,12 @@
-use std::fmt::{self, Debug, Display};
-use std::io;
-use std::io::Write;
-use std::ops::Deref;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fmt::{self, Debug, Display},
+    io,
+    io::Write,
+    ops::Deref,
+    path::{Path, PathBuf},
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use anyhow::{Context, anyhow, bail};
 use chrono::{DateTime, NaiveDate};

--- a/src/diskio/mod.rs
+++ b/src/diskio/mod.rs
@@ -52,18 +52,25 @@
 // f) data gathering: record (name, bytes, start, duration)
 //    write to disk afterwards as a csv file?
 use std::io::{self, Write};
-use std::ops::{Deref, DerefMut};
-use std::path::{Path, PathBuf};
-use std::sync::mpsc::{self, Receiver};
-use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, Instant};
-use std::{fmt::Debug, fs::OpenOptions};
+use std::{
+    fmt::Debug,
+    fs::OpenOptions,
+    ops::{Deref, DerefMut},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, Mutex, OnceLock,
+        mpsc::{self, Receiver},
+    },
+    time::{Duration, Instant},
+};
 
 use tracing::{error, trace, warn};
 
-use crate::diskio::immediate::{FileState, IncrementalFileWriter};
-use crate::process::IoThreadCount;
-use crate::utils::units::Size;
+use crate::{
+    diskio::immediate::{FileState, IncrementalFileWriter},
+    process::IoThreadCount,
+    utils::units::Size,
+};
 
 mod immediate;
 #[cfg(test)]

--- a/src/diskio/test.rs
+++ b/src/diskio/test.rs
@@ -1,8 +1,7 @@
 use std::collections::HashMap;
 
 use super::{Executor, Item, Kind, get_executor};
-use crate::process::TestProcess;
-use crate::test::test_dir;
+use crate::{process::TestProcess, test::test_dir};
 
 impl Item {
     /// The length of the file, for files (for stats)

--- a/src/diskio/threaded.rs
+++ b/src/diskio/threaded.rs
@@ -5,10 +5,14 @@
 /// very low latency per file, which even a few ms per syscall per file
 /// will cause minutes of wall clock time.
 use std::cell::{Cell, RefCell};
-use std::fmt;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc::{Receiver, Sender, channel};
+use std::{
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+        mpsc::{Receiver, Sender, channel},
+    },
+};
 
 use enum_map::{Enum, EnumMap, enum_map};
 use sharded_slab::pool::{OwnedRef, OwnedRefMut};

--- a/src/dist/component/components.rs
+++ b/src/dist/component/components.rs
@@ -272,9 +272,10 @@ impl Component {
         // and the version file.
 
         // Track visited directories
-        use std::collections::HashSet;
-        use std::collections::hash_set::IntoIter;
-        use std::fs::read_dir;
+        use std::{
+            collections::{HashSet, hash_set::IntoIter},
+            fs::read_dir,
+        };
 
         // dirs will contain the set of longest disjoint directory paths seen
         // ancestors help in filtering seen paths and constructing dirs

--- a/src/dist/component/mod.rs
+++ b/src/dist/component/mod.rs
@@ -1,9 +1,8 @@
-pub use self::components::*;
-pub use self::package::*;
 /// An interpreter for the rust-installer [1] installation format.
 ///
 /// https://github.com/rust-lang/rust-installer
 pub use self::transaction::*;
+pub use self::{components::*, package::*};
 
 // Transactional file system tools
 mod transaction;

--- a/src/dist/mod.rs
+++ b/src/dist/mod.rs
@@ -501,10 +501,16 @@ impl TargetTuple {
             /// it is only available on Windows 10 1511+, so we use `GetProcAddress`
             /// to maintain backward compatibility with older Windows versions.
             fn arch_primary() -> Option<&'static str> {
-                use windows_sys::Win32::Foundation::HANDLE;
-                use windows_sys::Win32::System::LibraryLoader::{GetModuleHandleA, GetProcAddress};
-                use windows_sys::Win32::System::Threading::GetCurrentProcess;
-                use windows_sys::core::{BOOL, s};
+                use windows_sys::{
+                    Win32::{
+                        Foundation::HANDLE,
+                        System::{
+                            LibraryLoader::{GetModuleHandleA, GetProcAddress},
+                            Threading::GetCurrentProcess,
+                        },
+                    },
+                    core::{BOOL, s},
+                };
 
                 const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
                 const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
@@ -570,8 +576,7 @@ impl TargetTuple {
 
         #[cfg(not(windows))]
         fn inner() -> Option<TargetTuple> {
-            use std::ffi::CStr;
-            use std::mem;
+            use std::{ffi::CStr, mem};
 
             let mut sys_info;
             let (sysname, machine) = unsafe {
@@ -732,8 +737,10 @@ static TUPLE_MIPS64_UNKNOWN_LINUX_GNUABI64: &str = "mips64el-unknown-linux-gnuab
 /// rustup-init.sh also relies on checking /bin/sh for bitness.
 #[cfg(not(windows))]
 fn is_32bit_userspace() -> bool {
-    use std::fs;
-    use std::io::{self, Read};
+    use std::{
+        fs,
+        io::{self, Read},
+    };
 
     // inner function is to simplify error handling.
     fn inner() -> io::Result<bool> {

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -1,15 +1,17 @@
 //! Easy file downloading
 
-use std::fs::{self, OpenOptions, remove_file};
-use std::io::{self, Read, Seek, SeekFrom, Write};
-use std::num::NonZero;
-use std::path::Path;
-use std::str::FromStr;
 #[cfg(feature = "reqwest-rustls-tls")]
 use std::sync::Arc;
 #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
 use std::sync::OnceLock;
-use std::time::Duration;
+use std::{
+    fs::{self, OpenOptions, remove_file},
+    io::{self, Read, Seek, SeekFrom, Write},
+    num::NonZero,
+    path::Path,
+    str::FromStr,
+    time::Duration,
+};
 
 use anyhow::{Context, anyhow};
 use reqwest::{Client, ClientBuilder, Proxy, header};

--- a/src/download/tests.rs
+++ b/src/download/tests.rs
@@ -1,28 +1,30 @@
-use std::convert::Infallible;
-use std::env::remove_var;
-use std::fs;
-use std::io;
-use std::net::SocketAddr;
-use std::path::Path;
-use std::sync::LazyLock;
-use std::sync::mpsc::{Sender, channel};
-use std::thread;
+use std::{
+    convert::Infallible,
+    env::remove_var,
+    fs, io,
+    net::SocketAddr,
+    path::Path,
+    sync::{
+        LazyLock,
+        mpsc::{Sender, channel},
+    },
+    thread,
+};
 
 use http_body_util::Full;
-use hyper::Request;
-use hyper::body::Bytes;
-use hyper::server::conn::http1;
-use hyper::service::service_fn;
+use hyper::{Request, body::Bytes, server::conn::http1, service::service_fn};
 use tempfile::TempDir;
 
 #[cfg(any(feature = "reqwest-rustls-tls", feature = "reqwest-native-tls"))]
 mod reqwest {
-    use std::env::set_var;
-    use std::error::Error;
-    use std::net::TcpListener;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::thread;
-    use std::time::Duration;
+    use std::{
+        env::set_var,
+        error::Error,
+        net::TcpListener,
+        sync::atomic::{AtomicUsize, Ordering},
+        thread,
+        time::Duration,
+    };
 
     use env_proxy::for_url;
     use reqwest::{Client, Proxy};

--- a/src/env_var.rs
+++ b/src/env_var.rs
@@ -1,7 +1,4 @@
-use std::collections::VecDeque;
-use std::env;
-use std::path::PathBuf;
-use std::process::Command;
+use std::{collections::VecDeque, env, path::PathBuf, process::Command};
 
 use crate::process::Process;
 
@@ -50,12 +47,13 @@ pub(crate) fn inc(name: &str, cmd: &mut Command, process: &Process) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use std::ffi::{OsStr, OsString};
+    use std::{
+        collections::HashMap,
+        ffi::{OsStr, OsString},
+    };
 
     use super::*;
-    use crate::process::TestProcess;
-    use crate::test::Env;
+    use crate::{process::TestProcess, test::Env};
 
     #[test]
     fn prepend_unique_path() {

--- a/src/process.rs
+++ b/src/process.rs
@@ -441,8 +441,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::process::TestProcess;
-    use crate::test::Env;
+    use crate::{process::TestProcess, test::Env};
 
     #[test]
     fn term_color_choice() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,17 +1,21 @@
-use std::cell::RefCell;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::path::{Path, PathBuf};
-use std::str::FromStr;
+use std::{
+    cell::RefCell,
+    collections::BTreeMap,
+    fmt,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
-use crate::cli::self_update::SelfUpdateMode;
-use crate::dist::{Profile, Switch};
-use crate::errors::RustupError;
-use crate::utils;
+use crate::{
+    cli::self_update::SelfUpdateMode,
+    dist::{Profile, Switch},
+    errors::RustupError,
+    utils,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SettingsFile {

--- a/src/test.rs
+++ b/src/test.rs
@@ -6,20 +6,20 @@
 )]
 //! Test support module; public to permit use from integration tests.
 
-use std::collections::HashMap;
-use std::env;
-use std::ffi::OsStr;
-use std::fmt;
-use std::fs;
-use std::fs::File;
-use std::io::{self, Read};
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    collections::HashMap,
+    env,
+    ffi::OsStr,
+    fmt, fs,
+    fs::File,
+    io::{self, Read},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use sha2::{Digest, Sha256};
 
-use crate::dist::TargetTuple;
-use crate::process::TestProcess;
+use crate::{dist::TargetTuple, process::TestProcess};
 
 #[cfg(all(windows, any(test, feature = "test")))]
 pub(crate) fn test_id() -> String {
@@ -258,8 +258,7 @@ where
 }
 
 pub mod topical_doc_data {
-    use std::collections::HashSet;
-    use std::path::PathBuf;
+    use std::{collections::HashSet, path::PathBuf};
 
     // Paths are written as a string in the UNIX format to make it easy
     // to maintain.

--- a/src/test/clitools.rs
+++ b/src/test/clitools.rs
@@ -25,22 +25,19 @@ use snapbox::{IntoData, RedactedValue, Redactions, assert_data_eq};
 use tempfile::TempDir;
 use url::Url;
 
-use crate::cli::rustup_mode;
-use crate::process;
-use crate::test as rustup_test;
-use crate::test::const_dist_dir;
-use crate::test::tempdir_in_with_prefix;
-use crate::test::this_host_tuple;
-use crate::utils;
-
-#[cfg(windows)]
-use crate::{cli::self_update::RUSTUP_REGISTRY_TEST_ID, test::test_id};
-
 use super::{
     CHECKPOINT_ENV, CROSS_ARCH1, CROSS_ARCH2, MULTI_ARCH1, checkpoint_path,
     dist::{MockDistServer, MockManifestVersion, Release, RlsStatus, change_channel_date},
     mock::MockFile,
 };
+use crate::{
+    cli::rustup_mode,
+    process, test as rustup_test,
+    test::{const_dist_dir, tempdir_in_with_prefix, this_host_tuple},
+    utils,
+};
+#[cfg(windows)]
+use crate::{cli::self_update::RUSTUP_REGISTRY_TEST_ID, test::test_id};
 
 /// The configuration used by the tests in this module
 #[derive(Debug)]

--- a/src/test/mock.rs
+++ b/src/test/mock.rs
@@ -1,12 +1,13 @@
 //! Mocks for testing
 
-use std::fs::{self, File, OpenOptions};
-use std::io::Write;
-use std::path::Path;
-use std::sync::Arc;
+use std::{
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::Path,
+    sync::Arc,
+};
 
-use super::clitools::mock_bin;
-use super::{this_host_tuple, topical_doc_data};
+use super::{clitools::mock_bin, this_host_tuple, topical_doc_data};
 
 // Mock of the on-disk structure of rust-installer installers
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]

--- a/src/toolchain/distributable.rs
+++ b/src/toolchain/distributable.rs
@@ -7,6 +7,10 @@ use anyhow::Context;
 use anyhow::anyhow;
 use platforms::Platform;
 
+use super::{
+    Toolchain,
+    names::{LocalToolchainName, ToolchainName},
+};
 use crate::{
     RustupError, component_for_bin,
     config::{ActiveSource, Cfg, EnsureInstalled},
@@ -18,14 +22,8 @@ use crate::{
         manifestation::{Changes, Manifestation},
         prefix::InstallPrefix,
     },
+    errors::UnknownComponentInfo,
     install::InstallMethod,
-};
-
-use crate::errors::UnknownComponentInfo;
-
-use super::{
-    Toolchain,
-    names::{LocalToolchainName, ToolchainName},
 };
 
 /// An official toolchain installed on the local disk

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,21 +1,25 @@
 //!  Utility functions for Rustup
 
-use std::env;
-use std::ffi::OsStr;
-use std::fs::{self, File};
-use std::io::{self, BufReader, Write};
-use std::ops::{BitAnd, BitAndAssign};
-use std::path::{Path, PathBuf};
-use std::process::ExitStatus;
+use std::{
+    env,
+    ffi::OsStr,
+    fs::{self, File},
+    io::{self, BufReader, Write},
+    ops::{BitAnd, BitAndAssign},
+    path::{Path, PathBuf},
+    process::ExitStatus,
+};
 
 use anyhow::{Context, anyhow};
-use retry::delay::{Fibonacci, jitter};
-use retry::{OperationResult, retry};
+use retry::{
+    OperationResult,
+    delay::{Fibonacci, jitter},
+    retry,
+};
 use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::errors::RustupError;
-
 #[cfg(not(windows))]
 pub(crate) use crate::utils::raw::find_cmd;
 pub(crate) use crate::utils::raw::is_directory;
@@ -509,10 +513,12 @@ pub(crate) fn buffered(path: &Path) -> anyhow::Result<BufReader<File>> {
 // search user database to get home dir of euid user
 #[cfg(unix)]
 pub(crate) fn home_dir_from_passwd() -> Option<PathBuf> {
-    use std::ffi::{CStr, OsString};
-    use std::mem::MaybeUninit;
-    use std::os::unix::ffi::OsStringExt;
-    use std::ptr;
+    use std::{
+        ffi::{CStr, OsString},
+        mem::MaybeUninit,
+        os::unix::ffi::OsStringExt,
+        ptr,
+    };
     unsafe {
         let init_size = match libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) {
             -1 => 1024,

--- a/src/utils/raw.rs
+++ b/src/utils/raw.rs
@@ -1,15 +1,20 @@
 #[cfg(not(windows))]
 use std::env;
-use std::fs;
-use std::fs::File;
-use std::io;
-use std::io::{Read, Seek, SeekFrom, Write};
-use std::path::Path;
-use std::str;
+use std::{
+    fs,
+    fs::File,
+    io,
+    io::{Read, Seek, SeekFrom, Write},
+    path::Path,
+    str,
+};
 
 use rand::RngExt;
-use retry::delay::{Fibonacci, jitter};
-use retry::{OperationResult, retry};
+use retry::{
+    OperationResult,
+    delay::{Fibonacci, jitter},
+    retry,
+};
 
 #[cfg(not(windows))]
 use crate::process::Process;
@@ -36,8 +41,7 @@ pub fn is_file<P: AsRef<Path>>(path: P) -> bool {
 
 #[cfg(windows)]
 pub fn open_dir_following_links(p: &Path) -> io::Result<File> {
-    use std::fs::OpenOptions;
-    use std::os::windows::fs::OpenOptionsExt;
+    use std::{fs::OpenOptions, os::windows::fs::OpenOptionsExt};
 
     use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
 
@@ -182,16 +186,19 @@ pub fn symlink_dir(src: &Path, dest: &Path) -> io::Result<()> {
 #[cfg(windows)]
 #[allow(non_snake_case)]
 fn symlink_junction_inner(target: &Path, junction: &Path) -> io::Result<()> {
-    use std::os::windows::ffi::OsStrExt;
-    use std::ptr;
-    use windows_sys::Win32::Foundation::GENERIC_WRITE;
-    use windows_sys::Win32::Storage::FileSystem::{
-        CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_DELETE,
-        FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+    use std::{os::windows::ffi::OsStrExt, ptr};
+
+    use windows_sys::Win32::{
+        Foundation::GENERIC_WRITE,
+        Storage::FileSystem::{
+            CreateFileW, FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT,
+            FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, OPEN_EXISTING,
+        },
+        System::{
+            IO::DeviceIoControl, Ioctl::FSCTL_SET_REPARSE_POINT,
+            SystemServices::IO_REPARSE_TAG_MOUNT_POINT,
+        },
     };
-    use windows_sys::Win32::System::IO::DeviceIoControl;
-    use windows_sys::Win32::System::Ioctl::FSCTL_SET_REPARSE_POINT;
-    use windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_MOUNT_POINT;
 
     const MAXIMUM_REPARSE_DATA_BUFFER_SIZE: usize = 16 * 1024;
 
@@ -364,9 +371,7 @@ pub(crate) fn find_cmd<'a>(cmds: &[&'a str], process: &Process) -> Option<&'a st
 
 #[cfg(windows)]
 pub(crate) mod windows {
-    use std::ffi::OsStr;
-    use std::io;
-    use std::os::windows::ffi::OsStrExt;
+    use std::{ffi::OsStr, io, os::windows::ffi::OsStrExt};
 
     pub(crate) fn to_u16s<S: AsRef<OsStr>>(s: S) -> io::Result<Vec<u16>> {
         fn inner(s: &OsStr) -> io::Result<Vec<u16>> {

--- a/tests/suite/cli_exact.rs
+++ b/tests/suite/cli_exact.rs
@@ -1,10 +1,10 @@
 //! Yet more cli test cases. These are testing that the output
 //! is exactly as expected.
 
-use rustup::test::{
-    CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_tuple,
+use rustup::{
+    test::{CROSS_ARCH1, CROSS_ARCH2, CliTestContext, MULTI_ARCH1, Scenario, this_host_tuple},
+    utils::raw,
 };
-use rustup::utils::raw;
 
 #[tokio::test]
 async fn update_once() {

--- a/tests/suite/cli_inst_interactive.rs
+++ b/tests/suite/cli_inst_interactive.rs
@@ -1,14 +1,13 @@
 //! Tests of the interactive console installer
 
-use std::env::consts::EXE_SUFFIX;
-use std::fs;
-use std::io::Write;
-use std::process::Stdio;
+use std::{env::consts::EXE_SUFFIX, fs, io::Write, process::Stdio};
 
-use rustup::test::{
-    Assert, CROSS_ARCH1, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple,
+use rustup::{
+    test::{
+        Assert, CROSS_ARCH1, CliTestContext, Config, SanitizedOutput, Scenario, this_host_tuple,
+    },
+    utils::raw,
 };
-use rustup::utils::raw;
 
 fn run_input(config: &Config, args: &[&str], input: &str) -> Assert {
     run_input_with_env(config, args, input, &[])

--- a/tests/suite/cli_misc.rs
+++ b/tests/suite/cli_misc.rs
@@ -1,15 +1,14 @@
 //! Test cases of the rustup command that do not depend on the
 //! dist server, mostly derived from multirust/test-v2.sh
 
-use std::fs;
-use std::str;
-use std::{env::consts::EXE_SUFFIX, path::Path};
+use std::{env::consts::EXE_SUFFIX, fs, path::Path, str};
 
 use itertools::Itertools;
-use rustup::test::Assert;
-use rustup::test::{CliTestContext, MULTI_ARCH1, Scenario, this_host_tuple};
-use rustup::utils;
-use rustup::utils::raw::symlink_dir;
+use rustup::{
+    test::{Assert, CliTestContext, MULTI_ARCH1, Scenario, this_host_tuple},
+    utils,
+    utils::raw::symlink_dir,
+};
 
 #[tokio::test]
 async fn smoke_test() {

--- a/tests/suite/cli_paths.rs
+++ b/tests/suite/cli_paths.rs
@@ -7,13 +7,14 @@ const INIT_NONE: [&str; 4] = ["rustup-init", "-y", "--default-toolchain", "none"
 
 #[cfg(unix)]
 mod unix {
-    use std::fmt::Display;
-    use std::fs;
-    use std::path::PathBuf;
+    use std::{fmt::Display, fs, path::PathBuf};
+
+    use rustup::{
+        test::{CliTestContext, Scenario},
+        utils::raw,
+    };
 
     use super::INIT_NONE;
-    use rustup::test::{CliTestContext, Scenario};
-    use rustup::utils::raw;
 
     // Let's write a fake .rc which looks vaguely like a real script.
     const FAKE_RC: &str = r#"
@@ -506,14 +507,15 @@ error: could not amend shell profile[..]
 mod windows {
     use std::ffi::OsStr;
 
-    use retry::delay::{Fibonacci, jitter};
-    use retry::{OperationResult, retry};
+    use retry::{
+        OperationResult,
+        delay::{Fibonacci, jitter},
+        retry,
+    };
+    use rustup::test::{CliTestContext, Scenario, USER_PATH, get_path};
+    use windows_registry::{CURRENT_USER, HSTRING, Value};
 
     use super::INIT_NONE;
-    use rustup::test::{CliTestContext, Scenario};
-    use rustup::test::{USER_PATH, get_path};
-
-    use windows_registry::{CURRENT_USER, HSTRING, Value};
 
     #[tokio::test]
     /// Smoke test for end-to-end code connectivity of the installer path mgmt on windows.

--- a/tests/suite/cli_rustup.rs
+++ b/tests/suite/cli_rustup.rs
@@ -3899,8 +3899,7 @@ async fn docs_custom() {
 #[cfg(unix)]
 #[tokio::test]
 async fn non_utf8_arg() {
-    use std::ffi::OsStr;
-    use std::os::unix::ffi::OsStrExt;
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
@@ -3927,8 +3926,7 @@ echoed non-utf8 arg:
 #[cfg(windows)]
 #[tokio::test]
 async fn non_utf8_arg() {
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
+    use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
@@ -3955,8 +3953,7 @@ echoed non-utf8 arg:
 #[cfg(unix)]
 #[tokio::test]
 async fn non_utf8_toolchain() {
-    use std::ffi::OsStr;
-    use std::os::unix::ffi::OsStrExt;
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config
@@ -3979,8 +3976,7 @@ error: invalid toolchain name '�('
 #[cfg(windows)]
 #[tokio::test]
 async fn non_utf8_toolchain() {
-    use std::ffi::OsString;
-    use std::os::windows::ffi::OsStringExt;
+    use std::{ffi::OsString, os::windows::ffi::OsStringExt};
 
     let cx = CliTestContext::new(Scenario::SimpleV2).await;
     cx.config

--- a/tests/suite/cli_rustup_init_ui.rs
+++ b/tests/suite/cli_rustup_init_ui.rs
@@ -1,8 +1,6 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::{fs::create_dir_all, path::Path};
 
-use snapbox::Data;
-use snapbox::cmd::Command;
+use snapbox::{Data, cmd::Command};
 
 #[track_caller]
 fn test_help(name: &str, args: &[&str]) {

--- a/tests/suite/cli_rustup_ui.rs
+++ b/tests/suite/cli_rustup_ui.rs
@@ -1,9 +1,7 @@
-use std::fs::create_dir_all;
-use std::path::Path;
+use std::{fs::create_dir_all, path::Path};
 
 use rustup::test::{CliTestContext, Scenario};
-use snapbox::Data;
-use snapbox::cmd::Command;
+use snapbox::{Data, cmd::Command};
 
 #[track_caller]
 fn test_help(name: &str, args: &[&str]) {

--- a/tests/suite/cli_self_upd.rs
+++ b/tests/suite/cli_self_upd.rs
@@ -1,13 +1,8 @@
 //! Testing self install, uninstall and update
 
-use std::env;
-use std::env::consts::EXE_SUFFIX;
-use std::fs;
-use std::path::Path;
-use std::process::Command;
+use std::{env, env::consts::EXE_SUFFIX, fs, path::Path, process::Command};
 
 use remove_dir_all::remove_dir_all;
-
 #[cfg(windows)]
 use retry::{
     delay::{Fibonacci, jitter},
@@ -15,12 +10,14 @@ use retry::{
 };
 #[cfg(windows)]
 use rustup::test::RegistryValueId;
-use rustup::test::{
-    CROSS_ARCH1, CliTestContext, Scenario, SelfUpdateTestContext, calc_hash, output_release_file,
-    this_host_tuple,
+use rustup::{
+    DUP_TOOLS, TOOLS,
+    test::{
+        CROSS_ARCH1, CliTestContext, Scenario, SelfUpdateTestContext, calc_hash,
+        output_release_file, this_host_tuple,
+    },
+    utils::{self, raw},
 };
-use rustup::utils::{self, raw};
-use rustup::{DUP_TOOLS, TOOLS};
 #[cfg(windows)]
 use windows_registry::{CURRENT_USER, Value};
 

--- a/tests/suite/cli_v2.rs
+++ b/tests/suite/cli_v2.rs
@@ -1,14 +1,13 @@
 //! Test cases of the rustup command, using v2 manifests, mostly
 //! derived from multirust/test-v2.sh
 
-use std::fs;
-use std::io::Write;
-use std::path::PathBuf;
+use std::{fs, io::Write, path::PathBuf};
 
-use rustup::dist::TargetTuple;
-use rustup::dist::manifest::Manifest;
-use rustup::test::{
-    CROSS_ARCH1, CROSS_ARCH2, CliTestContext, Config, Scenario, create_hash, this_host_tuple,
+use rustup::{
+    dist::{TargetTuple, manifest::Manifest},
+    test::{
+        CROSS_ARCH1, CROSS_ARCH2, CliTestContext, Config, Scenario, create_hash, this_host_tuple,
+    },
 };
 
 #[tokio::test]

--- a/tests/suite/dist_install.rs
+++ b/tests/suite/dist_install.rs
@@ -1,10 +1,13 @@
-use std::fs::File;
-use std::io::Write;
+use std::{fs::File, io::Write};
 
-use rustup::dist::component::{Components, DirectoryPackage, Transaction};
-use rustup::dist::prefix::InstallPrefix;
-use rustup::test::{DistContext, MockComponentBuilder, MockFile, MockInstallerBuilder};
-use rustup::utils;
+use rustup::{
+    dist::{
+        component::{Components, DirectoryPackage, Transaction},
+        prefix::InstallPrefix,
+    },
+    test::{DistContext, MockComponentBuilder, MockFile, MockInstallerBuilder},
+    utils,
+};
 
 // Just testing that the mocks work
 #[test]


### PR DESCRIPTION
Closes #5065.

The new `cargo +nightly xfmt` subcommand follows the [nextest](https://github.com/nextest-rs/nextest/blob/e499f2b15bb59415e8cf452560b73bf4d92a1835/.cargo/config.toml#L2) convention which is also used by [some other projects](https://github.com/search?q=path%3A%22.cargo%2Fconfig.toml%22+xfmt&type=code).

## Concerns

- [ ] Should we inline the formatting options in `.cargo/config.toml` like in the nextest example above? This way no `nightly` installation is required, but it may be less composable with the r-a configuration proposed in https://github.com/rust-lang/rustup/issues/5065#issuecomment-5596388177.