### PR TITLE
ci(windows): only generate hash for files in `prepare-deploy.ps1`

### DIFF
--- a/ci/prepare-deploy.ps1
+++ b/ci/prepare-deploy.ps1
@@ -1,9 +1,12 @@
-
 # Copy rustup-init to rustup-setup for backwards compatibility
 cp target\${env:TARGET}\release\rustup-init.exe target\${env:TARGET}\release\rustup-setup.exe
 
 # Generate hashes
-Get-FileHash .\target\${env:TARGET}\release\* | ForEach-Object {[io.file]::WriteAllText($_.Path + ".sha256", $_.Hash.ToLower() + "`n")}
+Get-ChildItem -LiteralPath ".\target\${env:TARGET}\release" -File | ForEach-Object {
+  Get-FileHash -LiteralPath $_.FullName | ForEach-Object {
+    [io.file]::WriteAllText($_.Path + ".sha256", $_.Hash.ToLower() + "`n")
+  }
+}
 
 # Prepare bins for upload
 $dest = "dist\$env:TARGET"


### PR DESCRIPTION
There is a loophole that has been exposed by https://github.com/rust-lang/rustup/pull/5070 when switching to short-circuiting `pwsh` for all `powershell`/`pwsh` scripts, as suggested by @ChrisDenton in https://github.com/rust-lang/rustup/pull/5070#issuecomment-5639591681.

Originally, the filtering logic for `*.sha256` generation in `prepare-deploy.ps1` didn't consider the fact that only files can be hashed. However, since the hashing of directories (which always fails) was silently skipped, the issue never became a CI error until today.

This patch fixes that by mirroring `prepare-deploy.bash`'s `find ... -type f` more closely so that we only generate hashes for files.

cc @Cloud0310 for review.